### PR TITLE
fix(workflows): decouple scheduled run status by instance

### DIFF
--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -52,8 +52,8 @@ pub async fn stop_workflow_triggers(app: AppHandle, workflow_id: String) -> Resu
 }
 
 #[tauri::command]
-pub async fn stop_workflow_run(app: AppHandle, workflow_id: String) -> Result<(), String> {
-    workflow_engine::stop_workflow_run(app, &workflow_id).await;
+pub async fn stop_workflow_run(app: AppHandle, run_instance_id: String) -> Result<(), String> {
+    workflow_engine::stop_workflow_run(app, &run_instance_id).await;
     Ok(())
 }
 

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -776,10 +776,10 @@ pub async fn stop_workflow_triggers(app: AppHandle, workflow_id: &str) {
     }
 }
 
-pub async fn stop_workflow_run(app: AppHandle, workflow_id: &str) {
+pub async fn stop_workflow_run(app: AppHandle, run_instance_id: &str) {
     let state = app.state::<crate::state::AppState>();
     let mut runs = state.workflow_runs.lock().await;
-    if let Some(handles) = runs.remove(workflow_id) {
+    if let Some(handles) = runs.remove(run_instance_id) {
         for handle in handles {
             handle.abort();
         }
@@ -1173,6 +1173,22 @@ pub async fn run_workflow(
         .find(|w| w.id == wf_id)
         .ok_or_else(|| format!("Workflow {} not found", wf_id))?;
 
+    let run_salt = Utc::now()
+        .timestamp_nanos_opt()
+        .unwrap_or_else(|| Utc::now().timestamp_micros() * 1000);
+
+    let scheduled_run_id = initial_payload
+        .as_ref()
+        .and_then(|p| p.get("scheduled_run_id").and_then(|v| v.as_str()))
+        .map(|s| s.to_string());
+
+    // Generate unique run_instance_id per execution.
+    let run_instance_id = if let Some(scheduled_id) = scheduled_run_id.as_ref() {
+        format!("run-{}-{}", scheduled_id, run_salt)
+    } else {
+        format!("manual-{}-{}", wf_id, run_salt)
+    };
+
     // Merge role_mappings from payload (e.g. from scheduler) into the workflow
     if let Some(ref payload) = initial_payload {
         if let Some(mappings) = payload.get("role_mappings").and_then(|v| v.as_object()) {
@@ -1191,6 +1207,8 @@ pub async fn run_workflow(
         "workflow-status-updated",
         serde_json::json!({
             "workflow_id": wf_id,
+            "run_instance_id": run_instance_id,
+            "scheduled_run_id": scheduled_run_id.clone(),
             "status": "running",
         }),
     );
@@ -1199,8 +1217,11 @@ pub async fn run_workflow(
     let log_path = log_dir.join(format!("{}.json", timestamp));
 
     // Store the run handle for cancellation support
-    let wf_id_for_handle = wf_id.clone();
     let app_for_handle = app.clone();
+    let run_instance_id_for_completion = run_instance_id.clone();
+    let run_instance_id_for_cleanup = run_instance_id.clone();
+    let run_instance_id_for_handle = run_instance_id.clone();
+    let scheduled_run_id_for_completion = scheduled_run_id.clone();
     let handle = tauri::async_runtime::spawn(async move {
         let mut trace = Vec::new();
         let mut pulsed_ports: HashMap<(String, String), u32> = HashMap::new(); // (node_id, port_id) -> count
@@ -1304,6 +1325,8 @@ pub async fn run_workflow(
                 "workflow-progress",
                 serde_json::json!({
                     "workflow_id": wf.id,
+                    "run_instance_id": run_instance_id,
+                    "scheduled_run_id": scheduled_run_id.clone(),
                     "workflow_name": wf.name,
                     "current_step": global_step_count,
                     "total_steps": total_enqueued + queue.len(),
@@ -2078,6 +2101,8 @@ pub async fn run_workflow(
             "workflow-status-updated",
             serde_json::json!({
                 "workflow_id": wf.id,
+                "run_instance_id": run_instance_id_for_completion,
+                "scheduled_run_id": scheduled_run_id_for_completion,
                 "status": if had_error { "failed" } else { "completed" },
             }),
         );
@@ -2086,13 +2111,17 @@ pub async fn run_workflow(
         if let Ok(json) = serde_json::to_string_pretty(&trace) {
             let _ = fs::write(log_path, json);
         }
+
+        let state = app.state::<crate::state::AppState>();
+        let mut runs = state.workflow_runs.lock().await;
+        runs.remove(&run_instance_id_for_cleanup);
     });
 
     // Store handle for cancellation
     {
         let state = app_for_handle.state::<crate::state::AppState>();
         let mut runs = state.workflow_runs.lock().await;
-        let handles = runs.entry(wf_id_for_handle).or_default();
+        let handles = runs.entry(run_instance_id_for_handle).or_default();
         handles.push(handle);
     }
 

--- a/src/features/workflows/ActiveMonitoring.test.tsx
+++ b/src/features/workflows/ActiveMonitoring.test.tsx
@@ -114,7 +114,8 @@ describe('ActiveMonitoring scheduled tasks', () => {
       <ActiveMonitoring
         activeRuns={[
           {
-            run_id: 'run-1',
+            run_instance_id: 'sched-1',
+            scheduled_run_id: 'sched-1',
             workflow_id: 'wf-1',
             workflow_name: 'Morning Sync',
             current_step: 1,
@@ -166,7 +167,45 @@ describe('ActiveMonitoring scheduled tasks', () => {
     expect(screen.getByRole('button', { name: /Run Now/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Pause schedule/i })).toBeInTheDocument();
   });
+
+  it('marks only the matching scheduled instance as running', () => {
+    render(
+      <ActiveMonitoring
+        activeRuns={[
+          {
+            run_instance_id: 'sched-2',
+            scheduled_run_id: 'sched-2',
+            workflow_id: 'wf-1',
+            workflow_name: 'Morning Sync',
+            current_step: 1,
+            total_steps: 3,
+            active_node_name: 'Research',
+          },
+        ]}
+        schedules={[
+          {
+            ...schedules[0],
+            id: 'sched-1',
+          },
+          {
+            ...schedules[0],
+            id: 'sched-2',
+          },
+        ]}
+        activeWorkflows={[]}
+        availableWorkflows={workflows}
+        agents={agents}
+        onStopRun={vi.fn()}
+        onStopTrigger={vi.fn()}
+        onToggleSchedule={vi.fn()}
+        onDeleteSchedule={vi.fn()}
+        onRunNow={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText('Running')).toHaveLength(1);
+    expect(screen.getAllByText('Live').length).toBeGreaterThan(0);
+  });
 });
-
-
 

--- a/src/features/workflows/ActiveMonitoring.tsx
+++ b/src/features/workflows/ActiveMonitoring.tsx
@@ -147,11 +147,11 @@ export const ActiveMonitoring: React.FC<ActiveMonitoringProps> = ({
             <div className="text-[9px] text-muted-neutral italic py-4 text-center border border-dashed border-wardian-border/20 rounded-lg">No active runs</div>
           ) : (
             activeRuns.map(run => (
-              <div key={run.run_id} className="p-2.5 rounded-lg bg-[var(--color-wardian-card-bg)] border border-wardian-border/40 group hover:border-[var(--color-wardian-accent)]/30 transition-colors">
+              <div key={run.run_instance_id} className="p-2.5 rounded-lg bg-[var(--color-wardian-card-bg)] border border-wardian-border/40 group hover:border-[var(--color-wardian-accent)]/30 transition-colors">
                 <div className="flex justify-between items-start mb-2">
                   <span className="text-[11px] font-bold text-primary truncate leading-tight tracking-tight">{run.workflow_name}</span>
                   <button
-                    onClick={() => onStopRun(run.run_id)}
+                    onClick={() => onStopRun(run.run_instance_id)}
                     className="opacity-0 group-hover:opacity-100 p-1 text-muted hover:text-red-500 transition-all hover:scale-110"
                     title="Terminate Run"
                   >
@@ -205,7 +205,7 @@ export const ActiveMonitoring: React.FC<ActiveMonitoringProps> = ({
             schedules.map(schedule => {
               const workflow = availableWorkflows.find(item => item.id === schedule.workflow_id);
               const isExpanded = selectedScheduleId === schedule.id;
-              const isRunning = activeRuns.some((run) => run.workflow_id === schedule.workflow_id);
+              const isRunning = activeRuns.some((run) => run.scheduled_run_id === schedule.id);
               const status = getScheduleStatus(schedule, isRunning);
               const targetSummary = summarizeScheduleTarget(schedule, workflow, agents);
               const roleMappings = Object.entries(schedule.role_mappings || {});
@@ -354,4 +354,3 @@ export const ActiveMonitoring: React.FC<ActiveMonitoringProps> = ({
     </div>
   );
 };
-

--- a/src/store/useWorkflowStore.ts
+++ b/src/store/useWorkflowStore.ts
@@ -49,7 +49,7 @@ interface WorkflowState {
   runScheduledWorkflowNow: (runId: string) => Promise<void>;
   stopAllTriggers: () => Promise<void>;
   stopWorkflowTriggers: (workflowId: string) => Promise<void>;
-  stopWorkflowRun: (workflowId: string) => Promise<void>;
+  stopWorkflowRun: (runInstanceId: string) => Promise<void>;
   pauseAllTriggers: () => Promise<void>;
   resumeAllTriggers: () => Promise<void>;
   clearActiveWorkflow: () => void;
@@ -283,11 +283,13 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   },
 
   handleProgress: (event) => {
-    const { workflow_id, current_step, total_steps, active_node_name, workflow_name } = event;
+    const { workflow_id, run_instance_id, scheduled_run_id, current_step, total_steps, active_node_name, workflow_name } = event;
+    const instanceId = run_instance_id || workflow_id;
     set((state) => {
-      const existingIdx = state.activeRuns.findIndex(r => r.workflow_id === workflow_id);
+      const existingIdx = state.activeRuns.findIndex(r => r.run_instance_id === instanceId);
       const newRun = {
-        run_id: workflow_id, // Simple mapping for now
+        run_instance_id: instanceId,
+        scheduled_run_id: scheduled_run_id || null,
         workflow_id,
         workflow_name: workflow_name || state.availableWorkflows.find(w => w.id === workflow_id)?.name || 'Unknown',
         current_step,
@@ -306,10 +308,12 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
   },
 
   handleStatusUpdate: (event) => {
-    const { workflow_id, status } = event;
+    const { workflow_id, run_instance_id, scheduled_run_id, status } = event;
+    const instanceId = run_instance_id || workflow_id;
+    
     if (status === 'running') {
       set((state) => {
-        if (state.activeRuns.some(run => run.workflow_id === workflow_id)) {
+        if (state.activeRuns.some(run => run.run_instance_id === instanceId)) {
           return state;
         }
 
@@ -317,7 +321,8 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
           activeRuns: [
             ...state.activeRuns,
             {
-              run_id: workflow_id,
+              run_instance_id: instanceId,
+              scheduled_run_id: scheduled_run_id || null,
               workflow_id,
               workflow_name: state.availableWorkflows.find(w => w.id === workflow_id)?.name || 'Unknown',
               current_step: 0,
@@ -332,7 +337,7 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
 
     if (status === 'completed' || status === 'failed') {
       set((state) => ({
-        activeRuns: state.activeRuns.filter(r => r.workflow_id !== workflow_id)
+        activeRuns: state.activeRuns.filter(r => r.run_instance_id !== instanceId)
       }));
     }
   },
@@ -390,11 +395,11 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
     }
   },
 
-  stopWorkflowRun: async (workflowId: string) => {
+  stopWorkflowRun: async (runInstanceId: string) => {
     try {
-      await invoke("stop_workflow_run", { workflowId });
+      await invoke("stop_workflow_run", { runInstanceId });
       set((state) => ({
-        activeRuns: state.activeRuns.filter(r => r.workflow_id !== workflowId)
+        activeRuns: state.activeRuns.filter(r => r.run_instance_id !== runInstanceId)
       }));
     } catch (err) {
       console.error("Failed to stop workflow run:", err);
@@ -468,8 +473,6 @@ export const useWorkflowStore = create<WorkflowState>((set, get) => ({
     }
   },
 }));
-
-
 
 
 

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -91,11 +91,11 @@ export interface ScheduledRun {
 }
 
 export interface ActiveRunTracker {
-  run_id: string;
+  run_instance_id: string;
+  scheduled_run_id?: string | null;
   workflow_id: string;
   workflow_name: string;
   current_step: number;
   total_steps: number;
   active_node_name: string;
 }
-


### PR DESCRIPTION
## Summary
- Fix workflow run tracking to use a unique `run_instance_id` per execution while preserving `scheduled_run_id` for schedule-level state.
- Update monitoring/store logic so scheduled cards show `Running` only for the matching scheduled instance instead of all schedules sharing the same workflow template.
- Align stop/cancellation flow to target run instances and clean completed run handles from backend state.

## Verification
- npm run lint
- npm run test
- cd src-tauri; cargo check
- cd src-tauri; cargo test