### PR TITLE
feat(providers): add codex support and stabilize agent status

### DIFF
--- a/docs/agents/roles.md
+++ b/docs/agents/roles.md
@@ -46,7 +46,8 @@ The system is built on a **Modular Multi-Agent Architecture** where each agent i
 
 ## 🛠️ Customizing Roles
 
-Roles are defined as standard Markdown files. When a new **Agent Class** is created, it resides in a dedicated directory within the application's configuration path, primarily managed via the `AGENTS.md` (the master instruction file).
+Roles are defined as standard Markdown files. When a new **Agent Class** is created, it resides in a dedicated directory within the application's configuration path, primarily managed via the `AGENTS.md` (the master instruction file). Providers like Codex read `AGENTS.md` directly, while providers like Gemini and Claude use thin stub files that point back to it.
+When a provider cannot discover those Wardian files from the repository root alone, Wardian projects them into a per-session `habitat` workspace so the provider still sees the same role and skill stack.
 
 ### Instruction Precedence:
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -7,6 +7,8 @@ Wardian is built as a **High-Performance Hybrid Environment**, using **Rust (Tau
 ### 1. The Physical Layer (Rust Backend)
 - **Source of Truth**: The Rust backend is the definitive authority on all agent sessions, PTY states, and telemetry.
 - **PTY Management**: Uses `portable-pty` for cross-platform PTY handles. On Windows, it leverages `win32job` to ensure child processes are strictly terminated when the agent session ends.
+- **Provider Adapters**: Agent CLIs are integrated behind a Rust provider layer so session spawn, headless execution, and telemetry enrichment can support Gemini, Claude, and Codex without rewriting the rest of the backend.
+- **Habitat Projection**: For providers that cannot natively discover Wardian instructions and skills from external include roots, the backend materializes a neutral per-session `habitat` directory. That habitat links the real workspace, projects a scoped `AGENTS.md`, and exposes provider-native skill layouts without mutating the user repository.
 - **State Management**: `AppState` holds `Mutex`-protected maps of active agents, metrics, and background triggers.
 - **Worker Threads**:
     - **Heartbeat (Scheduler)**: Handles periodic tasks and cron triggers.

--- a/docs/specs/009-codex-provider.md
+++ b/docs/specs/009-codex-provider.md
@@ -1,0 +1,49 @@
+# Spec 009: Codex Provider Support
+
+* **Status:** Implemented
+* **Date:** 2026-03-27
+* **Decider:** Architect
+
+## Context and Problem Statement
+Wardian already has a multi-provider backend, but the current implementation only supports Gemini and Claude. Codex support is required for local agent sessions, headless execution, and telemetry without expanding the workflow-engine merge surface.
+
+Codex also differs from Gemini and Claude in one important way: it uses `AGENTS.md` directly for repository instructions instead of a provider-specific markdown file.
+Wardian also stores shared instructions and deployed skills outside the active repository tree under `~/.wardian/`, which Codex does not discover natively from `--add-dir` roots.
+
+## Decision
+We will add Codex as a first-class provider in the Rust backend and expose it in the agent configuration UI.
+
+### 1. Provider Integration
+- Add a `CodexProvider` implementation under `src-tauri/src/providers/`.
+- Resolve `codex` from `ProviderFactory`.
+- Support:
+  - interactive resume via `codex resume <session_id>`
+  - headless bootstrap via `codex exec --json`
+  - headless follow-up runs via `codex exec resume <session_id> --json`
+
+### 2. Instruction Model
+- `AGENTS.md` remains the canonical instruction source for every class.
+- Gemini and Claude continue to use provider-specific stub files.
+- Codex does not introduce a `CODEX.md` stub because the CLI reads `AGENTS.md` natively.
+- For providers that need Wardian-managed context in scope, Wardian creates a neutral per-session `habitat` directory.
+- The habitat contains a generated root `AGENTS.md`, a linked `workspace/` junction to the real project, and a merged `.agents/skills/` tree sourced from `common`, `classes/<role>`, and `agents/<session_id>`.
+
+### 3. Codex Native Projection
+- Codex receives a projected `CODEX_HOME` inside the habitat rather than reading Wardian context directly from `--add-dir`.
+- The projected Codex home preserves native Codex state by mirroring the user’s real `~/.codex` home for auth, config, sessions, and logs.
+- The projected `skills/` directory overlays Wardian’s merged skill set on top of the user’s existing Codex skills and system skills.
+
+### 4. Telemetry
+- Codex session files are discovered under `~/.codex/sessions/YYYY/MM/DD/*.jsonl`.
+- Query counts and init timestamps are derived from Codex session JSONL when available.
+
+### 5. Workflow Scope
+- Workflow-engine refactoring is explicitly out of scope for this branch.
+- Only minimal provider-aware changes needed to avoid blocking Codex support should be considered elsewhere.
+
+## Consequences
+- **Positive**: Wardian can spawn and manage Codex-backed agents from the same provider architecture as Gemini and Claude.
+- **Positive**: Codex follows the existing markdown-as-truth model cleanly because it consumes `AGENTS.md` directly.
+- **Positive**: Habitat projection lets Wardian expose external instructions and skills to Codex without patching the Codex CLI.
+- **Positive**: The branch avoids unnecessary workflow-engine conflicts.
+- **Negative**: Codex support now depends on a projected home layout that must stay aligned with Codex’s on-disk conventions.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -14,6 +14,7 @@ This document serves as the historical ledger for all strategic and technical sp
 | [006](./006-explorer-view.md) | Explorer Left Sidebar | Implemented | 2026-03-22 |
 | [007](./007-workflow-engine.md) | Reliable Workflow Execution Engine | Proposed | 2026-03-25 |
 | [008](./008-continuous-integration.md) | Continuous Integration & Quality Gates | Proposed | 2026-03-25 |
+| [009](./009-codex-provider.md) | Codex Provider Support | Implemented | 2026-03-27 |
 
 ## How to use Specs
 Every significant feature must begin with a Spec that defines:

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -50,17 +50,20 @@ pub async fn spawn_agent(
             std::path::PathBuf::from(&folder)
         };
 
-        let provider_name = config_override.as_ref().map(|c| c.provider.clone()).unwrap_or_else(|| "gemini".to_string());
-        if let Some(real_sid) = manager::obtain_session_id(&cwd, &provider_name).await {
-            manager::log_debug(&format!(
-                "[WARDIAN] Intercepted stream-json session ID for {}: {}",
-                provider_name, real_sid
-            ));
-            // Properly set final_resume because manager::spawn_agent requires it to launch the persistent agent with --resume
-            session_id = Some(real_sid.clone());
-            actual_resume = Some(real_sid);
-        } else {
-            return Err("Failed to obtain session ID headlessly. Ensure the prompt \"Introduce yourself\" can execute.".to_string());
+        let provider_name = config_override.as_ref().map(|c| c.provider.clone()).unwrap_or_else(|| "claude".to_string());
+        match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref()).await {
+            Ok(real_sid) => {
+                manager::log_debug(&format!(
+                    "[WARDIAN] Intercepted stream-json session ID for {}: {}",
+                    provider_name, real_sid
+                ));
+                // Properly set final_resume because manager::spawn_agent requires it to launch the persistent agent with --resume
+                session_id = Some(real_sid.clone());
+                actual_resume = Some(real_sid);
+            }
+            Err(e) => {
+                return Err(format!("Failed to initialize the provider session: {}", e));
+            }
         }
     }
 

--- a/src-tauri/src/commands/class.rs
+++ b/src-tauri/src/commands/class.rs
@@ -54,7 +54,7 @@ pub async fn create_agent_class(
             let _ = std::fs::write(agents_md_path, content);
         }
 
-        // Create provider stubs
+        // Create provider stubs for providers that do not read AGENTS.md directly
         for stub_name in &["GEMINI.md", "CLAUDE.md"] {
             let stub_path = role_dir.join(stub_name);
             if !stub_path.exists() {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,14 +1,17 @@
 use tauri::State;
 use crate::state::AppState;
 use crate::manager;
+use tauri::{AppHandle, Emitter};
 
 #[tauri::command]
 pub async fn send_input_to_agent(
     session_id: String,
     input: String,
     state: State<'_, AppState>,
+    app: AppHandle,
 ) -> Result<(), String> {
-    let senders = match state.input_senders.try_read() {
+    let is_interrupt = input.contains('\u{3}');
+    let tx = match state.input_senders.try_read() {
         Ok(s) => s,
         Err(_) => {
             manager::log_debug(&format!(
@@ -17,10 +20,29 @@ pub async fn send_input_to_agent(
             ));
             return Err("Input channel temporarily locked".to_string());
         }
-    };
-    if let Some(tx) = senders.get(&session_id) {
+    }
+    .get(&session_id)
+    .cloned();
+    if let Some(tx) = tx {
         match tx.try_send(input) {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                if is_interrupt {
+                    let agents = state.agents.lock().await;
+                    if let Some(agent) = agents.get(&session_id) {
+                        if let Ok(mut status) = agent.current_status.lock() {
+                            *status = "Idle".to_string();
+                        }
+                        let _ = app.emit(
+                            "agent-status-updated",
+                            serde_json::json!({
+                                "session_id": session_id,
+                                "current_status": "Idle",
+                            }),
+                        );
+                    }
+                }
+                Ok(())
+            }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                 manager::log_debug(&format!(
                     "[Wardian] [{}] send_input_to_agent: channel FULL (writer thread likely blocked on ConPTY write_all)",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -50,10 +50,30 @@ pub fn run() {
             app.listen_any("terminal-input", move |event| {
                 let raw = event.payload();
                 if let Ok(payload) = serde_json::from_str::<TerminalInputPayload>(raw) {
+                    let is_interrupt = payload.input.contains('\u{3}');
                     if let Ok(senders) = event_handle.state::<AppState>().input_senders.try_read() {
                         if let Some(tx) = senders.get(&payload.session_id) {
                             let _ = tx.try_send(payload.input);
                         }
+                    }
+                    if is_interrupt {
+                        let app_handle = event_handle.clone();
+                        tauri::async_runtime::spawn(async move {
+                            let state = app_handle.state::<AppState>();
+                            let agents = state.agents.lock().await;
+                            if let Some(agent) = agents.get(&payload.session_id) {
+                                if let Ok(mut status) = agent.current_status.lock() {
+                                    *status = "Idle".to_string();
+                                }
+                                let _ = app_handle.emit(
+                                    "agent-status-updated",
+                                    serde_json::json!({
+                                        "session_id": payload.session_id,
+                                        "current_status": "Idle",
+                                    }),
+                                );
+                            }
+                        });
                     }
                 }
             });

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -3,11 +3,64 @@ use crate::providers::ProviderFactory;
 use crate::state::{ActiveAgent, AppState};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::collections::HashMap;
-use std::io::{Read, Write};
+use std::io::{BufRead, Read, Seek, Write};
 use tauri::{AppHandle, Emitter, Manager};
 
 pub use crate::utils::fs::*;
 pub use crate::utils::logging::log_debug;
+
+fn set_agent_status(
+    app: &AppHandle,
+    session_id: &str,
+    current_status: &std::sync::Arc<std::sync::Mutex<String>>,
+    next_status: &str,
+) {
+    if let Ok(mut status) = current_status.lock() {
+        if *status != next_status {
+            *status = next_status.to_string();
+            let _ = app.emit(
+                "agent-status-updated",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "current_status": next_status,
+                }),
+            );
+        }
+    }
+}
+
+fn apply_agent_event(
+    app: &AppHandle,
+    session_id: &str,
+    event: AgentEvent,
+    query_count: &std::sync::Arc<std::sync::Mutex<usize>>,
+    init_timestamp: &std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    current_status: &std::sync::Arc<std::sync::Mutex<String>>,
+) {
+    match event {
+        AgentEvent::UserQuery => {
+            if let Ok(mut count) = query_count.lock() {
+                *count += 1;
+            }
+            set_agent_status(app, session_id, current_status, "Processing...");
+        }
+        AgentEvent::Generating => {
+            set_agent_status(app, session_id, current_status, "Processing...");
+        }
+        AgentEvent::Init { timestamp, .. } => {
+            if let Ok(mut ts) = init_timestamp.lock() {
+                *ts = timestamp;
+            }
+        }
+        AgentEvent::ModelResponse => {
+            set_agent_status(app, session_id, current_status, "Idle");
+        }
+        AgentEvent::ActionRequired { .. } => {
+            set_agent_status(app, session_id, current_status, "Action Needed");
+        }
+        AgentEvent::Unknown => {}
+    }
+}
 
 pub fn save_state(_app: &AppHandle, agents: &HashMap<String, ActiveAgent>, order: &[String]) {
     let mut configs: Vec<AgentConfig> = Vec::new();
@@ -86,12 +139,26 @@ pub async fn spawn_agent(
     for arg in base_args {
         cmd.arg(arg);
     }
-    cmd.cwd(&expected_folder);
+    let habitat_root = prepare_provider_habitat(
+        &config.provider,
+        &cwd,
+        &config.agent_class,
+        Some(&config.session_id),
+    )?;
+    let provider_cwd = habitat_root
+        .as_ref()
+        .map(|root| habitat_workspace_cwd(root))
+        .unwrap_or_else(|| cwd.clone());
+    cmd.cwd(&provider_cwd);
 
     // Enable CLAUDE.md discovery from --add-dir directories so that
     // class/common/agent instruction files are loaded natively.
     if config.provider == "claude" {
         cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
+    } else if config.provider == "codex" {
+        if let Some(root) = habitat_root.as_ref() {
+            cmd.env("CODEX_HOME", habitat_codex_home(root));
+        }
     }
 
     let is_resume = config.resume_session.as_deref().is_some_and(|s| !s.is_empty());
@@ -167,8 +234,13 @@ pub async fn spawn_agent(
     let init_timestamp_clone = init_timestamp.clone();
     let current_status = std::sync::Arc::new(std::sync::Mutex::new("Idle".to_string()));
     let current_status_clone = current_status.clone();
+    let log_path = std::sync::Arc::new(std::sync::Mutex::new(None::<std::path::PathBuf>));
 
     // PTY reader thread: uses provider.parse_output() for event classification
+    let pty_app = app.clone();
+    let pty_provider = provider.clone();
+    let sid_for_pty = sid_out.clone();
+    let pty_emit_app = app.clone();
     std::thread::spawn(move || {
         let mut buf = [0; 4096];
         let mut current_line = String::new();
@@ -190,40 +262,17 @@ pub async fn spawn_agent(
                                 Some(Ok(parsed)) => {
                                     // Use provider to classify the raw JSON into an AgentEvent
                                     let raw_line = parsed.to_string();
-                                    if let Some(event) = provider.parse_output(&raw_line) {
-                                        match event {
-                                            AgentEvent::UserQuery => {
-                                                if let Ok(mut count) = query_count_clone.lock() {
-                                                    *count += 1;
-                                                }
-                                                if let Ok(mut status) = current_status_clone.lock() {
-                                                    *status = "Processing...".to_string();
-                                                }
-                                            }
-                                            AgentEvent::Generating => {
-                                                if let Ok(mut status) = current_status_clone.lock() {
-                                                    *status = "Processing...".to_string();
-                                                }
-                                            }
-                                            AgentEvent::Init { timestamp, .. } => {
-                                                if let Ok(mut ts) = init_timestamp_clone.lock() {
-                                                    *ts = timestamp;
-                                                }
-                                            }
-                                            AgentEvent::ModelResponse => {
-                                                if let Ok(mut status) = current_status_clone.lock() {
-                                                    *status = "Idle".to_string();
-                                                }
-                                            }
-                                            AgentEvent::ActionRequired { .. } => {
-                                                if let Ok(mut status) = current_status_clone.lock() {
-                                                    *status = "Action Needed".to_string();
-                                                }
-                                            }
-                                            _ => {}
-                                        }
+                                    if let Some(event) = pty_provider.parse_output(&raw_line) {
+                                        apply_agent_event(
+                                            &pty_app,
+                                            &sid_for_pty,
+                                            event,
+                                            &query_count_clone,
+                                            &init_timestamp_clone,
+                                            &current_status_clone,
+                                        );
                                     }
-                                    let _ = app.emit("agent-json-event", serde_json::json!({ "session_id": sid_out, "data": parsed }));
+                                    let _ = pty_emit_app.emit("agent-json-event", serde_json::json!({ "session_id": sid_out, "data": parsed }));
                                     let consumed = stream.byte_offset();
                                     current_line = current_line[start + consumed..].to_string();
                                     continue;
@@ -241,10 +290,87 @@ pub async fn spawn_agent(
             }
         }
         // Process terminated (EOF or error) — mark status as Off
-        if let Ok(mut status) = current_status_clone.lock() {
-            *status = "Off".to_string();
-        }
+        set_agent_status(&pty_app, &sid_for_pty, &current_status_clone, "Off");
     });
+
+    if config.provider == "codex" {
+        let watcher_app = app.clone();
+        let watcher_provider = provider.clone();
+        let watcher_session = config.session_id.clone();
+        let watcher_query_count = query_count.clone();
+        let watcher_init_timestamp = init_timestamp.clone();
+        let watcher_current_status = current_status.clone();
+        let watcher_log_path = log_path.clone();
+        let wardian_agent_dir = get_wardian_home()
+            .map(|home| home.join("agents").join(&watcher_session))
+            .filter(|path| path.exists())
+            .map(|path| path.to_string_lossy().to_string());
+
+        std::thread::spawn(move || {
+            let mut offset: u64 = 0;
+            loop {
+                let current = watcher_current_status
+                    .lock()
+                    .map(|s| s.clone())
+                    .unwrap_or_else(|e| e.into_inner().clone());
+                if current == "Off" {
+                    break;
+                }
+
+                let path = {
+                    let mut lock = watcher_log_path.lock().unwrap_or_else(|e| e.into_inner());
+                    if lock.is_none() {
+                        *lock = codex_session_file_path(&watcher_session, wardian_agent_dir.as_deref());
+                    }
+                    lock.clone()
+                };
+
+                if let Some(path) = path {
+                    if let Ok(mut out) = watcher_log_path.lock() {
+                        *out = Some(path.clone());
+                    }
+                    if let Ok(mut file) = std::fs::File::open(&path) {
+                        if let Ok(metadata) = file.metadata() {
+                            if metadata.len() < offset {
+                                offset = 0;
+                            }
+                        }
+                        if file.seek(std::io::SeekFrom::Start(offset)).is_ok() {
+                            let mut reader = std::io::BufReader::new(file);
+                            let mut line = String::new();
+                            loop {
+                                line.clear();
+                                let read = reader.read_line(&mut line).unwrap_or(0);
+                                if read == 0 {
+                                    break;
+                                }
+                                offset += read as u64;
+                                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+                                    let raw_line = parsed.to_string();
+                                    if let Some(event) = watcher_provider.parse_output(&raw_line) {
+                                        apply_agent_event(
+                                            &watcher_app,
+                                            &watcher_session,
+                                            event,
+                                            &watcher_query_count,
+                                            &watcher_init_timestamp,
+                                            &watcher_current_status,
+                                        );
+                                    }
+                                    let _ = watcher_app.emit(
+                                        "agent-json-event",
+                                        serde_json::json!({ "session_id": watcher_session, "data": parsed }),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
+                std::thread::sleep(std::time::Duration::from_millis(250));
+            }
+        });
+    }
 
     Ok(ActiveAgent {
         config: AgentConfig {
@@ -259,7 +385,7 @@ pub async fn spawn_agent(
         query_count,
         init_timestamp,
         current_status,
-        log_path: std::sync::Arc::new(std::sync::Mutex::new(None)),
+        log_path,
         #[cfg(windows)]
         job_object,
     })
@@ -286,15 +412,20 @@ pub async fn resize_pty(
         }
     };
     tokio::task::spawn_blocking(move || {
-        if let Ok(master) = master_arc.try_lock() {
-            let _ = master.resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            });
-        }
-    });
+        let master = match master_arc.lock() {
+            Ok(master) => master,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        master.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+    })
+    .await
+    .map_err(|e| format!("Failed to join PTY resize task: {}", e))?
+    .map_err(|e| format!("Failed to resize PTY: {}", e))?;
     Ok(())
 }
 
@@ -319,6 +450,13 @@ pub async fn run_headless(
         cmd.arg(arg);
     }
     match provider_name {
+        "codex" => {
+            cmd.arg("exec")
+                .arg("resume")
+                .arg(session_id)
+                .arg("--json")
+                .arg(prompt);
+        }
         "claude" => {
             cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1")
                 .arg("--print")
@@ -358,7 +496,54 @@ pub async fn run_headless(
 
     let _ = child.wait().await;
 
-    if output_format == "json" {
+    if provider_name == "codex" {
+        let mut last_message = None;
+        for line in output.lines() {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) {
+                match parsed.get("type").and_then(|v| v.as_str()).unwrap_or("") {
+                    "item.completed" => {
+                        if parsed
+                            .get("item")
+                            .and_then(|v| v.get("type"))
+                            .and_then(|v| v.as_str())
+                            == Some("agent_message")
+                        {
+                            last_message = parsed
+                                .get("item")
+                                .and_then(|v| v.get("text"))
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string());
+                        }
+                    }
+                    "event_msg" => {
+                        if parsed
+                            .get("payload")
+                            .and_then(|v| v.get("type"))
+                            .and_then(|v| v.as_str())
+                            == Some("agent_message")
+                        {
+                            last_message = parsed
+                                .get("payload")
+                                .and_then(|v| v.get("message"))
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if output_format == "json" {
+            Ok(serde_json::json!({
+                "thread_id": session_id,
+                "response": last_message.unwrap_or_default(),
+                "raw": output,
+            }))
+        } else {
+            Ok(serde_json::json!({ "text": last_message.unwrap_or(output) }))
+        }
+    } else if output_format == "json" {
         serde_json::from_str(&output)
             .map_err(|e| format!("Failed to parse JSON output: {}. Raw: {}", e, output))
     } else {
@@ -368,16 +553,98 @@ pub async fn run_headless(
 
 pub async fn obtain_session_id(
     cwd: &std::path::PathBuf,
-    provider_name: &str,
-) -> Option<String> {
+    agent_class: Option<&str>,
+    config: Option<&AgentConfig>,
+) -> Result<String, String> {
     use tokio::io::{AsyncBufReadExt, BufReader};
-    let provider = ProviderFactory::resolve(provider_name).ok()?;
+    let provider_name = config.map(|c| c.provider.as_str()).unwrap_or("claude");
+    let provider = ProviderFactory::resolve(provider_name)?;
     let (bin, base_args) = provider.get_executable();
-    let mut cmd = tokio::process::Command::new(&bin);
+    let mut cmd = if cfg!(target_os = "windows") && bin.ends_with(".cmd") {
+        let mut c = tokio::process::Command::new("cmd");
+        c.arg("/c").arg(&bin);
+        c
+    } else {
+        tokio::process::Command::new(&bin)
+    };
+    let class_name = agent_class
+        .filter(|name| !name.trim().is_empty())
+        .or_else(|| {
+            config
+                .and_then(|cfg| (!cfg.agent_class.trim().is_empty()).then_some(cfg.agent_class.as_str()))
+        })
+        .unwrap_or("");
+    let habitat_root = prepare_provider_habitat(provider_name, cwd, class_name, None)?;
+    let provider_cwd = habitat_root
+        .as_ref()
+        .map(|root| habitat_workspace_cwd(root))
+        .unwrap_or_else(|| cwd.clone());
     for arg in base_args {
         cmd.arg(arg);
     }
-    if provider_name == "claude" {
+    if provider_name == "codex" {
+        if let Some(root) = habitat_root.as_ref() {
+            cmd.env("CODEX_HOME", habitat_codex_home(root));
+        }
+        cmd.arg("exec");
+
+        if let Some(config) = config {
+            if let Some(ref model) = config.model {
+                cmd.arg("--model").arg(model);
+            }
+            if let Some(ref profile) = config.codex_profile {
+                if !profile.trim().is_empty() {
+                    cmd.arg("--profile").arg(profile);
+                }
+            }
+            if let Some(ref sandbox_mode) = config.codex_sandbox_mode {
+                if !sandbox_mode.trim().is_empty() {
+                    cmd.arg("--sandbox").arg(sandbox_mode);
+                }
+            }
+            if config.codex_full_auto.unwrap_or(false) {
+                cmd.arg("--full-auto");
+            }
+            if config.codex_search.unwrap_or(false) {
+                cmd.arg("--search");
+            }
+            if config.codex_skip_git_repo_check.unwrap_or(true) {
+                cmd.arg("--skip-git-repo-check");
+            }
+            if config.codex_ephemeral.unwrap_or(false) {
+                cmd.arg("--ephemeral");
+            }
+
+            let mut final_includes = config
+                .system_include_directories
+                .clone()
+                .unwrap_or_default();
+            if let Some(ref user_dirs) = config.include_directories {
+                for dir in user_dirs {
+                    if !final_includes.contains(dir) {
+                        final_includes.push(dir.clone());
+                    }
+                }
+            }
+            for dir in final_includes {
+                cmd.arg("--add-dir").arg(dir);
+            }
+
+            if let Some(ref custom) = config.custom_args {
+                if let Some(parsed) = shlex::split(custom) {
+                    for arg in parsed {
+                        cmd.arg(arg);
+                    }
+                }
+            }
+        }
+
+        cmd.arg("--json")
+            .arg("Introduce yourself")
+            .current_dir(&provider_cwd)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+    } else if provider_name == "claude" {
         cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1")
             .arg("--print")
             .arg("--verbose")
@@ -392,7 +659,7 @@ pub async fn obtain_session_id(
             .arg("Introduce yourself")
             .arg("-o")
             .arg("stream-json")
-            .current_dir(cwd)
+            .current_dir(&provider_cwd)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
     }
@@ -402,6 +669,7 @@ pub async fn obtain_session_id(
         Ok(mut child) => {
             log_debug("[WARDIAN-DEBUG] Spawned headless process. Reading stdout...");
             let mut session_id_res = None;
+            let mut stderr_output = String::new();
             
             if let Some(stdout) = child.stdout.take() {
                 let mut reader = BufReader::new(stdout);
@@ -426,13 +694,39 @@ pub async fn obtain_session_id(
                     line.clear();
                 }
             }
+            if let Some(stderr) = child.stderr.take() {
+                let mut reader = BufReader::new(stderr);
+                let mut line = String::new();
+                while let Ok(n) = reader.read_line(&mut line).await {
+                    if n == 0 {
+                        break;
+                    }
+                    stderr_output.push_str(&line);
+                    line.clear();
+                }
+            }
             let _ = child.wait().await;
+            if session_id_res.is_none() && !stderr_output.trim().is_empty() {
+                log_debug(&format!(
+                    "[WARDIAN-DEBUG] obtain_session_id stderr: {}",
+                    stderr_output.trim()
+                ));
+            }
             log_debug(&format!("[WARDIAN-DEBUG] Returning session_id: {:?}", session_id_res));
-            session_id_res
+            session_id_res.ok_or_else(|| {
+                if stderr_output.trim().is_empty() {
+                    format!(
+                        "Provider {} did not return a session ID during initialization.",
+                        provider_name
+                    )
+                } else {
+                    stderr_output.trim().to_string()
+                }
+            })
         }
         Err(e) => {
             log_debug(&format!("[WARDIAN-DEBUG] Failed to spawn cmd: {:?}", e));
-            None
+            Err(format!("Failed to spawn {} bootstrap command: {}", provider_name, e))
         }
     }
 }
@@ -448,6 +742,70 @@ fn claude_project_dir_name(workspace: &str) -> String {
             _ => c,
         })
         .collect()
+}
+
+fn codex_session_file_path_in(base: &std::path::Path, session_id: &str) -> Option<std::path::PathBuf> {
+    let base = base.join("sessions");
+    let years = std::fs::read_dir(base).ok()?;
+
+    for year in years.flatten() {
+        let months = match std::fs::read_dir(year.path()) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for month in months.flatten() {
+            let days = match std::fs::read_dir(month.path()) {
+                Ok(entries) => entries,
+                Err(_) => continue,
+            };
+            for day in days.flatten() {
+                let files = match std::fs::read_dir(day.path()) {
+                    Ok(entries) => entries,
+                    Err(_) => continue,
+                };
+                for file in files.flatten() {
+                    let path = file.path();
+                    if !path.is_file() {
+                        continue;
+                    }
+                    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if file_name.ends_with(&format!("{}.jsonl", session_id)) {
+                        return Some(path);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn codex_session_file_path(session_id: &str, wardian_agent_dir: Option<&str>) -> Option<std::path::PathBuf> {
+    if let Some(agent_dir) = wardian_agent_dir {
+        let projected_home = std::path::Path::new(agent_dir).join("habitat").join(".codex");
+        if let Some(path) = codex_session_file_path_in(&projected_home, session_id) {
+            return Some(path);
+        }
+    }
+
+    let global_home = dirs::home_dir()?.join(".codex");
+    codex_session_file_path_in(&global_home, session_id)
+}
+
+fn codex_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
+    for line in lines.iter().rev() {
+        let payload = line.get("payload")?;
+        let payload_type = payload.get("type").and_then(|v| v.as_str())?;
+        match payload_type {
+            "exec_approval_request" => return Some("Action Needed".to_string()),
+            "task_started" | "agent_message" | "exec_command_begin" | "exec_command_start" => {
+                return Some("Processing...".to_string())
+            }
+            "task_complete" => return Some("Idle".to_string()),
+            _ => {}
+        }
+    }
+    None
 }
 
 pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
@@ -541,6 +899,15 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
             // Provider-aware log discovery
             if log_path_lock.is_none() {
                 match snap.provider.as_str() {
+                    "codex" => {
+                        let agent_home = get_wardian_home()
+                            .map(|home| home.join("agents").join(&snap.session_id))
+                            .filter(|path| path.exists())
+                            .map(|path| path.to_string_lossy().to_string());
+                        if let Some(path) = codex_session_file_path(&snap.session_id, agent_home.as_deref()) {
+                            *log_path_lock = Some(path);
+                        }
+                    }
                     "claude" => {
                         // Claude Code stores sessions at:
                         // ~/.claude/projects/<project_dir>/<session_id>.jsonl
@@ -594,6 +961,36 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
             if let Some(ref path) = *log_path_lock {
                 if let Ok(content) = std::fs::read_to_string(path) {
                     match snap.provider.as_str() {
+                        "codex" => {
+                            let lines: Vec<serde_json::Value> = content
+                                .lines()
+                                .filter_map(|l| serde_json::from_str(l).ok())
+                                .collect();
+
+                            q_count = lines.iter().filter(|l| {
+                                l.get("type").and_then(|v| v.as_str()) == Some("event_msg")
+                                    && l.get("payload")
+                                        .and_then(|v| v.get("type"))
+                                        .and_then(|v| v.as_str())
+                                        == Some("user_message")
+                            }).count();
+
+                            if let Some(meta) = lines.iter().find(|l| {
+                                l.get("type").and_then(|v| v.as_str()) == Some("session_meta")
+                            }) {
+                                if let Some(ts) = meta
+                                    .get("payload")
+                                    .and_then(|v| v.get("timestamp"))
+                                    .and_then(|v| v.as_str())
+                                {
+                                    i_ts = Some(ts.to_string());
+                                }
+                            }
+
+                            if let Some(status) = codex_status_from_log(&lines) {
+                                *snap.current_status.lock().unwrap() = status;
+                            }
+                        }
                         "claude" => {
                             // Claude logs are JSONL — one JSON object per line
                             let lines: Vec<serde_json::Value> = content
@@ -610,6 +1007,7 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                     i_ts = Some(ts.to_string());
                                 }
                             }
+
                         }
                         _ => {
                             // Gemini logs are a single JSON object with a messages array
@@ -742,7 +1140,7 @@ pub fn init_agent_classes(app: &AppHandle) {
             // 2. Symlink .claude/skills/ → .agents/skills/ for Claude discovery
             ensure_claude_skills_link(&role_dir);
 
-            // 3. Create provider stub files
+            // 3. Create provider stub files for providers that do not read AGENTS.md directly
             for stub_name in &["GEMINI.md", "CLAUDE.md"] {
                 let stub_path = role_dir.join(stub_name);
                 if !stub_path.exists() {

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -62,6 +62,26 @@ fn apply_agent_event(
     }
 }
 
+fn apply_agent_status_event(
+    app: &AppHandle,
+    session_id: &str,
+    event: AgentEvent,
+    current_status: &std::sync::Arc<std::sync::Mutex<String>>,
+) {
+    match event {
+        AgentEvent::UserQuery | AgentEvent::Generating => {
+            set_agent_status(app, session_id, current_status, "Processing...");
+        }
+        AgentEvent::ModelResponse => {
+            set_agent_status(app, session_id, current_status, "Idle");
+        }
+        AgentEvent::ActionRequired { .. } => {
+            set_agent_status(app, session_id, current_status, "Action Needed");
+        }
+        AgentEvent::Init { .. } | AgentEvent::Unknown => {}
+    }
+}
+
 pub fn save_state(_app: &AppHandle, agents: &HashMap<String, ActiveAgent>, order: &[String]) {
     let mut configs: Vec<AgentConfig> = Vec::new();
     for id in order {
@@ -139,6 +159,11 @@ pub async fn spawn_agent(
     for arg in base_args {
         cmd.arg(arg);
     }
+    let claude_hook = if config.provider == "claude" {
+        Some(ensure_claude_permission_hook(&config.session_id)?)
+    } else {
+        None
+    };
     let habitat_root = prepare_provider_habitat(
         &config.provider,
         &cwd,
@@ -155,6 +180,10 @@ pub async fn spawn_agent(
     // class/common/agent instruction files are loaded natively.
     if config.provider == "claude" {
         cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
+        if let Some(hook) = claude_hook.as_ref() {
+            cmd.arg("--settings");
+            cmd.arg(&hook.settings_arg);
+        }
     } else if config.provider == "codex" {
         if let Some(root) = habitat_root.as_ref() {
             cmd.env("CODEX_HOME", habitat_codex_home(root));
@@ -226,6 +255,7 @@ pub async fn spawn_agent(
     });
 
     let sid_out = config.session_id.clone();
+    let provider_name_for_pty = config.provider.clone();
     let output_buffer = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
     let output_buffer_clone = output_buffer.clone();
     let query_count = std::sync::Arc::new(std::sync::Mutex::new(0));
@@ -263,14 +293,22 @@ pub async fn spawn_agent(
                                     // Use provider to classify the raw JSON into an AgentEvent
                                     let raw_line = parsed.to_string();
                                     if let Some(event) = pty_provider.parse_output(&raw_line) {
-                                        apply_agent_event(
-                                            &pty_app,
-                                            &sid_for_pty,
-                                            event,
-                                            &query_count_clone,
-                                            &init_timestamp_clone,
-                                            &current_status_clone,
-                                        );
+                                        if provider_name_for_pty == "claude" {
+                                            if let AgentEvent::Init { timestamp, .. } = event {
+                                                if let Ok(mut ts) = init_timestamp_clone.lock() {
+                                                    *ts = timestamp;
+                                                }
+                                            }
+                                        } else {
+                                            apply_agent_event(
+                                                &pty_app,
+                                                &sid_for_pty,
+                                                event,
+                                                &query_count_clone,
+                                                &init_timestamp_clone,
+                                                &current_status_clone,
+                                            );
+                                        }
                                     }
                                     let _ = pty_emit_app.emit("agent-json-event", serde_json::json!({ "session_id": sid_out, "data": parsed }));
                                     let consumed = stream.byte_offset();
@@ -370,6 +408,200 @@ pub async fn spawn_agent(
                 std::thread::sleep(std::time::Duration::from_millis(250));
             }
         });
+    } else if config.provider == "claude" {
+        let watcher_app = app.clone();
+        let watcher_provider = provider.clone();
+        let watcher_session = config.session_id.clone();
+        let watcher_current_status = current_status.clone();
+        let watcher_log_path = log_path.clone();
+        let watcher_folder = expected_folder.clone();
+        let hook_event_log = claude_hook.as_ref().map(|hook| hook.event_log_path.clone());
+        let waiting_for_permission = std::sync::Arc::new(std::sync::Mutex::new(false));
+        let log_waiting_for_permission = waiting_for_permission.clone();
+
+        std::thread::spawn(move || {
+            let mut offset: u64 = 0;
+            loop {
+                let current = watcher_current_status
+                    .lock()
+                    .map(|s| s.clone())
+                    .unwrap_or_else(|e| e.into_inner().clone());
+                if current == "Off" {
+                    break;
+                }
+
+                let path = {
+                    let mut lock = watcher_log_path.lock().unwrap_or_else(|e| e.into_inner());
+                    if lock.is_none() {
+                        if let Some(home) = dirs::home_dir() {
+                            let candidate = home
+                                .join(".claude")
+                                .join("projects")
+                                .join(claude_project_dir_name(&watcher_folder))
+                                .join(format!("{}.jsonl", watcher_session));
+                            if candidate.exists() {
+                                *lock = Some(candidate);
+                            }
+                        }
+                    }
+                    lock.clone()
+                };
+
+                if let Some(path) = path {
+                    if let Ok(mut out) = watcher_log_path.lock() {
+                        *out = Some(path.clone());
+                    }
+                    if let Ok(mut file) = std::fs::File::open(&path) {
+                        if let Ok(metadata) = file.metadata() {
+                            if metadata.len() < offset {
+                                offset = 0;
+                            }
+                        }
+                        if file.seek(std::io::SeekFrom::Start(offset)).is_ok() {
+                            let mut reader = std::io::BufReader::new(file);
+                            let mut line = String::new();
+                            loop {
+                                line.clear();
+                                let read = reader.read_line(&mut line).unwrap_or(0);
+                                if read == 0 {
+                                    break;
+                                }
+                                offset += read as u64;
+                                if let Some(event) = watcher_provider.parse_output(line.trim()) {
+                                    let mut waiting = log_waiting_for_permission
+                                        .lock()
+                                        .unwrap_or_else(|e| e.into_inner());
+                                    if *waiting {
+                                        match event {
+                                            AgentEvent::UserQuery | AgentEvent::Generating => {
+                                                if let Ok(parsed) =
+                                                    serde_json::from_str::<serde_json::Value>(
+                                                        line.trim(),
+                                                    )
+                                                {
+                                                    let is_tool_result = parsed
+                                                        .get("type")
+                                                        .and_then(|v| v.as_str())
+                                                        == Some("user")
+                                                        && !claude_is_real_user_query(&parsed);
+                                                    if is_tool_result {
+                                                        *waiting = false;
+                                                        apply_agent_status_event(
+                                                            &watcher_app,
+                                                            &watcher_session,
+                                                            event,
+                                                            &watcher_current_status,
+                                                        );
+                                                    }
+                                                }
+                                            }
+                                            AgentEvent::ModelResponse => {
+                                                *waiting = false;
+                                                apply_agent_status_event(
+                                                    &watcher_app,
+                                                    &watcher_session,
+                                                    event,
+                                                    &watcher_current_status,
+                                                );
+                                            }
+                                            AgentEvent::ActionRequired { .. } => {
+                                                apply_agent_status_event(
+                                                    &watcher_app,
+                                                    &watcher_session,
+                                                    event,
+                                                    &watcher_current_status,
+                                                );
+                                            }
+                                            AgentEvent::Init { .. } | AgentEvent::Unknown => {}
+                                        }
+                                    } else {
+                                        apply_agent_status_event(
+                                            &watcher_app,
+                                            &watcher_session,
+                                            event,
+                                            &watcher_current_status,
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                std::thread::sleep(std::time::Duration::from_millis(250));
+            }
+        });
+
+        if let Some(hook_event_log) = hook_event_log {
+            let hook_app = app.clone();
+            let hook_session = config.session_id.clone();
+            let hook_current_status = current_status.clone();
+            let hook_waiting_for_permission = waiting_for_permission.clone();
+
+            std::thread::spawn(move || {
+                let mut offset = 0;
+                loop {
+                    let current = hook_current_status
+                        .lock()
+                        .map(|s| s.clone())
+                        .unwrap_or_else(|e| e.into_inner().clone());
+                    if current == "Off" {
+                        break;
+                    }
+
+                    if let Ok(mut file) = std::fs::File::open(&hook_event_log) {
+                        if let Ok(metadata) = file.metadata() {
+                            if metadata.len() < offset {
+                                offset = 0;
+                            }
+                        }
+                        if file.seek(std::io::SeekFrom::Start(offset)).is_ok() {
+                            let mut reader = std::io::BufReader::new(file);
+                            let mut line = String::new();
+                            loop {
+                                line.clear();
+                                let read = reader.read_line(&mut line).unwrap_or(0);
+                                if read == 0 {
+                                    break;
+                                }
+                                offset += read as u64;
+                                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+                                    if let Ok(mut waiting) = hook_waiting_for_permission.lock() {
+                                        *waiting = true;
+                                    }
+                                    let tool_name = parsed
+                                        .get("tool_name")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("Tool approval required")
+                                        .to_string();
+                                    apply_agent_status_event(
+                                        &hook_app,
+                                        &hook_session,
+                                        AgentEvent::ActionRequired {
+                                            message: tool_name.clone(),
+                                        },
+                                        &hook_current_status,
+                                    );
+                                    let _ = hook_app.emit(
+                                        "agent-json-event",
+                                        serde_json::json!({
+                                            "session_id": hook_session,
+                                            "data": {
+                                                "type": "system",
+                                                "subtype": "permission_request",
+                                                "tool_name": tool_name,
+                                            }
+                                        }),
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    std::thread::sleep(std::time::Duration::from_millis(250));
+                }
+            });
+        }
     }
 
     Ok(ActiveAgent {
@@ -458,8 +690,11 @@ pub async fn run_headless(
                 .arg(prompt);
         }
         "claude" => {
-            cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1")
-                .arg("--print")
+            cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
+            if let Ok(hook) = ensure_claude_permission_hook(session_id) {
+                cmd.arg("--settings").arg(hook.settings_arg);
+            }
+            cmd.arg("--print")
                 .arg("--output-format")
                 .arg(output_format)
                 .arg("--resume")
@@ -808,6 +1043,55 @@ fn codex_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
     None
 }
 
+fn claude_is_real_user_query(line: &serde_json::Value) -> bool {
+    let Some(message) = line.get("message") else {
+        return true;
+    };
+    let Some(content) = message.get("content") else {
+        return true;
+    };
+
+    let Some(items) = content.as_array() else {
+        return true;
+    };
+
+    !items.iter().any(|item| item.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
+}
+
+fn claude_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
+    for line in lines.iter().rev() {
+        match line.get("type").and_then(|v| v.as_str()) {
+            Some("system") => {
+                if let Some("permission_request") =
+                    line.get("subtype").and_then(|v| v.as_str())
+                {
+                    return Some("Action Needed".to_string());
+                }
+            }
+            Some("assistant") => {
+                let stop_reason = line
+                    .get("message")
+                    .and_then(|v| v.get("stop_reason"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if stop_reason == "end_turn" || stop_reason == "stop_sequence" {
+                    return Some("Idle".to_string());
+                }
+                return Some("Processing...".to_string());
+            }
+            Some("progress") => return Some("Processing...".to_string()),
+            Some("user") => {
+                if claude_is_real_user_query(line) {
+                    return Some("Processing...".to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
 pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
     struct AgentSnapshot {
         session_id: String,
@@ -1000,6 +1284,7 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
 
                             q_count = lines.iter().filter(|l| {
                                 l.get("type").and_then(|v| v.as_str()) == Some("user")
+                                    && claude_is_real_user_query(l)
                             }).count();
 
                             if let Some(first) = lines.first() {
@@ -1008,6 +1293,13 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                 }
                             }
 
+                            let current_status =
+                                snap.current_status.lock().unwrap().clone();
+                            if current_status != "Action Needed" {
+                                if let Some(status) = claude_status_from_log(&lines) {
+                                    *snap.current_status.lock().unwrap() = status;
+                                }
+                            }
                         }
                         _ => {
                             // Gemini logs are a single JSON object with a messages array

--- a/src-tauri/src/models/agent_config.rs
+++ b/src-tauri/src/models/agent_config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 fn default_provider() -> String {
-    "gemini".to_string()
+    "claude".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -61,6 +61,22 @@ pub struct AgentConfig {
     pub append_system_prompt: Option<String>,
     #[serde(default)]
     pub mcp_config: Option<String>,
+
+    // Codex-specific fields
+    #[serde(default)]
+    pub codex_sandbox_mode: Option<String>,
+    #[serde(default)]
+    pub codex_approval_policy: Option<String>,
+    #[serde(default)]
+    pub codex_profile: Option<String>,
+    #[serde(default)]
+    pub codex_full_auto: Option<bool>,
+    #[serde(default)]
+    pub codex_search: Option<bool>,
+    #[serde(default)]
+    pub codex_skip_git_repo_check: Option<bool>,
+    #[serde(default)]
+    pub codex_ephemeral: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/models/provider.rs
+++ b/src-tauri/src/models/provider.rs
@@ -41,7 +41,7 @@ pub trait AgentProvider: Send + Sync {
     fn parse_output(&self, line: &str) -> Option<AgentEvent>;
 
     /// Returns the instruction filename that this provider reads from class
-    /// directories (e.g., `"GEMINI.md"`, `"CLAUDE.md"`).
+    /// directories (e.g., `"GEMINI.md"`, `"CLAUDE.md"`, `"AGENTS.md"`).
     fn get_instruction_filename(&self) -> &str;
 }
 

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -14,6 +14,35 @@ impl ClaudeProvider {
     pub fn new() -> Self {
         ClaudeProvider
     }
+
+    fn is_real_user_query(parsed: &serde_json::Value) -> bool {
+        let Some(message) = parsed.get("message") else {
+            return true;
+        };
+        let Some(content) = message.get("content") else {
+            return true;
+        };
+
+        let Some(items) = content.as_array() else {
+            return true;
+        };
+
+        !items.iter().any(|item| item.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
+    }
+
+    fn assistant_event(parsed: &serde_json::Value) -> AgentEvent {
+        let stop_reason = parsed
+            .get("message")
+            .and_then(|v| v.get("stop_reason"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if stop_reason == "end_turn" || stop_reason == "stop_sequence" {
+            return AgentEvent::ModelResponse;
+        }
+
+        AgentEvent::Generating
+    }
 }
 
 impl AgentProvider for ClaudeProvider {
@@ -156,13 +185,22 @@ impl AgentProvider for ClaudeProvider {
                             .to_string();
                         Some(AgentEvent::ActionRequired { message })
                     }
+                    "turn_duration" => Some(AgentEvent::ModelResponse),
                     _ => Some(AgentEvent::Unknown),
                 }
             }
-            // User input is sent via stdin; Claude echoes it on stdout when received
-            "user" => Some(AgentEvent::UserQuery),
+            // Only count real user prompts as queries. Tool results are part of the same turn.
+            "user" => {
+                if Self::is_real_user_query(&parsed) {
+                    Some(AgentEvent::UserQuery)
+                } else {
+                    Some(AgentEvent::Generating)
+                }
+            }
             // Claude is actively streaming a response
-            "assistant" | "message_stream" => Some(AgentEvent::Generating),
+            "assistant" => Some(Self::assistant_event(&parsed)),
+            "message_stream" => Some(AgentEvent::Generating),
+            "progress" => Some(AgentEvent::Generating),
             // Claude finished the full response turn
             "result" => Some(AgentEvent::ModelResponse),
             _ => Some(AgentEvent::Unknown),
@@ -245,6 +283,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_output_assistant_end_turn_is_idle() {
+        let p = make_provider();
+        let line = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}],"stop_reason":"end_turn"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::ModelResponse);
+    }
+
+    #[test]
+    fn parse_output_assistant_tool_use_is_generating() {
+        let p = make_provider();
+        let line = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","id":"tool-1","input":{"command":"git status"}}],"stop_reason":"tool_use"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Generating);
+    }
+
+    #[test]
     fn parse_output_result_is_idle() {
         let p = make_provider();
         let line = r#"{"type":"result","subtype":"success","result":"done"}"#;
@@ -256,6 +308,20 @@ mod tests {
         let p = make_provider();
         let line = r#"{"type":"user","message":{"role":"user","content":"hello"}}"#;
         assert_eq!(p.parse_output(line).unwrap(), AgentEvent::UserQuery);
+    }
+
+    #[test]
+    fn parse_output_user_tool_result_is_generating() {
+        let p = make_provider();
+        let line = r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-1","content":"ok"}]}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Generating);
+    }
+
+    #[test]
+    fn parse_output_turn_duration_is_idle() {
+        let p = make_provider();
+        let line = r#"{"type":"system","subtype":"turn_duration","durationMs":1234}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::ModelResponse);
     }
 
     #[test]

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -1,0 +1,354 @@
+use crate::models::provider::{AgentEvent, AgentProvider};
+use crate::models::AgentConfig;
+
+/// Provider adapter for the OpenAI Codex CLI.
+pub struct CodexProvider;
+
+impl Default for CodexProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexProvider {
+    pub fn new() -> Self {
+        CodexProvider
+    }
+
+    fn parse_action_required_from_arguments(arguments: &str) -> Option<String> {
+        let parsed: serde_json::Value = serde_json::from_str(arguments).ok()?;
+        let sandbox_permissions = parsed.get("sandbox_permissions")?.as_str()?;
+        if sandbox_permissions != "require_escalated" {
+            return None;
+        }
+
+        let justification = parsed
+            .get("justification")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        if let Some(justification) = justification {
+            return Some(justification.to_string());
+        }
+
+        let command = parsed
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        if let Some(command) = command {
+            return Some(command.to_string());
+        }
+
+        Some("Approval required".to_string())
+    }
+
+    fn append_common_args(&self, args: &mut Vec<String>, config: &AgentConfig, is_exec_mode: bool) {
+        if let Some(ref model) = config.model {
+            args.push("--model".into());
+            args.push(model.clone());
+        }
+
+        if let Some(ref profile) = config.codex_profile {
+            if !profile.trim().is_empty() {
+                args.push("--profile".into());
+                args.push(profile.clone());
+            }
+        }
+
+        let sandbox_mode = config
+            .codex_sandbox_mode
+            .as_ref()
+            .filter(|mode| !mode.trim().is_empty())
+            .cloned()
+            .unwrap_or_else(|| "workspace-write".to_string());
+        args.push("--sandbox".into());
+        args.push(sandbox_mode);
+
+        if let Some(ref approval_policy) = config.codex_approval_policy {
+            if !approval_policy.trim().is_empty() {
+                args.push("--ask-for-approval".into());
+                args.push(approval_policy.clone());
+            }
+        }
+
+        if config.codex_full_auto.unwrap_or(false) {
+            args.push("--full-auto".into());
+        }
+
+        if config.codex_search.unwrap_or(false) {
+            args.push("--search".into());
+        }
+
+        if is_exec_mode {
+            if config.codex_skip_git_repo_check.unwrap_or(true) {
+                args.push("--skip-git-repo-check".into());
+            }
+
+            if config.codex_ephemeral.unwrap_or(false) {
+                args.push("--ephemeral".into());
+            }
+        }
+
+        let mut final_includes = config
+            .system_include_directories
+            .clone()
+            .unwrap_or_default();
+        if let Some(ref user_dirs) = config.include_directories {
+            for dir in user_dirs {
+                if !final_includes.contains(dir) {
+                    final_includes.push(dir.clone());
+                }
+            }
+        }
+        for dir in final_includes {
+            args.push("--add-dir".into());
+            args.push(dir);
+        }
+    }
+}
+
+impl AgentProvider for CodexProvider {
+    fn name(&self) -> &str {
+        "Codex"
+    }
+
+    fn get_executable(&self) -> (String, Vec<String>) {
+        if cfg!(target_os = "windows") {
+            ("codex.cmd".to_string(), vec![])
+        } else {
+            ("codex".to_string(), vec![])
+        }
+    }
+
+    fn get_spawn_args(&self, config: &AgentConfig, is_resume: bool) -> Vec<String> {
+        let mut args: Vec<String> = Vec::new();
+
+        if is_resume {
+            args.push("resume".into());
+            if let Some(resume_id) = config.resume_session.as_ref().filter(|s| !s.trim().is_empty()) {
+                args.push(resume_id.clone());
+            }
+        }
+
+        self.append_common_args(&mut args, config, false);
+
+        if let Some(ref custom) = config.custom_args {
+            if let Some(parsed) = shlex::split(custom) {
+                args.extend(parsed);
+            }
+        }
+
+        args
+    }
+
+    fn parse_output(&self, line: &str) -> Option<AgentEvent> {
+        let parsed: serde_json::Value = serde_json::from_str(line).ok()?;
+        let msg_type = parsed.get("type")?.as_str()?;
+
+        match msg_type {
+            "thread.started" => {
+                let session_id = parsed
+                    .get("thread_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                Some(AgentEvent::Init {
+                    session_id,
+                    timestamp: None,
+                })
+            }
+            "turn.started" => Some(AgentEvent::UserQuery),
+            "turn.completed" => Some(AgentEvent::ModelResponse),
+            "item.completed" => {
+                let item_type = parsed
+                    .get("item")
+                    .and_then(|v| v.get("type"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                match item_type {
+                    "agent_message" => Some(AgentEvent::Generating),
+                    _ => Some(AgentEvent::Unknown),
+                }
+            }
+            "response_item" => {
+                let payload = parsed.get("payload")?;
+                let payload_type = payload.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                match payload_type {
+                    "function_call" => {
+                        let arguments = payload.get("arguments").and_then(|v| v.as_str()).unwrap_or("");
+                        Self::parse_action_required_from_arguments(arguments)
+                            .map(|message| AgentEvent::ActionRequired { message })
+                            .or(Some(AgentEvent::Unknown))
+                    }
+                    "function_call_output" => Some(AgentEvent::Generating),
+                    "message" => {
+                        let role = payload.get("role").and_then(|v| v.as_str()).unwrap_or("");
+                        match role {
+                            "assistant" => Some(AgentEvent::Generating),
+                            "user" => Some(AgentEvent::UserQuery),
+                            _ => Some(AgentEvent::Unknown),
+                        }
+                    }
+                    _ => Some(AgentEvent::Unknown),
+                }
+            }
+            "event_msg" => {
+                let inner_type = parsed
+                    .get("payload")
+                    .and_then(|v| v.get("type"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                match inner_type {
+                    "task_started" => Some(AgentEvent::Generating),
+                    "user_message" => Some(AgentEvent::UserQuery),
+                    "agent_message" => Some(AgentEvent::Generating),
+                    "task_complete" => Some(AgentEvent::ModelResponse),
+                    "exec_approval_request" => {
+                        let message = parsed
+                            .get("payload")
+                            .and_then(|v| v.get("command"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("command")
+                            .to_string();
+                        Some(AgentEvent::ActionRequired { message })
+                    }
+                    _ => Some(AgentEvent::Unknown),
+                }
+            }
+            _ => Some(AgentEvent::Unknown),
+        }
+    }
+
+    fn get_instruction_filename(&self) -> &str {
+        "AGENTS.md"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_provider() -> CodexProvider {
+        CodexProvider::new()
+    }
+
+    #[test]
+    fn name_returns_codex() {
+        let p = make_provider();
+        assert_eq!(p.name(), "Codex");
+    }
+
+    #[test]
+    fn instruction_filename_is_agents_md() {
+        let p = make_provider();
+        assert_eq!(p.get_instruction_filename(), "AGENTS.md");
+    }
+
+    #[test]
+    fn spawn_args_resume_and_model() {
+        let p = make_provider();
+        let config = AgentConfig {
+            resume_session: Some("session-abc".into()),
+            model: Some("gpt-5.4".into()),
+            codex_profile: Some("wardian".into()),
+            codex_sandbox_mode: Some("workspace-write".into()),
+            codex_approval_policy: Some("on-request".into()),
+            codex_search: Some(true),
+            ..Default::default()
+        };
+        let args = p.get_spawn_args(&config, true);
+        assert_eq!(args[0], "resume");
+        assert!(args.contains(&"session-abc".to_string()));
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"gpt-5.4".to_string()));
+        assert!(args.contains(&"--profile".to_string()));
+        assert!(args.contains(&"wardian".to_string()));
+        assert!(args.contains(&"--sandbox".to_string()));
+        assert!(args.contains(&"workspace-write".to_string()));
+        assert!(args.contains(&"--ask-for-approval".to_string()));
+        assert!(args.contains(&"on-request".to_string()));
+        assert!(args.contains(&"--search".to_string()));
+    }
+
+    #[test]
+    fn spawn_args_include_directories() {
+        let p = make_provider();
+        let config = AgentConfig {
+            system_include_directories: Some(vec!["/sys/dir".into()]),
+            include_directories: Some(vec!["/user/dir".into()]),
+            ..Default::default()
+        };
+        let args = p.get_spawn_args(&config, false);
+        let count = args.iter().filter(|a| *a == "--add-dir").count();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn parse_output_thread_started_event() {
+        let p = make_provider();
+        let line = r#"{"type":"thread.started","thread_id":"abc-123"}"#;
+        let event = p.parse_output(line).unwrap();
+        assert_eq!(
+            event,
+            AgentEvent::Init {
+                session_id: "abc-123".into(),
+                timestamp: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_output_turn_started_event() {
+        let p = make_provider();
+        let line = r#"{"type":"turn.started"}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::UserQuery);
+    }
+
+    #[test]
+    fn parse_output_turn_completed_event() {
+        let p = make_provider();
+        let line = r#"{"type":"turn.completed","usage":{"input_tokens":1}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::ModelResponse);
+    }
+
+    #[test]
+    fn parse_output_agent_message_event() {
+        let p = make_provider();
+        let line = r#"{"type":"item.completed","item":{"type":"agent_message","text":"hello"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Generating);
+    }
+
+    #[test]
+    fn parse_output_task_started_event() {
+        let p = make_provider();
+        let line = r#"{"type":"event_msg","payload":{"type":"task_started","turn_id":"abc"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Generating);
+    }
+
+    #[test]
+    fn parse_output_task_complete_event() {
+        let p = make_provider();
+        let line = r#"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"abc"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::ModelResponse);
+    }
+
+    #[test]
+    fn parse_output_response_item_function_call_requires_approval() {
+        let p = make_provider();
+        let line = r#"{"type":"response_item","payload":{"type":"function_call","arguments":"{\"command\":\"Get-Content foo\",\"sandbox_permissions\":\"require_escalated\",\"justification\":\"Allow reading foo?\"}"}}"#;
+        assert_eq!(
+            p.parse_output(line).unwrap(),
+            AgentEvent::ActionRequired {
+                message: "Allow reading foo?".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_output_response_item_function_call_without_approval_is_unknown() {
+        let p = make_provider();
+        let line = r#"{"type":"response_item","payload":{"type":"function_call","arguments":"{\"command\":\"Get-Content foo\"}"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Unknown);
+    }
+}

--- a/src-tauri/src/providers/factory.rs
+++ b/src-tauri/src/providers/factory.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use crate::models::provider::AgentProvider;
 use crate::providers::gemini::GeminiProvider;
 use crate::providers::claude::ClaudeProvider;
+use crate::providers::codex::CodexProvider;
 
 /// Resolves the correct `AgentProvider` implementation based on the provider name
 /// stored in `AgentConfig`.
@@ -16,9 +17,10 @@ impl ProviderFactory {
         let lower = provider_name.to_lowercase();
         match lower.as_str() {
             "gemini" => Ok(Arc::new(GeminiProvider::new())),
-            "claude" => Ok(Arc::new(ClaudeProvider::new())), // Added Claude provider
+            "claude" => Ok(Arc::new(ClaudeProvider::new())),
+            "codex" => Ok(Arc::new(CodexProvider::new())),
             other => Err(format!(
-                "Unknown provider '{}'. Supported providers: gemini, claude", // Updated error message
+                "Unknown provider '{}'. Supported providers: gemini, claude, codex",
                 other
             )),
         }
@@ -51,6 +53,13 @@ mod tests {
     }
 
     #[test]
+    fn resolve_codex_succeeds() {
+        let provider = ProviderFactory::resolve("codex");
+        assert!(provider.is_ok());
+        assert_eq!(provider.unwrap().name(), "Codex");
+    }
+
+    #[test]
     fn resolve_unknown_returns_error() {
         let result = ProviderFactory::resolve("invalid_provider_name");
         assert!(result.is_err());
@@ -76,5 +85,11 @@ mod tests {
         assert_eq!(provider.get_instruction_filename(), "GEMINI.md");
         let (bin, _) = provider.get_executable();
         assert!(!bin.is_empty());
+    }
+
+    #[test]
+    fn resolved_codex_provider_uses_agents_md() {
+        let provider = ProviderFactory::resolve("codex").unwrap();
+        assert_eq!(provider.get_instruction_filename(), "AGENTS.md");
     }
 }

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -1,5 +1,7 @@
 pub mod gemini;
 pub mod factory;
 pub mod claude;
+pub mod codex;
 pub use gemini::GeminiProvider;
+pub use codex::CodexProvider;
 pub use factory::ProviderFactory;

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -44,8 +44,7 @@ mod tests {
     #[test]
     fn app_state_constructs_without_panic() {
         let state = AppState::new();
-        // If we get here, construction succeeded
-        assert!(true, "AppState::new() succeeded");
+        assert!(state.agent_order.blocking_lock().is_empty());
         drop(state);
     }
 }

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -1,6 +1,11 @@
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
 
+pub struct ClaudePermissionHookPaths {
+    pub settings_arg: String,
+    pub event_log_path: std::path::PathBuf,
+}
+
 pub fn get_wardian_home() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".wardian"))
 }
@@ -33,6 +38,43 @@ pub fn habitat_workspace_cwd(habitat_root: &std::path::Path) -> std::path::PathB
 
 pub fn habitat_codex_home(habitat_root: &std::path::Path) -> std::path::PathBuf {
     habitat_root.join(".codex")
+}
+
+pub fn ensure_claude_permission_hook(
+    session_id: &str,
+) -> Result<ClaudePermissionHookPaths, String> {
+    let wardian_home = get_wardian_home().ok_or("Could not find Wardian home")?;
+    let hook_root = wardian_home.join("agents").join(session_id).join("claude");
+    std::fs::create_dir_all(&hook_root).map_err(|e| e.to_string())?;
+
+    let event_log_path = hook_root.join("permission-requests.jsonl");
+    if !event_log_path.exists() {
+        std::fs::write(&event_log_path, "").map_err(|e| e.to_string())?;
+    }
+
+    let script_path = write_claude_permission_hook_script(&hook_root, &event_log_path)?;
+    let command = claude_permission_hook_command(&script_path);
+    let settings_arg = serde_json::json!({
+        "hooks": {
+            "PermissionRequest": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": command,
+                        }
+                    ]
+                }
+            ]
+        }
+    })
+    .to_string();
+
+    Ok(ClaudePermissionHookPaths {
+        settings_arg,
+        event_log_path,
+    })
 }
 
 pub fn resolve_system_include_directories(class_name: &str, session_id: &str) -> Vec<String> {
@@ -265,6 +307,62 @@ fn build_habitat_skill_projection(
     }
 
     Ok(())
+}
+
+fn write_claude_permission_hook_script(
+    hook_root: &std::path::Path,
+    event_log_path: &std::path::Path,
+) -> Result<std::path::PathBuf, String> {
+    #[cfg(windows)]
+    {
+        let script_path = hook_root.join("permission-request-hook.ps1");
+        let script = format!(
+            "$payload = [Console]::In.ReadToEnd()\nif ([string]::IsNullOrWhiteSpace($payload)) {{ exit 0 }}\nAdd-Content -LiteralPath '{}' -Value $payload -Encoding utf8\n",
+            escape_powershell_single_quoted(&event_log_path.to_string_lossy())
+        );
+        std::fs::write(&script_path, script).map_err(|e| e.to_string())?;
+        Ok(script_path)
+    }
+    #[cfg(not(windows))]
+    {
+        let script_path = hook_root.join("permission-request-hook.sh");
+        let script = format!(
+            "#!/bin/sh\nset -eu\npayload=$(cat)\nif [ -z \"$payload\" ]; then\n  exit 0\nfi\nprintf '%s\\n' \"$payload\" >> '{}'\n",
+            escape_posix_single_quoted(&event_log_path.to_string_lossy())
+        );
+        std::fs::write(&script_path, script).map_err(|e| e.to_string())?;
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&script_path)
+            .map_err(|e| e.to_string())?
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script_path, permissions).map_err(|e| e.to_string())?;
+        Ok(script_path)
+    }
+}
+
+fn claude_permission_hook_command(script_path: &std::path::Path) -> String {
+    #[cfg(windows)]
+    {
+        format!(
+            "powershell -NoProfile -ExecutionPolicy Bypass -File \"{}\"",
+            script_path.to_string_lossy()
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        format!("sh \"{}\"", script_path.to_string_lossy())
+    }
+}
+
+#[cfg(windows)]
+fn escape_powershell_single_quoted(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+#[cfg(not(windows))]
+fn escape_posix_single_quoted(value: &str) -> String {
+    value.replace('\'', "'\"'\"'")
 }
 
 fn create_directory_link(target: &std::path::Path, link: &std::path::Path) -> Result<(), String> {

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -1,5 +1,38 @@
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
 pub fn get_wardian_home() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".wardian"))
+}
+
+pub fn provider_uses_projected_workspace(provider: &str) -> bool {
+    provider == "codex"
+}
+
+pub fn prepare_provider_habitat(
+    provider: &str,
+    workspace_root: &std::path::Path,
+    class_name: &str,
+    session_id: Option<&str>,
+) -> Result<Option<std::path::PathBuf>, String> {
+    if !provider_uses_projected_workspace(provider) {
+        return Ok(None);
+    }
+
+    let habitat_root = prepare_habitat_workspace(workspace_root, class_name, session_id)?;
+    if provider == "codex" {
+        ensure_codex_home_projection(&habitat_root)?;
+    }
+
+    Ok(Some(habitat_root))
+}
+
+pub fn habitat_workspace_cwd(habitat_root: &std::path::Path) -> std::path::PathBuf {
+    habitat_root.join("workspace")
+}
+
+pub fn habitat_codex_home(habitat_root: &std::path::Path) -> std::path::PathBuf {
+    habitat_root.join(".codex")
 }
 
 pub fn resolve_system_include_directories(class_name: &str, session_id: &str) -> Vec<String> {
@@ -27,6 +60,260 @@ pub fn resolve_system_include_directories(class_name: &str, session_id: &str) ->
         }
     }
     dirs
+}
+
+fn prepare_habitat_workspace(
+    workspace_root: &std::path::Path,
+    class_name: &str,
+    session_id: Option<&str>,
+) -> Result<std::path::PathBuf, String> {
+    let wardian_home = get_wardian_home().ok_or("Could not find Wardian home")?;
+    let habitat_root = if let Some(session_id) = session_id.filter(|sid| !sid.trim().is_empty()) {
+        wardian_home.join("agents").join(session_id).join("habitat")
+    } else {
+        wardian_home
+            .join("runtime")
+            .join("bootstrap")
+            .join(uuid::Uuid::new_v4().to_string())
+            .join("habitat")
+    };
+
+    std::fs::create_dir_all(&habitat_root).map_err(|e| e.to_string())?;
+
+    write_habitat_instruction_files(&wardian_home, &habitat_root, class_name, session_id)?;
+    build_habitat_skill_projection(&wardian_home, &habitat_root, class_name, session_id)?;
+
+    let workspace_link = habitat_root.join("workspace");
+    if workspace_link.exists() {
+        let _ = std::fs::remove_dir_all(&workspace_link).or_else(|_| std::fs::remove_dir(&workspace_link));
+    }
+    create_directory_link(workspace_root, &workspace_link)?;
+    if !workspace_link.exists() {
+        return Err(format!(
+            "Failed to create habitat workspace link from {} to {}",
+            workspace_link.to_string_lossy(),
+            workspace_root.to_string_lossy()
+        ));
+    }
+
+    Ok(habitat_root)
+}
+
+fn ensure_codex_home_projection(habitat_root: &std::path::Path) -> Result<(), String> {
+    let real_codex_home = dirs::home_dir()
+        .ok_or("Could not find user home directory")?
+        .join(".codex");
+    let projected_home = habitat_codex_home(habitat_root);
+    std::fs::create_dir_all(&projected_home).map_err(|e| e.to_string())?;
+
+    if real_codex_home.exists() {
+        let entries = std::fs::read_dir(&real_codex_home).map_err(|e| e.to_string())?;
+        for entry in entries.flatten() {
+            let source = entry.path();
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str == "skills" {
+                continue;
+            }
+
+            let target = projected_home.join(&name);
+            if source.is_dir() {
+                if target.exists() || target.symlink_metadata().is_ok() {
+                    continue;
+                }
+                create_directory_link(&source, &target)?;
+            } else if source.is_file() {
+                project_file(&source, &target)?;
+            }
+        }
+    }
+
+    let projected_skills = projected_home.join("skills");
+    if projected_skills.exists() {
+        let _ = std::fs::remove_dir_all(&projected_skills);
+    }
+    std::fs::create_dir_all(&projected_skills).map_err(|e| e.to_string())?;
+
+    let native_skills = real_codex_home.join("skills");
+    if native_skills.exists() {
+        let entries = std::fs::read_dir(&native_skills).map_err(|e| e.to_string())?;
+        for entry in entries.flatten() {
+            let source = entry.path();
+            let name = entry.file_name();
+            let target = projected_skills.join(&name);
+            if source.is_dir() {
+                create_directory_link(&source, &target)?;
+            } else if source.is_file() {
+                project_file(&source, &target)?;
+            }
+        }
+    }
+
+    let wardian_skills = habitat_root.join(".agents").join("skills");
+    if wardian_skills.exists() {
+        let entries = std::fs::read_dir(&wardian_skills).map_err(|e| e.to_string())?;
+        for entry in entries.flatten() {
+            let source = entry.path();
+            if !source.is_dir() {
+                continue;
+            }
+            let target = projected_skills.join(entry.file_name());
+            if target.exists() || target.symlink_metadata().is_ok() {
+                let _ = std::fs::remove_dir_all(&target).or_else(|_| std::fs::remove_file(&target));
+            }
+            create_directory_link(&source, &target)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_habitat_instruction_files(
+    wardian_home: &std::path::Path,
+    habitat_root: &std::path::Path,
+    class_name: &str,
+    session_id: Option<&str>,
+) -> Result<(), String> {
+    let common_agents = wardian_home.join("common").join("AGENTS.md");
+    let class_agents = wardian_home.join("classes").join(class_name).join("AGENTS.md");
+    let agent_agents = session_id
+        .filter(|sid| !sid.trim().is_empty())
+        .map(|sid| wardian_home.join("agents").join(sid).join("AGENTS.md"));
+
+    let mut sections = Vec::new();
+    let mut candidates = vec![("Common", common_agents), ("Class", class_agents)];
+    if let Some(agent_agents) = agent_agents {
+        candidates.push(("Agent", agent_agents));
+    }
+    for (label, path) in candidates {
+        if path.exists() {
+            if let Ok(content) = std::fs::read_to_string(&path) {
+                if !content.trim().is_empty() {
+                    sections.push(format!(
+                        "## {label}\nSource: {}\n\n{}\n",
+                        path.to_string_lossy(),
+                        content.trim()
+                    ));
+                }
+            }
+        }
+    }
+
+    let agents_md = if sections.is_empty() {
+        "# Wardian Habitat\n\nThis projected workspace has no additional Wardian instructions.\n".to_string()
+    } else {
+        format!(
+            "# Wardian Habitat\n\nThis file is generated by Wardian to project shared instructions into the active workspace scope.\n\n{}\n",
+            sections.join("\n")
+        )
+    };
+    std::fs::write(habitat_root.join("AGENTS.md"), agents_md).map_err(|e| e.to_string())?;
+
+    for stub_name in ["GEMINI.md", "CLAUDE.md"] {
+        std::fs::write(habitat_root.join(stub_name), "@AGENTS.md\n").map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
+fn build_habitat_skill_projection(
+    wardian_home: &std::path::Path,
+    habitat_root: &std::path::Path,
+    class_name: &str,
+    session_id: Option<&str>,
+) -> Result<(), String> {
+    let merged_skills = habitat_root.join(".agents").join("skills");
+    if merged_skills.exists() {
+        let _ = std::fs::remove_dir_all(&merged_skills);
+    }
+    std::fs::create_dir_all(&merged_skills).map_err(|e| e.to_string())?;
+
+    let mut sources = vec![
+        wardian_home.join("common").join(".agents").join("skills"),
+        wardian_home.join("classes").join(class_name).join(".agents").join("skills"),
+    ];
+    if let Some(session_id) = session_id.filter(|sid| !sid.trim().is_empty()) {
+        sources.push(
+            wardian_home
+                .join("agents")
+                .join(session_id)
+                .join(".agents")
+                .join("skills"),
+        );
+    }
+
+    for source in sources {
+        if !source.exists() {
+            continue;
+        }
+        let entries = match std::fs::read_dir(&source) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let skill_src = entry.path();
+            if !skill_src.is_dir() {
+                continue;
+            }
+            let skill_name = entry.file_name();
+            let skill_dst = merged_skills.join(skill_name);
+            if skill_dst.exists() {
+                let _ = std::fs::remove_dir_all(&skill_dst).or_else(|_| std::fs::remove_dir(&skill_dst));
+            }
+            create_directory_link(&skill_src, &skill_dst)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn create_directory_link(target: &std::path::Path, link: &std::path::Path) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        if let Some(parent) = link.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let command = format!(
+            "mklink /J \"{}\" \"{}\"",
+            link.to_string_lossy(),
+            target.to_string_lossy()
+        );
+        let output = std::process::Command::new("cmd")
+            .raw_arg("/c")
+            .raw_arg(&command)
+            .output()
+            .map_err(|e| e.to_string())?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Err(format!(
+                "Failed to create junction {} -> {}. {}{}",
+                link.to_string_lossy(),
+                target.to_string_lossy(),
+                stdout,
+                if stderr.is_empty() { String::new() } else { format!(" {}", stderr) }
+            ))
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        std::os::unix::fs::symlink(target, link).map_err(|e| e.to_string())
+    }
+}
+
+fn project_file(source: &std::path::Path, target: &std::path::Path) -> Result<(), String> {
+    if target.exists() {
+        let _ = std::fs::remove_file(target);
+    }
+
+    match std::fs::hard_link(source, target) {
+        Ok(_) => Ok(()),
+        Err(_) => std::fs::copy(source, target)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+    }
 }
 
 /// Ensures `.claude/skills` is a symlink (or junction on Windows) pointing to
@@ -59,19 +346,7 @@ pub fn ensure_claude_skills_link(base_dir: &std::path::Path) {
     let _ = std::fs::create_dir_all(base_dir.join(".claude"));
 
     // Create the symlink/junction
-    #[cfg(windows)]
-    {
-        // Use a junction (no elevated privileges required, unlike symlinks)
-        let _ = std::process::Command::new("cmd")
-            .args(["/c", "mklink", "/J"])
-            .arg(&link)
-            .arg(&canonical)
-            .output();
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = std::os::unix::fs::symlink(&canonical, &link);
-    }
+    let _ = create_directory_link(&canonical, &link);
 }
 
 pub fn validate_directory_path(path: &str) -> bool {

--- a/src/components/AdvancedSettings.tsx
+++ b/src/components/AdvancedSettings.tsx
@@ -43,7 +43,7 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                       <input type="checkbox" checked={config.debug || false} onChange={e => updateField("debug", e.target.checked)} className="accent-[var(--color-wardian-accent)]" />
                       Debug Mode
                   </label>
-                  {(!config.provider || config.provider === 'gemini') && (
+                  {config.provider === 'gemini' && (
                     <>
                       <label className="flex items-center gap-2 text-xs text-muted-neutral">
                           <input type="checkbox" checked={config.sandbox || false} onChange={e => updateField("sandbox", e.target.checked)} className="accent-[var(--color-wardian-accent)]" />
@@ -69,7 +69,7 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                   <label className="block text-[10px] font-bold text-muted-neutral mb-1">Model Override</label>
                   <input
                   className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
-                  placeholder="e.g. gemini-2.5-flash / claude-3-7-sonnet"
+                  placeholder="e.g. gemini-2.5-flash / claude-3-7-sonnet / gpt-5.4"
                   value={config.model || ""}
                   onChange={(e) => updateField("model", e.target.value || undefined)}
                   />
@@ -152,7 +152,7 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                 </>
               )}
 
-              {(!config.provider || config.provider === 'gemini') && (
+              {config.provider === 'gemini' && (
                 <>
                   <div>
                       <label className="block text-[10px] font-bold text-muted-neutral mb-1">Approval Mode</label>
@@ -202,6 +202,68 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                           <option value="json">JSON</option>
                           <option value="stream-json">Stream JSON</option>
                       </select>
+                  </div>
+                </>
+              )}
+
+              {config.provider === 'codex' && (
+                <>
+                  <div>
+                      <label className="block text-[10px] font-bold text-muted-neutral mb-1">Sandbox Mode</label>
+                      <select
+                      className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
+                      value={config.codex_sandbox_mode || ""}
+                      onChange={(e) => updateField("codex_sandbox_mode", (e.target.value as AgentConfig["codex_sandbox_mode"]) || undefined)}
+                      >
+                          <option value="">(None - Inherit Default)</option>
+                          <option value="read-only">read-only</option>
+                          <option value="workspace-write">workspace-write</option>
+                          <option value="danger-full-access">danger-full-access</option>
+                      </select>
+                  </div>
+
+                  <div>
+                      <label className="block text-[10px] font-bold text-muted-neutral mb-1">Approval Policy</label>
+                      <select
+                      className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
+                      value={config.codex_approval_policy || ""}
+                      onChange={(e) => updateField("codex_approval_policy", (e.target.value as AgentConfig["codex_approval_policy"]) || undefined)}
+                      >
+                          <option value="">(None - Inherit Default)</option>
+                          <option value="untrusted">untrusted</option>
+                          <option value="on-failure">on-failure</option>
+                          <option value="on-request">on-request</option>
+                          <option value="never">never</option>
+                      </select>
+                  </div>
+
+                  <div>
+                      <label className="block text-[10px] font-bold text-muted-neutral mb-1">Profile</label>
+                      <input
+                      className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
+                      placeholder="e.g. wardian"
+                      value={config.codex_profile || ""}
+                      onChange={(e) => updateField("codex_profile", e.target.value || undefined)}
+                      />
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-2 mb-1">
+                    <label className="flex items-center gap-2 text-xs text-muted-neutral">
+                        <input type="checkbox" checked={config.codex_full_auto || false} onChange={e => updateField("codex_full_auto", e.target.checked)} className="accent-[var(--color-wardian-accent)]" />
+                        Full Auto
+                    </label>
+                    <label className="flex items-center gap-2 text-xs text-muted-neutral">
+                        <input type="checkbox" checked={config.codex_search || false} onChange={e => updateField("codex_search", e.target.checked)} className="accent-[var(--color-wardian-accent)]" />
+                        Search
+                    </label>
+                    <label className="flex items-center gap-2 text-xs text-muted-neutral">
+                        <input type="checkbox" checked={config.codex_skip_git_repo_check ?? true} onChange={e => updateField("codex_skip_git_repo_check", e.target.checked)} className="accent-[var(--color-wardian-accent)]" />
+                        Skip Git Check
+                    </label>
+                    <label className="flex items-center gap-2 text-xs text-muted-neutral">
+                        <input type="checkbox" checked={config.codex_ephemeral || false} onChange={e => updateField("codex_ephemeral", e.target.checked)} className="accent-[var(--color-wardian-accent)]" />
+                        Ephemeral
+                    </label>
                   </div>
                 </>
               )}

--- a/src/features/agents/ConfigureAgentPanel.tsx
+++ b/src/features/agents/ConfigureAgentPanel.tsx
@@ -132,9 +132,10 @@ export const ConfigureAgentPanel: React.FC<Props> = ({
             <select
               disabled
               className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] opacity-60 cursor-not-allowed transition-colors"
-              value={config.provider || "gemini"}
+              value={config.provider || "claude"}
               onChange={(e) => updateField("provider", e.target.value)}
             >
+              <option value="codex">Codex</option>
               <option value="gemini">Gemini</option>
               <option value="claude">Claude</option>
             </select>

--- a/src/features/agents/SpawnAgentPanel.tsx
+++ b/src/features/agents/SpawnAgentPanel.tsx
@@ -136,11 +136,12 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
           </label>
           <select
             className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
-            value={spawnAdvancedConfig.provider || "gemini"}
+            value={spawnAdvancedConfig.provider || "claude"}
             onChange={(e) => setSpawnAdvancedConfig(prev => ({ ...prev, provider: e.target.value }))}
           >
-            <option value="gemini">Gemini</option>
             <option value="claude">Claude</option>
+            <option value="codex">Codex</option>
+            <option value="gemini">Gemini</option>
           </select>
         </div>
         <div>

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -68,11 +68,13 @@ export const AgentTerminal = memo(function AgentTerminal({
     const term = xtermRef.current;
     const fitAddon = fitAddonRef.current;
     if (!term || !fitAddon || !terminalRef.current) return;
-    if (terminalRef.current.offsetParent === null) return;
+    const rect = terminalRef.current.getBoundingClientRect();
+    if (rect.width < 10 || rect.height < 10) return;
 
     try {
       fitAddon.fit();
       if (term.cols > 10 && term.rows > 3) {
+        term.refresh(0, Math.max(term.rows - 1, 0));
         if (forceInvoke) {
           invoke("resize_agent_terminal", { sessionId, cols: term.cols, rows: term.rows }).catch(() => {});
         }
@@ -135,7 +137,9 @@ export const AgentTerminal = memo(function AgentTerminal({
       const checkSizingAndStart = () => {
         if (!isMounted || !fitAddon || !term || pollStartedRef.current) return;
         const el = terminalRef.current;
-        if (!el || el.offsetParent === null || el.clientWidth < 10) return;
+        if (!el) return;
+        const rect = el.getBoundingClientRect();
+        if (rect.width < 10 || rect.height < 10) return;
         
         try {
           fitAddon.fit();
@@ -145,7 +149,6 @@ export const AgentTerminal = memo(function AgentTerminal({
             invoke("resize_agent_terminal", { sessionId, cols: term.cols, rows: term.rows })
               .then(() => { if (isMounted) requestAnimationFrame(pollPty); })
               .catch(() => { if (isMounted) requestAnimationFrame(pollPty); });
-            term.focus();
           }
         } catch { /* ignore */ }
       };
@@ -156,7 +159,6 @@ export const AgentTerminal = memo(function AgentTerminal({
 
       term.onData((data) => {
         if (data === '\x1b[I' || data === '\x1b[O') return;
-        term!.scrollToBottom();
         emit('terminal-input', { sessionId, input: data });
       });
 
@@ -178,6 +180,15 @@ export const AgentTerminal = memo(function AgentTerminal({
         }, 16);
       });
       resizeObserver.observe(terminalRef.current);
+      if (terminalRef.current.parentElement) {
+        resizeObserver.observe(terminalRef.current.parentElement);
+      }
+
+      const handleWindowResize = () => {
+        if (!isMounted) return;
+        requestAnimationFrame(() => performFit(true));
+      };
+      window.addEventListener("resize", handleWindowResize);
 
       let ptyResizeTimeout: ReturnType<typeof setTimeout> | null = null;
       let lastCols = term.cols;
@@ -200,6 +211,7 @@ export const AgentTerminal = memo(function AgentTerminal({
         pollStartedRef.current = false;
         if (resizeTimeout) clearTimeout(resizeTimeout);
         if (ptyResizeTimeout) clearTimeout(ptyResizeTimeout);
+        window.removeEventListener("resize", handleWindowResize);
         resizeObserver?.disconnect();
         terminalMap.delete(sessionId);
         fitAddonMap.delete(sessionId);
@@ -226,6 +238,8 @@ export const AgentTerminal = memo(function AgentTerminal({
       setTimeout(() => isMounted && performFit(true), 50),
       setTimeout(() => isMounted && performFit(true), 150),
       setTimeout(() => isMounted && performFit(true), 400),
+      setTimeout(() => isMounted && performFit(true), 900),
+      setTimeout(() => isMounted && performFit(true), 1500),
     ];
     return () => {
       isMounted = false;

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -22,6 +22,7 @@ const LIGHT_TERM_THEME = {
 
 const terminalMap = new Map<string, Terminal>();
 const fitAddonMap = new Map<string, FitAddon>();
+const IS_WINDOWS = navigator.userAgent.includes("Windows");
 
 export const AgentTerminal = memo(function AgentTerminal({ 
   sessionId, 
@@ -94,10 +95,12 @@ export const AgentTerminal = memo(function AgentTerminal({
     try {
       term = new Terminal({
         theme: termTheme,
-        fontFamily: 'monospace', fontSize: 14, cursorBlink: true, scrollback: 1000,
+        fontFamily: 'monospace', fontSize: 14, cursorBlink: true, scrollback: 5000,
         allowProposedApi: true,
         convertEol: true,
-        disableStdin: false
+        disableStdin: false,
+        reflowCursorLine: true,
+        windowsPty: IS_WINDOWS ? { backend: 'conpty', buildNumber: 22621 } : undefined,
       });
       if (term.options) {
         term.options.scrollOnUserInput = false;

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -11,7 +11,7 @@ import {
   getListsContainingAgent,
   getListsNotContainingAgent,
 } from "./watchlistUtils";
-import { deriveCurrentThought, getStatusColorClass } from "../../utils/statusUtils";
+import { deriveCurrentThought, getStatusColorClass, getStatusLabel } from "../../utils/statusUtils";
 
 interface AgentWatchlistProps {
   agents: AgentConfig[];
@@ -344,7 +344,7 @@ export default function AgentWatchlist({
           {displayedAgents.map((agent) => {
             const agentId = agent.session_id;
             const isSelected = selectedAgentIds.has(agentId);
-            const { thought, status } = getAgentStatus(agentId);
+            const { status } = getAgentStatus(agentId);
             const statusColor = getStatusColorClass(status);
             const metrics = telemetry[agentId];
             const isDragTarget = dragOverAgentId === agentId && draggedAgentId !== null && draggedAgentId !== agentId;
@@ -447,7 +447,7 @@ export default function AgentWatchlist({
                   </p>
                 </div>
                 <span className={`text-[9px] truncate max-w-[60px] ${status === "Processing..." ? "text-[var(--color-wardian-accent)]" : status === "Action Needed" ? "text-wardian-warning" : "text-muted-neutral"}`}>
-                  {status === "Processing..." ? thought.substring(0, 12) : status === "Action Needed" ? "Action" : status === "Off" ? "Off" : "Idle"}
+                  {getStatusLabel(status)}
                 </span>
                 <span className="text-[9px] text-muted-neutral tabular-nums w-4 text-right">
                   {metrics?.query_count ?? "–"}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,15 @@ export interface AgentConfig {
     disallowed_tools?: string[];
     append_system_prompt?: string;
     mcp_config?: string;
+
+    // Codex-specific fields
+    codex_sandbox_mode?: "read-only" | "workspace-write" | "danger-full-access";
+    codex_approval_policy?: "untrusted" | "on-failure" | "on-request" | "never";
+    codex_profile?: string;
+    codex_full_auto?: boolean;
+    codex_search?: boolean;
+    codex_skip_git_repo_check?: boolean;
+    codex_ephemeral?: boolean;
 }
 
 export * from "./workflow";
@@ -41,6 +50,11 @@ export interface AgentOutputPayload {
 export interface AgentJsonEvent {
     session_id: string;
     data: any;
+}
+
+export interface AgentStatusUpdate {
+    session_id: string;
+    current_status: string;
 }
 
 export interface AgentTelemetry {

--- a/src/utils/statusUtils.test.ts
+++ b/src/utils/statusUtils.test.ts
@@ -5,6 +5,7 @@ import {
   deriveCurrentThought,
   classifyJsonEvent,
   getStatusColorClass,
+  getStatusLabel,
 } from "./statusUtils";
 import type { AgentTelemetry } from "../types";
 
@@ -32,15 +33,19 @@ describe("deriveEffectiveStatus", () => {
   });
 
   it("returns Processing when title contains Working", () => {
-    expect(deriveEffectiveStatus("Working on task", undefined, "Idle")).toBe("Processing...");
+    expect(deriveEffectiveStatus("Working on task", undefined, "Pending...")).toBe("Processing...");
   });
 
   it("returns Processing when title contains Executing", () => {
-    expect(deriveEffectiveStatus("Executing command", undefined, "Idle")).toBe("Processing...");
+    expect(deriveEffectiveStatus("Executing command", undefined, "Pending...")).toBe("Processing...");
   });
 
   it("returns Processing when title contains ✦ star", () => {
-    expect(deriveEffectiveStatus("✦ Running", undefined, "Idle")).toBe("Processing...");
+    expect(deriveEffectiveStatus("✦ Running", undefined, "Pending...")).toBe("Processing...");
+  });
+
+  it("does not let a stale Working title override backend Idle", () => {
+    expect(deriveEffectiveStatus("Working on task", undefined, "Idle")).toBe("Idle");
   });
 
   it("overrides to Processing when a live thought is present", () => {
@@ -121,7 +126,7 @@ describe("deriveCurrentThought", () => {
   });
 
   it("falls back to title when no live thought", () => {
-    const result = deriveCurrentThought("✦ Running tests", undefined, baseMetrics);
+    const result = deriveCurrentThought("✦ Running tests", undefined, { ...baseMetrics, current_status: "Pending..." });
     expect(result.thought).toBe("Running tests");
     expect(result.status).toBe("Processing...");
   });
@@ -260,6 +265,24 @@ describe("classifyJsonEvent", () => {
     expect(result).toEqual({ type: "progress", thought: "Responding..." });
   });
 
+  it("classifies Claude permission request as notification", () => {
+    const result = classifyJsonEvent({
+      type: "system",
+      subtype: "permission_request",
+      tool_name: "Bash",
+    });
+    expect(result).toEqual({ type: "notification", message: "Bash", level: "warning" });
+  });
+
+  it("classifies Claude turn duration as clear_thought", () => {
+    const result = classifyJsonEvent({
+      type: "system",
+      subtype: "turn_duration",
+      durationMs: 1234,
+    });
+    expect(result).toEqual({ type: "clear_thought" });
+  });
+
   it("classifies Claude result event as clear_thought", () => {
     expect(classifyJsonEvent({ type: "result", subtype: "success" })).toEqual({ type: "clear_thought" });
   });
@@ -325,5 +348,27 @@ describe("getStatusColorClass", () => {
 
   it("returns gray for unknown status", () => {
     expect(getStatusColorClass("Something Else")).toContain("bg-wardian-off");
+  });
+});
+
+describe("getStatusLabel", () => {
+  it("maps Processing to Working", () => {
+    expect(getStatusLabel("Processing...")).toBe("Working");
+  });
+
+  it("maps Action Needed to Action", () => {
+    expect(getStatusLabel("Action Needed")).toBe("Action");
+  });
+
+  it("maps Idle to Idle", () => {
+    expect(getStatusLabel("Idle")).toBe("Idle");
+  });
+
+  it("maps Off to Off", () => {
+    expect(getStatusLabel("Off")).toBe("Off");
+  });
+
+  it("maps unknown values to Pending", () => {
+    expect(getStatusLabel("Something Else")).toBe("Pending");
   });
 });

--- a/src/utils/statusUtils.test.ts
+++ b/src/utils/statusUtils.test.ts
@@ -263,6 +263,42 @@ describe("classifyJsonEvent", () => {
   it("classifies Claude result event as clear_thought", () => {
     expect(classifyJsonEvent({ type: "result", subtype: "success" })).toEqual({ type: "clear_thought" });
   });
+
+  it("classifies Codex turn.started as progress", () => {
+    expect(classifyJsonEvent({ type: "turn.started" })).toEqual({ type: "progress", thought: "Working..." });
+  });
+
+  it("classifies Codex turn.completed as clear_thought", () => {
+    expect(classifyJsonEvent({ type: "turn.completed" })).toEqual({ type: "clear_thought" });
+  });
+
+  it("classifies Codex agent_message payload as progress", () => {
+    expect(classifyJsonEvent({
+      type: "event_msg",
+      payload: { type: "agent_message", message: "Inspecting the repository now" },
+    })).toEqual({ type: "progress", thought: "Inspecting the repository now" });
+  });
+
+  it("classifies Codex exec command payload as progress", () => {
+    expect(classifyJsonEvent({
+      type: "event_msg",
+      payload: { type: "exec_command", command: "cargo test --all" },
+    })).toEqual({ type: "progress", thought: "cargo test --all" });
+  });
+
+  it("classifies Codex approval request as warning notification", () => {
+    expect(classifyJsonEvent({
+      type: "event_msg",
+      payload: { type: "exec_approval_request", command: "git status" },
+    })).toEqual({ type: "notification", message: "git status", level: "warning" });
+  });
+
+  it("classifies Codex task_complete as clear_thought", () => {
+    expect(classifyJsonEvent({
+      type: "event_msg",
+      payload: { type: "task_complete" },
+    })).toEqual({ type: "clear_thought" });
+  });
 });
 
 // ── getStatusColorClass ────────────────────────────────────────────────

--- a/src/utils/statusUtils.ts
+++ b/src/utils/statusUtils.ts
@@ -23,7 +23,9 @@ export function deriveEffectiveStatus(
       effectiveStatus = "Idle";
     }
   } else if (rawTitle.includes("Working") || rawTitle.includes("Executing") || rawTitle.includes("✦")) {
-    effectiveStatus = "Processing...";
+    if (effectiveStatus === "Pending...") {
+      effectiveStatus = "Processing...";
+    }
   }
 
   // A live thought signals activity, but must not override an explicit "Action Needed".
@@ -86,6 +88,21 @@ export function deriveCurrentThought(
   return { thought: currentThought, status: effectiveStatus };
 }
 
+export function getStatusLabel(status: string): "Idle" | "Working" | "Action" | "Pending" | "Off" {
+  switch (status) {
+    case "Processing...":
+      return "Working";
+    case "Action Needed":
+      return "Action";
+    case "Idle":
+      return "Idle";
+    case "Off":
+      return "Off";
+    default:
+      return "Pending";
+  }
+}
+
 /**
  * Classifies a JSON event from the agent stream for notification/state handling.
  */
@@ -122,6 +139,16 @@ export function classifyJsonEvent(data: Record<string, unknown>): JsonEventEffec
   // Claude + Gemini: user turn or result → clear thought
   if (data.type === "user" || data.type === "result") {
     return { type: "clear_thought" };
+  }
+  if (data.type === "system") {
+    const subtype = data.subtype as string | undefined;
+    if (subtype === "permission_request") {
+      const toolName = (data.tool_name as string) || "Tool approval required";
+      return { type: "notification", message: toolName, level: "warning" };
+    }
+    if (subtype === "turn_duration") {
+      return { type: "clear_thought" };
+    }
   }
   // Codex: top-level turn lifecycle
   if (data.type === "turn.started") {

--- a/src/utils/statusUtils.ts
+++ b/src/utils/statusUtils.ts
@@ -95,6 +95,12 @@ export type JsonEventEffect =
   | { type: "notification"; message: string; level: string }
   | { type: "none" };
 
+function truncateThought(raw: string, fallback: string): string {
+  const firstLine = raw.split("\n")[0].trim();
+  if (firstLine.length === 0) return fallback;
+  return firstLine.length > 50 ? firstLine.slice(0, 47) + "..." : firstLine;
+}
+
 export function classifyJsonEvent(data: Record<string, unknown>): JsonEventEffect {
   // Gemini: live progress thought
   if (data.type === "progress") {
@@ -111,15 +117,90 @@ export function classifyJsonEvent(data: Record<string, unknown>): JsonEventEffec
     const content = msg?.content as Array<Record<string, unknown>> | undefined;
     const textBlock = content?.find((c) => c.type === "text");
     const raw = (textBlock?.text as string) ?? "";
-    const firstLine = raw.split("\n")[0].trim();
-    const thought = firstLine.length > 0
-      ? (firstLine.length > 50 ? firstLine.slice(0, 47) + "..." : firstLine)
-      : "Responding...";
-    return { type: "progress", thought };
+    return { type: "progress", thought: truncateThought(raw, "Responding...") };
   }
   // Claude + Gemini: user turn or result → clear thought
   if (data.type === "user" || data.type === "result") {
     return { type: "clear_thought" };
+  }
+  // Codex: top-level turn lifecycle
+  if (data.type === "turn.started") {
+    return { type: "progress", thought: "Working..." };
+  }
+  if (data.type === "turn.completed" || data.type === "thread.started") {
+    return { type: "clear_thought" };
+  }
+  // Codex: completed items provide useful progress hints during active turns.
+  if (data.type === "item.completed") {
+    const item = data.item as Record<string, unknown> | undefined;
+    const itemType = item?.type as string | undefined;
+    if (itemType === "agent_message") {
+      return {
+        type: "progress",
+        thought: truncateThought((item?.text as string) || "", "Responding..."),
+      };
+    }
+    if (itemType === "exec_command") {
+      return {
+        type: "progress",
+        thought: truncateThought((item?.command as string) || "", "Running command..."),
+      };
+    }
+  }
+  // Codex: nested stream events carry the best action/progress signals.
+  if (data.type === "event_msg") {
+    const payload = data.payload as Record<string, unknown> | undefined;
+    const payloadType = payload?.type as string | undefined;
+
+    if (payloadType === "agent_message") {
+      const text =
+        (payload?.message as string) ||
+        (payload?.text as string) ||
+        "";
+      return { type: "progress", thought: truncateThought(text, "Responding...") };
+    }
+
+    if (payloadType === "exec_command" || payloadType === "exec_started") {
+      const command =
+        (payload?.command as string) ||
+        (payload?.raw_command as string) ||
+        "";
+      return { type: "progress", thought: truncateThought(command, "Running command...") };
+    }
+
+    if (payloadType === "user_message" || payloadType === "task_complete") {
+      return { type: "clear_thought" };
+    }
+
+    if (payloadType === "exec_approval_request") {
+      const command =
+        (payload?.command as string) ||
+        (payload?.raw_command as string) ||
+        "Command approval required";
+      return { type: "notification", message: command, level: "warning" };
+    }
+  }
+  if (data.type === "response_item") {
+    const payload = data.payload as Record<string, unknown> | undefined;
+    const payloadType = payload?.type as string | undefined;
+
+    if (payloadType === "function_call") {
+      const rawArguments = payload?.arguments as string | undefined;
+      if (rawArguments) {
+        try {
+          const parsedArguments = JSON.parse(rawArguments) as Record<string, unknown>;
+          if (parsedArguments.sandbox_permissions === "require_escalated") {
+            const message =
+              (parsedArguments.justification as string) ||
+              (parsedArguments.command as string) ||
+              "Approval required";
+            return { type: "notification", message, level: "warning" };
+          }
+        } catch {
+          return { type: "none" };
+        }
+      }
+    }
   }
   if (data.type === "alert" || (data.type !== "progress" && data.message)) {
     const message = (data.message as string) || JSON.stringify(data);

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -77,7 +77,6 @@ function AppBody() {
     setTerminalTitles(prev => ({ ...prev, [agentId]: title }));
   }, []);
   const [currentThoughts, setCurrentThoughts] = useState<Record<string, string>>({});
-  const [notifications, setNotifications] = useState<{ id: string; session_id: string; message: string; type: string }[]>([]);
   const [broadcastMessage, setBroadcastMessage] = useState("");
 
   const [activeTab, setActiveTab] = useState<SidebarTab>("agent-config");
@@ -260,15 +259,6 @@ function AppBody() {
         setCurrentThoughts(prev => ({ ...prev, [session_id]: effect.thought }));
       } else if (effect.type === "clear_thought") {
         setCurrentThoughts(prev => ({ ...prev, [session_id]: "" }));
-      } else if (effect.type === "notification") {
-        const id = Math.random().toString(36).substring(7);
-        setNotifications(prev => [{
-          id,
-          session_id,
-          message: effect.message,
-          type: effect.level
-        }, ...prev]);
-        setTimeout(() => setNotifications(prev => prev.filter(n => n.id !== id)), 10000);
       }
     });
     const unlistenUpdate = listen("agents-updated", () => fetchAgents());
@@ -292,6 +282,9 @@ function AppBody() {
     });
     const unlistenStatus = listen<AgentStatusUpdate>("agent-status-updated", (event) => {
       const { session_id, current_status } = event.payload;
+      if (current_status === "Idle" || current_status === "Off" || current_status === "Action Needed") {
+        setCurrentThoughts(prev => ({ ...prev, [session_id]: "" }));
+      }
       setTelemetry(prev => ({
         ...prev,
         [session_id]: {
@@ -419,22 +412,6 @@ function AppBody() {
             className="flex-1 overflow-y-auto p-2 flex flex-col"
             onClick={() => { setSelectedAgentIds(new Set()); lastSelectedIdRef.current = null; }}
           >
-            {notifications.length > 0 && (
-              <div className="fixed top-[calc(var(--topbar-height)+0.5rem)] right-[calc(var(--sidebar-secondary-width)+2rem)] z-50 flex flex-col gap-2 max-w-md pointer-events-none">
-                {notifications.map(n => (
-                  <div key={n.id} className="bg-wardian-card border-l-4 border-wardian-accent p-4 shadow-2xl animate-in slide-in-from-right rounded-r pointer-events-auto">
-                    <div className="flex justify-between items-start gap-4">
-                      <div>
-                        <p className="text-xs font-bold text-wardian-accent mb-1">{agents.find(a => a.session_id === n.session_id)?.session_name || "Unknown Agent"}</p>
-                        <p className="text-sm text-primary">{n.message}</p>
-                      </div>
-                      <button onClick={() => setNotifications(prev => prev.filter(notif => notif.id !== n.id))} className="text-muted hover:text-primary">&times;</button>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
             {viewMode === "workflow-builder" && (
               <div className="flex-1 min-h-0 bg-wardian-bg">
                 <WorkflowBuilderView theme={theme} />

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { AgentConfig, AgentJsonEvent, AgentTelemetry, AgentClassDefinition } from "../types";
+import { AgentConfig, AgentJsonEvent, AgentTelemetry, AgentClassDefinition, AgentStatusUpdate } from "../types";
 import "../styles/App.css";
 
 import AgentWatchlist from "../layout/watchlist/AgentWatchlist";
-import { deriveCurrentThought, getStatusColorClass } from "../utils/statusUtils";
+import { classifyJsonEvent, deriveCurrentThought, getStatusColorClass } from "../utils/statusUtils";
 import { getAgentsForList } from "../layout/watchlist/watchlistUtils";
 import type { Watchlist } from "../layout/watchlist/types";
 
@@ -255,19 +255,18 @@ function AppBody() {
     fetchAgentClasses();
     const unlistenJson = listen<AgentJsonEvent>("agent-json-event", (event) => {
       const { session_id, data } = event.payload;
-      if (data.type === "progress") {
-        const thought = data.content || data.message || "Working...";
-        setCurrentThoughts(prev => ({ ...prev, [session_id]: thought }));
-      } else if (["gemini", "model", "user", "info"].includes(data.type)) {
+      const effect = classifyJsonEvent(data as Record<string, unknown>);
+      if (effect.type === "progress") {
+        setCurrentThoughts(prev => ({ ...prev, [session_id]: effect.thought }));
+      } else if (effect.type === "clear_thought") {
         setCurrentThoughts(prev => ({ ...prev, [session_id]: "" }));
-      }
-      if (data.type === "alert" || (data.type !== "progress" && data.message)) {
+      } else if (effect.type === "notification") {
         const id = Math.random().toString(36).substring(7);
         setNotifications(prev => [{
           id,
           session_id,
-          message: data.message || JSON.stringify(data),
-          type: data.level || "info"
+          message: effect.message,
+          type: effect.level
         }, ...prev]);
         setTimeout(() => setNotifications(prev => prev.filter(n => n.id !== id)), 10000);
       }
@@ -283,9 +282,34 @@ function AppBody() {
     const unlistenMetrics = listen<AgentTelemetry[]>('agent-metrics', (event) => {
       const mapping: Record<string, AgentTelemetry> = {};
       for (const m of event.payload) mapping[m.session_id] = m;
-      setTelemetry(mapping);
+      setTelemetry(prev => {
+        const next = { ...prev };
+        for (const [sessionId, metric] of Object.entries(mapping)) {
+          next[sessionId] = metric;
+        }
+        return next;
+      });
     });
-    return () => { unlistenMetrics.then(fn => fn()); };
+    const unlistenStatus = listen<AgentStatusUpdate>("agent-status-updated", (event) => {
+      const { session_id, current_status } = event.payload;
+      setTelemetry(prev => ({
+        ...prev,
+        [session_id]: {
+          session_id,
+          cpu_usage: prev[session_id]?.cpu_usage ?? 0,
+          memory_mb: prev[session_id]?.memory_mb ?? 0,
+          uptime_seconds: prev[session_id]?.uptime_seconds ?? 0,
+          query_count: prev[session_id]?.query_count ?? 0,
+          init_timestamp: prev[session_id]?.init_timestamp ?? null,
+          current_status,
+          log_path: prev[session_id]?.log_path ?? null,
+        },
+      }));
+    });
+    return () => {
+      unlistenMetrics.then(fn => fn());
+      unlistenStatus.then(fn => fn());
+    };
   }, []);
 
   async function sendCommand(sessionId: string, cmd: string) {


### PR DESCRIPTION
## Description
Adds Codex as a backend provider, projects Wardian instructions/skills into a provider habitat for Codex, and stabilizes live agent status handling across Codex and Claude. This also switches Claude approval detection to a real PermissionRequest hook path, standardizes compact status labels in the UI, and disables noisy top-right alert popups for now.

## Related Issues
Fixes #66 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm run lint`
- `npm run test`
- `npm run build`

Notes:
- `npm run test` still prints the existing React `act(...)` warning in `src/views/App.test.tsx`, but the suite passes.
- `npm run build` still prints the existing Vite chunk-size warning, but the build succeeds.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
