### PR TITLE
MacOS Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "autoprefixer": "^10.4.24",
         "jimp": "^1.6.0",
         "jsdom": "^28.1.0",
+        "lucide-react": "^0.577.0",
         "postcss": "^8.5.6",
         "sharp": "^0.34.5",
         "tailwindcss": "^4.2.0",
@@ -4400,6 +4401,16 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,9 +26,7 @@ serde_json = "1"
 tokio = { version = "1.49.0", features = ["process", "sync", "macros", "rt-multi-thread", "time"] }
 uuid = { version = "1.21.0", features = ["v4"] }
 portable-pty = "0.9.0"
-win32job = "2.0.3"
 sysinfo = "0.38.2"
-winapi = { version = "0.3.9", features = ["processthreadsapi", "winnt", "handleapi"] }
 chrono = "0.4.38"
 dirs = "5.0.1"
 shlex = "1.3.0"
@@ -37,6 +35,10 @@ regex = "1.12.3"
 tauri-plugin-notification = "2.0.0-rc.3"
 cron = "0.12.1"
 notify = "6.1.1"
+
+[target.'cfg(windows)'.dependencies]
+win32job = "2.0.3"
+winapi = { version = "0.3.9", features = ["processthreadsapi", "winnt", "handleapi"] }
 windows = { version = "0.58.0", features = [
     "Win32_Foundation",
     "Win32_UI_Shell", 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -23,19 +23,7 @@ pub async fn spawn_agent(
     let mut session_id = actual_resume.clone();
 
     if actual_resume.is_none() {
-        let cwd = if folder.is_empty() {
-            if cfg!(windows) {
-                std::env::var("USERPROFILE")
-                    .map(std::path::PathBuf::from)
-                    .unwrap_or_else(|_| std::path::PathBuf::from("C:"))
-            } else {
-                std::env::var("HOME")
-                    .map(std::path::PathBuf::from)
-                    .unwrap_or_else(|_| std::path::PathBuf::from("/"))
-            }
-        } else {
-            std::path::PathBuf::from(&folder)
-        };
+        let cwd = crate::utils::fs::resolve_cwd(&folder, "");
 
         let provider_name = config_override.as_ref().map(|c| c.provider.clone()).unwrap_or_else(|| "gemini".to_string());
         if let Some(real_sid) = manager::obtain_session_id(&cwd, &provider_name).await {

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -135,9 +135,6 @@ pub async fn spawn_agent(
             None
         }
     };
-    #[cfg(not(windows))]
-    let job_object = None;
-
     let mut reader = pair
         .master
         .try_clone_reader()

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -425,8 +425,9 @@ pub async fn obtain_session_id(
             log_debug("[WARDIAN-DEBUG] Spawned headless process. Reading stdout...");
             let mut session_id_res = None;
 
-            let timeout = tokio::time::Duration::from_secs(30);
+            let timeout = tokio::time::Duration::from_secs(60);
             let read_future = async {
+                let mut session_id: Option<String> = None;
                 if let Some(stdout) = child.stdout.take() {
                     let mut reader = BufReader::new(stdout);
                     let mut line = String::new();
@@ -439,26 +440,37 @@ pub async fn obtain_session_id(
                         if let Some(start) = trimmed.find('{') {
                             let json_part = &trimmed[start..];
                             if let Some(evt) = provider.parse_output(json_part) {
-                                if let AgentEvent::Init { session_id, .. } = evt {
-                                    if !session_id.is_empty() {
-                                        log_debug(&format!("[WARDIAN-DEBUG] Found session_id: {}", session_id));
-                                        return Some(session_id);
+                                match evt {
+                                    AgentEvent::Init { session_id: sid, .. } if !sid.is_empty() => {
+                                        log_debug(&format!("[WARDIAN-DEBUG] Found session_id: {}", sid));
+                                        session_id = Some(sid);
                                     }
+                                    // ModelResponse means the prompt completed and the session
+                                    // has been persisted to disk — safe to stop reading.
+                                    AgentEvent::ModelResponse => {
+                                        log_debug("[WARDIAN-DEBUG] Prompt complete, session saved.");
+                                        break;
+                                    }
+                                    _ => {}
                                 }
                             }
                         }
                         line.clear();
                     }
                 }
-                None
+                session_id
             };
 
-            match tokio::time::timeout(timeout, read_future).await {
-                Ok(sid) => session_id_res = sid,
-                Err(_) => log_debug("[WARDIAN-DEBUG] Timed out waiting for session_id."),
-            }
+            let timed_out = match tokio::time::timeout(timeout, read_future).await {
+                Ok(sid) => { session_id_res = sid; false }
+                Err(_) => { log_debug("[WARDIAN-DEBUG] Timed out waiting for session_id."); true }
+            };
 
-            let _ = child.kill().await;
+            // Only force-kill if we timed out; otherwise let the process exit naturally
+            // so the session is fully flushed to disk before we attempt --resume.
+            if timed_out {
+                let _ = child.kill().await;
+            }
             let _ = child.wait().await;
             log_debug(&format!("[WARDIAN-DEBUG] Returning session_id: {:?}", session_id_res));
             session_id_res

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -9,6 +9,24 @@ use tauri::{AppHandle, Emitter, Manager};
 pub use crate::utils::fs::*;
 pub use crate::utils::logging::log_debug;
 
+/// On macOS, GUI apps inherit a minimal PATH that excludes Homebrew, npm globals,
+/// Volta, and other user-level tool installs. Prepend the common locations so that
+/// `claude`, `gemini`, and similar CLIs can be found when spawning child processes.
+#[cfg(target_os = "macos")]
+fn macos_extended_path() -> String {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let existing = std::env::var("PATH").unwrap_or_default();
+    let extra = format!(
+        "{home}/.local/bin:/usr/local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:{home}/.npm-global/bin:{home}/.volta/bin",
+        home = home
+    );
+    if existing.is_empty() {
+        format!("{}:/usr/bin:/bin:/usr/sbin:/sbin", extra)
+    } else {
+        format!("{}:{}", extra, existing)
+    }
+}
+
 pub fn save_state(_app: &AppHandle, agents: &HashMap<String, ActiveAgent>, order: &[String]) {
     let mut configs: Vec<AgentConfig> = Vec::new();
     for id in order {
@@ -93,6 +111,8 @@ pub async fn spawn_agent(
     if config.provider == "claude" {
         cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
     }
+    #[cfg(target_os = "macos")]
+    cmd.env("PATH", macos_extended_path());
 
     let is_resume = config.resume_session.as_deref().is_some_and(|s| !s.is_empty());
     let spawn_args = provider.get_spawn_args(&config, is_resume);
@@ -382,6 +402,7 @@ pub async fn obtain_session_id(
             .arg("stream-json")
             .arg("Introduce yourself")
             .current_dir(cwd)
+            .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
     } else {
@@ -390,41 +411,54 @@ pub async fn obtain_session_id(
             .arg("-o")
             .arg("stream-json")
             .current_dir(cwd)
+            .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
     }
+
+    #[cfg(target_os = "macos")]
+    cmd.env("PATH", macos_extended_path());
 
     log_debug(&format!("[WARDIAN-DEBUG] Running obtain_session_id for provider {}", provider_name));
     match cmd.spawn() {
         Ok(mut child) => {
             log_debug("[WARDIAN-DEBUG] Spawned headless process. Reading stdout...");
             let mut session_id_res = None;
-            
-            if let Some(stdout) = child.stdout.take() {
-                let mut reader = BufReader::new(stdout);
-                let mut line = String::new();
-                while let Ok(n) = reader.read_line(&mut line).await {
-                    if n == 0 {
-                        log_debug("[WARDIAN-DEBUG] Reached EOF on stdout.");
-                        break;
-                    }
-                    let trimmed = line.trim();
-                    if session_id_res.is_none() {
+
+            let timeout = tokio::time::Duration::from_secs(30);
+            let read_future = async {
+                if let Some(stdout) = child.stdout.take() {
+                    let mut reader = BufReader::new(stdout);
+                    let mut line = String::new();
+                    while let Ok(n) = reader.read_line(&mut line).await {
+                        if n == 0 {
+                            log_debug("[WARDIAN-DEBUG] Reached EOF on stdout.");
+                            break;
+                        }
+                        let trimmed = line.trim();
                         if let Some(start) = trimmed.find('{') {
                             let json_part = &trimmed[start..];
                             if let Some(evt) = provider.parse_output(json_part) {
                                 if let AgentEvent::Init { session_id, .. } = evt {
                                     if !session_id.is_empty() {
                                         log_debug(&format!("[WARDIAN-DEBUG] Found session_id: {}", session_id));
-                                        session_id_res = Some(session_id);
+                                        return Some(session_id);
                                     }
                                 }
                             }
                         }
+                        line.clear();
                     }
-                    line.clear();
                 }
+                None
+            };
+
+            match tokio::time::timeout(timeout, read_future).await {
+                Ok(sid) => session_id_res = sid,
+                Err(_) => log_debug("[WARDIAN-DEBUG] Timed out waiting for session_id."),
             }
+
+            let _ = child.kill().await;
             let _ = child.wait().await;
             log_debug(&format!("[WARDIAN-DEBUG] Returning session_id: {:?}", session_id_res));
             session_id_res

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -51,19 +51,7 @@ pub async fn spawn_agent(
 ) -> Result<ActiveAgent, String> {
     let provider = ProviderFactory::resolve(&config.provider)?;
 
-    let cwd = if config.folder.is_empty() {
-        if cfg!(windows) {
-            std::env::var("USERPROFILE")
-                .map(std::path::PathBuf::from)
-                .unwrap_or_else(|_| std::path::PathBuf::from("C:\\"))
-        } else {
-            std::env::var("HOME")
-                .map(std::path::PathBuf::from)
-                .unwrap_or_else(|_| std::path::PathBuf::from("/"))
-        }
-    } else {
-        std::path::PathBuf::from(&config.folder)
-    };
+    let cwd = crate::utils::fs::resolve_cwd(&config.folder, &config.session_id);
 
     let expected_folder = if config.folder.is_empty() {
         cwd.to_string_lossy().to_string()

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -22,7 +22,42 @@ impl AgentProvider for ClaudeProvider {
     }
 
     fn get_executable(&self) -> (String, Vec<String>) {
-        ("claude".to_string(), vec![])
+        let exe_name = if cfg!(target_os = "windows") { "claude.cmd" } else { "claude" };
+
+        // 1. Try bare command in PATH
+        if let Some(paths) = std::env::var_os("PATH") {
+            for path in std::env::split_paths(&paths) {
+                let full_path = path.join(exe_name);
+                if full_path.exists() {
+                    return (exe_name.to_string(), vec![]);
+                }
+            }
+        }
+
+        // 2. Robust Fallback
+        if cfg!(target_os = "windows") {
+            if let Some(appdata) = dirs::data_dir() {
+                let npm_claude = appdata.join("npm").join("claude.cmd");
+                if npm_claude.exists() {
+                    return (npm_claude.to_string_lossy().to_string(), vec![]);
+                }
+            }
+        } else {
+            let home = dirs::home_dir().unwrap_or_default();
+            let fallbacks = vec![
+                home.join(".npm-global/bin/claude"),
+                std::path::PathBuf::from("/usr/local/bin/claude"),
+                std::path::PathBuf::from("/opt/homebrew/bin/claude"),
+            ];
+            for path in fallbacks {
+                if path.exists() {
+                    return (path.to_string_lossy().to_string(), vec![]);
+                }
+            }
+        }
+
+        // 3. Ultimate Fallback
+        (exe_name.to_string(), vec![])
     }
 
     fn get_spawn_args(&self, config: &AgentConfig, is_resume: bool) -> Vec<String> {

--- a/src-tauri/src/providers/gemini.rs
+++ b/src-tauri/src/providers/gemini.rs
@@ -22,27 +22,53 @@ impl AgentProvider for GeminiProvider {
     }
 
     fn get_executable(&self) -> (String, Vec<String>) {
-        if cfg!(target_os = "windows") {
-            let appdata = std::env::var("APPDATA").unwrap_or_default();
-            let target = std::path::Path::new(&appdata)
-                .join("npm")
-                .join("node_modules")
-                .join("@google")
-                .join("gemini-cli")
-                .join("dist")
-                .join("index.js");
+        let exe_name = if cfg!(target_os = "windows") { "gemini.cmd" } else { "gemini" };
 
-            if target.exists() {
-                (
-                    "node".to_string(),
-                    vec![target.to_string_lossy().to_string()],
-                )
-            } else {
-                ("gemini.cmd".to_string(), vec![])
+        // 1. Try bare command in PATH
+        if let Some(paths) = std::env::var_os("PATH") {
+            for path in std::env::split_paths(&paths) {
+                let full_path = path.join(exe_name);
+                if full_path.exists() {
+                    return (exe_name.to_string(), vec![]);
+                }
+            }
+        }
+
+        // 2. Robust Fallback
+        if cfg!(target_os = "windows") {
+            if let Some(appdata) = dirs::data_dir() {
+                let npm_gemini = appdata.join("npm").join("gemini.cmd");
+                if npm_gemini.exists() {
+                    return (npm_gemini.to_string_lossy().to_string(), vec![]);
+                }
+                
+                // Legacy index.js lookup
+                let index_js = appdata.join("npm")
+                    .join("node_modules")
+                    .join("@google")
+                    .join("gemini-cli")
+                    .join("dist")
+                    .join("index.js");
+                if index_js.exists() {
+                    return ("node".to_string(), vec![index_js.to_string_lossy().to_string()]);
+                }
             }
         } else {
-            ("gemini".to_string(), vec![])
+            let home = dirs::home_dir().unwrap_or_default();
+            let fallbacks = vec![
+                home.join(".npm-global/bin/gemini"),
+                std::path::PathBuf::from("/usr/local/bin/gemini"),
+                std::path::PathBuf::from("/opt/homebrew/bin/gemini"),
+            ];
+            for path in fallbacks {
+                if path.exists() {
+                    return (path.to_string_lossy().to_string(), vec![]);
+                }
+            }
         }
+
+        // 3. Ultimate Fallback
+        (exe_name.to_string(), vec![])
     }
 
     fn get_spawn_args(&self, config: &AgentConfig, is_resume: bool) -> Vec<String> {

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -2,6 +2,48 @@ pub fn get_wardian_home() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".wardian"))
 }
 
+pub fn get_default_user_dir() -> std::path::PathBuf {
+    dirs::home_dir().unwrap_or_else(|| {
+        if cfg!(windows) {
+            std::env::var("USERPROFILE")
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|_| std::path::PathBuf::from("C:\\"))
+        } else {
+            std::path::PathBuf::from("/")
+        }
+    })
+}
+
+pub fn resolve_cwd(folder: &str, agent_id: &str) -> std::path::PathBuf {
+    // Priority 1: Explicitly provided folder
+    if !folder.is_empty() {
+        let p = std::path::PathBuf::from(folder);
+        if let Ok(validated) = validate_workspace_path(&p) {
+            return validated;
+        }
+    }
+
+    // Priority 2: Persistent agent configuration (if agent_id is provided)
+    if !agent_id.is_empty() {
+        if let Some(home) = get_wardian_home() {
+            if let Ok(data) = std::fs::read_to_string(home.join("wardian_state.json")) {
+                if let Ok(configs) = serde_json::from_str::<Vec<crate::models::AgentConfig>>(&data) {
+                    if let Some(cfg) = configs.iter().find(|c| c.session_id == agent_id) {
+                        if !cfg.folder.is_empty() {
+                            let p = std::path::PathBuf::from(&cfg.folder);
+                            if let Ok(validated) = validate_workspace_path(&p) {
+                                return validated;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    get_default_user_dir()
+}
+
 pub fn resolve_system_include_directories(class_name: &str, session_id: &str) -> Vec<String> {
     let mut dirs = Vec::new();
     if let Some(app_dir) = get_wardian_home() {

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -19,37 +19,8 @@ use std::process::Stdio;
 
 /// Resolves the current working directory for a node.
 fn resolve_cwd(node_config: &Value, agent_id: &str) -> PathBuf {
-    let cwd = std::env::var("USERPROFILE").map(PathBuf::from).unwrap_or_else(|_| PathBuf::from("C:\\"));
-    
-    // Priority 1: Explicitly provided folder in node config
-    if let Some(folder) = node_config.get("folder").and_then(|v| v.as_str()) {
-        if !folder.is_empty() {
-            let p = PathBuf::from(folder);
-            if let Ok(validated) = validate_workspace_path(&p) {
-                return validated;
-            }
-        }
-    }
-
-    // Priority 2: Persistent agent configuration (if agent_id is provided)
-    if !agent_id.is_empty() {
-        if let Some(home) = get_wardian_home() {
-            if let Ok(data) = std::fs::read_to_string(home.join("wardian_state.json")) {
-                if let Ok(configs) = serde_json::from_str::<Vec<crate::models::AgentConfig>>(&data) {
-                    if let Some(cfg) = configs.iter().find(|c| c.session_id == agent_id) {
-                        if !cfg.folder.is_empty() {
-                            let p = PathBuf::from(&cfg.folder);
-                            if let Ok(validated) = validate_workspace_path(&p) {
-                                return validated;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    cwd
+    let folder = node_config.get("folder").and_then(|v| v.as_str()).unwrap_or("");
+    crate::utils::fs::resolve_cwd(folder, agent_id)
 }
 
 /// Executes a command headlessly and returns the result in the mandatory schema.
@@ -660,27 +631,8 @@ pub async fn run_workflow(app: AppHandle, wf_id: String, initial_payload: Option
                         log_debug(&format!("[Wardian] Agent node output_format: {}. Final Prompt Length: {}", output_format, prompt.len()));
                         
                         // 1. Resolve CWD logic (Shared between modes)
-                        let mut cwd = std::env::var("USERPROFILE").map(PathBuf::from).unwrap_or_else(|_| PathBuf::from("C:\\"));
-                        
-                        // Priority 1: Explicitly provided folder in node config
-                        if let Some(folder) = node.config.get("folder").and_then(|v| v.as_str()) {
-                            if !folder.is_empty() {
-                                cwd = PathBuf::from(folder);
-                            }
-                        } else {
-                            // Priority 2: Persistent agent configuration
-                            if let Some(home) = get_wardian_home() {
-                                if let Ok(data) = std::fs::read_to_string(home.join("wardian_state.json")) {
-                                    if let Ok(configs) = serde_json::from_str::<Vec<crate::models::AgentConfig>>(&data) {
-                                        if let Some(cfg) = configs.iter().find(|c| c.session_id == agent_id) {
-                                            if !cfg.folder.is_empty() {
-                                                cwd = PathBuf::from(&cfg.folder);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        let folder = node.config.get("folder").and_then(|v| v.as_str()).unwrap_or("");
+                        let cwd = crate::utils::fs::resolve_cwd(folder, &agent_id);
 
                         if output_format == "json" {
                             // --- HEADLESS JSON MODE (Always kills PTY for clean structured output) ---

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,14 @@
+{
+  "app": {
+    "windows": [
+      {
+        "title": "Wardian",
+        "width": 800,
+        "height": 600,
+        "transparent": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
+      }
+    ]
+  }
+}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useContext, useState, useCallback } from "react";
+
+type ConfirmFn = (message: string) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmFn>(async () => false);
+
+export const useConfirm = () => useContext(ConfirmContext);
+
+interface ConfirmState {
+  open: boolean;
+  message: string;
+  resolve: ((value: boolean) => void) | null;
+}
+
+export const ConfirmProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, setState] = useState<ConfirmState>({ open: false, message: "", resolve: null });
+
+  const confirm = useCallback((message: string): Promise<boolean> => {
+    return new Promise(resolve => {
+      setState({ open: true, message, resolve });
+    });
+  }, []);
+
+  const settle = (value: boolean) => {
+    setState(prev => ({ ...prev, open: false }));
+    state.resolve?.(value);
+  };
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {state.open && (
+        <div
+          className="fixed inset-0 z-[200] flex items-center justify-center"
+          style={{ backgroundColor: "rgba(0,0,0,0.4)" }}
+          onClick={() => settle(false)}
+        >
+          <div
+            className="relative rounded-lg p-6 max-w-sm w-full mx-4 shadow-2xl"
+            style={{
+              background: "var(--color-wardian-sidebar-primary)",
+              border: "1px solid var(--color-wardian-border-heavy)",
+            }}
+            onClick={e => e.stopPropagation()}
+          >
+            <p className="text-sm text-primary mb-6 leading-relaxed">{state.message}</p>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => settle(false)}
+                className="px-4 py-2 text-xs font-bold rounded transition-colors text-muted hover:text-primary"
+                style={{
+                  background: "var(--color-wardian-card-bg-muted)",
+                  border: "1px solid var(--color-wardian-border)",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => settle(true)}
+                className="px-4 py-2 text-xs font-bold rounded transition-colors"
+                style={{
+                  background: "var(--color-wardian-error)",
+                  color: "white",
+                }}
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </ConfirmContext.Provider>
+  );
+};

--- a/src/components/ListEditor.tsx
+++ b/src/components/ListEditor.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useConfirm } from './ConfirmDialog';
 
 interface ValidatedInputProps {
   value: string;
@@ -51,15 +52,16 @@ interface ListEditorProps {
   onSystemValueDelete?: (idx: number) => void;
 }
 
-export const ListEditor: React.FC<ListEditorProps> = ({ 
-  label, 
-  values = [], 
+export const ListEditor: React.FC<ListEditorProps> = ({
+  label,
+  values = [],
   systemValues = [],
-  placeholder, 
-  onChange, 
+  placeholder,
+  onChange,
   validate,
   onSystemValueDelete
 }) => {
+  const confirm = useConfirm();
   const safeValues = values || [];
   const safeSystemValues = systemValues || [];
 
@@ -77,8 +79,8 @@ export const ListEditor: React.FC<ListEditorProps> = ({
             />
             <button
               type="button"
-              onClick={() => {
-                if (confirm("This is a system-managed directory. Are you sure you want to remove it?")) {
+              onClick={async () => {
+                if (await confirm("This is a system-managed directory. Are you sure you want to remove it?")) {
                   onSystemValueDelete?.(idx);
                 }
               }}

--- a/src/features/agents/ClassManagerPanel.tsx
+++ b/src/features/agents/ClassManagerPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { AgentClassDefinition } from "../../types";
+import { useConfirm } from "../../components/ConfirmDialog";
 
 import { ManageSkills } from "../library/ManageSkills";
 
@@ -13,6 +14,7 @@ export const ClassManagerPanel: React.FC<ClassManagerPanelProps> = ({
   agentClasses,
   onClassesUpdated,
 }) => {
+  const confirm = useConfirm();
   const [newClassName, setNewClassName] = useState("");
   const [newClassDesc, setNewClassDesc] = useState("");
   const [newClassInstruction, setNewClassInstruction] = useState("");
@@ -40,7 +42,7 @@ export const ClassManagerPanel: React.FC<ClassManagerPanelProps> = ({
   };
 
   const deleteAgentClass = async (name: string) => {
-    if (!confirm(`Delete custom class "${name}"? This will also remove its directory.`)) return;
+    if (!await confirm(`Delete custom class "${name}"? This will also remove its directory.`)) return;
     try {
       await invoke("delete_agent_class", { name });
       onClassesUpdated();

--- a/src/features/commands/CommandPanel.tsx
+++ b/src/features/commands/CommandPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useLibraryStore } from "../../store/useLibraryStore";
 import { LibraryFolder, LibraryPrompt } from "../../types";
+import { useConfirm } from "../../components/ConfirmDialog";
 
 interface CommandPanelProps {
   selectedAgentIds: Set<string>;
@@ -16,6 +17,7 @@ export const CommandPanel: React.FC<CommandPanelProps> = ({
   setBroadcastMessage,
   onBroadcast,
 }) => {
+  const confirm = useConfirm();
   const { promptTree, fetchLibraryTree } = useLibraryStore();
 
   useEffect(() => {
@@ -52,7 +54,7 @@ export const CommandPanel: React.FC<CommandPanelProps> = ({
           await invoke("send_input_to_agent", { sessionId: id, input: flattenedPrompt });
         }
       } else {
-        if (window.confirm("No agents selected. This will broadcast the prompt to ALL agents. Are you sure?")) {
+        if (await confirm("No agents selected. This will broadcast the prompt to ALL agents. Are you sure?")) {
           await invoke("broadcast_input", { input: flattenedPrompt });
         }
       }
@@ -61,10 +63,10 @@ export const CommandPanel: React.FC<CommandPanelProps> = ({
     }
   };
 
-  const handleBroadcastSubmit = (e: React.FormEvent) => {
+  const handleBroadcastSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (selectedAgentIds.size === 0) {
-      if (!window.confirm("No agents selected. This will broadcast to ALL agents. Are you sure?")) {
+      if (!await confirm("No agents selected. This will broadcast to ALL agents. Are you sure?")) {
         return;
       }
     }

--- a/src/features/explorer/ExplorerPanel.tsx
+++ b/src/features/explorer/ExplorerPanel.tsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { FileTree, FileNode } from './FileTree';
+import { useConfirm } from '../../components/ConfirmDialog';
 
 interface ExplorerPanelProps {
   selectedAgentIds: Set<string>;
 }
 
 export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }) => {
+  const confirm = useConfirm();
   const [rootPath, setRootPath] = useState<string | null>(null);
   
   // Context Menu State
@@ -80,7 +82,7 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }
 
   const handleDelete = async () => {
     if (activeNode) {
-      if (window.confirm(`Are you sure you want to delete ${activeNode.name}?`)) {
+      if (await confirm(`Are you sure you want to delete ${activeNode.name}?`)) {
         try {
           await invoke('delete_file', { path: activeNode.path });
           setRefreshKey(prev => prev + 1); // trigger remount of root FileTree

--- a/src/features/workflows/WorkflowLibrary.tsx
+++ b/src/features/workflows/WorkflowLibrary.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useWorkflowLibrary } from './useWorkflowLibrary';
 import { ContextMenu, ContextMenuItem } from '../../components/ContextMenu';
+import { useConfirm } from '../../components/ConfirmDialog';
 
 // Icons
 
@@ -32,6 +33,7 @@ interface WorkflowLibraryProps {
 }
 
 export const WorkflowLibrary: React.FC<WorkflowLibraryProps> = ({ workflows, onRun, onEdit, onDelete }) => {
+  const confirm = useConfirm();
   const { folders, rootWorkflowIds, toggleFolderCollapse, moveWorkflowToFolder, addFolder, renameFolder, deleteFolder } = useWorkflowLibrary();
   const [contextMenu, setContextMenu] = useState<{ x: number, y: number, items: ContextMenuItem[] } | null>(null);
   const [draggedWorkflowId, setDraggedWorkflowId] = useState<string | null>(null);
@@ -101,8 +103,8 @@ export const WorkflowLibrary: React.FC<WorkflowLibraryProps> = ({ workflows, onR
           if (name) renameFolder(targetId!, name);
         }},
         { label: 'Pause All Triggers in Folder', onClick: () => console.log('Pause All in Folder', targetId) },
-        { label: 'Delete Folder', danger: true, onClick: () => {
-          if (confirm('Delete folder and all workflows within?')) deleteFolder(targetId!);
+        { label: 'Delete Folder', danger: true, onClick: async () => {
+          if (await confirm('Delete folder and all workflows within?')) deleteFolder(targetId!);
         }},
       ];
     } else {

--- a/src/features/workflows/WorkflowSidebar.tsx
+++ b/src/features/workflows/WorkflowSidebar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { useWorkflowStore } from '../../store/useWorkflowStore';
 import { WorkflowLibrary } from './WorkflowLibrary';
 import { ActiveMonitoring } from './ActiveMonitoring';
+import { useConfirm } from '../../components/ConfirmDialog';
 
 // Icons
 const StopAllIcon = () => <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20"><path d="M5 5h10v10H5z" /></svg>;
@@ -25,6 +26,7 @@ export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = () => {
     schedules
   } = useWorkflowStore();
   
+  const confirm = useConfirm();
   const [searchQuery, setSearchQuery] = useState('');
 
   const filteredWorkflows = useMemo(() => {
@@ -42,7 +44,7 @@ export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = () => {
   [availableWorkflows]);
 
   const handleStopAll = async () => {
-    if (confirm('STOP ALL: Immediately terminate all active runs and triggers?')) {
+    if (await confirm('STOP ALL: Immediately terminate all active runs and triggers?')) {
       await stopAllTriggers();
       fetchWorkflows();
     }

--- a/src/layout/titlebar/CustomTitleBar.tsx
+++ b/src/layout/titlebar/CustomTitleBar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LeftSidebarControls } from "./LeftSidebarControls";
 import { WorkspaceTabs } from "./WorkspaceTabs";
 import type { ViewMode } from "./WorkspaceTabs";
@@ -6,6 +7,9 @@ import { RightWindowControls } from "./RightWindowControls";
 import type { AgentTelemetry, AgentConfig } from "../../types";
 
 export type { ViewMode };
+
+const isTauri = typeof window !== "undefined" && !!(window as any).__TAURI_INTERNALS__;
+const isMac = typeof navigator !== "undefined" && navigator.userAgent.includes("Macintosh");
 
 interface CustomTitleBarProps {
   viewMode: ViewMode;
@@ -23,10 +27,17 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = (props) => {
   const leftWidth = 64 + (props.leftCollapsed ? 0 : 260);
   const rightWidth = props.rightCollapsed ? 0 : 240;
 
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!isMac || !isTauri) return;
+    if ((e.target as HTMLElement).closest("button, input, select, a")) return;
+    getCurrentWindow().startDragging();
+  };
+
   return (
-    <div 
-      className="titlebar" 
+    <div
+      className="titlebar"
       data-tauri-drag-region
+      onMouseDown={handleMouseDown}
       style={{ 
         "--titlebar-left-width": `${leftWidth}px`,
         "--titlebar-right-width": `${rightWidth}px`

--- a/src/layout/titlebar/LeftSidebarControls.tsx
+++ b/src/layout/titlebar/LeftSidebarControls.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import type { AgentTelemetry, AgentConfig } from "../../types";
 
+const isMac = typeof navigator !== "undefined" && navigator.userAgent.includes("Macintosh");
+
 interface LeftSidebarControlsProps {
   leftCollapsed: boolean;
   setLeftCollapsed: (collapsed: boolean) => void;
@@ -16,7 +18,7 @@ export const LeftSidebarControls: React.FC<LeftSidebarControlsProps> = ({
   agents,
   offAgentIds,
 }) => (
-  <div className="titlebar-zone titlebar-left">
+  <div className="titlebar-zone titlebar-left" style={isMac ? { paddingLeft: "76px" } : undefined}>
     <button
       onClick={() => setLeftCollapsed(!leftCollapsed)}
       className={`titlebar-toggle ${!leftCollapsed ? "active" : ""}`}

--- a/src/layout/titlebar/LeftSidebarControls.tsx
+++ b/src/layout/titlebar/LeftSidebarControls.tsx
@@ -18,7 +18,7 @@ export const LeftSidebarControls: React.FC<LeftSidebarControlsProps> = ({
   agents,
   offAgentIds,
 }) => (
-  <div className="titlebar-zone titlebar-left" style={isMac ? { paddingLeft: "76px" } : undefined}>
+  <div className="titlebar-zone titlebar-left" style={isMac ? { paddingLeft: "72px" } : undefined}>
     <button
       onClick={() => setLeftCollapsed(!leftCollapsed)}
       className={`titlebar-toggle ${!leftCollapsed ? "active" : ""}`}

--- a/src/layout/titlebar/RightWindowControls.tsx
+++ b/src/layout/titlebar/RightWindowControls.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 const isTauri = typeof window !== "undefined" && !!(window as any).__TAURI_INTERNALS__;
+const isMac = typeof navigator !== "undefined" && navigator.userAgent.includes("Macintosh");
 
 interface RightWindowControlsProps {
   rightCollapsed: boolean;
@@ -53,8 +54,8 @@ export const RightWindowControls: React.FC<RightWindowControlsProps> = ({
           </svg>
         </button>
 
-        {/* ── Window Controls ────────────────────────── */}
-        <div className="titlebar-window-controls">
+        {/* ── Window Controls (Windows/Linux only — macOS uses native traffic lights) */}
+        {!isMac && <div className="titlebar-window-controls">
           <button
             onClick={() => appWindow?.minimize()}
             className="titlebar-winbtn"
@@ -90,7 +91,7 @@ export const RightWindowControls: React.FC<RightWindowControlsProps> = ({
               <line x1="8.5" y1="1.5" x2="1.5" y2="8.5" stroke="currentColor" strokeWidth="1.2" />
             </svg>
           </button>
-        </div>
+        </div>}
       </div>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,9 @@
 import ReactDOM from "react-dom/client";
 import App from "./views/App";
+import { ConfirmProvider } from "./components/ConfirmDialog";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <App />
+  <ConfirmProvider>
+    <App />
+  </ConfirmProvider>
 );

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -31,6 +31,7 @@
   --color-wardian-sidebar-primary: #f9fafb;
   --color-wardian-sidebar-secondary: #f3f4f6;
   --color-wardian-input-bg: rgba(255, 255, 255, 0.9);
+  --color-wardian-input-bg-rgb: 255, 255, 255;
   --color-wardian-card-bg-muted: rgba(0, 0, 0, 0.04);
 
   /* Sidebar Widths */
@@ -68,7 +69,7 @@
 /* Zone 1: Aligns with entire left sidebar (rail + content) */
 .titlebar-left {
   width: var(--titlebar-left-width);
-  padding: 0 8px;
+  padding: 0 12px;
   justify-content: flex-start;
   border-right: 1px solid var(--color-wardian-border);
   flex-shrink: 0;
@@ -287,6 +288,7 @@
   --color-wardian-sidebar-primary: #111827;
   --color-wardian-sidebar-secondary: #0f172a;
   --color-wardian-input-bg: rgba(31, 41, 55, 0.5);
+  --color-wardian-input-bg-rgb: 31, 41, 55;
   --color-wardian-card-bg-muted: rgba(31, 41, 55, 0.3);
 
   --shadow-wardian-accent: 0 0 15px color-mix(in srgb, var(--color-wardian-accent), transparent 90%);
@@ -607,4 +609,38 @@
 .edge-pulse-done path.react-flow__edge-path {
   stroke: var(--color-wardian-error) !important; 
   stroke-width: 3;
+}
+
+/* ── Custom Select (macOS Polished) ─────────────────── */
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%2388a088' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1rem;
+  padding-right: 2.5rem !important;
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  background-color: rgba(var(--color-wardian-input-bg-rgb), 0.65) !important;
+  border: 1px solid var(--color-wardian-border-light) !important;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+select:focus {
+  border-color: var(--color-wardian-accent) !important;
+  box-shadow: 0 0 0 2px rgba(212, 175, 55, 0.15);
+}
+
+select optgroup {
+  background-color: var(--color-wardian-card);
+  color: var(--color-wardian-text);
+  font-weight: 700;
+  font-size: 11px;
+}
+
+select option {
+  background-color: var(--color-wardian-card);
+  color: var(--color-wardian-text);
+  padding: 8px;
 }

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -10,6 +10,7 @@ import { getAgentsForList } from "../layout/watchlist/watchlistUtils";
 import type { Watchlist } from "../layout/watchlist/types";
 
 import { ErrorBoundary } from "../components/ErrorBoundary";
+import { useConfirm } from "../components/ConfirmDialog";
 import { SidebarIconRail, SidebarTab } from "../layout/SidebarIconRail";
 import { SidebarContentPane } from "../layout/SidebarContentPane";
 import { CustomTitleBar } from "../layout/titlebar/CustomTitleBar";
@@ -31,6 +32,7 @@ function App() {
 }
 
 function AppBody() {
+  const confirm = useConfirm();
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const handleWorkflowTelemetry = useWorkflowStore(s => s.handleTelemetry);
@@ -339,7 +341,7 @@ function AppBody() {
   };
 
   const onDelete = async (id: string) => {
-    if (confirm('Delete?')) {
+    if (await confirm('Delete this agent?')) {
       try {
         await invoke('kill_agent', { sessionId: id });
         setOffAgentIds(prev => {

--- a/src/views/WorkflowBuilderView.tsx
+++ b/src/views/WorkflowBuilderView.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useEffect } from 'react';
+import { useConfirm } from '../components/ConfirmDialog';
 import { 
   ReactFlow, 
   Background, 
@@ -80,6 +81,7 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
     isSaving
   } = useWorkflowStore();
 
+  const confirm = useConfirm();
   const [selectedNodeId, setSelectedNodeId] = React.useState<string | null>(null);
   const [isLibraryOpen, setIsBlockLibraryOpen] = React.useState(false);
   const [activeCategory, setActiveCategory] = React.useState("ALL");
@@ -419,9 +421,9 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2"></path></svg>
                 </button>
 
-                <button 
-                  onClick={() => {
-                    if (activeWorkflowId && confirm("Delete this workflow?")) {
+                <button
+                  onClick={async () => {
+                    if (activeWorkflowId && await confirm("Delete this workflow?")) {
                       deleteWorkflow(activeWorkflowId);
                     }
                   }}


### PR DESCRIPTION
There commits, all pretty small: 

1. Add `lucide-react` library to `package-lock.json` (it looks like you added it but the package-lock wasn't updated)
1. Gate win32job, winapi, and windows crates behind cfg(windows) so the Rust backend compiles on macOS
1. Add native macOS traffic light controls via `tauri.macos.conf.json` override, and hide the custom Win32 window buttons on Mac
