### PR TITLE
feat(runtime): add unified shell selection

### DIFF
--- a/docs/developer/pty-lifecycle.md
+++ b/docs/developer/pty-lifecycle.md
@@ -10,7 +10,7 @@ Wardian utilizes the `portable-pty` crate to provide a consistent PTY interface 
 
 ### The PTY Model:
 - **Master**: The control end of the PTY, used for reading output and writing input.
-- **Slave**: The application end, where the `gemini-cli` (or another agent provider) is spawned.
+- **Slave**: The application end, where the selected runtime shell hosts the provider command.
 
 ## 🛡️ Process Integrity (Windows Job Objects)
 To prevent "zombie" processes when Wardian crashes or is force-closed, the Windows implementation uses **Job Objects** via the `win32job` crate.
@@ -21,15 +21,22 @@ To prevent "zombie" processes when Wardian crashes or is force-closed, the Windo
 4. When the Wardian process terminates, the job object is closed by the OS, which automatically kills all processes assigned to it.
 
 ## 🔁 Spawning Lifecycle
-Spawning an agent follows a deterministic sequence in `manager::spawn_gemini_cli`:
+Spawning an agent follows a deterministic sequence in `manager::spawn_agent`:
 
 1. **Open PTY**: Create a new master/slave pair.
-2. **Build Command**: Configure the command (e.g., `node gemini-cli dist/index.js`) with flags based on the `AgentConfig` (model, sandbox, policy, include directories).
-3. **Spawn**: The slave spawns the command.
-4. **Piping**:
-    - A **Writer Thread** is spawned to handle input from the UI.
-    - A **Reader Thread** is spawned to capture output, parsing it for JSON logs and truthiness (status tracking).
-5. **Registration**: The `ActiveAgent` handle is added to the `AppState`.
+2. **Resolve Runtime Shell**: Select the configured shell profile (`Auto`, discovered shell, or `Custom`).
+3. **Build Provider Command**: Assemble the provider executable plus provider-specific flags from the `AgentConfig`.
+4. **Wrap for Host Shell**: Convert the provider command into a shell-hosted invocation that respects the selected shell family.
+5. **Spawn**: The PTY slave spawns the shell-hosted command.
+6. **Piping**:
+   - A **Writer Thread** is spawned to handle input from the UI.
+   - A **Reader Thread** is spawned to capture output, parsing it for JSON logs and status transitions.
+7. **Registration**: The `ActiveAgent` handle is added to the `AppState`.
+
+### Shell-hosted Launch Notes
+- Workflow shell-command nodes and headless provider runs use the same shell resolver as interactive PTY sessions.
+- On Windows, `.cmd` and `.bat` provider shims may be re-routed through `cmd.exe` when the selected host shell is PowerShell, Git Bash, or WSL.
+- On Linux and macOS, Wardian resolves shells from the standard shell list and executes the provider command through that shell's command-string mode.
 
 ## 📐 Terminal Resizing
-Terminal resizing is handled asynchronously in `manager::resize_pty`. When the UI grid layout changes, it invokes a Tauri command that updates the PTY dimensions (`rows` and `cols`) via the `pty_master` handle, ensuring the agent's TUI (like a terminal dashboard) renders correctly.
+Terminal resizing is handled asynchronously in `manager::resize_pty`. When the UI grid layout changes, it invokes a Tauri command that updates the PTY dimensions (`rows` and `cols`) via the `pty_master` handle, ensuring the agent's TUI renders correctly.

--- a/docs/guide/ui-overview.md
+++ b/docs/guide/ui-overview.md
@@ -21,7 +21,7 @@ The Left Sidebar provides the "Context" for your work. It consists of:
     - **Explorer**: Browse the physical files of the selected agent or the Wardian home.
     - **Agent Configuration**: Quick settings for spawning and tuning agents.
     - **Command Center**: Broadcast prompts to multiple agents simultaneously.
-    - **Settings**: System-wide preferences and theme engine.
+    - **Settings**: System-wide preferences, theme engine, and the default runtime shell used by agents and shell-based workflows.
 - **Content Pane**: Displays the detailed menu or tree for the active rail icon.
 
 ### 3. Right Sidebar (The Roster)

--- a/docs/specs/010-runtime-shell-selection.md
+++ b/docs/specs/010-runtime-shell-selection.md
@@ -1,0 +1,50 @@
+# 010 Runtime Shell Selection
+
+- Status: Implemented
+- Date: 2026-03-30
+- Tags: runtime, pty, settings, cross-platform
+
+## Context
+Wardian previously mixed several process-launch models.
+
+- Agent providers were attached directly to PTYs.
+- Workflow shell-command nodes used OS defaults such as `cmd /C` or `sh -c`.
+- Headless provider execution and session bootstrap used their own launch paths.
+
+That made shell behavior inconsistent across the product and prevented users from intentionally choosing a shell profile such as Git Bash for both agent sessions and workflow command execution.
+
+## Decision
+Wardian now exposes a single runtime shell setting in Settings.
+
+- The setting is dynamically populated from shells discoverable on the current operating system.
+- Workflow shell-command nodes execute through the selected shell.
+- Interactive provider PTY sessions execute through the selected shell.
+- Headless provider execution and provider bootstrap execute through the selected shell.
+- `Auto` selects the best discovered shell for the host OS.
+- `Custom` allows an explicit executable path plus command arguments.
+
+Provider binaries still keep their provider-specific arguments and environment variables. Wardian wraps the full provider invocation in the selected shell rather than rewriting provider semantics.
+
+On Windows, shim handling is host-aware.
+
+- PowerShell hosts route `.cmd` and `.bat` provider shims through `cmd.exe /d /c`.
+- POSIX-like hosts on Windows such as Git Bash or WSL route Windows commands through `cmd.exe /c`.
+- Claude now resolves the actual executable found on `PATH` instead of assuming `claude.cmd`.
+
+## Consequences
+Positive:
+
+- Users can align agent sessions, workflow shell commands, and headless execution under one shell profile.
+- Git Bash, PowerShell, Command Prompt, and WSL can be selected intentionally on Windows.
+- Cross-platform launch behavior is easier to reason about because it is centralized in one resolver.
+
+Trade-offs:
+
+- Provider startup now depends on shell quoting and host-shell compatibility, especially on Windows.
+- Shell discovery on Windows remains heuristic rather than API-driven.
+- Provider launch testing must cover both direct executables and shim-based CLIs.
+
+Operational guidance:
+
+- Treat shell selection as a runtime host setting, not just a workflow-command preference.
+- When debugging launch failures, inspect both the provider executable resolver and the shell wrapper chosen by the resolver.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -15,6 +15,7 @@ This document serves as the historical ledger for all strategic and technical sp
 | [007](./007-workflow-engine.md) | Reliable Workflow Execution Engine | Proposed | 2026-03-25 |
 | [008](./008-continuous-integration.md) | Continuous Integration & Quality Gates | Proposed | 2026-03-25 |
 | [009](./009-codex-provider.md) | Codex Provider Support | Implemented | 2026-03-27 |
+| [010](./010-runtime-shell-selection.md) | Unified Runtime Shell Selection | Implemented | 2026-03-30 |
 
 ## How to use Specs
 Every significant feature must begin with a Spec that defines:

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -38,7 +38,10 @@ pub async fn spawn_agent(
     if actual_resume.is_none() {
         let cwd = crate::utils::fs::resolve_cwd(&folder, "");
 
-        let provider_name = config_override.as_ref().map(|c| c.provider.clone()).unwrap_or_else(|| "claude".to_string());
+        let provider_name = config_override
+            .as_ref()
+            .map(|c| c.provider.clone())
+            .unwrap_or_else(|| "claude".to_string());
         if provider_name == "claude" {
             let fresh_sid = uuid::Uuid::new_v4().to_string();
             manager::log_debug(&format!(
@@ -47,7 +50,9 @@ pub async fn spawn_agent(
             ));
             session_id = Some(fresh_sid);
         } else {
-            match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref()).await {
+            match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref())
+                .await
+            {
                 Ok(real_sid) => {
                     manager::log_debug(&format!(
                         "[WARDIAN] Intercepted stream-json session ID for {}: {}",
@@ -122,6 +127,7 @@ pub async fn kill_agent(
     ));
     let mut agents = state.agents.lock().await;
     let mut order = state.agent_order.lock().await;
+    #[allow(unused_mut)]
     if let Some(mut agent) = agents.remove(&session_id) {
         // Remove from input_senders immediately
         if let Ok(mut senders) = state.input_senders.write() {
@@ -143,9 +149,15 @@ pub async fn kill_agent(
             let agent_dir = home.join("agents").join(&session_id);
             if agent_dir.exists() {
                 if let Err(e) = std::fs::remove_dir_all(&agent_dir) {
-                    manager::log_debug(&format!("[WARDIAN] Failed to remove agent directory {:?}: {}", agent_dir, e));
+                    manager::log_debug(&format!(
+                        "[WARDIAN] Failed to remove agent directory {:?}: {}",
+                        agent_dir, e
+                    ));
                 } else {
-                    manager::log_debug(&format!("[WARDIAN] Successfully removed agent directory {:?}", agent_dir));
+                    manager::log_debug(&format!(
+                        "[WARDIAN] Successfully removed agent directory {:?}",
+                        agent_dir
+                    ));
                 }
             }
         }
@@ -291,9 +303,11 @@ pub async fn update_agent_config(
                 "[WARDIAN] Agent class changed from {} to {}. Updating system include directories.",
                 agent.config.agent_class, new_config.agent_class
             ));
-            new_config.system_include_directories = Some(
-                crate::utils::fs::resolve_system_include_directories(&new_config.agent_class, &new_config.session_id),
-            );
+            new_config.system_include_directories =
+                Some(crate::utils::fs::resolve_system_include_directories(
+                    &new_config.agent_class,
+                    &new_config.session_id,
+                ));
         }
 
         agent.config = new_config.clone();

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,17 +1,19 @@
 pub mod agent;
-pub mod terminal;
 pub mod class;
-pub mod watchlist;
 pub mod fs;
-pub mod workflow;
 pub mod library;
 pub mod patch;
+pub mod settings;
+pub mod terminal;
+pub mod watchlist;
+pub mod workflow;
 
 pub use agent::*;
-pub use terminal::*;
 pub use class::*;
-pub use watchlist::*;
 pub use fs::*;
-pub use workflow::*;
 pub use library::*;
 pub use patch::*;
+pub use settings::*;
+pub use terminal::*;
+pub use watchlist::*;
+pub use workflow::*;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,0 +1,16 @@
+use crate::utils::{ShellOption, ShellSettings};
+
+#[tauri::command]
+pub fn list_available_shells() -> Result<Vec<ShellOption>, String> {
+    Ok(crate::utils::list_available_shells())
+}
+
+#[tauri::command]
+pub fn load_shell_settings() -> Result<ShellSettings, String> {
+    crate::utils::load_shell_settings()
+}
+
+#[tauri::command]
+pub fn save_shell_settings(settings: ShellSettings) -> Result<ShellSettings, String> {
+    crate::utils::save_shell_settings(&settings)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,14 @@
+pub mod commands;
 pub mod manager;
 pub mod models;
 pub mod providers;
 pub mod state;
 pub mod utils;
-pub mod commands;
 pub mod workflow_engine;
 
-use tauri::{Emitter, Listener, Manager};
 use crate::models::AgentConfig;
 use crate::state::AppState;
+use tauri::{Emitter, Listener, Manager};
 
 #[derive(serde::Deserialize, Clone)]
 struct TerminalInputPayload {
@@ -23,8 +23,8 @@ struct TerminalInputPayload {
 pub fn run() {
     #[cfg(windows)]
     {
-        use windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
         use windows::core::PCWSTR;
+        use windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
         let aumid: Vec<u16> = "org.wardian.desktop"
             .encode_utf16()
             .chain(std::iter::once(0))
@@ -92,7 +92,7 @@ pub fn run() {
             // Restore agents from state
             tauri::async_runtime::spawn(async move {
                 let state = app_handle.state::<AppState>();
-                
+
                 // Initialize Workflow Triggers
                 workflow_engine::init_triggers(app_handle.clone()).await;
 
@@ -104,12 +104,16 @@ pub fn run() {
                             let mut order_map = state.agent_order.lock().await;
                             for mut config in configs {
                                 // Retroactively ensure the private agent directory is included
-                                config.system_include_directories = Some(utils::fs::resolve_system_include_directories(
-                                    &config.agent_class,
-                                    &config.session_id,
-                                ));
+                                config.system_include_directories =
+                                    Some(utils::fs::resolve_system_include_directories(
+                                        &config.agent_class,
+                                        &config.session_id,
+                                    ));
 
-                                if let Ok(agent) = manager::spawn_agent(app_handle.clone(), config.clone(), true).await {
+                                if let Ok(agent) =
+                                    manager::spawn_agent(app_handle.clone(), config.clone(), true)
+                                        .await
+                                {
                                     if let Some(ref tx) = agent.stdin_tx {
                                         if let Ok(mut senders) = state.input_senders.write() {
                                             senders.insert(config.session_id.clone(), tx.clone());
@@ -179,11 +183,11 @@ pub fn run() {
             commands::library::remove_deployed_skill,
             commands::library::list_deployed_skills,
             commands::library::list_skill_deployments,
-            commands::patch::run_gemini_patch
+            commands::patch::run_gemini_patch,
+            commands::settings::list_available_shells,
+            commands::settings::load_shell_settings,
+            commands::settings::save_shell_settings
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
-
-
-

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -9,6 +9,7 @@ use tauri::{AppHandle, Emitter, Manager};
 pub use crate::utils::fs::*;
 pub use crate::utils::logging::log_debug;
 pub use crate::utils::process::new_headless_command;
+pub use crate::utils::shell::build_program_launch;
 
 fn set_agent_status(
     app: &AppHandle,
@@ -167,11 +168,7 @@ pub async fn spawn_agent(
         })
         .map_err(|e| format!("Failed to open pty: {}", e))?;
 
-    let (bin, base_args) = provider.get_executable();
-    let mut cmd = CommandBuilder::new(bin);
-    for arg in base_args {
-        cmd.arg(arg);
-    }
+    let (bin, mut provider_args) = provider.get_executable();
     let claude_hook = if config.provider == "claude" {
         Some(ensure_claude_permission_hook(&config.session_id)?)
     } else {
@@ -184,43 +181,57 @@ pub async fn spawn_agent(
         Some(&config.session_id),
     )?;
     let provider_cwd = if config.provider == "codex" {
-        cwd.clone()
+        cwd.to_path_buf()
     } else {
         habitat_root
             .as_ref()
             .map(|root| habitat_workspace_cwd(root))
-            .unwrap_or_else(|| cwd.clone())
+            .unwrap_or_else(|| cwd.to_path_buf())
     };
+
+    if config.provider == "claude" {
+        if let Some(hook) = claude_hook.as_ref() {
+            provider_args.push("--settings".to_string());
+            provider_args.push(hook.settings_arg.clone());
+        }
+    } else if config.provider == "codex" {
+        provider_args.push("--cd".to_string());
+        provider_args.push(provider_cwd.to_string_lossy().to_string());
+    }
+
+    let is_resume = config
+        .resume_session
+        .as_deref()
+        .is_some_and(|s| !s.is_empty());
+    let spawn_args = provider.get_spawn_args(&config, is_resume);
+    provider_args.extend(spawn_args);
+
+    let launch_spec = build_program_launch(&bin, &provider_args)?;
+    let mut cmd = CommandBuilder::new(&launch_spec.executable);
+    for arg in launch_spec.args {
+        cmd.arg(arg);
+    }
     cmd.cwd(&provider_cwd);
 
     // Enable CLAUDE.md discovery from --add-dir directories so that
     // class/common/agent instruction files are loaded natively.
     if config.provider == "claude" {
         cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
-        if let Some(hook) = claude_hook.as_ref() {
-            cmd.arg("--settings");
-            cmd.arg(&hook.settings_arg);
-        }
     } else if config.provider == "codex" {
         if let Some(root) = habitat_root.as_ref() {
             cmd.env("CODEX_HOME", habitat_codex_home(root));
         }
-        cmd.arg("--cd");
-        cmd.arg(&provider_cwd);
     }
     #[cfg(target_os = "macos")]
     cmd.env("PATH", macos_extended_path());
 
-    let is_resume = config.resume_session.as_deref().is_some_and(|s| !s.is_empty());
-    let spawn_args = provider.get_spawn_args(&config, is_resume);
-    for arg in &spawn_args {
-        cmd.arg(arg);
-    }
-
     let resume_id = config.resume_session.as_deref().unwrap_or("");
     log_debug(&format!(
         "[Wardian] Spawning {} agent. Session: {}, Resume ID: {}, Restored: {}",
-        provider.name(), config.session_id, resume_id, is_restored
+        provider.name(),
+        config.session_id,
+        resume_id,
+        is_restored
     ));
 
     let child = pair
@@ -279,7 +290,7 @@ pub async fn spawn_agent(
     let query_count = std::sync::Arc::new(std::sync::Mutex::new(0));
     let query_count_clone = query_count.clone();
     let init_timestamp = std::sync::Arc::new(std::sync::Mutex::new(Some(
-        chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
     )));
     let init_timestamp_clone = init_timestamp.clone();
     let current_status = std::sync::Arc::new(std::sync::Mutex::new("Idle".to_string()));
@@ -378,7 +389,8 @@ pub async fn spawn_agent(
                 let path = {
                     let mut lock = watcher_log_path.lock().unwrap_or_else(|e| e.into_inner());
                     if lock.is_none() {
-                        *lock = codex_session_file_path(&watcher_session, wardian_agent_dir.as_deref());
+                        *lock =
+                            codex_session_file_path(&watcher_session, wardian_agent_dir.as_deref());
                     }
                     lock.clone()
                 };
@@ -403,7 +415,9 @@ pub async fn spawn_agent(
                                     break;
                                 }
                                 offset += read as u64;
-                                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+                                if let Ok(parsed) =
+                                    serde_json::from_str::<serde_json::Value>(line.trim())
+                                {
                                     let raw_line = parsed.to_string();
                                     if let Some(event) = watcher_provider.parse_output(&raw_line) {
                                         apply_agent_event(
@@ -499,11 +513,10 @@ pub async fn spawn_agent(
                                                         line.trim(),
                                                     )
                                                 {
-                                                    let is_tool_result = parsed
-                                                        .get("type")
-                                                        .and_then(|v| v.as_str())
-                                                        == Some("user")
-                                                        && !claude_is_real_user_query(&parsed);
+                                                    let is_tool_result =
+                                                        parsed.get("type").and_then(|v| v.as_str())
+                                                            == Some("user")
+                                                            && !claude_is_real_user_query(&parsed);
                                                     if is_tool_result {
                                                         *waiting = false;
                                                         apply_agent_status_event(
@@ -594,7 +607,9 @@ pub async fn spawn_agent(
                                     break;
                                 }
                                 offset += read as u64;
-                                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line.trim()) {
+                                if let Ok(parsed) =
+                                    serde_json::from_str::<serde_json::Value>(line.trim())
+                                {
                                     if let Ok(mut waiting) = hook_waiting_for_permission.lock() {
                                         *waiting = true;
                                     }
@@ -758,7 +773,7 @@ fn migrate_codex_bootstrap_home(
 }
 
 pub async fn run_headless(
-    cwd: &std::path::PathBuf,
+    cwd: &std::path::Path,
     prompt: &str,
     session_id: &str,
     output_format: &str,
@@ -767,52 +782,64 @@ pub async fn run_headless(
     use tokio::io::{AsyncBufReadExt, BufReader};
     let provider = ProviderFactory::resolve(provider_name)?;
     let habitat_root = prepare_provider_habitat(provider_name, cwd, "", Some(session_id))?;
-    let provider_cwd = cwd.clone();
-    let (bin, base_args) = provider.get_executable();
-    let mut cmd = new_headless_command(&bin);
-    for arg in base_args {
-        cmd.arg(arg);
-    }
+    let provider_cwd = cwd.to_path_buf();
+    let (bin, mut provider_args) = provider.get_executable();
+    let claude_hook = if provider_name == "claude" {
+        ensure_claude_permission_hook(session_id).ok()
+    } else {
+        None
+    };
     match provider_name {
         "codex" => {
-            if let Some(root) = habitat_root.as_ref() {
-                cmd.env("CODEX_HOME", habitat_codex_home(root));
-            }
-            cmd.arg("--cd")
-                .arg(&provider_cwd)
-                .arg("exec")
-                .arg("resume")
-                .arg(session_id)
-                .arg("--json")
-                .arg(prompt);
+            provider_args.push("--cd".to_string());
+            provider_args.push(provider_cwd.to_string_lossy().to_string());
+            provider_args.push("exec".to_string());
+            provider_args.push("resume".to_string());
+            provider_args.push(session_id.to_string());
+            provider_args.push("--json".to_string());
+            provider_args.push(prompt.to_string());
         }
         "claude" => {
-            cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
-            if let Ok(hook) = ensure_claude_permission_hook(session_id) {
-                cmd.arg("--settings").arg(hook.settings_arg);
+            if let Some(hook) = claude_hook.as_ref() {
+                provider_args.push("--settings".to_string());
+                provider_args.push(hook.settings_arg.clone());
             }
-            cmd.arg("--print")
-                .arg("--output-format")
-                .arg(output_format);
+            provider_args.push("--print".to_string());
+            provider_args.push("--output-format".to_string());
+            provider_args.push(output_format.to_string());
             if !session_id.is_empty() {
-                cmd.arg("--resume").arg(session_id);
+                provider_args.push("--resume".to_string());
+                provider_args.push(session_id.to_string());
             }
-            cmd.arg(prompt);
+            provider_args.push(prompt.to_string());
         }
         _ => {
-            cmd.arg("-p")
-                .arg(prompt)
-                .arg("--output-format")
-                .arg(output_format);
+            provider_args.push("-p".to_string());
+            provider_args.push(prompt.to_string());
+            provider_args.push("--output-format".to_string());
+            provider_args.push(output_format.to_string());
             if !session_id.is_empty() {
-                cmd.arg("--resume").arg(session_id);
+                provider_args.push("--resume".to_string());
+                provider_args.push(session_id.to_string());
             }
         }
+    }
+
+    let launch_spec = build_program_launch(&bin, &provider_args)?;
+    let mut cmd = new_headless_command(&launch_spec.executable);
+    for arg in launch_spec.args {
+        cmd.arg(arg);
+    }
+    if provider_name == "codex" {
+        if let Some(root) = habitat_root.as_ref() {
+            cmd.env("CODEX_HOME", habitat_codex_home(root));
+        }
+    } else if provider_name == "claude" {
+        cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
     }
     cmd.current_dir(&provider_cwd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
-
 
     log_debug(&format!(
         "[Wardian] run_headless: provider={}, session_id={}, cwd={}, prompt_len={}, output_format={}",
@@ -834,7 +861,9 @@ pub async fn run_headless(
                 let mut reader = BufReader::new(stream);
                 let mut line = String::new();
                 while let Ok(n) = reader.read_line(&mut line).await {
-                    if n == 0 { break; }
+                    if n == 0 {
+                        break;
+                    }
                     out.push_str(&line);
                     line.clear();
                 }
@@ -851,7 +880,9 @@ pub async fn run_headless(
                 let mut reader = BufReader::new(stream);
                 let mut line = String::new();
                 while let Ok(n) = reader.read_line(&mut line).await {
-                    if n == 0 { break; }
+                    if n == 0 {
+                        break;
+                    }
                     err.push_str(&line);
                     line.clear();
                 }
@@ -926,20 +957,20 @@ pub async fn run_headless(
 }
 
 pub async fn obtain_session_id(
-    cwd: &std::path::PathBuf,
+    cwd: &std::path::Path,
     agent_class: Option<&str>,
     config: Option<&AgentConfig>,
 ) -> Result<String, String> {
     use tokio::io::{AsyncBufReadExt, BufReader};
     let provider_name = config.map(|c| c.provider.as_str()).unwrap_or("claude");
     let provider = ProviderFactory::resolve(provider_name)?;
-    let (bin, base_args) = provider.get_executable();
-    let mut cmd = new_headless_command(&bin);
+    let (bin, mut provider_args) = provider.get_executable();
     let class_name = agent_class
         .filter(|name| !name.trim().is_empty())
         .or_else(|| {
-            config
-                .and_then(|cfg| (!cfg.agent_class.trim().is_empty()).then_some(cfg.agent_class.as_str()))
+            config.and_then(|cfg| {
+                (!cfg.agent_class.trim().is_empty()).then_some(cfg.agent_class.as_str())
+            })
         })
         .unwrap_or("");
     let habitat_root = prepare_provider_habitat(provider_name, cwd, class_name, None)?;
@@ -955,49 +986,42 @@ pub async fn obtain_session_id(
         habitat_root
             .as_ref()
             .map(|root| habitat_workspace_cwd(root))
-            .unwrap_or_else(|| cwd.clone())
+            .unwrap_or_else(|| cwd.to_path_buf())
     };
-    for arg in base_args {
-        cmd.arg(arg);
-    }
+
     if provider_name == "codex" {
-        if let Some((_, bootstrap_home)) = codex_bootstrap.as_ref() {
-            let real_codex_home = dirs::home_dir()
-                .ok_or("Could not find user home directory")?
-                .join(".codex");
-            sync_codex_agent_home(&real_codex_home, bootstrap_home, std::path::Path::new(""))?;
-            cmd.env("CODEX_HOME", bootstrap_home);
-        } else if let Some(root) = habitat_root.as_ref() {
-            cmd.env("CODEX_HOME", habitat_codex_home(root));
-        }
-        cmd.arg("--cd").arg(&provider_cwd);
-        cmd.arg("exec");
+        provider_args.push("--cd".to_string());
+        provider_args.push(provider_cwd.to_string_lossy().to_string());
+        provider_args.push("exec".to_string());
 
         if let Some(config) = config {
             if let Some(ref model) = config.model {
-                cmd.arg("--model").arg(model);
+                provider_args.push("--model".to_string());
+                provider_args.push(model.clone());
             }
             if let Some(ref profile) = config.codex_profile {
                 if !profile.trim().is_empty() {
-                    cmd.arg("--profile").arg(profile);
+                    provider_args.push("--profile".to_string());
+                    provider_args.push(profile.clone());
                 }
             }
             if let Some(ref sandbox_mode) = config.codex_sandbox_mode {
                 if !sandbox_mode.trim().is_empty() {
-                    cmd.arg("--sandbox").arg(sandbox_mode);
+                    provider_args.push("--sandbox".to_string());
+                    provider_args.push(sandbox_mode.clone());
                 }
             }
             if config.codex_full_auto.unwrap_or(false) {
-                cmd.arg("--full-auto");
+                provider_args.push("--full-auto".to_string());
             }
             if config.codex_search.unwrap_or(false) {
-                cmd.arg("--search");
+                provider_args.push("--search".to_string());
             }
             if config.codex_skip_git_repo_check.unwrap_or(true) {
-                cmd.arg("--skip-git-repo-check");
+                provider_args.push("--skip-git-repo-check".to_string());
             }
             if config.codex_ephemeral.unwrap_or(false) {
-                cmd.arg("--ephemeral");
+                provider_args.push("--ephemeral".to_string());
             }
 
             let mut final_includes = config
@@ -1012,49 +1036,72 @@ pub async fn obtain_session_id(
                 }
             }
             for dir in final_includes {
-                cmd.arg("--add-dir").arg(dir);
+                provider_args.push("--add-dir".to_string());
+                provider_args.push(dir);
             }
 
             if let Some(ref custom) = config.custom_args {
                 if let Some(parsed) = shlex::split(custom) {
-                    for arg in parsed {
-                        cmd.arg(arg);
-                    }
+                    provider_args.extend(parsed);
                 }
             }
         }
 
-        cmd.arg("--json")
-            .arg("Introduce yourself")
-            .current_dir(&provider_cwd)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
+        provider_args.push("--json".to_string());
+        provider_args.push("Introduce yourself".to_string());
     } else if provider_name == "claude" {
-        cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1")
-            .arg("--print")
-            .arg("--verbose")
-            .arg("--output-format")
-            .arg("stream-json")
-            .arg("Introduce yourself")
-            .current_dir(cwd)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
+        provider_args.push("--print".to_string());
+        provider_args.push("--verbose".to_string());
+        provider_args.push("--output-format".to_string());
+        provider_args.push("stream-json".to_string());
+        provider_args.push("Introduce yourself".to_string());
     } else {
-        cmd.arg("-p")
-            .arg("Introduce yourself")
-            .arg("-o")
-            .arg("stream-json")
-            .current_dir(&provider_cwd)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped());
+        provider_args.push("-p".to_string());
+        provider_args.push("Introduce yourself".to_string());
+        provider_args.push("-o".to_string());
+        provider_args.push("stream-json".to_string());
     }
+
+    let launch_spec = build_program_launch(&bin, &provider_args)?;
+    let mut cmd = new_headless_command(&launch_spec.executable);
+    for arg in launch_spec.args {
+        cmd.arg(arg);
+    }
+
+    if provider_name == "codex" {
+        if let Some((_, bootstrap_home)) = codex_bootstrap.as_ref() {
+            let real_codex_home = dirs::home_dir()
+                .ok_or("Could not find user home directory")?
+                .join(".codex");
+            sync_codex_agent_home(&real_codex_home, bootstrap_home, std::path::Path::new(""))?;
+            cmd.env("CODEX_HOME", bootstrap_home);
+        } else if let Some(root) = habitat_root.as_ref() {
+            cmd.env("CODEX_HOME", habitat_codex_home(root));
+        }
+    } else if provider_name == "claude" {
+        cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
+        cmd.stdin(std::process::Stdio::null());
+    } else {
+        cmd.stdin(std::process::Stdio::null());
+    }
+
+    let command_cwd = if provider_name == "claude" {
+        cwd.to_path_buf()
+    } else {
+        provider_cwd.clone()
+    };
+
+    cmd.current_dir(&command_cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
 
     #[cfg(target_os = "macos")]
     cmd.env("PATH", macos_extended_path());
 
-    log_debug(&format!("[WARDIAN-DEBUG] Running obtain_session_id for provider {}", provider_name));
+    log_debug(&format!(
+        "[WARDIAN-DEBUG] Running obtain_session_id for provider {}",
+        provider_name
+    ));
     match cmd.spawn() {
         Ok(mut child) => {
             log_debug("[WARDIAN-DEBUG] Spawned headless process. Reading stdout...");
@@ -1077,14 +1124,21 @@ pub async fn obtain_session_id(
                             let json_part = &trimmed[start..];
                             if let Some(evt) = provider.parse_output(json_part) {
                                 match evt {
-                                    AgentEvent::Init { session_id: sid, .. } if !sid.is_empty() => {
-                                        log_debug(&format!("[WARDIAN-DEBUG] Found session_id: {}", sid));
+                                    AgentEvent::Init {
+                                        session_id: sid, ..
+                                    } if !sid.is_empty() => {
+                                        log_debug(&format!(
+                                            "[WARDIAN-DEBUG] Found session_id: {}",
+                                            sid
+                                        ));
                                         session_id = Some(sid);
                                     }
                                     // ModelResponse means the prompt completed and the session
                                     // has been persisted to disk — safe to stop reading.
                                     AgentEvent::ModelResponse => {
-                                        log_debug("[WARDIAN-DEBUG] Prompt complete, session saved.");
+                                        log_debug(
+                                            "[WARDIAN-DEBUG] Prompt complete, session saved.",
+                                        );
                                         break;
                                     }
                                     _ => {}
@@ -1098,8 +1152,14 @@ pub async fn obtain_session_id(
             };
 
             let timed_out = match tokio::time::timeout(timeout, read_future).await {
-                Ok(sid) => { session_id_res = sid; false }
-                Err(_) => { log_debug("[WARDIAN-DEBUG] Timed out waiting for session_id."); true }
+                Ok(sid) => {
+                    session_id_res = sid;
+                    false
+                }
+                Err(_) => {
+                    log_debug("[WARDIAN-DEBUG] Timed out waiting for session_id.");
+                    true
+                }
             };
 
             // Only force-kill if we timed out; otherwise let the process exit naturally
@@ -1126,13 +1186,23 @@ pub async fn obtain_session_id(
                 ));
             }
             if provider_name == "codex" {
-                if let (Some(session_id), Some((_, bootstrap_home))) = (session_id_res.as_ref(), codex_bootstrap.as_ref()) {
-                    if let Some(final_habitat_root) = prepare_provider_habitat(provider_name, cwd, class_name, Some(session_id))? {
-                        migrate_codex_bootstrap_home(bootstrap_home, &habitat_codex_home(&final_habitat_root))?;
+                if let (Some(session_id), Some((_, bootstrap_home))) =
+                    (session_id_res.as_ref(), codex_bootstrap.as_ref())
+                {
+                    if let Some(final_habitat_root) =
+                        prepare_provider_habitat(provider_name, cwd, class_name, Some(session_id))?
+                    {
+                        migrate_codex_bootstrap_home(
+                            bootstrap_home,
+                            &habitat_codex_home(&final_habitat_root),
+                        )?;
                     }
                 }
             }
-            log_debug(&format!("[WARDIAN-DEBUG] Returning session_id: {:?}", session_id_res));
+            log_debug(&format!(
+                "[WARDIAN-DEBUG] Returning session_id: {:?}",
+                session_id_res
+            ));
             session_id_res.ok_or_else(|| {
                 if stderr_output.trim().is_empty() {
                     format!(
@@ -1146,7 +1216,10 @@ pub async fn obtain_session_id(
         }
         Err(e) => {
             log_debug(&format!("[WARDIAN-DEBUG] Failed to spawn cmd: {:?}", e));
-            Err(format!("Failed to spawn {} bootstrap command: {}", provider_name, e))
+            Err(format!(
+                "Failed to spawn {} bootstrap command: {}",
+                provider_name, e
+            ))
         }
     }
 }
@@ -1164,7 +1237,10 @@ fn claude_project_dir_name(workspace: &str) -> String {
         .collect()
 }
 
-fn codex_session_file_path_in(base: &std::path::Path, session_id: &str) -> Option<std::path::PathBuf> {
+fn codex_session_file_path_in(
+    base: &std::path::Path,
+    session_id: &str,
+) -> Option<std::path::PathBuf> {
     let base = base.join("sessions");
     let years = std::fs::read_dir(base).ok()?;
 
@@ -1200,9 +1276,14 @@ fn codex_session_file_path_in(base: &std::path::Path, session_id: &str) -> Optio
     None
 }
 
-fn codex_session_file_path(session_id: &str, wardian_agent_dir: Option<&str>) -> Option<std::path::PathBuf> {
+fn codex_session_file_path(
+    session_id: &str,
+    wardian_agent_dir: Option<&str>,
+) -> Option<std::path::PathBuf> {
     if let Some(agent_dir) = wardian_agent_dir {
-        let projected_home = std::path::Path::new(agent_dir).join("habitat").join(".codex");
+        let projected_home = std::path::Path::new(agent_dir)
+            .join("habitat")
+            .join(".codex");
         if let Some(path) = codex_session_file_path_in(&projected_home, session_id) {
             return Some(path);
         }
@@ -1240,16 +1321,16 @@ fn claude_is_real_user_query(line: &serde_json::Value) -> bool {
         return true;
     };
 
-    !items.iter().any(|item| item.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
+    !items
+        .iter()
+        .any(|item| item.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
 }
 
 fn claude_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
     for line in lines.iter().rev() {
         match line.get("type").and_then(|v| v.as_str()) {
             Some("system") => {
-                if let Some("permission_request") =
-                    line.get("subtype").and_then(|v| v.as_str())
-                {
+                if let Some("permission_request") = line.get("subtype").and_then(|v| v.as_str()) {
                     return Some("Action Needed".to_string());
                 }
             }
@@ -1373,7 +1454,9 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                             .map(|home| home.join("agents").join(&snap.session_id))
                             .filter(|path| path.exists())
                             .map(|path| path.to_string_lossy().to_string());
-                        if let Some(path) = codex_session_file_path(&snap.session_id, agent_home.as_deref()) {
+                        if let Some(path) =
+                            codex_session_file_path(&snap.session_id, agent_home.as_deref())
+                        {
                             *log_path_lock = Some(path);
                         }
                     }
@@ -1402,9 +1485,13 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                     let chat_dir = entry.path().join("chats");
                                     if let Ok(chat_files) = std::fs::read_dir(chat_dir) {
                                         for chat_file in chat_files.flatten() {
-                                            if let Ok(content) = std::fs::read_to_string(chat_file.path()) {
+                                            if let Ok(content) =
+                                                std::fs::read_to_string(chat_file.path())
+                                            {
                                                 if let Ok(p) =
-                                                    serde_json::from_str::<serde_json::Value>(&content)
+                                                    serde_json::from_str::<serde_json::Value>(
+                                                        &content,
+                                                    )
                                                 {
                                                     if p.get("sessionId").and_then(|v| v.as_str())
                                                         == Some(&snap.session_id)
@@ -1436,13 +1523,16 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                 .filter_map(|l| serde_json::from_str(l).ok())
                                 .collect();
 
-                            q_count = lines.iter().filter(|l| {
-                                l.get("type").and_then(|v| v.as_str()) == Some("event_msg")
-                                    && l.get("payload")
-                                        .and_then(|v| v.get("type"))
-                                        .and_then(|v| v.as_str())
-                                        == Some("user_message")
-                            }).count();
+                            q_count = lines
+                                .iter()
+                                .filter(|l| {
+                                    l.get("type").and_then(|v| v.as_str()) == Some("event_msg")
+                                        && l.get("payload")
+                                            .and_then(|v| v.get("type"))
+                                            .and_then(|v| v.as_str())
+                                            == Some("user_message")
+                                })
+                                .count();
 
                             if let Some(meta) = lines.iter().find(|l| {
                                 l.get("type").and_then(|v| v.as_str()) == Some("session_meta")
@@ -1467,24 +1557,32 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                 .filter_map(|l| serde_json::from_str(l).ok())
                                 .collect();
 
-                            q_count = lines.iter().filter(|l| {
-                                l.get("type").and_then(|v| v.as_str()) == Some("user")
-                                    && claude_is_real_user_query(l)
-                            }).count();
+                            q_count = lines
+                                .iter()
+                                .filter(|l| {
+                                    l.get("type").and_then(|v| v.as_str()) == Some("user")
+                                        && claude_is_real_user_query(l)
+                                })
+                                .count();
 
                             if let Some(first) = lines.first() {
                                 if let Some(ts) = first.get("timestamp").and_then(|v| v.as_str()) {
                                     i_ts = Some(ts.to_string());
-                                } else if let Some(ts_num) = first.get("timestamp").and_then(|v| v.as_i64()) {
+                                } else if let Some(ts_num) =
+                                    first.get("timestamp").and_then(|v| v.as_i64())
+                                {
                                     // Fallback if timestamp is an epoch number
-                                    if let Some(dt) = chrono::DateTime::from_timestamp_millis(ts_num) {
-                                        i_ts = Some(dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
+                                    if let Some(dt) =
+                                        chrono::DateTime::from_timestamp_millis(ts_num)
+                                    {
+                                        i_ts = Some(
+                                            dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                                        );
                                     }
                                 }
                             }
 
-                            let current_status =
-                                snap.current_status.lock().unwrap().clone();
+                            let current_status = snap.current_status.lock().unwrap().clone();
                             if current_status != "Action Needed" {
                                 if let Some(status) = claude_status_from_log(&lines) {
                                     *snap.current_status.lock().unwrap() = status;
@@ -1495,9 +1593,14 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                             // Gemini logs are a single JSON object with a messages array
                             if let Ok(p) = serde_json::from_str::<serde_json::Value>(&content) {
                                 if let Some(msgs) = p.get("messages").and_then(|v| v.as_array()) {
-                                    q_count = msgs.iter().filter(|m| {
-                                        m.get("type").and_then(|v| v.as_str()) == Some("user") || m.get("role").and_then(|v| v.as_str()) == Some("user")
-                                    }).count();
+                                    q_count = msgs
+                                        .iter()
+                                        .filter(|m| {
+                                            m.get("type").and_then(|v| v.as_str()) == Some("user")
+                                                || m.get("role").and_then(|v| v.as_str())
+                                                    == Some("user")
+                                        })
+                                        .count();
                                 }
                                 if let Some(st) = p.get("startTime").and_then(|v| v.as_str()) {
                                     i_ts = Some(st.to_string());
@@ -1550,10 +1653,7 @@ pub fn get_all_agent_classes(_app: &AppHandle) -> Vec<AgentClassDefinition> {
     Vec::new()
 }
 
-pub fn save_classes(
-    _app: &AppHandle,
-    classes: &[AgentClassDefinition],
-) -> Result<(), String> {
+pub fn save_classes(_app: &AppHandle, classes: &[AgentClassDefinition]) -> Result<(), String> {
     let app_dir = get_wardian_home().ok_or("No home dir")?;
     let json = serde_json::to_string_pretty(classes).map_err(|e| e.to_string())?;
     std::fs::write(app_dir.join("classes.json"), json).map_err(|e| e.to_string())?;
@@ -1571,7 +1671,7 @@ pub fn init_agent_classes(app: &AppHandle) {
         ensure_claude_skills_link(&app_dir.join("common"));
 
         let classes_path = app_dir.join("classes.json");
-        
+
         // Migration and Initialization
         if !classes_path.exists() {
             let mut defaults: Vec<AgentClassDefinition> =
@@ -1583,7 +1683,8 @@ pub fn init_agent_classes(app: &AppHandle) {
             let custom_path = app_dir.join("custom_classes.json");
             if custom_path.exists() {
                 if let Ok(data) = std::fs::read_to_string(&custom_path) {
-                    let mut custom = serde_json::from_str::<Vec<AgentClassDefinition>>(&data).unwrap_or_default();
+                    let mut custom = serde_json::from_str::<Vec<AgentClassDefinition>>(&data)
+                        .unwrap_or_default();
                     for c in custom.iter_mut() {
                         c.is_default = false;
                     }
@@ -1600,7 +1701,7 @@ pub fn init_agent_classes(app: &AppHandle) {
         for cls in &classes {
             let role_dir = classes_dir.join(&cls.name);
             let _ = std::fs::create_dir_all(&role_dir);
-            
+
             // 1. Create AGENTS.md master file
             let agents_md_path = role_dir.join("AGENTS.md");
             if !agents_md_path.exists() {
@@ -1658,7 +1759,6 @@ pub async fn kill_all_agents(state: &AppState) {
     state.agent_order.lock().await.clear();
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::codex_bootstrap_launch_context;
@@ -1668,7 +1768,8 @@ mod tests {
     fn codex_bootstrap_launch_context_uses_real_workspace_cwd() {
         let wardian_home = Path::new("C:/Users/test/.wardian");
         let workspace_cwd = Path::new("D:/Development/Wardian");
-        let (provider_cwd, bootstrap_home) = codex_bootstrap_launch_context(wardian_home, workspace_cwd);
+        let (provider_cwd, bootstrap_home) =
+            codex_bootstrap_launch_context(wardian_home, workspace_cwd);
 
         assert_eq!(provider_cwd, workspace_cwd);
         assert!(bootstrap_home.starts_with(wardian_home.join("provider-bootstrap").join("codex")));

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1746,6 +1746,7 @@ pub fn get_agent_class_default_instruction(app: &AppHandle, class_name: &str) ->
 
 pub async fn kill_all_agents(state: &AppState) {
     let mut agents = state.agents.lock().await;
+    #[allow(unused_mut)]
     for (sid, mut agent) in agents.drain() {
         log_debug(&format!("[Wardian] Killing session {}", sid));
         if let Some(mut child) = agent.child_process {

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -15,6 +15,21 @@ impl ClaudeProvider {
         ClaudeProvider
     }
 
+    #[cfg(not(target_os = "windows"))]
+    fn find_unix_claude_in_paths<I>(paths: I) -> Option<String>
+    where
+        I: IntoIterator<Item = std::path::PathBuf>,
+    {
+        for path in paths {
+            let full_path = path.join("claude");
+            if full_path.exists() {
+                return Some(full_path.to_string_lossy().to_string());
+            }
+        }
+
+        None
+    }
+
     fn is_real_user_query(parsed: &serde_json::Value) -> bool {
         let Some(message) = parsed.get("message") else {
             return true;
@@ -103,11 +118,8 @@ impl AgentProvider for ClaudeProvider {
         #[cfg(not(target_os = "windows"))]
         {
             if let Some(paths) = std::env::var_os("PATH") {
-                for path in std::env::split_paths(&paths) {
-                    let full_path = path.join("claude");
-                    if full_path.exists() {
-                        ("claude".to_string(), vec![])
-                    }
+                if let Some(executable) = Self::find_unix_claude_in_paths(std::env::split_paths(&paths)) {
+                    return (executable, vec![]);
                 }
             }
 
@@ -506,6 +518,18 @@ mod tests {
         let args_resume = p.get_spawn_args(&config, true);
         assert!(!args_resume.contains(&"--name".to_string()));
         assert!(args_resume.contains(&"--resume".to_string()));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn unix_path_lookup_prefers_discovered_claude_binary() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let claude_path = temp.path().join("claude");
+        std::fs::write(&claude_path, "").expect("create fake claude");
+
+        let resolved = ClaudeProvider::find_unix_claude_in_paths(vec![temp.path().to_path_buf()]);
+
+        assert_eq!(resolved, Some(claude_path.to_string_lossy().to_string()));
     }
 
     #[test]

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -27,7 +27,9 @@ impl ClaudeProvider {
             return true;
         };
 
-        !items.iter().any(|item| item.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
+        !items
+            .iter()
+            .any(|item| item.get("type").and_then(|v| v.as_str()) == Some("tool_result"))
     }
 
     fn assistant_event(parsed: &serde_json::Value) -> AgentEvent {
@@ -51,27 +53,64 @@ impl AgentProvider for ClaudeProvider {
     }
 
     fn get_executable(&self) -> (String, Vec<String>) {
-        let exe_name = if cfg!(target_os = "windows") { "claude.cmd" } else { "claude" };
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(paths) = std::env::var_os("PATH") {
+                let path_exts = std::env::var("PATHEXT")
+                    .ok()
+                    .map(|value| {
+                        value
+                            .split(';')
+                            .filter_map(|segment| {
+                                let trimmed = segment.trim();
+                                if trimmed.is_empty() {
+                                    None
+                                } else {
+                                    Some(trimmed.to_ascii_lowercase())
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|exts| !exts.is_empty())
+                    .unwrap_or_else(|| {
+                        vec![".exe".to_string(), ".cmd".to_string(), ".bat".to_string()]
+                    });
 
-        // 1. Try bare command in PATH
-        if let Some(paths) = std::env::var_os("PATH") {
-            for path in std::env::split_paths(&paths) {
-                let full_path = path.join(exe_name);
-                if full_path.exists() {
-                    return (exe_name.to_string(), vec![]);
+                for path in std::env::split_paths(&paths) {
+                    let direct = path.join("claude");
+                    if direct.exists() {
+                        return (direct.to_string_lossy().to_string(), vec![]);
+                    }
+                    for ext in &path_exts {
+                        let candidate = path.join(format!("claude{ext}"));
+                        if candidate.exists() {
+                            return (candidate.to_string_lossy().to_string(), vec![]);
+                        }
+                    }
                 }
             }
-        }
 
-        // 2. Robust Fallback
-        if cfg!(target_os = "windows") {
             if let Some(appdata) = dirs::data_dir() {
                 let npm_claude = appdata.join("npm").join("claude.cmd");
                 if npm_claude.exists() {
                     return (npm_claude.to_string_lossy().to_string(), vec![]);
                 }
             }
-        } else {
+
+            ("claude".to_string(), vec![])
+        }
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            if let Some(paths) = std::env::var_os("PATH") {
+                for path in std::env::split_paths(&paths) {
+                    let full_path = path.join("claude");
+                    if full_path.exists() {
+                        ("claude".to_string(), vec![])
+                    }
+                }
+            }
+
             let home = dirs::home_dir().unwrap_or_default();
             let fallbacks = vec![
                 home.join(".npm-global/bin/claude"),
@@ -83,10 +122,9 @@ impl AgentProvider for ClaudeProvider {
                     return (path.to_string_lossy().to_string(), vec![]);
                 }
             }
-        }
 
-        // 3. Ultimate Fallback
-        (exe_name.to_string(), vec![])
+            ("claude".to_string(), vec![])
+        }
     }
 
     fn get_spawn_args(&self, config: &AgentConfig, is_resume: bool) -> Vec<String> {
@@ -213,7 +251,10 @@ impl AgentProvider for ClaudeProvider {
                             .get("timestamp")
                             .and_then(|v| v.as_str())
                             .map(|s| s.to_string());
-                        Some(AgentEvent::Init { session_id, timestamp })
+                        Some(AgentEvent::Init {
+                            session_id,
+                            timestamp,
+                        })
                     }
                     // Claude Code emits this when a tool call needs explicit permission
                     "permission_request" => {
@@ -310,7 +351,9 @@ mod tests {
         let event = p.parse_output(line).unwrap();
         assert_eq!(
             event,
-            AgentEvent::ActionRequired { message: "bash".into() }
+            AgentEvent::ActionRequired {
+                message: "bash".into()
+            }
         );
     }
 

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,7 +1,9 @@
 pub mod fs;
 pub mod logging;
 pub mod process;
+pub mod shell;
 
 pub use fs::*;
 pub use logging::*;
 pub use process::*;
+pub use shell::*;

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -1,0 +1,877 @@
+use crate::utils::get_wardian_home;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+const SHELL_SETTINGS_FILE: &str = "shell_settings.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShellOption {
+    pub id: String,
+    pub label: String,
+    pub executable: String,
+    #[serde(default)]
+    pub default_args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ShellSettings {
+    pub shell_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_executable: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_args: Option<String>,
+}
+
+impl Default for ShellSettings {
+    fn default() -> Self {
+        Self {
+            shell_id: "auto".to_string(),
+            custom_executable: None,
+            custom_args: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShellLaunchSpec {
+    pub executable: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedShell {
+    id: String,
+    executable: String,
+    default_args: Vec<String>,
+}
+
+pub fn list_available_shells() -> Vec<ShellOption> {
+    #[cfg(windows)]
+    {
+        discover_windows_shells()
+    }
+    #[cfg(not(windows))]
+    {
+        discover_unix_shells()
+    }
+}
+
+pub fn load_shell_settings() -> Result<ShellSettings, String> {
+    let path = shell_settings_path()?;
+    load_shell_settings_from_path(&path)
+}
+
+pub fn save_shell_settings(settings: &ShellSettings) -> Result<ShellSettings, String> {
+    let path = shell_settings_path()?;
+    save_shell_settings_to_path(&path, settings)
+}
+
+pub fn build_shell_command(command: &str) -> Result<ShellLaunchSpec, String> {
+    let settings = load_shell_settings().unwrap_or_default();
+    let available = list_available_shells();
+    build_shell_command_with_settings(command, &settings, &available)
+}
+
+pub fn build_program_launch(program: &str, args: &[String]) -> Result<ShellLaunchSpec, String> {
+    let settings = load_shell_settings().unwrap_or_default();
+    let available = list_available_shells();
+    build_program_launch_with_settings(program, args, &settings, &available)
+}
+
+fn shell_settings_path() -> Result<PathBuf, String> {
+    let wardian_home = get_wardian_home().ok_or("Could not find Wardian home")?;
+    Ok(wardian_home.join(SHELL_SETTINGS_FILE))
+}
+
+fn load_shell_settings_from_path(path: &Path) -> Result<ShellSettings, String> {
+    if !path.exists() {
+        return Ok(ShellSettings::default());
+    }
+
+    let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let settings = serde_json::from_str::<ShellSettings>(&content).map_err(|e| e.to_string())?;
+    Ok(normalize_settings(settings))
+}
+
+fn save_shell_settings_to_path(
+    path: &Path,
+    settings: &ShellSettings,
+) -> Result<ShellSettings, String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+
+    let normalized = normalize_settings(settings.clone());
+    validate_shell_settings(&normalized, &list_available_shells())?;
+    let content = serde_json::to_string_pretty(&normalized).map_err(|e| e.to_string())?;
+    std::fs::write(path, content).map_err(|e| e.to_string())?;
+    Ok(normalized)
+}
+
+fn normalize_settings(mut settings: ShellSettings) -> ShellSettings {
+    settings.shell_id = if settings.shell_id.trim().is_empty() {
+        "auto".to_string()
+    } else {
+        settings.shell_id.trim().to_string()
+    };
+    settings.custom_executable = settings
+        .custom_executable
+        .and_then(|value| trim_to_option(&value));
+    settings.custom_args = settings
+        .custom_args
+        .and_then(|value| trim_to_option(&value));
+    settings
+}
+
+fn trim_to_option(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn validate_shell_settings(
+    settings: &ShellSettings,
+    available: &[ShellOption],
+) -> Result<(), String> {
+    resolve_shell(settings, available).map(|_| ())
+}
+
+pub fn build_shell_command_with_settings(
+    command: &str,
+    settings: &ShellSettings,
+    available: &[ShellOption],
+) -> Result<ShellLaunchSpec, String> {
+    if command.trim().is_empty() {
+        return Err("Missing shell command".to_string());
+    }
+
+    let shell = resolve_shell(settings, available)?;
+    let mut args = shell.default_args;
+    if args.is_empty() {
+        return Err("Selected shell does not define how to execute a command string".to_string());
+    }
+    args.push(command.to_string());
+
+    Ok(ShellLaunchSpec {
+        executable: shell.executable,
+        args,
+    })
+}
+
+pub fn build_program_launch_with_settings(
+    program: &str,
+    program_args: &[String],
+    settings: &ShellSettings,
+    available: &[ShellOption],
+) -> Result<ShellLaunchSpec, String> {
+    if program.trim().is_empty() {
+        return Err("Missing program executable".to_string());
+    }
+
+    let shell = resolve_shell(settings, available)?;
+    let command_text = build_program_command_text(&shell.id, program, program_args);
+    let mut args = shell.default_args;
+    if args.is_empty() {
+        return Err("Selected shell does not define how to execute a command string".to_string());
+    }
+    args.push(command_text);
+
+    Ok(ShellLaunchSpec {
+        executable: shell.executable,
+        args,
+    })
+}
+
+fn resolve_shell(
+    settings: &ShellSettings,
+    available: &[ShellOption],
+) -> Result<ResolvedShell, String> {
+    match settings.shell_id.as_str() {
+        "auto" => resolve_auto_shell(available)
+            .cloned()
+            .map(shell_option_to_resolved)
+            .ok_or("No compatible shell was discovered on this system".to_string()),
+        "custom" => {
+            let executable = settings
+                .custom_executable
+                .clone()
+                .ok_or("Custom shell requires an executable path")?;
+            let default_args = inferred_custom_args(&executable, settings.custom_args.as_deref())?;
+            if default_args.is_empty() {
+                return Err(
+                    "Custom shell must provide command arguments such as -Command, -c, or /C"
+                        .to_string(),
+                );
+            }
+
+            Ok(ResolvedShell {
+                id: shell_id_from_executable(Path::new(&executable)),
+                executable,
+                default_args,
+            })
+        }
+        shell_id => available
+            .iter()
+            .find(|option| option.id == shell_id)
+            .cloned()
+            .map(shell_option_to_resolved)
+            .ok_or_else(|| {
+                format!(
+                    "Selected shell '{}' is not available on this system",
+                    shell_id
+                )
+            }),
+    }
+}
+
+fn shell_option_to_resolved(option: ShellOption) -> ResolvedShell {
+    ResolvedShell {
+        id: option.id,
+        executable: option.executable,
+        default_args: option.default_args,
+    }
+}
+
+fn inferred_custom_args(
+    executable: &str,
+    custom_args: Option<&str>,
+) -> Result<Vec<String>, String> {
+    if let Some(custom_args) = custom_args {
+        let parsed =
+            shlex::split(custom_args).ok_or("Custom shell arguments could not be parsed")?;
+        if !parsed.is_empty() {
+            return Ok(parsed);
+        }
+    }
+
+    Ok(default_shell_args(&shell_id_from_executable(Path::new(
+        executable,
+    ))))
+}
+
+fn build_program_command_text(shell_id: &str, program: &str, program_args: &[String]) -> String {
+    #[cfg(windows)]
+    if shell_id == "wsl" {
+        let cmd_invocation = build_cmd_invocation(program, program_args);
+        return format!("exec cmd.exe /c {}", quote_posix_arg(&cmd_invocation));
+    }
+
+    match shell_id {
+        "cmd" => build_cmd_invocation(program, program_args),
+        "powershell" | "pwsh" => build_powershell_invocation(program, program_args),
+        _ => {
+            #[cfg(windows)]
+            {
+                if is_windows_cmd_shim(program) {
+                    let cmd_invocation = build_cmd_invocation(program, program_args);
+                    return format!("exec cmd.exe /c {}", quote_posix_arg(&cmd_invocation));
+                }
+            }
+            build_posix_invocation(program, program_args)
+        }
+    }
+}
+
+fn build_cmd_invocation(program: &str, program_args: &[String]) -> String {
+    let mut fragments = Vec::with_capacity(program_args.len() + 2);
+    if is_windows_cmd_shim(program) {
+        fragments.push("call".to_string());
+    }
+    fragments.push(quote_cmd_arg(program));
+    fragments.extend(program_args.iter().map(|arg| quote_cmd_arg(arg)));
+    fragments.join(" ")
+}
+
+fn build_powershell_invocation(program: &str, program_args: &[String]) -> String {
+    #[cfg(windows)]
+    if is_windows_cmd_shim(program) {
+        let cmd_invocation = build_cmd_invocation(program, program_args);
+        return format!(
+            "& $env:ComSpec /d /c {}",
+            quote_powershell_arg(&cmd_invocation)
+        );
+    }
+
+    let mut fragments = Vec::with_capacity(program_args.len() + 2);
+    fragments.push("&".to_string());
+    fragments.push(quote_powershell_arg(program));
+    fragments.extend(program_args.iter().map(|arg| quote_powershell_arg(arg)));
+    fragments.join(" ")
+}
+
+fn build_posix_invocation(program: &str, program_args: &[String]) -> String {
+    let mut fragments = Vec::with_capacity(program_args.len() + 2);
+    fragments.push("exec".to_string());
+    fragments.push(quote_posix_arg(program));
+    fragments.extend(program_args.iter().map(|arg| quote_posix_arg(arg)));
+    fragments.join(" ")
+}
+
+fn quote_cmd_arg(value: &str) -> String {
+    let escaped = value.replace('"', r#"\""#);
+    if escaped.is_empty()
+        || escaped
+            .chars()
+            .any(|ch| ch.is_whitespace() || matches!(ch, '^' | '&' | '|' | '<' | '>' | '(' | ')'))
+    {
+        format!("\"{}\"", escaped)
+    } else {
+        escaped
+    }
+}
+
+fn quote_powershell_arg(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn quote_posix_arg(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn resolve_auto_shell(available: &[ShellOption]) -> Option<&ShellOption> {
+    #[cfg(windows)]
+    let preferred_ids = ["pwsh", "powershell", "cmd", "git-bash", "wsl", "bash"];
+    #[cfg(not(windows))]
+    let preferred_ids = ["zsh", "bash", "sh", "fish"];
+
+    #[cfg(not(windows))]
+    if let Ok(current_shell) = std::env::var("SHELL") {
+        let current_id = shell_id_from_executable(Path::new(&current_shell));
+        if let Some(shell) = available.iter().find(|option| option.id == current_id) {
+            return Some(shell);
+        }
+    }
+
+    preferred_ids
+        .iter()
+        .find_map(|id| available.iter().find(|option| option.id == *id))
+        .or_else(|| available.first())
+}
+
+#[cfg(windows)]
+fn discover_windows_shells() -> Vec<ShellOption> {
+    let mut shells = Vec::new();
+
+    if let Some(executable) = system_executable("cmd.exe") {
+        shells.push(shell_option(
+            "cmd",
+            "Command Prompt",
+            executable,
+            default_shell_args("cmd"),
+        ));
+    }
+    if let Some(executable) = find_executable("pwsh") {
+        shells.push(shell_option(
+            "pwsh",
+            "PowerShell 7",
+            executable,
+            default_shell_args("pwsh"),
+        ));
+    }
+    if let Some(executable) = system_executable("WindowsPowerShell\\v1.0\\powershell.exe") {
+        shells.push(shell_option(
+            "powershell",
+            "Windows PowerShell",
+            executable,
+            default_shell_args("powershell"),
+        ));
+    }
+    if let Some(executable) = discover_git_bash() {
+        shells.push(shell_option(
+            "git-bash",
+            "Git Bash",
+            executable,
+            default_shell_args("git-bash"),
+        ));
+    } else if let Some(executable) = find_executable("bash") {
+        shells.push(shell_option(
+            "bash",
+            "Bash",
+            executable,
+            default_shell_args("bash"),
+        ));
+    }
+    if let Some(executable) = system_executable("wsl.exe") {
+        shells.push(shell_option(
+            "wsl",
+            "WSL",
+            executable,
+            default_shell_args("wsl"),
+        ));
+    }
+
+    dedupe_shells(shells)
+}
+
+#[cfg(not(windows))]
+fn discover_unix_shells() -> Vec<ShellOption> {
+    let mut candidates = Vec::new();
+
+    if let Ok(current_shell) = std::env::var("SHELL") {
+        candidates.push(PathBuf::from(current_shell));
+    }
+
+    if let Ok(content) = std::fs::read_to_string("/etc/shells") {
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            candidates.push(PathBuf::from(trimmed));
+        }
+    }
+
+    let shells = candidates
+        .into_iter()
+        .filter(|candidate| candidate.exists())
+        .map(|candidate| {
+            let id = shell_id_from_executable(&candidate);
+            let label = shell_label_for_id(&id);
+            shell_option(id.as_str(), &label, candidate, default_shell_args(&id))
+        })
+        .collect::<Vec<_>>();
+
+    dedupe_shells(shells)
+}
+
+fn dedupe_shells(shells: Vec<ShellOption>) -> Vec<ShellOption> {
+    let mut seen = HashSet::new();
+    let mut deduped = Vec::new();
+    for shell in shells {
+        if seen.insert(shell.id.clone()) {
+            deduped.push(shell);
+        }
+    }
+    deduped
+}
+
+fn shell_option(
+    id: &str,
+    label: &str,
+    executable: PathBuf,
+    default_args: Vec<String>,
+) -> ShellOption {
+    ShellOption {
+        id: id.to_string(),
+        label: label.to_string(),
+        executable: executable.to_string_lossy().to_string(),
+        default_args,
+    }
+}
+
+fn default_shell_args(shell_id: &str) -> Vec<String> {
+    match shell_id {
+        "cmd" => vec!["/C".to_string()],
+        "powershell" | "pwsh" => vec!["-NoProfile".to_string(), "-Command".to_string()],
+        "bash" | "git-bash" | "zsh" => vec!["-lc".to_string()],
+        "wsl" => vec!["-e".to_string(), "bash".to_string(), "-lc".to_string()],
+        "sh" | "dash" | "ksh" | "fish" => vec!["-c".to_string()],
+        _ => vec!["-c".to_string()],
+    }
+}
+
+fn shell_id_from_executable(path: &Path) -> String {
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    match file_name.as_str() {
+        "cmd" | "cmd.exe" => "cmd".to_string(),
+        "pwsh" | "pwsh.exe" => "pwsh".to_string(),
+        "powershell" | "powershell.exe" => "powershell".to_string(),
+        "wsl" | "wsl.exe" => "wsl".to_string(),
+        "bash" | "bash.exe" => {
+            if path.to_string_lossy().to_ascii_lowercase().contains("git") {
+                "git-bash".to_string()
+            } else {
+                "bash".to_string()
+            }
+        }
+        "zsh" => "zsh".to_string(),
+        "sh" => "sh".to_string(),
+        "fish" => "fish".to_string(),
+        "dash" => "dash".to_string(),
+        "ksh" => "ksh".to_string(),
+        other => other.trim_end_matches(".exe").to_string(),
+    }
+}
+
+#[cfg(not(windows))]
+fn shell_label_for_id(shell_id: &str) -> String {
+    match shell_id {
+        "cmd" => "Command Prompt".to_string(),
+        "pwsh" => "PowerShell 7".to_string(),
+        "powershell" => "Windows PowerShell".to_string(),
+        "git-bash" => "Git Bash".to_string(),
+        "wsl" => "WSL".to_string(),
+        "bash" => "Bash".to_string(),
+        "zsh" => "Zsh".to_string(),
+        "sh" => "Sh".to_string(),
+        "fish" => "Fish".to_string(),
+        "dash" => "Dash".to_string(),
+        "ksh" => "Ksh".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(windows)]
+fn discover_git_bash() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Ok(program_files) = std::env::var("ProgramFiles") {
+        candidates.push(
+            PathBuf::from(&program_files)
+                .join("Git")
+                .join("bin")
+                .join("bash.exe"),
+        );
+        candidates.push(
+            PathBuf::from(program_files)
+                .join("Git")
+                .join("usr")
+                .join("bin")
+                .join("bash.exe"),
+        );
+    }
+    if let Ok(program_files_x86) = std::env::var("ProgramFiles(x86)") {
+        candidates.push(
+            PathBuf::from(&program_files_x86)
+                .join("Git")
+                .join("bin")
+                .join("bash.exe"),
+        );
+        candidates.push(
+            PathBuf::from(program_files_x86)
+                .join("Git")
+                .join("usr")
+                .join("bin")
+                .join("bash.exe"),
+        );
+    }
+    if let Ok(local_app_data) = std::env::var("LocalAppData") {
+        candidates.push(
+            PathBuf::from(&local_app_data)
+                .join("Programs")
+                .join("Git")
+                .join("bin")
+                .join("bash.exe"),
+        );
+        candidates.push(
+            PathBuf::from(local_app_data)
+                .join("Programs")
+                .join("Git")
+                .join("usr")
+                .join("bin")
+                .join("bash.exe"),
+        );
+    }
+
+    candidates.into_iter().find(|candidate| candidate.exists())
+}
+
+#[cfg(windows)]
+fn system_executable(relative_path: &str) -> Option<PathBuf> {
+    std::env::var("SystemRoot")
+        .ok()
+        .map(PathBuf::from)
+        .map(|root| root.join("System32").join(relative_path))
+        .filter(|candidate| candidate.exists())
+}
+
+fn find_executable(name: &str) -> Option<PathBuf> {
+    let mut candidate_names = vec![name.to_string()];
+
+    #[cfg(windows)]
+    {
+        let has_extension = Path::new(name).extension().is_some();
+        if !has_extension {
+            for extension in executable_extensions() {
+                candidate_names.push(format!("{name}{extension}"));
+            }
+        }
+    }
+
+    std::env::var_os("PATH").and_then(|path| {
+        for directory in std::env::split_paths(&path) {
+            for candidate_name in &candidate_names {
+                let candidate = directory.join(candidate_name);
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+        None
+    })
+}
+
+#[cfg(windows)]
+fn executable_extensions() -> Vec<String> {
+    std::env::var("PATHEXT")
+        .ok()
+        .map(|value| {
+            value
+                .split(';')
+                .filter_map(|segment| {
+                    let trimmed = segment.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_ascii_lowercase())
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|extensions| !extensions.is_empty())
+        .unwrap_or_else(|| vec![".exe".to_string(), ".cmd".to_string(), ".bat".to_string()])
+}
+
+fn is_windows_cmd_shim(program: &str) -> bool {
+    #[cfg(windows)]
+    {
+        Path::new(program)
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat"))
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = program;
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_program_launch_with_settings, build_shell_command_with_settings, default_shell_args,
+        load_shell_settings_from_path, save_shell_settings_to_path, shell_id_from_executable,
+        ShellOption, ShellSettings,
+    };
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    #[test]
+    fn shell_settings_round_trip_through_json_file() {
+        let temp_dir = tempdir().expect("temp dir");
+        let path = temp_dir.path().join("shell_settings.json");
+        let settings = ShellSettings {
+            shell_id: "custom".to_string(),
+            custom_executable: Some("C:/Program Files/PowerShell/7/pwsh.exe".to_string()),
+            custom_args: Some("-NoProfile -Command".to_string()),
+        };
+
+        let saved = save_shell_settings_to_path(&path, &settings).expect("save settings");
+        let loaded = load_shell_settings_from_path(&path).expect("load settings");
+
+        assert_eq!(saved, settings);
+        assert_eq!(loaded, settings);
+    }
+
+    #[test]
+    fn custom_shell_uses_inferred_args_when_not_provided() {
+        let settings = ShellSettings {
+            shell_id: "custom".to_string(),
+            custom_executable: Some(if cfg!(windows) {
+                "powershell.exe".to_string()
+            } else {
+                "/bin/bash".to_string()
+            }),
+            custom_args: None,
+        };
+
+        let spec = build_shell_command_with_settings("echo hello", &settings, &[])
+            .expect("build shell command");
+
+        if cfg!(windows) {
+            assert_eq!(spec.executable, "powershell.exe");
+            assert_eq!(
+                spec.args,
+                vec![
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    "echo hello".to_string()
+                ]
+            );
+        } else {
+            assert_eq!(spec.executable, "/bin/bash");
+            assert_eq!(spec.args, vec!["-lc".to_string(), "echo hello".to_string()]);
+        }
+    }
+
+    #[test]
+    fn selected_shell_uses_its_registered_command_args() {
+        let available = vec![ShellOption {
+            id: "pwsh".to_string(),
+            label: "PowerShell 7".to_string(),
+            executable: "pwsh".to_string(),
+            default_args: vec!["-NoProfile".to_string(), "-Command".to_string()],
+        }];
+
+        let spec = build_shell_command_with_settings(
+            "$PSVersionTable.PSVersion",
+            &ShellSettings {
+                shell_id: "pwsh".to_string(),
+                custom_executable: None,
+                custom_args: None,
+            },
+            &available,
+        )
+        .expect("build shell command");
+
+        assert_eq!(spec.executable, "pwsh");
+        assert_eq!(
+            spec.args,
+            vec![
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "$PSVersionTable.PSVersion".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn program_launch_wraps_provider_in_powershell_command() {
+        let available = vec![ShellOption {
+            id: "pwsh".to_string(),
+            label: "PowerShell 7".to_string(),
+            executable: "pwsh".to_string(),
+            default_args: vec!["-NoProfile".to_string(), "-Command".to_string()],
+        }];
+        let args = vec!["--resume".to_string(), "session-123".to_string()];
+
+        let spec = build_program_launch_with_settings(
+            "codex.cmd",
+            &args,
+            &ShellSettings {
+                shell_id: "pwsh".to_string(),
+                custom_executable: None,
+                custom_args: None,
+            },
+            &available,
+        )
+        .expect("build program launch");
+
+        assert_eq!(spec.executable, "pwsh");
+        assert_eq!(spec.args[0..2], ["-NoProfile", "-Command"]);
+        if cfg!(windows) {
+            assert!(spec.args[2].contains("$env:ComSpec"));
+            assert!(spec.args[2].contains("codex.cmd"));
+            assert!(spec.args[2].contains("--resume"));
+        } else {
+            assert!(spec.args[2].contains("codex.cmd"));
+        }
+    }
+
+    #[test]
+    fn auto_shell_falls_back_to_first_available_option() {
+        let available = vec![ShellOption {
+            id: "custom-sh".to_string(),
+            label: "Custom Sh".to_string(),
+            executable: "custom-sh".to_string(),
+            default_args: vec!["-c".to_string()],
+        }];
+
+        let spec = build_shell_command_with_settings(
+            "echo fallback",
+            &ShellSettings::default(),
+            &available,
+        )
+        .expect("build shell command");
+
+        assert_eq!(spec.executable, "custom-sh");
+        assert_eq!(
+            spec.args,
+            vec!["-c".to_string(), "echo fallback".to_string()]
+        );
+    }
+
+    #[test]
+    fn shell_id_normalizes_known_executable_names() {
+        assert_eq!(
+            shell_id_from_executable(Path::new("C:/Windows/System32/cmd.exe")),
+            "cmd"
+        );
+        assert_eq!(shell_id_from_executable(Path::new("/bin/bash")), "bash");
+        assert_eq!(
+            shell_id_from_executable(Path::new("C:/Program Files/PowerShell/7/pwsh.exe")),
+            "pwsh"
+        );
+    }
+
+    #[test]
+    fn default_shell_args_cover_standard_shell_families() {
+        assert_eq!(default_shell_args("cmd"), vec!["/C".to_string()]);
+        assert_eq!(
+            default_shell_args("pwsh"),
+            vec!["-NoProfile".to_string(), "-Command".to_string()]
+        );
+        assert_eq!(default_shell_args("bash"), vec!["-lc".to_string()]);
+        assert_eq!(default_shell_args("sh"), vec!["-c".to_string()]);
+    }
+
+    #[test]
+    fn windows_cmd_shims_are_wrapped_for_posix_hosts() {
+        let available = vec![ShellOption {
+            id: "git-bash".to_string(),
+            label: "Git Bash".to_string(),
+            executable: "C:/Program Files/Git/bin/bash.exe".to_string(),
+            default_args: vec!["-lc".to_string()],
+        }];
+        let args = vec!["--verbose".to_string()];
+
+        let spec = build_program_launch_with_settings(
+            "claude.cmd",
+            &args,
+            &ShellSettings {
+                shell_id: "git-bash".to_string(),
+                custom_executable: None,
+                custom_args: None,
+            },
+            &available,
+        )
+        .expect("build program launch");
+
+        assert_eq!(spec.executable, "C:/Program Files/Git/bin/bash.exe");
+        assert_eq!(spec.args[0], "-lc");
+        if cfg!(windows) {
+            assert!(spec.args[1].starts_with("exec cmd.exe /c "));
+        } else {
+            assert!(spec.args[1].starts_with("exec 'claude.cmd'"));
+        }
+    }
+    #[test]
+    fn wsl_wraps_windows_programs_through_cmd() {
+        let available = vec![ShellOption {
+            id: "wsl".to_string(),
+            label: "WSL".to_string(),
+            executable: "C:/Windows/System32/wsl.exe".to_string(),
+            default_args: vec!["-e".to_string(), "bash".to_string(), "-lc".to_string()],
+        }];
+        let args = vec!["--version".to_string()];
+
+        let spec = build_program_launch_with_settings(
+            "node",
+            &args,
+            &ShellSettings {
+                shell_id: "wsl".to_string(),
+                custom_executable: None,
+                custom_args: None,
+            },
+            &available,
+        )
+        .expect("build program launch");
+
+        assert_eq!(spec.executable, "C:/Windows/System32/wsl.exe");
+        assert_eq!(spec.args[0..3], ["-e", "bash", "-lc"]);
+        if cfg!(windows) {
+            assert!(spec.args[3].starts_with("exec cmd.exe /c "));
+            assert!(spec.args[3].contains("node"));
+        }
+    }
+}

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -585,7 +585,10 @@ fn system_executable(relative_path: &str) -> Option<PathBuf> {
 }
 
 fn find_executable(name: &str) -> Option<PathBuf> {
+    #[cfg(windows)]
     let mut candidate_names = vec![name.to_string()];
+    #[cfg(not(windows))]
+    let candidate_names = vec![name.to_string()];
 
     #[cfg(windows)]
     {

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -173,12 +173,17 @@ pub fn build_program_launch_with_settings(
     }
 
     let shell = resolve_shell(settings, available)?;
-    let command_text = build_program_command_text(&shell.id, program, program_args);
     let mut args = shell.default_args;
     if args.is_empty() {
         return Err("Selected shell does not define how to execute a command string".to_string());
     }
-    args.push(command_text);
+
+    if uses_positional_program_forwarding(&shell.id) {
+        args.extend(build_forwarded_program_args(&shell.id, program, program_args));
+    } else {
+        let command_text = build_program_command_text(&shell.id, program, program_args);
+        args.push(command_text);
+    }
 
     Ok(ShellLaunchSpec {
         executable: shell.executable,
@@ -251,6 +256,28 @@ fn inferred_custom_args(
     Ok(default_shell_args(&shell_id_from_executable(Path::new(
         executable,
     ))))
+}
+
+fn uses_positional_program_forwarding(shell_id: &str) -> bool {
+    matches!(shell_id, "bash" | "git-bash" | "zsh" | "sh" | "dash" | "ksh")
+}
+
+fn build_forwarded_program_args(
+    shell_id: &str,
+    program: &str,
+    program_args: &[String],
+) -> Vec<String> {
+    let mut args = vec!["exec \"$@\"".to_string(), "wardian-shell".to_string()];
+
+    if shell_id != "wsl" && is_windows_cmd_shim(program) {
+        args.push("cmd.exe".to_string());
+        args.push("/d".to_string());
+        args.push("/c".to_string());
+    }
+
+    args.push(program.to_string());
+    args.extend(program_args.iter().cloned());
+    args
 }
 
 fn build_program_command_text(shell_id: &str, program: &str, program_args: &[String]) -> String {
@@ -843,9 +870,51 @@ mod tests {
         assert_eq!(spec.executable, "C:/Program Files/Git/bin/bash.exe");
         assert_eq!(spec.args[0], "-lc");
         if cfg!(windows) {
-            assert!(spec.args[1].starts_with("exec cmd.exe /c "));
+            assert_eq!(spec.args[1], "exec \"$@\"");
+            assert_eq!(spec.args[2], "wardian-shell");
+            assert_eq!(spec.args[3], "cmd.exe");
+            assert_eq!(spec.args[4], "/d");
+            assert_eq!(spec.args[5], "/c");
+            assert_eq!(spec.args[6], "claude.cmd");
+            assert_eq!(spec.args[7], "--verbose");
         } else {
             assert!(spec.args[1].starts_with("exec 'claude.cmd'"));
+        }
+    }
+
+    #[test]
+    fn git_bash_preserves_json_arguments_without_flattening() {
+        let available = vec![ShellOption {
+            id: "git-bash".to_string(),
+            label: "Git Bash".to_string(),
+            executable: "C:/Program Files/Git/bin/bash.exe".to_string(),
+            default_args: vec!["-lc".to_string()],
+        }];
+        let args = vec![
+            "--settings".to_string(),
+            "{\"hooks\":{\"PermissionRequest\":[{\"matcher\":\"*\"}]}}".to_string(),
+        ];
+
+        let spec = build_program_launch_with_settings(
+            "claude.exe",
+            &args,
+            &ShellSettings {
+                shell_id: "git-bash".to_string(),
+                custom_executable: None,
+                custom_args: None,
+            },
+            &available,
+        )
+        .expect("build program launch");
+
+        assert_eq!(spec.executable, "C:/Program Files/Git/bin/bash.exe");
+        assert_eq!(spec.args[0], "-lc");
+        if cfg!(windows) {
+            assert_eq!(spec.args[1], "exec \"$@\"");
+            assert_eq!(spec.args[2], "wardian-shell");
+            assert_eq!(spec.args[3], "claude.exe");
+            assert_eq!(spec.args[4], "--settings");
+            assert_eq!(spec.args[5], "{\"hooks\":{\"PermissionRequest\":[{\"matcher\":\"*\"}]}}");
         }
     }
     #[test]

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -2,7 +2,9 @@ mod migrate;
 
 use crate::manager::log_debug;
 use crate::models::{WorkflowDefinition, WorkflowTelemetryEvent};
-use crate::utils::{get_wardian_home, new_headless_command, validate_workspace_path};
+use crate::utils::{
+    build_shell_command, get_wardian_home, new_headless_command, validate_workspace_path,
+};
 use chrono::{Datelike, TimeZone, Utc};
 use notify::{Event, RecursiveMode, Watcher};
 use regex::Regex;
@@ -40,7 +42,10 @@ fn flatten_headless_response(mut data: Value) -> Value {
 
 /// Resolves the current working directory for a node.
 fn resolve_cwd(node_config: &Value, agent_id: &str) -> PathBuf {
-    let folder = node_config.get("folder").and_then(|v| v.as_str()).unwrap_or("");
+    let folder = node_config
+        .get("folder")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     crate::utils::fs::resolve_cwd(folder, agent_id)
 }
 
@@ -172,7 +177,10 @@ pub fn toggle_scheduled_run_state(
     Ok(runs)
 }
 
-fn sync_scheduled_runs_for_workflow(wf: &WorkflowDefinition, existing_runs: &[crate::models::ScheduledRun]) -> Vec<crate::models::ScheduledRun> {
+fn sync_scheduled_runs_for_workflow(
+    wf: &WorkflowDefinition,
+    existing_runs: &[crate::models::ScheduledRun],
+) -> Vec<crate::models::ScheduledRun> {
     let mut synced_runs: Vec<crate::models::ScheduledRun> = existing_runs
         .iter()
         .filter(|run| run.workflow_id != wf.id)
@@ -197,10 +205,19 @@ fn sync_scheduled_runs_for_workflow(wf: &WorkflowDefinition, existing_runs: &[cr
             continue;
         };
 
-        let interval = config.get("interval").and_then(|v| v.as_str()).unwrap_or("");
-        let time = config.get("time").and_then(|v| v.as_str()).unwrap_or("00:00");
+        let interval = config
+            .get("interval")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let time = config
+            .get("time")
+            .and_then(|v| v.as_str())
+            .unwrap_or("00:00");
         let days = config.get("days").and_then(|v| v.as_str()).unwrap_or("");
-        let datetime = config.get("datetime").and_then(|v| v.as_str()).unwrap_or("");
+        let datetime = config
+            .get("datetime")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
 
         let (model_type, value) = match sched_type {
             "Minutes" => ("minutes".to_string(), interval.to_string()),
@@ -583,27 +600,47 @@ fn compute_next_run(schedule: &crate::models::ScheduleDefinition, now_ms: u64) -
             // Try ISO8601/RFC3339 first, then "YYYY-MM-DDTHH:MM" local time
             if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&schedule.value) {
                 let ms = dt.timestamp_millis() as u64;
-                if ms > now_ms { Some(ms) } else { None }
-            } else if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(&schedule.value, "%Y-%m-%dT%H:%M") {
+                if ms > now_ms {
+                    Some(ms)
+                } else {
+                    None
+                }
+            } else if let Ok(dt) =
+                chrono::NaiveDateTime::parse_from_str(&schedule.value, "%Y-%m-%dT%H:%M")
+            {
                 let local = chrono::Local.from_local_datetime(&dt).earliest()?;
                 let ms = local.timestamp_millis() as u64;
-                if ms > now_ms { Some(ms) } else { None }
+                if ms > now_ms {
+                    Some(ms)
+                } else {
+                    None
+                }
             } else {
                 None
             }
         }
         "minutes" => {
             let mins: u64 = schedule.value.parse().unwrap_or(0);
-            if mins > 0 { Some(now_ms + mins * 60_000) } else { None }
+            if mins > 0 {
+                Some(now_ms + mins * 60_000)
+            } else {
+                None
+            }
         }
         "hours" => {
             let hours: u64 = schedule.value.parse().unwrap_or(0);
-            if hours > 0 { Some(now_ms + hours * 3_600_000) } else { None }
+            if hours > 0 {
+                Some(now_ms + hours * 3_600_000)
+            } else {
+                None
+            }
         }
         "daily" => {
             // value = "HH:MM"
             let parts: Vec<&str> = schedule.value.split(':').collect();
-            if parts.len() != 2 { return None; }
+            if parts.len() != 2 {
+                return None;
+            }
             let hour: u32 = parts[0].parse().unwrap_or(0);
             let minute: u32 = parts[1].parse().unwrap_or(0);
 
@@ -611,7 +648,9 @@ fn compute_next_run(schedule: &crate::models::ScheduleDefinition, now_ms: u64) -
             let today = now_local.date_naive();
             let target_time = chrono::NaiveTime::from_hms_opt(hour, minute, 0)?;
             let target_naive = today.and_time(target_time);
-            let target_local = chrono::Local.from_local_datetime(&target_naive).earliest()?;
+            let target_local = chrono::Local
+                .from_local_datetime(&target_naive)
+                .earliest()?;
 
             let target_ms = target_local.timestamp_millis() as u64;
             if target_ms > now_ms {
@@ -624,10 +663,14 @@ fn compute_next_run(schedule: &crate::models::ScheduleDefinition, now_ms: u64) -
         "weekly" => {
             // value = "Mon,Wed@09:00"
             let parts: Vec<&str> = schedule.value.split('@').collect();
-            if parts.len() != 2 { return None; }
+            if parts.len() != 2 {
+                return None;
+            }
             let day_names: Vec<&str> = parts[0].split(',').map(|s| s.trim()).collect();
             let time_parts: Vec<&str> = parts[1].split(':').collect();
-            if time_parts.len() != 2 { return None; }
+            if time_parts.len() != 2 {
+                return None;
+            }
             let hour: u32 = time_parts[0].parse().unwrap_or(0);
             let minute: u32 = time_parts[1].parse().unwrap_or(0);
 
@@ -651,14 +694,20 @@ fn compute_next_run(schedule: &crate::models::ScheduleDefinition, now_ms: u64) -
                 if let Some(target_day) = day_map(day_name) {
                     // Find next occurrence of this weekday
                     for offset in 0..8u32 {
-                        let candidate_date = (now_local + chrono::Duration::days(offset as i64)).date_naive();
+                        let candidate_date =
+                            (now_local + chrono::Duration::days(offset as i64)).date_naive();
                         if candidate_date.weekday() == target_day {
                             let target_time = chrono::NaiveTime::from_hms_opt(hour, minute, 0)?;
                             let candidate_naive = candidate_date.and_time(target_time);
-                            if let Some(candidate_local) = chrono::Local.from_local_datetime(&candidate_naive).earliest() {
+                            if let Some(candidate_local) = chrono::Local
+                                .from_local_datetime(&candidate_naive)
+                                .earliest()
+                            {
                                 let candidate_ms = candidate_local.timestamp_millis() as u64;
                                 if candidate_ms > now_ms {
-                                    best = Some(best.map_or(candidate_ms, |b: u64| b.min(candidate_ms)));
+                                    best = Some(
+                                        best.map_or(candidate_ms, |b: u64| b.min(candidate_ms)),
+                                    );
                                     break;
                                 }
                             }
@@ -717,7 +766,11 @@ pub fn resume_all_triggers(app: AppHandle) {
         .store(false, std::sync::atomic::Ordering::SeqCst);
 }
 
-pub async fn start_workflow_triggers(app: AppHandle, wf: WorkflowDefinition, register_schedules: bool) {
+pub async fn start_workflow_triggers(
+    app: AppHandle,
+    wf: WorkflowDefinition,
+    register_schedules: bool,
+) {
     // 1. Clean up existing triggers for this workflow
     stop_workflow_triggers(app.clone(), &wf.id).await;
 
@@ -776,7 +829,10 @@ pub async fn start_workflow_triggers(app: AppHandle, wf: WorkflowDefinition, reg
                             })
                             .unwrap();
 
-                        if watcher.watch(&path_clone, RecursiveMode::NonRecursive).is_ok() {
+                        if watcher
+                            .watch(&path_clone, RecursiveMode::NonRecursive)
+                            .is_ok()
+                        {
                             while let Some(payload) = rx.recv().await {
                                 let state = app_file.state::<crate::state::AppState>();
                                 if state
@@ -818,7 +874,10 @@ pub async fn run_scheduled_workflow_now(app: AppHandle, run_id: String) -> Resul
     let mut runs = load_scheduled_runs();
     let now_ms = Utc::now().timestamp_millis() as u64;
 
-    let Some(run) = runs.iter_mut().find(|scheduled_run| scheduled_run.id == run_id) else {
+    let Some(run) = runs
+        .iter_mut()
+        .find(|scheduled_run| scheduled_run.id == run_id)
+    else {
         return Err(format!("Scheduled run {} not found", run_id));
     };
 
@@ -865,7 +924,10 @@ pub async fn delete_workflow(app: AppHandle, id: String) -> Result<(), String> {
 }
 
 pub fn disable_scheduled_trigger(run_id: &str) -> Result<(), String> {
-    let Some(run) = load_scheduled_runs().into_iter().find(|scheduled_run| scheduled_run.id == run_id) else {
+    let Some(run) = load_scheduled_runs()
+        .into_iter()
+        .find(|scheduled_run| scheduled_run.id == run_id)
+    else {
         return Ok(());
     };
 
@@ -876,7 +938,8 @@ pub fn disable_scheduled_trigger(run_id: &str) -> Result<(), String> {
     }
 
     let content = fs::read_to_string(&path).map_err(|e| e.to_string())?;
-    let mut workflow = serde_json::from_str::<WorkflowDefinition>(&content).map_err(|e| e.to_string())?;
+    let mut workflow =
+        serde_json::from_str::<WorkflowDefinition>(&content).map_err(|e| e.to_string())?;
 
     for node in workflow.nodes.iter_mut() {
         if node.r#type != "trigger" || node.name.as_deref() != Some("Scheduled Trigger") {
@@ -890,7 +953,10 @@ pub fn disable_scheduled_trigger(run_id: &str) -> Result<(), String> {
 
         match node.config.as_object_mut() {
             Some(config) => {
-                config.insert("status".to_string(), serde_json::Value::String("off".to_string()));
+                config.insert(
+                    "status".to_string(),
+                    serde_json::Value::String("off".to_string()),
+                );
             }
             None => {
                 node.config = serde_json::json!({ "status": "off" });
@@ -905,7 +971,9 @@ pub fn disable_scheduled_trigger(run_id: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::sync_scheduled_runs_for_workflow;
-    use crate::models::{ScheduleDefinition, ScheduledRun, WorkflowDefinition, WorkflowNode, WorkflowSettings};
+    use crate::models::{
+        ScheduleDefinition, ScheduledRun, WorkflowDefinition, WorkflowNode, WorkflowSettings,
+    };
     use serde_json::json;
     use std::collections::HashMap;
 
@@ -1039,10 +1107,13 @@ pub async fn run_workflow(
     let log_dir = get_logs_dir(&wf_id).ok_or("Could not find log path")?;
     fs::create_dir_all(&log_dir).map_err(|e| e.to_string())?;
 
-    let _ = app.emit("workflow-status-updated", serde_json::json!({
-        "workflow_id": wf_id,
-        "status": "running",
-    }));
+    let _ = app.emit(
+        "workflow-status-updated",
+        serde_json::json!({
+            "workflow_id": wf_id,
+            "status": "running",
+        }),
+    );
 
     let timestamp = Utc::now().format("%Y%m%d_%H%M%S").to_string();
     let log_path = log_dir.join(format!("{}.json", timestamp));
@@ -1149,13 +1220,16 @@ pub async fn run_workflow(
                 },
             );
 
-            let _ = app.emit("workflow-progress", serde_json::json!({
-                "workflow_id": wf.id,
-                "workflow_name": wf.name,
-                "current_step": global_step_count,
-                "total_steps": total_enqueued + queue.len(),
-                "active_node_name": node.name.clone().unwrap_or_else(|| node.id.clone()),
-            }));
+            let _ = app.emit(
+                "workflow-progress",
+                serde_json::json!({
+                    "workflow_id": wf.id,
+                    "workflow_name": wf.name,
+                    "current_step": global_step_count,
+                    "total_steps": total_enqueued + queue.len(),
+                    "active_node_name": node.name.clone().unwrap_or_else(|| node.id.clone()),
+                }),
+            );
 
             // --- NODE LOGIC ---
             let mut result_ports = vec!["default".to_string()];
@@ -1352,7 +1426,11 @@ pub async fn run_workflow(
                         ));
 
                         // 1. Resolve CWD logic (Shared between modes)
-                        let folder = node.config.get("folder").and_then(|v| v.as_str()).unwrap_or("");
+                        let folder = node
+                            .config
+                            .get("folder")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
                         let cwd = crate::utils::fs::resolve_cwd(folder, agent_id);
 
                         if output_format == "json" {
@@ -1641,27 +1719,32 @@ pub async fn run_workflow(
                     if interpolated_cmd.is_empty() {
                         node_error = Some("Missing command string".to_string());
                     } else {
-                        // On Windows, we use cmd /C for better compatibility with built-ins
-                        #[cfg(windows)]
-                        let (executable, args) = ("cmd", vec!["/C".to_string(), interpolated_cmd]);
-                        #[cfg(not(windows))]
-                        let (executable, args) = ("sh", vec!["-c".to_string(), interpolated_cmd]);
-
-                        match run_command_headless(executable, args, &cwd, env, timeout_ms).await {
-                            Ok(res) => {
-                                let exit_code =
-                                    res.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0);
-                                if exit_code != 0 {
-                                    node_error = Some(format!(
-                                        "Exit code {}: {}",
-                                        exit_code,
-                                        res.get("stderr")
-                                            .and_then(|v| v.as_str())
-                                            .unwrap_or("Unknown error")
-                                    ));
+                        match build_shell_command(&interpolated_cmd) {
+                            Ok(spec) => match run_command_headless(
+                                &spec.executable,
+                                spec.args,
+                                &cwd,
+                                env,
+                                timeout_ms,
+                            )
+                            .await
+                            {
+                                Ok(res) => {
+                                    let exit_code =
+                                        res.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0);
+                                    if exit_code != 0 {
+                                        node_error = Some(format!(
+                                            "Exit code {}: {}",
+                                            exit_code,
+                                            res.get("stderr")
+                                                .and_then(|v| v.as_str())
+                                                .unwrap_or("Unknown error")
+                                        ));
+                                    }
+                                    output_payload = res;
                                 }
-                                output_payload = res;
-                            }
+                                Err(e) => node_error = Some(e),
+                            },
                             Err(e) => node_error = Some(e),
                         }
                     }
@@ -1872,10 +1955,13 @@ pub async fn run_workflow(
 
         // Emit workflow completion status
         let had_error = trace.iter().any(|e| e.status == "failed");
-        let _ = app.emit("workflow-status-updated", serde_json::json!({
-            "workflow_id": wf.id,
-            "status": if had_error { "failed" } else { "completed" },
-        }));
+        let _ = app.emit(
+            "workflow-status-updated",
+            serde_json::json!({
+                "workflow_id": wf.id,
+                "status": if had_error { "failed" } else { "completed" },
+            }),
+        );
 
         // Save the execution log
         if let Ok(json) = serde_json::to_string_pretty(&trace) {
@@ -1893,4 +1979,3 @@ pub async fn run_workflow(
 
     Ok(())
 }
-

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -50,6 +50,20 @@ fn resolve_cwd(node_config: &Value, agent_id: &str) -> PathBuf {
 }
 
 /// Executes a command headlessly and returns the result in the mandatory schema.
+fn resolve_command_node_launch<F>(
+    command: &str,
+    resolver: F,
+) -> Result<crate::utils::ShellLaunchSpec, String>
+where
+    F: FnOnce(&str) -> Result<crate::utils::ShellLaunchSpec, String>,
+{
+    if command.trim().is_empty() {
+        Err("Missing command string".to_string())
+    } else {
+        resolver(command)
+    }
+}
+
 async fn run_command_headless(
     executable: &str,
     args: Vec<String>,
@@ -970,10 +984,11 @@ pub fn disable_scheduled_trigger(run_id: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::sync_scheduled_runs_for_workflow;
+    use super::{resolve_command_node_launch, sync_scheduled_runs_for_workflow};
     use crate::models::{
         ScheduleDefinition, ScheduledRun, WorkflowDefinition, WorkflowNode, WorkflowSettings,
     };
+    use crate::utils::ShellLaunchSpec;
     use serde_json::json;
     use std::collections::HashMap;
 
@@ -999,6 +1014,41 @@ mod tests {
             }],
             role_mappings: HashMap::from([("analyst".to_string(), "agent-1".to_string())]),
         }
+    }
+
+    #[test]
+    fn resolve_command_node_launch_returns_shell_spec() {
+        let spec = resolve_command_node_launch("echo hi", |_| {
+            Ok(ShellLaunchSpec {
+                executable: "pwsh".to_string(),
+                args: vec![
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    "echo hi".to_string(),
+                ],
+            })
+        })
+        .expect("shell spec");
+
+        assert_eq!(spec.executable, "pwsh");
+        assert_eq!(spec.args[2], "echo hi");
+    }
+
+    #[test]
+    fn resolve_command_node_launch_surfaces_shell_resolution_errors() {
+        let err =
+            resolve_command_node_launch("echo hi", |_| Err("No compatible shell".to_string()))
+                .expect_err("shell resolution should fail");
+
+        assert_eq!(err, "No compatible shell");
+    }
+
+    #[test]
+    fn resolve_command_node_launch_rejects_empty_commands() {
+        let err = resolve_command_node_launch("   ", |_| unreachable!("resolver should not run"))
+            .expect_err("empty commands should fail");
+
+        assert_eq!(err, "Missing command string");
     }
 
     #[test]
@@ -1716,37 +1766,33 @@ pub async fn run_workflow(
                         })
                         .unwrap_or(30000);
 
-                    if interpolated_cmd.is_empty() {
-                        node_error = Some("Missing command string".to_string());
-                    } else {
-                        match build_shell_command(&interpolated_cmd) {
-                            Ok(spec) => match run_command_headless(
-                                &spec.executable,
-                                spec.args,
-                                &cwd,
-                                env,
-                                timeout_ms,
-                            )
-                            .await
-                            {
-                                Ok(res) => {
-                                    let exit_code =
-                                        res.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0);
-                                    if exit_code != 0 {
-                                        node_error = Some(format!(
-                                            "Exit code {}: {}",
-                                            exit_code,
-                                            res.get("stderr")
-                                                .and_then(|v| v.as_str())
-                                                .unwrap_or("Unknown error")
-                                        ));
-                                    }
-                                    output_payload = res;
+                    match resolve_command_node_launch(&interpolated_cmd, build_shell_command) {
+                        Ok(spec) => match run_command_headless(
+                            &spec.executable,
+                            spec.args,
+                            &cwd,
+                            env,
+                            timeout_ms,
+                        )
+                        .await
+                        {
+                            Ok(res) => {
+                                let exit_code =
+                                    res.get("exit_code").and_then(|v| v.as_i64()).unwrap_or(0);
+                                if exit_code != 0 {
+                                    node_error = Some(format!(
+                                        "Exit code {}: {}",
+                                        exit_code,
+                                        res.get("stderr")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("Unknown error")
+                                    ));
                                 }
-                                Err(e) => node_error = Some(e),
-                            },
+                                output_payload = res;
+                            }
                             Err(e) => node_error = Some(e),
-                        }
+                        },
+                        Err(e) => node_error = Some(e),
                     }
                 }
                 "script" => {

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { invoke } from '@tauri-apps/api/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsPanel } from './SettingsPanel';
+import { useSettingsStore } from '../../store/useSettingsStore';
+
+const mockInvoke = vi.mocked(invoke);
+
+describe('SettingsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useSettingsStore.setState({
+      theme: 'system',
+      autoPatchGemini: false,
+      shell_id: 'auto',
+      custom_executable: '',
+      custom_args: '',
+      available_shells: [],
+      shell_settings_loaded: false,
+      shells_loaded: false,
+    });
+
+    mockInvoke.mockImplementation(async (command, args) => {
+      switch (command) {
+        case 'load_shell_settings':
+          return {
+            shell_id: 'pwsh',
+            custom_executable: null,
+            custom_args: null,
+          };
+        case 'list_available_shells':
+          return [
+            {
+              id: 'pwsh',
+              label: 'PowerShell 7',
+              executable: 'C:/Program Files/PowerShell/7/pwsh.exe',
+              default_args: ['-NoProfile', '-Command'],
+            },
+            {
+              id: 'cmd',
+              label: 'Command Prompt',
+              executable: 'C:/Windows/System32/cmd.exe',
+              default_args: ['/C'],
+            },
+          ];
+        case 'save_shell_settings':
+          return (args as { settings?: unknown } | undefined)?.settings;
+        case 'run_gemini_patch':
+          return 'ok';
+        default:
+          return null;
+      }
+    });
+  });
+
+  it('loads discovered shells and current shell settings on mount', async () => {
+    render(<SettingsPanel />);
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('load_shell_settings');
+      expect(mockInvoke).toHaveBeenCalledWith('list_available_shells');
+    });
+
+    const select = await screen.findByLabelText('Shell / Interpreter');
+    expect(select).toHaveValue('pwsh');
+    expect(screen.getByText('C:/Program Files/PowerShell/7/pwsh.exe')).toBeInTheDocument();
+  });
+
+  it('saves custom shell settings through tauri', async () => {
+    render(<SettingsPanel />);
+
+    const select = await screen.findByLabelText('Shell / Interpreter');
+    fireEvent.change(select, { target: { value: 'custom' } });
+
+    fireEvent.change(screen.getByLabelText('Custom executable'), {
+      target: { value: 'C:/Tools/custom-shell.exe' },
+    });
+    fireEvent.change(screen.getByLabelText('Command args'), {
+      target: { value: '--command' },
+    });
+
+    fireEvent.click(screen.getByText('Save Shell'));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('save_shell_settings', {
+        settings: {
+          shell_id: 'custom',
+          custom_executable: 'C:/Tools/custom-shell.exe',
+          custom_args: '--command',
+        },
+      });
+    });
+
+    expect(await screen.findByText('Default shell updated.')).toBeInTheDocument();
+  });
+});

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -1,13 +1,41 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useSettingsStore } from "../../store/useSettingsStore";
 
 interface SettingsPanelProps {}
 
 export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
-  const { theme, setTheme, autoPatchGemini, setAutoPatchGemini } = useSettingsStore();
+  const {
+    theme,
+    setTheme,
+    autoPatchGemini,
+    setAutoPatchGemini,
+    shell_id,
+    custom_executable,
+    custom_args,
+    available_shells,
+    shell_settings_loaded,
+    shells_loaded,
+    setShellId,
+    setCustomExecutable,
+    setCustomArgs,
+    loadShellSettings,
+    loadAvailableShells,
+    saveShellSettings,
+  } = useSettingsStore();
   const [patchStatus, setPatchStatus] = useState<"idle" | "running" | "success" | "error">("idle");
   const [patchMessage, setPatchMessage] = useState("");
+  const [shellStatus, setShellStatus] = useState<"idle" | "saving" | "success" | "error">("idle");
+  const [shellMessage, setShellMessage] = useState("");
+
+  useEffect(() => {
+    if (!shell_settings_loaded) {
+      loadShellSettings();
+    }
+    if (!shells_loaded) {
+      loadAvailableShells();
+    }
+  }, [loadAvailableShells, loadShellSettings, shell_settings_loaded, shells_loaded]);
 
   const handleRunPatch = async () => {
     setPatchStatus("running");
@@ -20,11 +48,30 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
         setPatchStatus("idle");
         setPatchMessage("");
       }, 5000);
-    } catch (e: any) {
+    } catch (e: unknown) {
       setPatchStatus("error");
-      setPatchMessage(`Patch failed: ${e}`);
+      setPatchMessage(`Patch failed: ${String(e)}`);
     }
   };
+
+  const handleSaveShell = async () => {
+    setShellStatus("saving");
+    setShellMessage("");
+    try {
+      await saveShellSettings();
+      setShellStatus("success");
+      setShellMessage("Default shell updated.");
+      setTimeout(() => {
+        setShellStatus("idle");
+        setShellMessage("");
+      }, 4000);
+    } catch (e: unknown) {
+      setShellStatus("error");
+      setShellMessage(`Shell update failed: ${String(e)}`);
+    }
+  };
+
+  const selectedShell = available_shells.find((option) => option.id === shell_id);
 
   return (
     <div className="flex flex-col h-full">
@@ -36,7 +83,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
         <div className="bg-transparent">
           <h3 className="text-[10px] font-bold text-muted-neutral tracking-wide mb-4">Theme</h3>
           <div className="grid grid-cols-3 gap-3">
-            {/* System Theme Card */}
             <button
               type="button"
               onClick={() => setTheme("system")}
@@ -49,7 +95,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
               <span className={`text-[11px] font-bold tracking-tight ${theme === 'system' ? 'text-[var(--color-wardian-accent)]' : 'text-muted-neutral'}`}>System</span>
             </button>
 
-            {/* Dark Theme Card */}
             <button
               type="button"
               onClick={() => setTheme("dark")}
@@ -65,7 +110,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
               <span className={`text-[11px] font-bold tracking-tight ${theme === 'dark' ? 'text-[var(--color-wardian-accent)]' : 'text-muted-neutral'}`}>Dark</span>
             </button>
 
-            {/* Light Theme Card */}
             <button
               type="button"
               onClick={() => setTheme("light")}
@@ -85,6 +129,95 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
             <p className="text-[10px] text-muted-neutral leading-relaxed">
               <span className="text-[var(--color-wardian-accent)] font-bold">NOTE:</span> For complete terminal synchronization, update the gemini CLI theme as well, and then restart the application.
             </p>
+          </div>
+        </div>
+
+        <div className="border-t border-wardian-border pt-6">
+          <h3 className="text-[10px] font-bold text-muted-neutral tracking-wide mb-4">Default Shell</h3>
+
+          <div className="bg-wardian-card-bg-muted border border-wardian-light/50 rounded-xl p-4 flex flex-col gap-3">
+            <label className="text-sm font-bold text-primary" htmlFor="default-shell-select">
+              Shell / Interpreter
+            </label>
+            <select
+              id="default-shell-select"
+              value={shell_id}
+              onChange={(e) => setShellId(e.target.value)}
+              className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+            >
+              <option value="auto">Auto</option>
+              {available_shells.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+              <option value="custom">Custom</option>
+            </select>
+
+            {shell_id === 'custom' ? (
+              <>
+                <label className="text-xs font-bold text-primary" htmlFor="custom-shell-executable">
+                  Custom executable
+                </label>
+                <input
+                  id="custom-shell-executable"
+                  type="text"
+                  value={custom_executable}
+                  onChange={(e) => setCustomExecutable(e.target.value)}
+                  placeholder={navigator.platform.toLowerCase().includes('win') ? 'C:/Program Files/PowerShell/7/pwsh.exe' : '/usr/local/bin/fish'}
+                  className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+                />
+                <label className="text-xs font-bold text-primary" htmlFor="custom-shell-args">
+                  Command args
+                </label>
+                <input
+                  id="custom-shell-args"
+                  type="text"
+                  value={custom_args}
+                  onChange={(e) => setCustomArgs(e.target.value)}
+                  placeholder={navigator.platform.toLowerCase().includes('win') ? '-NoProfile -Command' : '-lc'}
+                  className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+                />
+              </>
+            ) : (
+              <div className="rounded-lg border border-wardian-border bg-wardian-bg px-3 py-2">
+                <p className="text-[11px] font-bold text-primary">
+                  {shell_id === 'auto' ? 'Wardian will choose the best available shell for this system.' : selectedShell?.label ?? 'Loading shell details...'}
+                </p>
+                {shell_id !== 'auto' && selectedShell && (
+                  <p className="text-[10px] text-muted-neutral mt-1 break-all">
+                    {selectedShell.executable}
+                  </p>
+                )}
+              </div>
+            )}
+
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-[10px] text-muted-neutral">
+                {shells_loaded ? `${available_shells.length} discovered shell${available_shells.length === 1 ? '' : 's'}` : 'Detecting installed shells...'}
+              </p>
+              <button
+                type="button"
+                onClick={handleSaveShell}
+                disabled={!shell_settings_loaded || shellStatus === 'saving'}
+                className={`px-4 py-2 text-xs font-bold rounded-lg border transition-all whitespace-nowrap ${
+                  shellStatus === 'saving'
+                    ? 'bg-wardian-border text-muted border-transparent cursor-not-allowed'
+                    : 'bg-wardian-bg border-wardian-light text-primary hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]'
+                }`}
+              >
+                {shellStatus === 'saving' ? 'Saving...' : 'Save Shell'}
+              </button>
+            </div>
+
+            {shellMessage && (
+              <div className={`p-2 mt-1 rounded border text-xs font-medium text-left ${
+                shellStatus === 'success' ? 'bg-cyan-500/10 border-cyan-500/20 text-cyan-400' :
+                'bg-red-500/10 border-red-500/20 text-red-400'
+              }`}>
+                {shellMessage}
+              </div>
+            )}
           </div>
         </div>
 
@@ -115,9 +248,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
               </button>
             </div>
             
-            <p className="text-[10px] text-muted-neutral leading-relaxed text-left">
-              Applies a custom patch to enable skill discovery in included directories. Reruns on every launch.
-            </p>
 
             {patchMessage && (
               <div className={`p-2 mt-1 rounded border text-xs font-medium text-left ${
@@ -137,3 +267,4 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     </div>
   );
 };
+

--- a/src/store/useSettingsStore.ts
+++ b/src/store/useSettingsStore.ts
@@ -1,23 +1,98 @@
+import { invoke } from '@tauri-apps/api/core';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import type { ShellOption, ShellSettings } from '../types/settings';
 
 interface SettingsState {
   theme: 'dark' | 'light' | 'system';
   autoPatchGemini: boolean;
+  shell_id: string;
+  custom_executable: string;
+  custom_args: string;
+  available_shells: ShellOption[];
+  shell_settings_loaded: boolean;
+  shells_loaded: boolean;
   setTheme: (theme: 'dark' | 'light' | 'system') => void;
   setAutoPatchGemini: (enabled: boolean) => void;
+  setShellId: (shellId: string) => void;
+  setCustomExecutable: (value: string) => void;
+  setCustomArgs: (value: string) => void;
+  loadShellSettings: () => Promise<void>;
+  loadAvailableShells: () => Promise<void>;
+  saveShellSettings: () => Promise<void>;
 }
+
+const DEFAULT_SHELL_SETTINGS: ShellSettings = {
+  shell_id: 'auto',
+  custom_executable: null,
+  custom_args: null,
+};
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       theme: 'system',
       autoPatchGemini: false,
+      shell_id: DEFAULT_SHELL_SETTINGS.shell_id,
+      custom_executable: DEFAULT_SHELL_SETTINGS.custom_executable ?? '',
+      custom_args: DEFAULT_SHELL_SETTINGS.custom_args ?? '',
+      available_shells: [],
+      shell_settings_loaded: false,
+      shells_loaded: false,
       setTheme: (theme) => set({ theme }),
       setAutoPatchGemini: (autoPatchGemini) => set({ autoPatchGemini }),
+      setShellId: (shell_id) => set({ shell_id }),
+      setCustomExecutable: (custom_executable) => set({ custom_executable }),
+      setCustomArgs: (custom_args) => set({ custom_args }),
+      loadShellSettings: async () => {
+        try {
+          const settings = await invoke<ShellSettings>('load_shell_settings');
+          set({
+            shell_id: settings.shell_id,
+            custom_executable: settings.custom_executable ?? '',
+            custom_args: settings.custom_args ?? '',
+            shell_settings_loaded: true,
+          });
+        } catch (error) {
+          console.error('Failed to load shell settings:', error);
+          set({
+            shell_id: DEFAULT_SHELL_SETTINGS.shell_id,
+            custom_executable: '',
+            custom_args: '',
+            shell_settings_loaded: true,
+          });
+        }
+      },
+      loadAvailableShells: async () => {
+        try {
+          const available_shells = await invoke<ShellOption[]>('list_available_shells');
+          set({ available_shells, shells_loaded: true });
+        } catch (error) {
+          console.error('Failed to load available shells:', error);
+          set({ available_shells: [], shells_loaded: true });
+        }
+      },
+      saveShellSettings: async () => {
+        const settings: ShellSettings = {
+          shell_id: get().shell_id,
+          custom_executable: get().custom_executable.trim() || null,
+          custom_args: get().custom_args.trim() || null,
+        };
+        const saved = await invoke<ShellSettings>('save_shell_settings', { settings });
+        set({
+          shell_id: saved.shell_id,
+          custom_executable: saved.custom_executable ?? '',
+          custom_args: saved.custom_args ?? '',
+          shell_settings_loaded: true,
+        });
+      },
     }),
     {
-      name: 'wardian-settings', // name of the item in the storage (must be unique)
+      name: 'wardian-settings',
+      partialize: (state) => ({
+        theme: state.theme,
+        autoPatchGemini: state.autoPatchGemini,
+      }),
     }
   )
 );

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -390,21 +390,6 @@
 .xterm-cursor-layer {
   display: none !important;
 }
-/* Maximized Mode Utility */
-.maximized-mode {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  z-index: 100;
-  background: var(--color-wardian-bg);
-}
-
-.maximized-mode .terminal-container {
-  height: calc(100vh - 40px);
-}
-
 /* Inline Edit Style */
 .inline-edit-input {
   background: transparent;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,12 @@
+export interface ShellOption {
+  id: string;
+  label: string;
+  executable: string;
+  default_args: string[];
+}
+
+export interface ShellSettings {
+  shell_id: string;
+  custom_executable: string | null;
+  custom_args: string | null;
+}

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -14,10 +14,10 @@ const agents: AgentConfig[] = [
 
 const telemetry: Record<string, AgentTelemetry> = {};
 
-function renderGrid(maximizedAgentId: string | null) {
+function renderGrid(maximizedAgentId: string | null, filteredAgents: AgentConfig[] = agents) {
   return render(
     <GridView
-      filteredAgents={agents}
+      filteredAgents={filteredAgents}
       telemetry={telemetry}
       terminalTitles={{}}
       currentThoughts={{}}
@@ -58,5 +58,15 @@ describe('GridView maximize behavior', () => {
     expect(card?.className).not.toContain('fixed');
     expect(card?.className).not.toContain('h-screen');
     expect(card?.className).not.toContain('w-screen');
+  });
+
+  it('falls back to the filtered grid when the maximized agent is no longer visible', () => {
+    const visibleSubset = agents.filter((agent) => agent.session_id !== 'agent-1');
+    const { container } = renderGrid('agent-1', visibleSubset);
+
+    const root = container.firstElementChild;
+    expect(root?.className).toContain('flex gap-2');
+    expect(root?.className).not.toContain('relative overflow-hidden');
+    expect(screen.getByTestId('terminal-agent-2')).toBeInTheDocument();
   });
 });

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GridView } from './GridView';
+import type { AgentConfig, AgentTelemetry } from '../types';
+
+vi.mock('../features/terminal/AgentTerminal', () => ({
+  AgentTerminal: ({ sessionId }: { sessionId: string }) => <div data-testid={`terminal-${sessionId}`}>Terminal {sessionId}</div>,
+}));
+
+const agents: AgentConfig[] = [
+  { session_id: 'agent-1', session_name: 'Alpha', agent_class: 'Coder', folder: 'C:/project', is_off: false },
+  { session_id: 'agent-2', session_name: 'Beta', agent_class: 'Architect', folder: 'C:/project', is_off: false },
+];
+
+const telemetry: Record<string, AgentTelemetry> = {};
+
+function renderGrid(maximizedAgentId: string | null) {
+  return render(
+    <GridView
+      filteredAgents={agents}
+      telemetry={telemetry}
+      terminalTitles={{}}
+      currentThoughts={{}}
+      selectedAgentIds={new Set()}
+      offAgentIds={new Set()}
+      maximizedAgentId={maximizedAgentId}
+      draggedAgentId={null}
+      dragOverAgentId={null}
+      editingAgentId={null}
+      tempName=""
+      theme="dark"
+      onMouseEnterCard={() => {}}
+      onMouseUp={() => {}}
+      onMouseDown={() => {}}
+      onCardClick={() => {}}
+      onMaximize={() => {}}
+      onDelete={() => {}}
+      onRename={() => {}}
+      setEditingAgentId={() => {}}
+      setTempName={() => {}}
+      handleTitleChange={() => {}}
+      deriveCurrentThought={() => ({ thought: '', status: 'Idle' })}
+      getStatusColorClass={() => 'bg-wardian-success'}
+    />
+  );
+}
+
+describe('GridView maximize behavior', () => {
+  it('keeps maximized terminals scoped to the grid container', () => {
+    const { container } = renderGrid('agent-1');
+
+    const root = container.firstElementChild;
+    expect(root?.className).toContain('relative');
+
+    const card = screen.getByTestId('terminal-agent-1').closest('#agent-card-agent-1');
+    expect(card?.className).toContain('absolute');
+    expect(card?.className).toContain('inset-0');
+    expect(card?.className).not.toContain('fixed');
+    expect(card?.className).not.toContain('h-screen');
+    expect(card?.className).not.toContain('w-screen');
+  });
+});

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -55,9 +55,13 @@ export const GridView: React.FC<GridViewProps> = ({
   draggedAgentId,
   dragOverAgentId,
 }) => {
+  const visibleAgents = maximizedAgentId
+    ? filteredAgents.filter((agent: AgentConfig) => agent.session_id.toString() === maximizedAgentId)
+    : filteredAgents;
+
   return (
-    <div className="flex-1 flex gap-2 min-h-full flex-row flex-wrap content-start pb-[200px]">
-      {filteredAgents.map((agent: AgentConfig) => {
+    <div className={`flex-1 min-h-full ${maximizedAgentId ? 'relative overflow-hidden' : 'flex gap-2 flex-row flex-wrap content-start pb-[200px]'}`}>
+      {visibleAgents.map((agent: AgentConfig) => {
         const agentId = agent.session_id.toString();
         const isMaximized = maximizedAgentId === agentId;
         const isOff = offAgentIds.has(agentId);
@@ -84,7 +88,7 @@ export const GridView: React.FC<GridViewProps> = ({
             onMouseEnter={() => onMouseEnterCard(agentId)}
             onDragStart={(e) => e.preventDefault()}
             onMouseUp={() => onMouseUp()}
-            className={`bg-[var(--color-wardian-card)] overflow-hidden flex flex-col shadow-lg ${isMaximized ? 'fixed inset-0 z-[100] h-screen w-screen rounded-none m-0 border-none transition-none' : 'relative transition-all rounded-xl border h-[500px] w-[calc(50%-0.5rem)] min-w-[650px] ' + (isSelected || draggedAgentId === agentId || dragOverAgentId === agentId ? 'border-[var(--color-wardian-accent)] ring-1 ring-[var(--color-wardian-accent)]/50 shadow-wardian-accent' : 'border-wardian-border')} ${draggedAgentId === agentId && !isMaximized ? 'opacity-50 scale-[0.98]' : ''} ${dragOverAgentId === agentId && !isMaximized ? 'translate-y-[-2px]' : ''}`}
+            className={`bg-[var(--color-wardian-card)] overflow-hidden flex flex-col shadow-lg ${isMaximized ? 'absolute inset-0 z-20 rounded-xl border border-wardian-border transition-none' : 'relative transition-all rounded-xl border h-[500px] w-[calc(50%-0.5rem)] min-w-[650px] ' + (isSelected || draggedAgentId === agentId || dragOverAgentId === agentId ? 'border-[var(--color-wardian-accent)] ring-1 ring-[var(--color-wardian-accent)]/50 shadow-wardian-accent' : 'border-wardian-border')} ${draggedAgentId === agentId && !isMaximized ? 'opacity-50 scale-[0.98]' : ''} ${dragOverAgentId === agentId && !isMaximized ? 'translate-y-[-2px]' : ''}`}
           >
             <div 
               onMouseEnter={() => onMouseEnterCard(agentId)}

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -55,12 +55,14 @@ export const GridView: React.FC<GridViewProps> = ({
   draggedAgentId,
   dragOverAgentId,
 }) => {
-  const visibleAgents = maximizedAgentId
+  const maximizedAgents = maximizedAgentId
     ? filteredAgents.filter((agent: AgentConfig) => agent.session_id.toString() === maximizedAgentId)
-    : filteredAgents;
+    : [];
+  const hasVisibleMaximizedAgent = maximizedAgents.length > 0;
+  const visibleAgents = hasVisibleMaximizedAgent ? maximizedAgents : filteredAgents;
 
   return (
-    <div className={`flex-1 min-h-full ${maximizedAgentId ? 'relative overflow-hidden' : 'flex gap-2 flex-row flex-wrap content-start pb-[200px]'}`}>
+    <div className={`flex-1 min-h-full ${hasVisibleMaximizedAgent ? 'relative overflow-hidden' : 'flex gap-2 flex-row flex-wrap content-start pb-[200px]'}`}>
       {visibleAgents.map((agent: AgentConfig) => {
         const agentId = agent.session_id.toString();
         const isMaximized = maximizedAgentId === agentId;


### PR DESCRIPTION
## Summary
- add a configurable runtime shell setting that drives agent PTYs, provider bootstrap/headless runs, and workflow shell-command execution
- discover available shells dynamically on each platform, including Git Bash and WSL on Windows, and fix Claude executable resolution on Windows
- keep terminal maximize scoped to Grid and document the runtime shell model in specs and developer/user docs

## Verification
- npm run lint
- npm run test
- npm run build
- cargo clippy
- cargo test
- cargo check

Closes #48