### PR TITLE
docs(workflows): add workflow documentation hub

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -8,6 +8,7 @@ Wardian is built as a **High-Performance Hybrid Environment**, using **Rust (Tau
 - **Source of Truth**: The Rust backend is the definitive authority on all agent sessions, PTY states, and telemetry.
 - **PTY Management**: Uses `portable-pty` for cross-platform PTY handles. On Windows, it leverages `win32job` to ensure child processes are strictly terminated when the agent session ends.
 - **Provider Adapters**: Agent CLIs are integrated behind a Rust provider layer so session spawn, headless execution, and telemetry enrichment can support Gemini, Claude, and Codex without rewriting the rest of the backend.
+  See [Provider Runtime Notes](./provider-runtimes.md) for the provider-specific working-root, skill, and session rules that sit behind this abstraction.
 - **Habitat Projection**: For providers that cannot natively discover Wardian instructions and skills from external include roots, the backend materializes a neutral per-session `habitat` directory. That habitat links the real workspace, projects a scoped `AGENTS.md`, and exposes provider-native skill layouts without mutating the user repository.
 - **State Management**: `AppState` holds `Mutex`-protected maps of active agents, metrics, and background triggers.
 - **Worker Threads**:

--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -1,0 +1,144 @@
+# Provider Runtime Notes
+
+This document captures the practical runtime differences between Wardian's three supported CLI providers: Gemini, Claude, and Codex. It is intended for maintainers working on spawn, resume, workflow execution, skill projection, and status/approval handling.
+
+## Shared Wardian Invariants
+
+- The Rust backend remains the source of truth for provider process lifecycle, session IDs, PTY ownership, and status telemetry.
+- Every provider receives Wardian's `system_include_directories`, which are resolved from `common`, `classes/<class>`, and `agents/<session_id>`.
+- Headless execution and interactive execution use the same provider-specific assumptions where possible. Differences should stay explicit in `manager.rs` instead of being hidden in frontend state.
+- Provider-native instruction discovery matters more than Wardian's abstract model. The backend adapts Wardian's files and directories to each CLI instead of expecting the CLI to understand Wardian directly.
+
+## Quick Comparison
+
+| Provider | Working root | Instruction file | Skill model | Session identity |
+| --- | --- | --- | --- | --- |
+| Gemini | Real target workspace | `GEMINI.md` | Patched CLI can discover skills from include directories | Discovered from provider output |
+| Claude | Real target workspace | `CLAUDE.md` | `.claude/skills` points at Wardian's `.agents/skills` | Wardian assigns `--session-id` up front |
+| Codex | Real target workspace via `--cd` | `AGENTS.md` | Per-agent `CODEX_HOME/skills` under habitat | Discovered from provider output, then adopted |
+
+## Gemini
+
+### Working-root model
+
+Gemini runs directly in the real target workspace. Wardian does not project a habitat workspace for Gemini.
+
+### Instruction and skill discovery
+
+- Gemini reads `GEMINI.md`.
+- Wardian passes include roots through `--include-directories`.
+- Skill discovery depends on Wardian's Gemini patching flow; see [Gemini CLI Patches](./gemini-cli-patches.md).
+- If Gemini stops seeing Wardian-managed skills, check the patched CLI bundle before changing spawn logic.
+
+### Session and telemetry behavior
+
+- Gemini session identity is learned from provider output rather than assigned before launch.
+- Wardian parses Gemini JSON events into `Init`, `UserQuery`, `Generating`, and `TurnCompleted` states.
+
+### Practical implications
+
+- Gemini is the least habitat-dependent provider.
+- Regressions here are usually about CLI patch drift, include-directory handling, or event parsing, not workspace projection.
+
+## Claude
+
+### Working-root model
+
+Claude also runs directly in the real target workspace. Wardian does not use a projected workspace for Claude.
+
+### Session identity
+
+- Fresh Claude spawns use an explicit Wardian-generated `--session-id`.
+- This avoids a bootstrap phase just to discover the provider session ID.
+- Resume launches use `--resume <session_id>` and do not resend `--session-id` or `--name`.
+
+### Instruction and skill discovery
+
+- Claude reads `CLAUDE.md`.
+- Wardian enables `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1` so Claude can discover instruction files from `--add-dir` roots.
+- Wardian also maintains `.claude/skills -> .agents/skills` links where needed so provider-native skill discovery still works.
+
+### Approval handling
+
+- Claude permission requests are surfaced through a generated hook under `.wardian/agents/<session_id>/claude/`.
+- The hook writes permission request events to a JSONL file that Wardian watches.
+- If Claude appears stuck in approval state, inspect the hook output before changing status code.
+
+### Practical implications
+
+- Claude depends heavily on the permission-hook path being writable and stable.
+- Bugs here are usually about hook setup, `CLAUDE.md` discovery, or resume/session flags.
+
+## Codex
+
+### Working-root model
+
+Codex must run with the real project workspace as its effective working root. Wardian now enforces this by passing `--cd <real workspace>` for interactive spawn, headless resume, and bootstrap session creation.
+
+Wardian still keeps Codex state in a per-agent habitat:
+
+- final agent home: `.wardian/agents/<provider_session_id>/habitat/.codex`
+- temporary bootstrap home: `.wardian/provider-bootstrap/codex/session-*/.codex`
+
+The critical rule is: **trust should bind to the real workspace, not to the bootstrap directory or habitat path**.
+
+### Skill discovery model
+
+Codex does not treat `--add-dir` as a skill-discovery mechanism. Wardian therefore projects assigned skills into the agent-specific `CODEX_HOME/skills` tree.
+
+Current model:
+
+- shared Codex files copied into each agent home:
+  - `auth.json`
+  - `config.toml`
+  - `cap_sid`
+- Codex system skills remain under `CODEX_HOME/skills/.system`
+- Wardian-assigned skills are projected into `CODEX_HOME/skills/<skill-name>`
+
+This preserves per-agent skill scope without forcing the project repo itself to hold agent-specific skill directories.
+
+### Session identity and bootstrap
+
+Codex session IDs are still discovered from provider output, so fresh session creation has a bootstrap phase.
+
+Current sequence:
+
+1. Create a temporary bootstrap `CODEX_HOME` under `.wardian/provider-bootstrap/codex/session-*/.codex`.
+2. Seed it with shared Codex auth/trust files.
+3. Launch Codex with the real workspace as `--cd`.
+4. Parse `thread.started` to get the provider session ID.
+5. Create the final habitat at `.wardian/agents/<provider_session_id>/habitat/.codex`.
+6. Migrate session artifacts from the bootstrap home into the final agent home.
+
+If Codex starts asking for trust every launch again, first verify that the session was born with the real workspace as `cwd`, not the bootstrap path.
+
+### Approval and status handling
+
+Codex emits several different event shapes across live PTY output and persisted session logs.
+
+Wardian treats these as the important lifecycle markers:
+
+- `thread.started`: session identity available
+- `turn.started`: processing begins
+- `exec_approval_request` or escalated `function_call`: action required
+- `exec_command_begin`, `exec_command_start`, `function_call_output`: processing resumes after approval
+- `task_complete` / `turn.completed`: idle
+
+Codex commentary events like `agent_message` should not be used as hard status transitions.
+
+### Known operational edge cases
+
+- Codex skill discovery can be correct while shell execution is still blocked by the CLI sandbox. In that case, the agent sees the skill but fails when the skill tries to invoke shell tools.
+- On Windows, those failures may surface as `CreateProcessAsUserW failed: 5` or setup-helper launch errors.
+- When debugging Codex, separate these questions explicitly:
+  - Did Codex discover the skill?
+  - Did Codex trust the workspace?
+  - Did Codex succeed in spawning a shell command under its sandbox?
+
+## Choosing Where to Debug
+
+When provider behavior breaks, start with the provider-specific seam instead of the generic agent UI.
+
+- Gemini problems: inspect patching, include directories, and JSON event parsing.
+- Claude problems: inspect `CLAUDE.md` discovery, permission hooks, and explicit session flags.
+- Codex problems: inspect `CODEX_HOME`, `--cd`, bootstrap migration, and sandbox approval transitions.

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -1,36 +1,41 @@
-# Visual Workflows
+# Workflow View
 
-Wardian includes a deterministic, event-driven execution engine that allows you to automate complex multi-agent sequences through a visual node-based canvas.
+The Workflow view is Wardian's canvas for building and testing automations.
 
-## 🧱 Core Concepts
+Use this page as a quick manual for the view itself. For the full workflow reference, start at [Workflows](../workflows/index.md).
 
-### 1. The Canvas
-The Workflow view provides a grid-based workspace where you can drag and drop functional "Nodes" and connect them with "Edges" to define the flow of execution.
+## What You Can Do Here
 
-### 2. Node Types
-- **Agent Node**: Injects a prompt into a live agent session or runs a headless command.
-- **Logic Node**: Branches the flow based on a condition (e.g., "If the test passed, continue").
-- **Loop Node**: Repeats a sequence of actions a specific number of times or until a condition is met.
-- **Trigger Node**: The entry point for the workflow (e.g., a Cron schedule or File Watcher).
+- open an existing workflow
+- create a new workflow
+- add nodes from the block library
+- wire nodes together on the canvas
+- edit node settings
+- save changes
+- launch the workflow according to its trigger type
 
-### 3. Execution (The Pulse Model)
-Wardian uses a unique "Pulse" model for execution. A node only triggers when it has received an unconsumed pulse from all of its upstream dependencies. This allows for complex cycles and loops that are impossible in traditional DAG engines.
+## Main Areas
 
-## 🚀 Creating a Workflow
+- **Top action bar**: select, save, reset, duplicate, delete, or run the active workflow
+- **Canvas**: place and connect nodes
+- **Block Library**: add new blocks to the workflow
+- **Node Settings drawer**: edit the selected node
+- **Variable Assistant**: inspect upstream values and interpolation paths
 
-1. Click **WORKFLOWS** in the top bar.
-2. Drag nodes from the **Workflow Library** sidebar onto the canvas.
-3. Connect the output port of one node to the input port of another.
-4. **Configure Node**: Click a node to open its settings (e.g., selecting the target agent or writing the prompt).
-5. **Save & Run**: Click the **Run** button in the top header to execute the sequence manually.
+## Running From This View
 
-## 🕰️ Automation & Triggers
+The **Run Workflow** button saves the current canvas first, then launches based on the workflow's trigger:
 
-You can automate your workflows using built-in triggers:
-- **Cron**: Schedule workflows to run at specific times (e.g., `0 0 * * *` for every midnight).
-- **File Watcher**: Trigger a workflow whenever a file in your project changes (perfect for auto-testing).
+- manual workflows run immediately
+- scheduled workflows create scheduled task instances
+- file-watcher or webhook-style workflows activate as live listeners
 
-Scheduled tasks now appear in the workflow sidebar as interactive cards. Click a scheduled task card to pause or resume it instantly. Use the details affordance on the right side of the card to inspect the schedule, run it immediately, open the workflow in the builder, or delete the schedule.
+If the workflow needs agent assignment or manual input parameters, Wardian opens the run modal before launching.
 
-## 📊 Monitoring
-During execution, nodes will change color to indicate their status (Processing, Success, or Error). You can monitor the real-time registry values to see the data being passed between nodes.
+## Where to Learn More
+
+- [Workflows](../workflows/index.md)
+- [Building Workflows](../workflows/building-workflows.md)
+- [Triggers](../workflows/triggers.md)
+- [Scheduled Runs](../workflows/scheduled-runs.md)
+- [Node Reference](../workflows/node-reference.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ Wardian provides a professional-grade interface for managing, monitoring, and au
 Whether you are a user looking to manage your daily agent operations or a developer looking to extend the ecosystem, we have you covered:
 
 - **[User Guide](./guide/getting-started.md)**: Install Wardian, spawn your first agent, and learn the UI.
+- **[Workflows](./workflows/index.md)**: Learn how to build, launch, schedule, assign, and troubleshoot workflows.
 - **[Developer Docs](./developer/architecture.md)**: Explore the Rust backend, PTY lifecycle, and state management.
 - **[Provider Runtime Notes](./developer/provider-runtimes.md)**: Understand the Gemini, Claude, and Codex runtime differences Wardian has to manage.
 - **[Agent Roles](./agents/roles.md)**: Understand the specialized missions of Architect, Coder, and more.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Whether you are a user looking to manage your daily agent operations or a develo
 
 - **[User Guide](./guide/getting-started.md)**: Install Wardian, spawn your first agent, and learn the UI.
 - **[Developer Docs](./developer/architecture.md)**: Explore the Rust backend, PTY lifecycle, and state management.
+- **[Provider Runtime Notes](./developer/provider-runtimes.md)**: Understand the Gemini, Claude, and Codex runtime differences Wardian has to manage.
 - **[Agent Roles](./agents/roles.md)**: Understand the specialized missions of Architect, Coder, and more.
 
 ## 🏛️ Architecture & Governance

--- a/docs/workflows/agent-assignment.md
+++ b/docs/workflows/agent-assignment.md
@@ -1,0 +1,89 @@
+# Agent Assignment
+
+Workflows can target specific agents directly or ask you to assign agents at launch time.
+
+The assignment model is built around **roles**.
+
+## Roles vs Direct Agent IDs
+
+An Agent node can target work in two different ways:
+
+- **Direct agent ID**: the workflow is already tied to a specific agent
+- **Role mapping**: the workflow defines a role name, and you choose which live agent should fill that role when you launch it
+
+Wardian normalizes agent roles before launch so a workflow can be reused without hardcoding the same session ID forever.
+
+## When the Run Modal Appears
+
+The run modal appears when the workflow needs launch-time configuration.
+
+Common reasons:
+
+- at least one Agent node needs assignment
+- the Manual Trigger defines an input schema
+- a scheduled workflow needs both assignment and schedule creation in the same launch flow
+
+The modal can show two sections:
+
+- **Agent Assignments**
+- **Input Parameters**
+
+If neither section is needed, Wardian skips the modal and launches directly.
+
+## What the Assignment Section Shows
+
+For each agent role, the modal shows:
+
+- the node name from the workflow graph
+- the internal role key
+- a selector for the target live agent
+
+This lets one workflow template be reused across different agent rosters or different scheduled instances.
+
+## Persistent vs Temporary Agent Nodes
+
+Agent nodes support two user-facing modes in the builder:
+
+- **Persistent**: target a real agent session that already exists
+- **Temporary**: choose an agent class and workspace so Wardian can execute against a temporary agent context
+
+From a user perspective, the important difference is that persistent mode is about targeting an existing agent, while temporary mode is about launching work from a class-based configuration.
+
+## Off Agents and Headless Execution
+
+If a target agent is off, Wardian can still execute the workflow through headless provider logic instead of requiring the terminal to be visibly open.
+
+What users should expect:
+
+- the workflow still attempts to run if the provider supports headless execution
+- role mappings still matter even if the target agent is not currently open in a visible terminal
+- provider-specific quirks can affect the outcome, especially for structured output or approvals
+
+## Scheduled Assignment
+
+When you create a scheduled task, the chosen role mappings become part of that scheduled instance.
+
+That is why:
+
+- multiple schedules of the same workflow can target different agents
+- the sidebar can summarize the target for each schedule separately
+- deleting a scheduled task does not change the workflow template itself
+
+## Practical Guidance
+
+Use **roles** when:
+
+- the workflow should be reusable
+- different teams or classes may fill the same responsibility
+- you expect to create multiple scheduled variants
+
+Use **direct agent targeting** when:
+
+- the workflow truly belongs to one specific long-lived agent
+- reusability is not important for that automation
+
+## Related References
+
+- [Triggers](./triggers.md)
+- [Scheduled Runs](./scheduled-runs.md)
+- [Provider Runtime Notes](../developer/provider-runtimes.md)

--- a/docs/workflows/building-workflows.md
+++ b/docs/workflows/building-workflows.md
@@ -1,0 +1,91 @@
+# Building Workflows
+
+Use the Workflow Builder when you want to create, edit, or test workflow logic directly on the canvas.
+
+## Builder Layout
+
+The Workflow view is made of four main working areas:
+
+- **Workflow selector and action bar**: choose a saved workflow, create a new one, save changes, reset, duplicate, delete, or run.
+- **Canvas**: place nodes and draw connections between them.
+- **Block Library**: add new nodes to the graph.
+- **Node Settings drawer**: configure the currently selected node.
+
+The builder also includes the **Variable Assistant**, which shows upstream values you can interpolate into prompts, conditions, paths, and commands.
+
+## Basic Authoring Flow
+
+1. Create or open a workflow.
+2. Add nodes from the Block Library.
+3. Connect outputs to downstream inputs.
+4. Configure each node in the right-side settings drawer.
+5. Save changes.
+6. Run the workflow or activate its trigger behavior.
+
+## Working With Nodes
+
+When you click a node, Wardian opens the node settings drawer. That drawer shows the fields for the selected block type and hides fields that do not apply to the current mode.
+
+Examples:
+
+- Scheduled Trigger shows different fields depending on whether you pick `Minutes`, `Hours`, `Daily`, `Weekly`, or `One-Time`.
+- Agent shows different targeting fields depending on whether the session type is `persistent` or `temporary`.
+- Loop shows different fields for `count` versus `conditional` mode.
+
+## Connections and Flow
+
+Nodes run based on their incoming dependencies and output ports.
+
+Common patterns:
+
+- connect a trigger into an execution node to start work
+- connect a `Branch` into different follow-up paths
+- connect a `Loop` body back into downstream work and let `done` exit the cycle
+- use `Wait` when multiple branches need to synchronize before continuing
+
+## Save, Reset, and Run
+
+The builder has three important actions:
+
+- **Reset**: discard unsaved canvas changes and reload the saved version.
+- **Save Changes**: persist the current workflow graph.
+- **Run Workflow**: save first, then launch based on the workflow's trigger type.
+
+Builder launch behavior is intentionally type-aware:
+
+- workflows with a **Manual Trigger** run immediately
+- workflows with a **Scheduled Trigger** create a scheduled task instance
+- workflows with a **File Watcher** or webhook-style listener activate a live listener instead of doing a one-off run
+
+## When the Run Modal Appears
+
+Wardian opens the run modal when the workflow needs extra launch-time input.
+
+That usually means one or both of these are true:
+
+- the workflow has a **Manual Trigger** with an input schema
+- the workflow contains **Agent** nodes that need role-to-agent assignments
+
+If neither is needed, the workflow launches immediately based on its trigger type.
+
+## Builder vs Library
+
+Use the **Workflow Builder** when you need to:
+
+- change the graph
+- edit node settings
+- test a workflow while looking at the canvas
+- confirm exactly what will be saved before launch
+
+Use the **Workflow Library** when you need to:
+
+- launch an existing workflow quickly
+- create another scheduled instance of a saved workflow
+- start or reactivate a listener without opening the graph
+
+## Related References
+
+- [Triggers](./triggers.md)
+- [Node Reference](./node-reference.md)
+- [Agent Assignment](./agent-assignment.md)
+- [Visual Builder Architecture](../developer/visual-builder.md)

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -1,0 +1,49 @@
+# Workflows
+
+Wardian workflows are reusable automations built from nodes, connections, and runtime assignment data. This section is the main user-facing reference for building workflows, understanding how they launch, and managing scheduled or live workflow behavior over time.
+
+## Workflow Mental Model
+
+A workflow has three layers:
+
+- **Template**: the saved graph of nodes, edges, and workflow settings.
+- **Launch behavior**: whether that template runs manually, creates a scheduled task, or starts a live listener.
+- **Runtime state**: active runs, scheduled instances, listener status, node outputs, and role mappings.
+
+In practice, you usually move through workflows in this order:
+
+1. Build or edit the graph in the Workflow view.
+2. Save and launch it from either the main builder or the sidebar library.
+3. Monitor active runs, live listeners, and scheduled tasks from the workflow sidebar.
+
+## Start Here
+
+- **[Building Workflows](./building-workflows.md)**: Use the canvas, block library, node settings, and variable assistant.
+- **[Triggers](./triggers.md)**: Understand manual runs, scheduled triggers, and live listeners.
+- **[Scheduled Runs](./scheduled-runs.md)**: Manage scheduled task instances, pause/resume, run now, and deletion.
+- **[Node Reference](./node-reference.md)**: Reference every current workflow node type and its user-visible behavior.
+- **[Agent Assignment](./agent-assignment.md)**: Learn how roles, direct agent selection, and the run modal work.
+- **[Troubleshooting](./troubleshooting.md)**: Diagnose the most common workflow problems quickly.
+
+## Workflow Surfaces
+
+Wardian exposes workflows in three main surfaces:
+
+- **Workflow Builder**: best for authoring, wiring, configuring, and testing workflows.
+- **Workflow Library**: best for launching saved workflows quickly without opening the canvas.
+- **Active Monitoring**: best for watching active runs, live listeners, and scheduled task instances.
+
+## What This Section Covers
+
+This workflow section focuses on user-visible behavior:
+
+- what each node is for
+- when a run modal appears
+- how scheduled tasks behave
+- what happens when a workflow is launched from different surfaces
+- how agent assignments affect execution
+
+For backend implementation details, see:
+
+- [Workflow Engine Architecture](../developer/workflow-engine.md)
+- [Visual Builder Architecture](../developer/visual-builder.md)

--- a/docs/workflows/node-reference.md
+++ b/docs/workflows/node-reference.md
@@ -1,0 +1,252 @@
+# Workflow Node Reference
+
+This page documents the current workflow node surface from a user perspective.
+
+Two important notes:
+
+- the **type system** contains a few node types that are not fully exposed or executed yet
+- the **block names** shown in the UI matter more than the raw internal type names when you are building workflows
+
+## Support Levels
+
+- **Available in the builder and runtime**: you can add the node today and expect user-visible behavior.
+- **Reserved / not fully wired**: the type exists, but the builder and runtime do not yet expose a complete user-facing implementation.
+
+## Trigger and Entry Nodes
+
+### Manual Trigger
+
+**Status:** Available in the builder and runtime
+
+Use it when you want a workflow to run on demand.
+
+Behavior:
+
+- starts the workflow immediately when launched
+- can define an input schema for launch-time parameters
+- outputs trigger context into the workflow registry
+
+Common pitfall:
+
+- forgetting that the input schema controls whether the run modal asks for manual parameters
+
+### Scheduled Trigger
+
+**Status:** Available in the builder and runtime
+
+Use it when the workflow should create scheduled task instances.
+
+Behavior:
+
+- supports `Minutes`, `Hours`, `Daily`, `Weekly`, and `One-Time`
+- creates scheduled tasks instead of immediate runs
+- stores schedule metadata that appears in the sidebar
+
+Common pitfall:
+
+- expecting a scheduled workflow launch to behave like a live listener
+
+### File Watcher
+
+**Status:** Available in the builder and runtime
+
+Use it when the workflow should react to file events.
+
+Behavior:
+
+- listens for matching file changes
+- activates as a live listener
+- appears in the sidebar under live listeners when active
+
+Common pitfall:
+
+- using it for time-based automation instead of a scheduled trigger
+
+## Execution Nodes
+
+### Agent
+
+**Status:** Available in the builder and runtime
+
+Use it to send a prompt into an agent session or run an agent headlessly when the target is off.
+
+Behavior:
+
+- supports direct targeting or role-based assignment
+- supports `persistent` and `temporary` session modes in the builder
+- supports `text` or `json` output formats
+- can require launch-time assignment through the run modal
+
+Common pitfalls:
+
+- leaving a role unmapped, which prevents execution
+- assuming JSON mode behaves exactly like an interactive PTY run
+
+### Shell Command
+
+**Status:** Available in the builder and runtime
+
+Use it to run a shell command inside the workflow.
+
+Behavior:
+
+- executes in the configured folder
+- can receive interpolated values from upstream nodes
+- returns command result data, including failures
+
+Common pitfall:
+
+- forgetting to set the execution directory when the command depends on a specific workspace
+
+### Script
+
+**Status:** Available in the builder and runtime
+
+Use it to run a local script file through a selected runtime.
+
+Behavior:
+
+- supports `python`, `node`, and `sh`
+- resolves the script path relative to the chosen execution directory
+- passes optional arguments and environment variables
+
+Common pitfall:
+
+- confusing a shell command with a script path; use Script for a file and Shell Command for inline command text
+
+### Tool Call
+
+**Status:** Reserved / not fully wired
+
+The node type exists in the workflow model and block library, but the current runtime does not execute a distinct tool-call branch yet.
+
+Current behavior:
+
+- you may see the node type in the code model
+- the backend does not yet expose full user-facing execution semantics for it
+
+### Sub-Flow
+
+**Status:** Reserved / not fully wired
+
+The builder taxonomy includes `Sub-Flow`, but the runtime does not currently execute it as a dedicated node behavior.
+
+Current behavior:
+
+- useful as a planned concept in the model
+- not yet a complete nested-workflow feature for users
+
+## Control-Flow Nodes
+
+### Branch
+
+**Status:** Available in the builder and runtime
+
+Use it to split flow based on a condition.
+
+Behavior:
+
+- evaluates a condition against registry values
+- pulses either `on_true` or `on_false`
+
+Common pitfall:
+
+- writing a condition against a value that does not exist yet in the registry
+
+### Loop
+
+**Status:** Available in the builder and runtime
+
+Use it for repeated execution.
+
+Behavior:
+
+- supports `count` mode and `conditional` mode
+- emits `body` while continuing and `done` when finished
+- stores iterator state in workflow runtime data
+
+Common pitfall:
+
+- forgetting to bound the loop correctly, which can create confusing repeated behavior
+
+### Wait
+
+**Status:** Available in the builder and runtime
+
+Use it as a synchronization barrier.
+
+Behavior:
+
+- waits for the required upstream pulses before continuing
+- useful after branches or parallel-looking flows that must rejoin
+
+Common pitfall:
+
+- treating it like a timed sleep; its main purpose is dependency synchronization
+
+### Parallel
+
+**Status:** Reserved / not fully wired
+
+The type exists in the workflow model, but the current builder library and runtime do not expose it as a separate executable node.
+
+## Coordination and State Nodes
+
+### KV Storage
+
+**Status:** Available in the builder and runtime
+
+Use it to read or update shared workflow storage.
+
+Behavior:
+
+- supports `get`, `set`, and `delete`
+- works with workspace-level or run-level state concepts in the UI
+- exposes storage values back to downstream nodes
+
+Common pitfall:
+
+- expecting deep nested object semantics everywhere; keep storage keys simple unless you have confirmed the exact shape you need
+
+### Notify
+
+**Status:** Available in the builder and runtime
+
+Use it to send a UI notification from a workflow.
+
+Behavior:
+
+- emits a Wardian notification message
+- is best for operator-facing alerts
+
+### Broadcast
+
+**Status:** Partially available
+
+Use it when you conceptually want to send a message broadly.
+
+Current behavior:
+
+- it is exposed in the builder
+- the runtime currently treats it as a communication node, but broad agent delivery is still limited compared with the long-term intent
+
+### Governance
+
+**Status:** Reserved / not fully wired
+
+The `governance` node type exists in the workflow model, but it is not currently surfaced as a full builder block with distinct runtime behavior.
+
+## Reading Internal Types vs UI Names
+
+A few nodes share internal types while presenting different names in the builder:
+
+- `Notify` and `Broadcast` both use the `communication` node type
+- all trigger blocks use the `trigger` node type with different names and configs
+
+When in doubt, trust the block name you see in the Workflow Builder first, then use the internal type only when comparing against developer notes or exported JSON.
+
+## Related References
+
+- [Building Workflows](./building-workflows.md)
+- [Triggers](./triggers.md)
+- [Workflow Engine Architecture](../developer/workflow-engine.md)

--- a/docs/workflows/scheduled-runs.md
+++ b/docs/workflows/scheduled-runs.md
@@ -1,0 +1,96 @@
+# Scheduled Runs
+
+A scheduled run is a runtime instance created from a workflow template that contains a **Scheduled Trigger**. It is separate from the workflow definition itself.
+
+This distinction matters because Wardian supports multiple scheduled instances of the same workflow at the same time.
+
+## What a Scheduled Task Stores
+
+Each scheduled task instance keeps track of:
+
+- the source workflow
+- the schedule definition
+- the assigned agents or role mappings
+- whether the task is paused
+- the next expected run time
+- any remaining delay if the task was paused mid-countdown
+
+That means you can schedule the same workflow more than once with different targets without overwriting the original workflow template.
+
+## Creating Scheduled Tasks
+
+Scheduled tasks can be created from either launch surface:
+
+- **Workflow Builder**: saves the workflow first, then creates the schedule instance
+- **Workflow Library**: creates the schedule instance from the saved workflow
+
+If a workflow needs launch-time input or agent assignment, the run modal appears before the schedule is created.
+
+## Sidebar Statuses
+
+Scheduled tasks appear in the sidebar under **Scheduled Tasks**.
+
+The current card statuses are:
+
+- **Live**: active and waiting for the next run time
+- **Paused**: temporarily stopped
+- **Due**: the task should run as soon as the scheduler processes it
+- **Running**: a scheduled run is currently executing
+
+## Expanding and Acting on a Scheduled Task
+
+The scheduled task row expands inline to show more detail, including:
+
+- schedule summary
+- current status
+- next run timing
+- target summary
+- role-to-agent mappings when present
+
+Available actions:
+
+- **Pause / Resume**
+- **Run Now**
+- **Edit Workflow**
+- **Delete Schedule**
+
+The same actions are also available from the schedule context menu.
+
+## Pause and Resume Behavior
+
+Pause and resume preserve the remaining timer.
+
+That means Wardian does **not** restart the full interval from scratch when you resume a repeating schedule. If a task had 17 minutes left when paused, it resumes with roughly 17 minutes left.
+
+## Run Now
+
+**Run Now** launches the workflow immediately from the scheduled task instance.
+
+For repeating schedules, Wardian also re-arms the next scheduled execution after the immediate run.
+
+## One-Time Schedules
+
+One-time schedules are temporary by design.
+
+Behavior:
+
+- they wait until the specified datetime
+- they execute once
+- after the run completes, the scheduled task is removed from the sidebar instead of remaining as overdue state
+
+## How Targets Are Shown
+
+Scheduled task cards summarize their target using the most specific information available:
+
+- assigned agents from runtime role mappings
+- direct agent IDs configured on agent nodes
+- roles, if no concrete agent is assigned yet
+- `Unassigned` when no target can be resolved
+
+This is why two scheduled instances of the same workflow can share the same workflow name but still show different targets in the sidebar.
+
+## Related References
+
+- [Triggers](./triggers.md)
+- [Agent Assignment](./agent-assignment.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/docs/workflows/triggers.md
+++ b/docs/workflows/triggers.md
@@ -1,0 +1,100 @@
+# Triggers
+
+Triggers decide how a workflow enters the runtime.
+
+In Wardian, not every workflow launch means the same thing. A launch can:
+
+- run immediately
+- create a scheduled task
+- activate a live listener
+
+The trigger nodes in the workflow decide which one happens.
+
+## Manual Trigger
+
+Use **Manual Trigger** when you want an on-demand workflow.
+
+Best for:
+
+- testing a workflow from the builder
+- ad hoc automations
+- workflows that should only run when a user explicitly starts them
+
+Behavior:
+
+- launching the workflow starts a run immediately
+- if the manual trigger defines an input schema, the run modal asks for those values first
+- if the workflow also contains agent roles, the same modal can collect agent assignments
+
+## Scheduled Trigger
+
+Use **Scheduled Trigger** when you want Wardian to create a scheduled task instance.
+
+Best for:
+
+- recurring reviews
+- timed maintenance tasks
+- delayed one-time automations
+- repeating agent routines
+
+Behavior:
+
+- launching from the **sidebar library** creates a new scheduled task instance
+- launching from the **main builder** also creates a scheduled task instance after saving first
+- launching a scheduled workflow does **not** create a live listener
+- a workflow can have multiple scheduled task instances at the same time
+
+If the workflow contains agent nodes or a manual input schema, Wardian opens the run modal before creating the schedule so you can set runtime assignments.
+
+### Schedule Types
+
+The current scheduled trigger supports:
+
+- **Minutes**
+- **Hours**
+- **Daily**
+- **Weekly**
+- **One-Time**
+
+User-visible timing rules:
+
+- interval schedules such as `Minutes` and `Hours` schedule the first run **after** the interval elapses, not immediately
+- `Daily` and `Weekly` wait for the next matching wall-clock time
+- `One-Time` runs once at the specified datetime and then disappears after completion
+
+## File Watcher and Listener-Style Triggers
+
+Wardian currently treats file watching and webhook-style triggers as **live listeners**.
+
+Behavior:
+
+- launching them activates the workflow instead of running it immediately
+- active listener workflows appear in the **Live Listeners** section of the sidebar
+- stopping them disables the active trigger instead of deleting the workflow
+
+Use listener triggers for:
+
+- file-change automation
+- event-driven workflows that should keep watching for input
+
+Do **not** use scheduled triggers when you really want an always-on listener. Scheduled workflows and live listeners are distinct runtime behaviors.
+
+## Launch Surface Differences
+
+The trigger type matters more than the button you clicked, but the surface still affects the flow:
+
+- **Builder**: saves current canvas state first, then launches
+- **Library**: launches the saved workflow directly
+- **Monitoring sidebar**: acts on existing runtime instances such as listeners and scheduled tasks
+
+## Practical Rule of Thumb
+
+- want one run right now: use **Manual Trigger**
+- want repeated or delayed runs: use **Scheduled Trigger**
+- want an always-on background watcher: use **File Watcher** or webhook-style listener
+
+## Related References
+
+- [Scheduled Runs](./scheduled-runs.md)
+- [Agent Assignment](./agent-assignment.md)
+- [Workflow Engine Architecture](../developer/workflow-engine.md)

--- a/docs/workflows/troubleshooting.md
+++ b/docs/workflows/troubleshooting.md
@@ -1,0 +1,87 @@
+# Workflow Troubleshooting
+
+This page is for diagnosing the most common workflow issues from a user perspective before diving into backend internals.
+
+## A Scheduled Workflow Did Not Run Immediately
+
+This is usually expected.
+
+Interval-based scheduled workflows do not fire at creation time. They schedule the first run in the future based on the selected interval or wall-clock time.
+
+Check:
+
+- whether the workflow uses a **Scheduled Trigger** instead of a **Manual Trigger**
+- whether the schedule card shows `Live` with a future next-run time
+- whether you expected a listener but actually created a scheduled task
+
+## A Scheduled Task Looks Stuck on Due
+
+A `Due` state means the task is ready or overdue relative to the current clock.
+
+Check:
+
+- whether the task is actually running right now
+- whether it is a one-time schedule that should disappear after completion
+- whether the scheduler is active and the app is still open
+
+If the behavior seems wrong after that, inspect the developer-side scheduler notes in [Workflow Engine Architecture](../developer/workflow-engine.md).
+
+## Pause and Resume Changed the Timing
+
+Current expected behavior is that pause/resume preserves remaining time.
+
+If the task appears to restart a full interval after resume, treat that as a regression rather than normal behavior.
+
+## The Run Modal Appears When I Did Not Expect It
+
+Wardian opens the modal when launch-time data is needed.
+
+Check whether the workflow has:
+
+- agent roles that need assignment
+- a Manual Trigger input schema
+- both of the above
+
+If yes, the modal is working as designed.
+
+## My Workflow Became a Live Listener Instead of Running
+
+That usually means the workflow was launched through a listener-style trigger.
+
+Expected listener-style behavior:
+
+- File Watcher and webhook-style workflows activate as live listeners
+- scheduled workflows should not appear under live listeners
+- manual workflows should run immediately instead of entering listener mode
+
+## A Scheduled Task Was Deleted but the Workflow Still Exists
+
+This is expected.
+
+Deleting a schedule removes the **scheduled instance**, not the workflow definition. The workflow remains available in the builder and library unless you delete the workflow itself.
+
+## I Created Two Schedules With the Same Workflow Name
+
+This is also expected.
+
+Wardian allows multiple scheduled instances of the same workflow. Distinguish them by:
+
+- target summary
+- role mappings
+- schedule timing
+
+## A Node Exists in the Model but Not in the Builder
+
+The workflow model currently includes a few reserved or partially wired node types.
+
+If you see names like `parallel`, `governance`, `tool`, or `subflow` in exported data or internal references, confirm their current support level in [Node Reference](./node-reference.md) before assuming they are fully available.
+
+## Where to Go Next
+
+For deeper debugging:
+
+- user behavior and launch rules: [Triggers](./triggers.md)
+- scheduling behavior: [Scheduled Runs](./scheduled-runs.md)
+- node capabilities: [Node Reference](./node-reference.md)
+- backend execution details: [Workflow Engine Architecture](../developer/workflow-engine.md)
+- builder internals: [Visual Builder Architecture](../developer/visual-builder.md)

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -39,18 +39,27 @@ pub async fn spawn_agent(
         let cwd = crate::utils::fs::resolve_cwd(&folder, "");
 
         let provider_name = config_override.as_ref().map(|c| c.provider.clone()).unwrap_or_else(|| "claude".to_string());
-        match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref()).await {
-            Ok(real_sid) => {
-                manager::log_debug(&format!(
-                    "[WARDIAN] Intercepted stream-json session ID for {}: {}",
-                    provider_name, real_sid
-                ));
-                // Properly set final_resume because manager::spawn_agent requires it to launch the persistent agent with --resume
-                session_id = Some(real_sid.clone());
-                actual_resume = Some(real_sid);
-            }
-            Err(e) => {
-                return Err(format!("Failed to initialize the provider session: {}", e));
+        if provider_name == "claude" {
+            let fresh_sid = uuid::Uuid::new_v4().to_string();
+            manager::log_debug(&format!(
+                "[WARDIAN] Using explicit Claude session ID in target workspace: {}",
+                fresh_sid
+            ));
+            session_id = Some(fresh_sid);
+        } else {
+            match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref()).await {
+                Ok(real_sid) => {
+                    manager::log_debug(&format!(
+                        "[WARDIAN] Intercepted stream-json session ID for {}: {}",
+                        provider_name, real_sid
+                    ));
+                    // Properly set final_resume because manager::spawn_agent requires it to launch the persistent agent with --resume
+                    session_id = Some(real_sid.clone());
+                    actual_resume = Some(real_sid);
+                }
+                Err(e) => {
+                    return Err(format!("Failed to initialize the provider session: {}", e));
+                }
             }
         }
     }

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -183,10 +183,14 @@ pub async fn spawn_agent(
         &config.agent_class,
         Some(&config.session_id),
     )?;
-    let provider_cwd = habitat_root
-        .as_ref()
-        .map(|root| habitat_workspace_cwd(root))
-        .unwrap_or_else(|| cwd.clone());
+    let provider_cwd = if config.provider == "codex" {
+        cwd.clone()
+    } else {
+        habitat_root
+            .as_ref()
+            .map(|root| habitat_workspace_cwd(root))
+            .unwrap_or_else(|| cwd.clone())
+    };
     cmd.cwd(&provider_cwd);
 
     // Enable CLAUDE.md discovery from --add-dir directories so that
@@ -201,6 +205,8 @@ pub async fn spawn_agent(
         if let Some(root) = habitat_root.as_ref() {
             cmd.env("CODEX_HOME", habitat_codex_home(root));
         }
+        cmd.arg("--cd");
+        cmd.arg(&provider_cwd);
     }
     #[cfg(target_os = "macos")]
     cmd.env("PATH", macos_extended_path());
@@ -684,6 +690,73 @@ pub async fn resize_pty(
     Ok(())
 }
 
+fn codex_bootstrap_launch_context(
+    wardian_home: &std::path::Path,
+    workspace_cwd: &std::path::Path,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_nanos();
+    let bootstrap_home = wardian_home
+        .join("provider-bootstrap")
+        .join("codex")
+        .join(format!("session-{stamp}"))
+        .join(".codex");
+    (workspace_cwd.to_path_buf(), bootstrap_home)
+}
+
+fn migrate_codex_bootstrap_home(
+    bootstrap_home: &std::path::Path,
+    final_home: &std::path::Path,
+) -> Result<(), String> {
+    if !bootstrap_home.exists() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(final_home).map_err(|e| e.to_string())?;
+
+    let entries = std::fs::read_dir(bootstrap_home).map_err(|e| e.to_string())?;
+    for entry in entries.flatten() {
+        let source = entry.path();
+        let name = entry.file_name();
+        let target = final_home.join(&name);
+        let name_str = name.to_string_lossy();
+
+        if matches!(name_str.as_ref(), "auth.json" | "config.toml" | "cap_sid") {
+            continue;
+        }
+
+        if name_str == "skills" {
+            std::fs::create_dir_all(&target).map_err(|e| e.to_string())?;
+            let skill_entries = std::fs::read_dir(&source).map_err(|e| e.to_string())?;
+            for skill_entry in skill_entries.flatten() {
+                let skill_source = skill_entry.path();
+                let skill_target = target.join(skill_entry.file_name());
+                if skill_target.exists() || skill_target.symlink_metadata().is_ok() {
+                    continue;
+                }
+                std::fs::rename(&skill_source, &skill_target).map_err(|e| e.to_string())?;
+            }
+            let _ = std::fs::remove_dir_all(&source);
+            continue;
+        }
+
+        if target.exists() || target.symlink_metadata().is_ok() {
+            continue;
+        }
+
+        std::fs::rename(&source, &target).map_err(|e| e.to_string())?;
+    }
+
+    let _ = std::fs::remove_dir_all(bootstrap_home);
+    if let Some(parent) = bootstrap_home.parent() {
+        let _ = std::fs::remove_dir(parent);
+    }
+
+    Ok(())
+}
+
 pub async fn run_headless(
     cwd: &std::path::PathBuf,
     prompt: &str,
@@ -693,6 +766,8 @@ pub async fn run_headless(
 ) -> Result<serde_json::Value, String> {
     use tokio::io::{AsyncBufReadExt, BufReader};
     let provider = ProviderFactory::resolve(provider_name)?;
+    let habitat_root = prepare_provider_habitat(provider_name, cwd, "", Some(session_id))?;
+    let provider_cwd = cwd.clone();
     let (bin, base_args) = provider.get_executable();
     let mut cmd = new_headless_command(&bin);
     for arg in base_args {
@@ -700,7 +775,12 @@ pub async fn run_headless(
     }
     match provider_name {
         "codex" => {
-            cmd.arg("exec")
+            if let Some(root) = habitat_root.as_ref() {
+                cmd.env("CODEX_HOME", habitat_codex_home(root));
+            }
+            cmd.arg("--cd")
+                .arg(&provider_cwd)
+                .arg("exec")
                 .arg("resume")
                 .arg(session_id)
                 .arg("--json")
@@ -729,7 +809,7 @@ pub async fn run_headless(
             }
         }
     }
-    cmd.current_dir(cwd)
+    cmd.current_dir(&provider_cwd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
@@ -863,17 +943,34 @@ pub async fn obtain_session_id(
         })
         .unwrap_or("");
     let habitat_root = prepare_provider_habitat(provider_name, cwd, class_name, None)?;
-    let provider_cwd = habitat_root
-        .as_ref()
-        .map(|root| habitat_workspace_cwd(root))
-        .unwrap_or_else(|| cwd.clone());
+    let codex_bootstrap = if provider_name == "codex" {
+        let wardian_home = get_wardian_home().ok_or("Could not find Wardian home")?;
+        Some(codex_bootstrap_launch_context(&wardian_home, cwd))
+    } else {
+        None
+    };
+    let provider_cwd = if let Some((provider_cwd, _)) = codex_bootstrap.as_ref() {
+        provider_cwd.clone()
+    } else {
+        habitat_root
+            .as_ref()
+            .map(|root| habitat_workspace_cwd(root))
+            .unwrap_or_else(|| cwd.clone())
+    };
     for arg in base_args {
         cmd.arg(arg);
     }
     if provider_name == "codex" {
-        if let Some(root) = habitat_root.as_ref() {
+        if let Some((_, bootstrap_home)) = codex_bootstrap.as_ref() {
+            let real_codex_home = dirs::home_dir()
+                .ok_or("Could not find user home directory")?
+                .join(".codex");
+            sync_codex_agent_home(&real_codex_home, bootstrap_home, std::path::Path::new(""))?;
+            cmd.env("CODEX_HOME", bootstrap_home);
+        } else if let Some(root) = habitat_root.as_ref() {
             cmd.env("CODEX_HOME", habitat_codex_home(root));
         }
+        cmd.arg("--cd").arg(&provider_cwd);
         cmd.arg("exec");
 
         if let Some(config) = config {
@@ -1027,6 +1124,13 @@ pub async fn obtain_session_id(
                     "[WARDIAN-DEBUG] obtain_session_id stderr: {}",
                     stderr_output.trim()
                 ));
+            }
+            if provider_name == "codex" {
+                if let (Some(session_id), Some((_, bootstrap_home))) = (session_id_res.as_ref(), codex_bootstrap.as_ref()) {
+                    if let Some(final_habitat_root) = prepare_provider_habitat(provider_name, cwd, class_name, Some(session_id))? {
+                        migrate_codex_bootstrap_home(bootstrap_home, &habitat_codex_home(&final_habitat_root))?;
+                    }
+                }
             }
             log_debug(&format!("[WARDIAN-DEBUG] Returning session_id: {:?}", session_id_res));
             session_id_res.ok_or_else(|| {
@@ -1552,4 +1656,22 @@ pub async fn kill_all_agents(state: &AppState) {
         }
     }
     state.agent_order.lock().await.clear();
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::codex_bootstrap_launch_context;
+    use std::path::Path;
+
+    #[test]
+    fn codex_bootstrap_launch_context_uses_real_workspace_cwd() {
+        let wardian_home = Path::new("C:/Users/test/.wardian");
+        let workspace_cwd = Path::new("D:/Development/Wardian");
+        let (provider_cwd, bootstrap_home) = codex_bootstrap_launch_context(wardian_home, workspace_cwd);
+
+        assert_eq!(provider_cwd, workspace_cwd);
+        assert!(bootstrap_home.starts_with(wardian_home.join("provider-bootstrap").join("codex")));
+        assert_ne!(bootstrap_home, workspace_cwd);
+    }
 }

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -103,7 +103,11 @@ impl AgentProvider for ClaudeProvider {
             args.push(model.clone());
         }
 
-        // Only set --name on fresh sessions; skip on resume to avoid conflicts with --resume
+        // Only set fresh-session identity on non-resume launches.
+        if !is_resume && !config.session_id.trim().is_empty() {
+            args.push("--session-id".into());
+            args.push(config.session_id.clone());
+        }
         if !is_resume && !config.session_name.trim().is_empty() {
             args.push("--name".into());
             args.push(config.session_name.clone());
@@ -459,5 +463,17 @@ mod tests {
         let args_resume = p.get_spawn_args(&config, true);
         assert!(!args_resume.contains(&"--name".to_string()));
         assert!(args_resume.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn fresh_spawn_uses_explicit_session_id() {
+        let p = make_provider();
+        let config = AgentConfig {
+            session_id: "019d331a-0500-7592-969f-8f437886f42b".into(),
+            ..Default::default()
+        };
+        let args = p.get_spawn_args(&config, false);
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(args.contains(&"019d331a-0500-7592-969f-8f437886f42b".to_string()));
     }
 }

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -167,7 +167,7 @@ impl AgentProvider for CodexProvider {
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
                 match item_type {
-                    "agent_message" => Some(AgentEvent::Generating),
+                    "agent_message" => Some(AgentEvent::Unknown),
                     _ => Some(AgentEvent::Unknown),
                 }
             }
@@ -185,7 +185,7 @@ impl AgentProvider for CodexProvider {
                     "message" => {
                         let role = payload.get("role").and_then(|v| v.as_str()).unwrap_or("");
                         match role {
-                            "assistant" => Some(AgentEvent::Generating),
+                            "assistant" => Some(AgentEvent::Unknown),
                             "user" => Some(AgentEvent::UserQuery),
                             _ => Some(AgentEvent::Unknown),
                         }
@@ -200,9 +200,11 @@ impl AgentProvider for CodexProvider {
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
                 match inner_type {
-                    "task_started" => Some(AgentEvent::Generating),
+                    "task_started" | "exec_command_begin" | "exec_command_start" => {
+                        Some(AgentEvent::Generating)
+                    }
                     "user_message" => Some(AgentEvent::UserQuery),
-                    "agent_message" => Some(AgentEvent::Generating),
+                    "agent_message" => Some(AgentEvent::Unknown),
                     "task_complete" => Some(AgentEvent::ModelResponse),
                     "exec_approval_request" => {
                         let message = parsed
@@ -316,7 +318,7 @@ mod tests {
     fn parse_output_agent_message_event() {
         let p = make_provider();
         let line = r#"{"type":"item.completed","item":{"type":"agent_message","text":"hello"}}"#;
-        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Generating);
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Unknown);
     }
 
     #[test]
@@ -331,6 +333,27 @@ mod tests {
         let p = make_provider();
         let line = r#"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"abc"}}"#;
         assert_eq!(p.parse_output(line).unwrap(), AgentEvent::ModelResponse);
+    }
+
+    #[test]
+    fn parse_output_agent_message_does_not_change_status() {
+        let p = make_provider();
+        let line = r#"{"type":"event_msg","payload":{"type":"agent_message","message":"Waiting for approval"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Unknown);
+    }
+
+    #[test]
+    fn parse_output_exec_command_begin_sets_generating() {
+        let p = make_provider();
+        let line = r#"{"type":"event_msg","payload":{"type":"exec_command_begin","command":"git status"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Generating);
+    }
+
+    #[test]
+    fn parse_output_function_call_output_resumes_processing() {
+        let p = make_provider();
+        let line = r#"{"type":"response_item","payload":{"type":"function_call_output","call_id":"abc"}}"#;
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::Generating);
     }
 
     #[test]

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -22,6 +22,26 @@ pub fn get_default_user_dir() -> std::path::PathBuf {
     })
 }
 
+pub fn prepare_provider_bootstrap_cwd(provider: &str) -> Result<std::path::PathBuf, String> {
+    let wardian_home = get_wardian_home().ok_or("Could not find Wardian home")?;
+    let safe_provider: String = provider
+        .trim()
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => ch,
+            _ => '_',
+        })
+        .collect();
+    let provider_name = if safe_provider.is_empty() {
+        "default".to_string()
+    } else {
+        safe_provider
+    };
+    let bootstrap_cwd = wardian_home.join("provider-bootstrap").join(provider_name);
+    std::fs::create_dir_all(&bootstrap_cwd).map_err(|e| e.to_string())?;
+    Ok(bootstrap_cwd)
+}
+
 pub fn resolve_cwd(folder: &str, agent_id: &str) -> std::path::PathBuf {
     // Priority 1: Explicitly provided folder
     if !folder.is_empty() {
@@ -176,11 +196,14 @@ fn prepare_habitat_workspace(
     build_habitat_skill_projection(&wardian_home, &habitat_root, class_name, Some(session_id))?;
 
     let workspace_link = habitat_root.join("workspace");
-    if workspace_link.exists() {
-        let _ = std::fs::remove_dir_all(&workspace_link).or_else(|_| std::fs::remove_dir(&workspace_link));
+    if !projected_link_matches_target(&workspace_link, workspace_root) {
+        if workspace_link.exists() || workspace_link.symlink_metadata().is_ok() {
+            let _ = std::fs::remove_dir_all(&workspace_link)
+                .or_else(|_| std::fs::remove_dir(&workspace_link));
+        }
+        create_directory_link(workspace_root, &workspace_link)?;
     }
-    create_directory_link(workspace_root, &workspace_link)?;
-    if !workspace_link.exists() {
+    if !projected_link_matches_target(&workspace_link, workspace_root) {
         return Err(format!(
             "Failed to create habitat workspace link from {} to {}",
             workspace_link.to_string_lossy(),
@@ -191,74 +214,78 @@ fn prepare_habitat_workspace(
     Ok(habitat_root)
 }
 
+fn normalize_comparison_path(path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let canonical = path.canonicalize().ok()?;
+    #[cfg(windows)]
+    {
+        let text = canonical.to_string_lossy();
+        if let Some(stripped) = text.strip_prefix(r"\?") {
+            return Some(std::path::PathBuf::from(stripped));
+        }
+    }
+    Some(canonical)
+}
+
+fn projected_link_matches_target(link: &std::path::Path, target: &std::path::Path) -> bool {
+    if !(link.exists() || link.symlink_metadata().is_ok()) {
+        return false;
+    }
+
+    match (
+        normalize_comparison_path(link),
+        normalize_comparison_path(target),
+    ) {
+        (Some(link_path), Some(target_path)) => link_path == target_path,
+        _ => false,
+    }
+}
+
 fn ensure_codex_home_projection(habitat_root: &std::path::Path) -> Result<(), String> {
     let real_codex_home = dirs::home_dir()
         .ok_or("Could not find user home directory")?
         .join(".codex");
     let projected_home = habitat_codex_home(habitat_root);
-    std::fs::create_dir_all(&projected_home).map_err(|e| e.to_string())?;
+    let wardian_skills = habitat_root.join(".agents").join("skills");
+    sync_codex_agent_home(&real_codex_home, &projected_home, &wardian_skills)
+}
 
-    if real_codex_home.exists() {
-        let entries = std::fs::read_dir(&real_codex_home).map_err(|e| e.to_string())?;
-        for entry in entries.flatten() {
-            let source = entry.path();
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-            if name_str == "skills" {
-                continue;
-            }
+pub(crate) fn sync_codex_agent_home(
+    real_codex_home: &std::path::Path,
+    projected_home: &std::path::Path,
+    wardian_skills: &std::path::Path,
+) -> Result<(), String> {
+    std::fs::create_dir_all(projected_home).map_err(|e| e.to_string())?;
 
-            let target = projected_home.join(&name);
-            if source.is_dir() {
-                if target.exists() || target.symlink_metadata().is_ok() {
-                    continue;
-                }
-                create_directory_link(&source, &target)?;
-            } else if source.is_file() {
-                project_file(&source, &target)?;
-            }
+    for shared_name in ["auth.json", "config.toml", "cap_sid"] {
+        let source = real_codex_home.join(shared_name);
+        if source.exists() && source.is_file() {
+            project_file(&source, &projected_home.join(shared_name))?;
         }
     }
 
     let projected_skills = projected_home.join("skills");
-    if projected_skills.exists() {
-        let _ = std::fs::remove_dir_all(&projected_skills);
-    }
     std::fs::create_dir_all(&projected_skills).map_err(|e| e.to_string())?;
 
-    let native_skills = real_codex_home.join("skills");
-    if native_skills.exists() {
-        let entries = std::fs::read_dir(&native_skills).map_err(|e| e.to_string())?;
-        for entry in entries.flatten() {
-            let source = entry.path();
-            let name = entry.file_name();
-            let target = projected_skills.join(&name);
-            if source.is_dir() {
-                create_directory_link(&source, &target)?;
-            } else if source.is_file() {
-                project_file(&source, &target)?;
-            }
-        }
+    if !wardian_skills.exists() {
+        return Ok(());
     }
 
-    let wardian_skills = habitat_root.join(".agents").join("skills");
-    if wardian_skills.exists() {
-        let entries = std::fs::read_dir(&wardian_skills).map_err(|e| e.to_string())?;
-        for entry in entries.flatten() {
-            let source = entry.path();
-            if !source.is_dir() {
-                continue;
-            }
-            let target = projected_skills.join(entry.file_name());
-            if target.exists() || target.symlink_metadata().is_ok() {
-                let _ = std::fs::remove_dir_all(&target).or_else(|_| std::fs::remove_file(&target));
-            }
-            create_directory_link(&source, &target)?;
+    let entries = std::fs::read_dir(wardian_skills).map_err(|e| e.to_string())?;
+    for entry in entries.flatten() {
+        let source = entry.path();
+        if !source.is_dir() {
+            continue;
         }
+        let target = projected_skills.join(entry.file_name());
+        if target.exists() || target.symlink_metadata().is_ok() {
+            let _ = std::fs::remove_dir_all(&target).or_else(|_| std::fs::remove_file(&target));
+        }
+        create_directory_link(&source, &target)?;
     }
 
     Ok(())
 }
+
 
 fn write_habitat_instruction_files(
     wardian_home: &std::path::Path,
@@ -551,8 +578,25 @@ pub fn validate_workspace_path(path: &std::path::Path) -> Result<std::path::Path
 
 #[cfg(test)]
 mod tests {
-    use super::habitat_root_for_session;
-    use std::path::Path;
+    use super::{
+        create_directory_link,
+        get_wardian_home,
+        habitat_root_for_session,
+        prepare_provider_bootstrap_cwd,
+        projected_link_matches_target,
+        provider_uses_projected_workspace,
+        sync_codex_agent_home,
+    };
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("wardian-{label}-{stamp}"))
+    }
 
     #[test]
     fn habitat_root_uses_provider_session_id_under_agents() {
@@ -575,4 +619,87 @@ mod tests {
 
         assert!(err.contains("Provider session ID is required"));
     }
+
+    #[test]
+    fn only_codex_uses_projected_workspaces() {
+        assert!(!provider_uses_projected_workspace("claude"));
+        assert!(provider_uses_projected_workspace("codex"));
+        assert!(!provider_uses_projected_workspace("gemini"));
+    }
+
+    #[test]
+    fn projected_link_match_detects_existing_workspace_projection() {
+        let root = unique_temp_dir("workspace-link-test");
+        let target = root.join("target");
+        let link = root.join("link");
+
+        std::fs::create_dir_all(&target).expect("create target dir");
+        create_directory_link(&target, &link).expect("create projected link");
+
+        assert!(projected_link_matches_target(&link, &target));
+
+        let _ = std::fs::remove_dir_all(&link).or_else(|_| std::fs::remove_dir(&link));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn codex_home_projection_only_seeds_shared_files() {
+        let root = unique_temp_dir("codex-home-shared-files");
+        let real_home = root.join("real-codex-home");
+        let projected_home = root.join("projected-home");
+        let wardian_skills = root.join("wardian-skills");
+
+        std::fs::create_dir_all(&real_home).expect("create real codex home");
+        std::fs::create_dir_all(&projected_home).expect("create projected codex home");
+        std::fs::create_dir_all(&wardian_skills).expect("create wardian skills");
+
+        std::fs::write(real_home.join("auth.json"), "auth").expect("write auth");
+        std::fs::write(real_home.join("config.toml"), "config").expect("write config");
+        std::fs::write(real_home.join("cap_sid"), "cap").expect("write cap sid");
+        std::fs::write(real_home.join("history.jsonl"), "history").expect("write unrelated file");
+
+        sync_codex_agent_home(&real_home, &projected_home, &wardian_skills)
+            .expect("sync codex agent home");
+
+        assert!(projected_home.join("auth.json").exists());
+        assert!(projected_home.join("config.toml").exists());
+        assert!(projected_home.join("cap_sid").exists());
+        assert!(!projected_home.join("history.jsonl").exists());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn codex_home_projection_preserves_system_skills_and_adds_wardian_skills() {
+        let root = unique_temp_dir("codex-home-skills");
+        let real_home = root.join("real-codex-home");
+        let projected_home = root.join("projected-home");
+        let projected_system_skill = projected_home.join("skills").join(".system").join("marker-skill");
+        let wardian_skill = root.join("wardian-skills").join("role-skill");
+
+        std::fs::create_dir_all(&real_home).expect("create real codex home");
+        std::fs::create_dir_all(&projected_system_skill).expect("create projected system skill");
+        std::fs::create_dir_all(&wardian_skill).expect("create wardian skill dir");
+        std::fs::write(wardian_skill.join("SKILL.md"), "wardian skill").expect("write wardian skill");
+
+        sync_codex_agent_home(&real_home, &projected_home, &root.join("wardian-skills"))
+            .expect("sync codex agent home");
+
+        assert!(projected_system_skill.exists());
+        assert!(projected_home.join("skills").join("role-skill").exists());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn provider_bootstrap_cwd_stays_under_wardian_home() {
+        let bootstrap = prepare_provider_bootstrap_cwd("claude").expect("bootstrap cwd");
+        let wardian_home = get_wardian_home().expect("wardian home");
+
+        assert!(bootstrap.starts_with(wardian_home.join("provider-bootstrap")));
+        assert!(bootstrap.ends_with("claude"));
+    }
 }
+
+
+

--- a/src/features/workflows/RunPayloadModal.test.tsx
+++ b/src/features/workflows/RunPayloadModal.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RunPayloadModal } from "./RunPayloadModal";
+import type { WorkflowDefinition } from "../../types/workflow";
+
+const workflow: WorkflowDefinition = {
+  id: "wf-1",
+  name: "Agent Handoff",
+  settings: { max_iterations: 10, on_limit_reached: "pause" },
+  role_mappings: {},
+  nodes: [
+    { id: "agent-1", type: "agent", name: "Planner", config: { role: "planner" } },
+  ],
+};
+
+describe("RunPayloadModal", () => {
+  it("shows the workflow name in the header", () => {
+    render(
+      <RunPayloadModal
+        workflow={workflow}
+        isOpen={true}
+        agents={[]}
+        onRun={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Agent Handoff" })).toBeInTheDocument();
+  });
+});

--- a/src/features/workflows/RunPayloadModal.tsx
+++ b/src/features/workflows/RunPayloadModal.tsx
@@ -141,7 +141,7 @@ export const RunPayloadModal: React.FC<RunPayloadModalProps> = ({
       <div className="bg-[var(--color-wardian-card)] border border-wardian-border-heavy w-full max-w-lg rounded-3xl shadow-2xl flex flex-col overflow-hidden animate-in zoom-in-95 duration-300">
         <div className="p-6 border-b border-wardian-border flex items-center justify-between">
           <div className="flex flex-col">
-            <h3 className="text-xl font-bold text-[var(--color-wardian-text)] tracking-tight">Run Workflow</h3>
+            <h3 className="text-xl font-bold text-[var(--color-wardian-text)] tracking-tight">{workflow.name}</h3>
             <span className="text-[10px] font-bold text-muted-neutral uppercase tracking-widest">
               {hasInputs && hasRoles ? 'Configure Inputs & Agents' : hasRoles ? 'Assign Agents' : 'Provide Input Parameters'}
             </span>

--- a/src/features/workflows/WorkflowLibrary.tsx
+++ b/src/features/workflows/WorkflowLibrary.tsx
@@ -146,7 +146,11 @@ export const WorkflowLibrary: React.FC<WorkflowLibraryProps> = ({ workflows, onR
       }
     };
 
-    const statusColorClass = triggerType === 'scheduled' ? 'text-cyan-400' : status === 'active' ? 'text-emerald-500' : status === 'muted' ? 'text-amber-500' : 'text-gray-500';
+    const statusColorClass = status === 'active'
+      ? 'text-wardian-processing'
+      : status === 'muted'
+        ? 'text-wardian-warning'
+        : 'text-muted-neutral';
     const isDragTarget = dragOverWorkflowId === wf.id && draggedWorkflowId !== null && draggedWorkflowId !== wf.id;
     const isBeingDragged = draggedWorkflowId === wf.id;
 
@@ -262,4 +266,7 @@ export const WorkflowLibrary: React.FC<WorkflowLibraryProps> = ({ workflows, onR
     </div>
   );
 };
+
+
+
 

--- a/src/features/workflows/WorkflowSidebar.test.tsx
+++ b/src/features/workflows/WorkflowSidebar.test.tsx
@@ -12,7 +12,15 @@ vi.mock('./WorkflowLibrary', () => ({
   WorkflowLibrary: ({ workflows, onRun }: any) => (
     <div data-testid="workflow-library">
       {workflows.map((wf: any) => (
-        <button key={wf.id} onClick={() => onRun(wf.id)}>{wf.name}</button>
+        <button
+          key={wf.id}
+          data-workflow-id={wf.id}
+          data-trigger-status={wf.trigger_status}
+          data-trigger-type={wf.trigger_type}
+          onClick={() => onRun(wf.id)}
+        >
+          {wf.name}
+        </button>
       ))}
     </div>
   ),
@@ -129,5 +137,64 @@ describe('WorkflowSidebar', () => {
   it('correctly identifies active workflows for monitoring', () => {
     renderWithProvider(<WorkflowSidebar />);
     expect(screen.getByTestId('active-monitoring')).toBeInTheDocument();
+  });
+
+
+  it('derives scheduled workflow status from scheduled runs instead of trigger node config', () => {
+    (useWorkflowStore as any).mockReturnValue({
+      ...defaultStoreValues,
+      availableWorkflows: [
+        {
+          id: 'wf-1',
+          name: 'Alpha Workflow',
+          settings: { max_iterations: 10, on_limit_reached: 'pause' },
+          role_mappings: {},
+          nodes: [{ id: 'trigger-1', type: 'trigger', name: 'Scheduled Trigger', config: { schedule_type: 'Hours', interval: '2', status: 'off' } }],
+        },
+      ],
+      scheduledRuns: [
+        {
+          id: 'schedule-1',
+          workflow_id: 'wf-1',
+          workflow_name: 'Alpha Workflow',
+          schedule: { schedule_type: 'hours', value: '2', active: true },
+          role_mappings: {},
+          next_run_epoch_ms: Date.now() + 1000,
+          is_paused: false,
+        },
+      ],
+    });
+
+    renderWithProvider(<WorkflowSidebar />);
+
+    expect(screen.getByRole('button', { name: 'Alpha Workflow' })).toHaveAttribute('data-trigger-status', 'active');
+  });
+
+  it('marks a workflow active in the library while it has an in-flight run', () => {
+    (useWorkflowStore as any).mockReturnValue({
+      ...defaultStoreValues,
+      availableWorkflows: [
+        {
+          id: 'wf-2',
+          name: 'Beta Workflow',
+          settings: { max_iterations: 10, on_limit_reached: 'pause' },
+          role_mappings: {},
+          nodes: [{ id: 'trigger-2', type: 'trigger', name: 'Manual Trigger', config: { type: 'manual', status: 'off' } }],
+        },
+      ],
+      activeRuns: [
+        {
+          workflow_id: 'wf-2',
+          node_id: 'agent-1',
+          node_name: 'Agent',
+          status: 'running',
+          output: null,
+        },
+      ],
+    });
+
+    renderWithProvider(<WorkflowSidebar />);
+
+    expect(screen.getByRole('button', { name: 'Beta Workflow' })).toHaveAttribute('data-trigger-status', 'active');
   });
 });

--- a/src/features/workflows/WorkflowSidebar.tsx
+++ b/src/features/workflows/WorkflowSidebar.tsx
@@ -113,6 +113,27 @@ export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = ({ onOpenWorkflow
     );
   }, [availableWorkflows, searchQuery]);
 
+  const scheduledStatusByWorkflow = useMemo(() => {
+    const statuses: Record<string, 'active' | 'muted'> = {};
+
+    for (const run of scheduledRuns) {
+      const nextStatus = run.is_paused ? 'muted' : 'active';
+      if (statuses[run.workflow_id] !== 'active') {
+        statuses[run.workflow_id] = nextStatus;
+      }
+    }
+
+    return statuses;
+  }, [scheduledRuns]);
+
+  const runningWorkflowIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const run of activeRuns) {
+      ids.add(run.workflow_id);
+    }
+    return ids;
+  }, [activeRuns]);
+
   const activeWorkflows = useMemo(() =>
     availableWorkflows.filter(wf => {
       const triggerNode = wf.nodes.find(n => n.type === 'trigger');
@@ -214,10 +235,17 @@ export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = ({ onOpenWorkflow
               if (triggerNode?.name === 'Scheduled Trigger') trigger_type = 'scheduled';
               else if (triggerNode?.name === 'File Watcher') trigger_type = 'watcher';
               else if (triggerNode?.config?.type === 'Webhook') trigger_type = 'webhook';
+
+              const trigger_status = runningWorkflowIds.has(wf.id)
+                ? 'active'
+                : trigger_type === 'scheduled'
+                  ? scheduledStatusByWorkflow[wf.id] || 'off'
+                  : triggerNode?.config?.status || 'off';
+
               return {
                 ...wf,
                 trigger_type,
-                trigger_status: triggerNode?.config?.status || 'off'
+                trigger_status,
               };
             })}
             onRun={handleRunFromLibrary}


### PR DESCRIPTION
## Summary
- add a new top-level docs/workflows/ section as the main user-facing workflow reference
- convert docs/guide/workflows.md into a view-oriented quick manual and link it into the new hub
- document current trigger behavior, scheduled runs, agent assignment, troubleshooting, and the full workflow node surface

## Test Plan
- [x] Reviewed generated docs diff for navigation and scope consistency
- [x] Verified the content against current workflow frontend/backend behavior in source
- [ ] Not run: frontend/backend test suites, because this PR is documentation-only

Closes #97