### PR TITLE
feat(session): refine persistence policy and add source control panel

### DIFF
--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -8,6 +8,10 @@ This document captures the practical runtime differences between Wardian's suppo
 - Every provider receives Wardian's `system_include_directories`, which are resolved from `common`, `classes/<class>`, and `agents/<session_id>`.
 - Headless execution and interactive execution use the same provider-specific assumptions where possible. Differences should stay explicit in `manager.rs` instead of being hidden in frontend state.
 - Provider-native instruction discovery matters more than Wardian's abstract model. The backend adapts Wardian's files and directories to each CLI instead of expecting the CLI to understand Wardian directly.
+- Workflow Agent nodes expose one run mode: `ephemeral`, `inherit_fresh`, or `inherit_resume`. Provider resume flags are emitted only for `inherit_resume`.
+- `inherit_fresh` clones the selected agent's runtime configuration and scoped read context, but writes workflow artifacts under a workflow-run session ID and clears provider resume state.
+- Workflow-spawned fresh runs skip interactive startup prompts. The workflow node prompt is the first provider input.
+- Regular visible agents use the global `Regular agent sessions` setting. `resume` keeps the previous provider session where possible; `fresh` restarts without provider resume flags.
 
 ## Quick Comparison
 

--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -11,7 +11,7 @@ This document captures the practical runtime differences between Wardian's suppo
 - Workflow Agent nodes expose one run mode: `ephemeral`, `inherit_fresh`, or `inherit_resume`. Provider resume flags are emitted only for `inherit_resume`.
 - `inherit_fresh` clones the selected agent's runtime configuration and scoped read context, but writes workflow artifacts under a workflow-run session ID and clears provider resume state.
 - Workflow-spawned fresh runs skip interactive startup prompts. The workflow node prompt is the first provider input.
-- Regular visible agents use the global `Regular agent sessions` setting. `resume` keeps the previous provider session where possible; `fresh` restarts without provider resume flags.
+- Regular visible agents use the global `Regular agent sessions` setting unless the agent config sets `session_persistence` to `fresh` or `resume`. The agent-level `default` value inherits the global setting.
 
 ## Quick Comparison
 
@@ -56,6 +56,7 @@ Claude also runs directly in the real target workspace. Wardian does not use a p
 - Fresh Claude spawns use an explicit Wardian-generated `--session-id`.
 - This avoids a bootstrap phase just to discover the provider session ID.
 - Resume launches use `--resume <session_id>` and do not resend `--session-id` or `--name`.
+- Fresh resume of an existing Wardian agent uses a new transient Claude provider session ID while keeping the Wardian agent ID stable. After launch, Wardian stores the transient Claude ID as the next `resume_session`.
 
 ### Instruction and skill discovery
 

--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -12,6 +12,7 @@ This document captures the practical runtime differences between Wardian's suppo
 - `inherit_fresh` clones the selected agent's runtime configuration and scoped read context, but writes workflow artifacts under a workflow-run session ID and clears provider resume state.
 - Workflow-spawned fresh runs skip interactive startup prompts. The workflow node prompt is the first provider input.
 - Regular visible agents use the global `Regular agent sessions` setting unless the agent config sets `session_persistence` to `fresh` or `resume`. The agent-level `default` value inherits the global setting.
+- The regular-agent context menu `Clear` action forces a fresh provider launch for that one action and clears both the backend PTY output buffer and frontend terminal scrollback cache.
 
 ## Quick Comparison
 

--- a/docs/developer/workflow-engine.md
+++ b/docs/developer/workflow-engine.md
@@ -37,9 +37,15 @@ Unlike traditional DAGs, Wardian supports **Cycles** and **Loops** through a pul
 ## 🧩 Node Types & Logic
 
 ### Agent Node
-The most complex node type. It can run in two modes:
-- **PTY (Text) Mode**: Injects a prompt into a live agent's terminal and waits for an "Idle" JSON event from the CLI.
-- **Headless (JSON) Mode**: Temporarily kills the live PTY, runs a one-off `gemini-cli` command for structured JSON output, and then restores the PTY.
+The most complex node type. The builder exposes one execution policy selector:
+
+- **`ephemeral`**: build a fresh workflow-run agent config from the node's class and folder fields.
+- **`inherit_fresh`**: clone the selected agent's provider, class, workspace, skills, and scoped read configuration, but clear provider resume state and run under a workflow-run session ID.
+- **`inherit_resume`**: intentionally use the selected agent's provider session and mutable runtime state.
+
+The backend resolves that selector into an `AgentExecutionContext` before launch. Fresh modes use headless execution and must not kill or mutate a live source agent. Resume mode may use the live PTY for text output, or temporarily switch to provider-native headless execution for structured JSON output when the provider requires it.
+
+Workflow-spawned agent runs skip interactive startup prompts. Provider resume flags are emitted only when the resolved context is `inherit_resume`.
 
 ### Logic Node
 Evaluates a string condition (e.g., `nodes.gatekeeper.output.decision === 'PROCEED'`) using a regex-based parser. Pulses either the `on_true` or `on_false` port.

--- a/docs/specs/015-evidence-first-memory.md
+++ b/docs/specs/015-evidence-first-memory.md
@@ -1,0 +1,74 @@
+# Spec 015: Evidence-First Memory
+
+- **Status:** Placeholder
+- **Date:** 2026-04-17
+- **Decider:** User
+
+## Context and Problem Statement
+
+Wardian needs a memory model that avoids using provider-native session replay as long-term memory. Provider sessions are useful runtime continuity, but they are expensive, provider-specific, and difficult to inspect. Wardian's memory system should instead preserve evidence, index it for retrieval, and build prompt context selectively.
+
+This placeholder records one immediate design constraint from the session-persistence work. A fuller memory architecture will replace this document later.
+
+## Proposed Decision
+
+### Continuity Is Not Memory
+
+Provider-native session IDs, PTY state, provider homes, approval hooks, and provider logs are runtime continuity. They should not be the primary memory substrate.
+
+Wardian memory should be based on:
+
+- raw evidence artifacts
+- workflow run outputs
+- transcripts or excerpts with provenance
+- promoted knowledge records
+- scoped retrieval into prompts
+
+### Scoped Memory For Inherited Workflow Runs
+
+Workflow mode affects memory access:
+
+| Workflow run mode | Read scope | Default write target |
+| --- | --- | --- |
+| `ephemeral` | common and class scopes | workflow run artifacts |
+| `inherit_fresh` | common, class, and source-agent scopes | workflow run artifacts |
+| `inherit_resume` | source agent runtime and provider session | source agent continuity, plus workflow artifacts |
+
+`inherit_fresh` is the important case. It may read source-agent scoped memories so the run behaves like the selected agent's profile, but it must not automatically write back to that source agent's durable memory.
+
+Default write behavior:
+
+```text
+inherit_fresh during run:
+  read source agent scoped memory
+  write workflow run artifacts
+  do not mutate source agent memory
+
+after run:
+  preserve workflow output/evidence
+  discard or archive provider session state as non-resumable
+  require explicit promotion to source-agent memory
+```
+
+### Promotion Must Be Explicit
+
+Future memory features should support explicit promotion paths:
+
+- promote workflow artifact to source-agent memory
+- attach evidence to an agent
+- append a provenance-backed memory record
+- propose memory updates for user review
+
+Automatic source-agent memory writes from `inherit_fresh` should be avoided in the initial implementation. If added later, they should use a backend memory API with locking, append-only records, provenance, and conflict handling rather than allowing providers to write shared memory files directly.
+
+### Runtime Directories Are Not Durable Memory
+
+A workflow-run runtime directory may be retained after completion for auditability, but it is an artifact container, not a resumable agent home. Fresh workflow runs should not write provider-discovered session IDs back to the source agent's `resume_session`.
+
+## Consequences
+
+- **Positive**: Workflow runs can use an agent's scoped context without silently changing that agent.
+- **Positive**: Memory becomes inspectable and provenance-backed instead of hidden inside provider sessions.
+- **Positive**: Token growth is controlled because prompt context is selected, not replayed wholesale.
+- **Negative**: Users must explicitly promote useful workflow outputs into durable agent memory.
+- **Negative**: The future memory system needs a real API for promotion, locking, provenance, and retrieval.

--- a/docs/specs/018-source-control-panel.md
+++ b/docs/specs/018-source-control-panel.md
@@ -1,0 +1,61 @@
+# Spec 018: Source Control Panel
+
+- **Status:** Implemented
+- **Date:** 2026-04-17
+- **Decider:** User
+
+## Context and Problem Statement
+
+Wardian lacked integrated git awareness. Agents often modify files in the workspace and users had no in-app way to review changes, stage files, commit, or push without switching to an external terminal. Additionally, the worktree feature (used for agent isolation) was hidden behind AdvancedSettings with no clear UX flow.
+
+A secondary problem: polling git in the background on Windows caused a visible console window to flash on every poll, which was disruptive.
+
+## Proposed Decision
+
+### Source Control Icon Rail Tab
+
+A new `"git"` tab is added to the sidebar icon rail, represented by a commit-graph SVG (two nodes on a vertical line with a branch extending from the lower node to a side node — matching VS Code's iconography).
+
+### Git Sidebar Panel (`GitPanel`, `GitFileList`, `GitDiffView`)
+
+Layout matches VS Code Source Control conventions:
+- **Branch bar**: shows current branch name
+- **Worktree action row**: action-first UX — `+ Worktree` dashed button when inactive; a cyan chip showing the worktree branch with `×` dismiss when active. Clicking either calls `update_agent_config` then `resume_agent` if the agent is running, so the change takes effect mid-session without spawning a new agent.
+- **Commit box at top**: text area + commit button with checkmark icon
+- **File sections**: "Staged Changes" and "Changes" with pill count badges; files show status letter (M/A/D/?) on the right and hover actions (stage/unstage/discard) in the middle
+- **Diff view**: modal overlay with line-level colorization using `color-mix(in srgb, var(--color-wardian-*), transparent 90%)`
+
+All colors use theme variables (`var(--color-wardian-warning)`, `var(--color-wardian-success)`, etc.).
+
+### Rust Git Command Module (`commands/git.rs`, `models/git.rs`)
+
+Twelve Tauri commands: `git_status`, `git_current_branch`, `git_log`, `git_diff_file`, `git_stage`, `git_unstage`, `git_discard_changes`, `git_commit`, `git_pull`, `git_push`, `git_create_worktree`, `git_remove_worktree`.
+
+All commands use `new_headless_std_command("git")` (sets `CREATE_NO_WINDOW` on Windows) plus env vars `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS=echo` to prevent console window flashes and credential-prompt hangs — matching VS Code's git extension behavior.
+
+### Explorer Git Color Coding
+
+`ExplorerPanel` polls `git_status` every 3 seconds using the agent's workspace root as cwd. A normalized `Record<string, string>` (forward-slash relative path → status letter) is passed to `FileTree`, which colors file names and shows a small status letter badge on the right:
+
+| Status | Color |
+|--------|-------|
+| M (modified) | `var(--color-wardian-warning)` |
+| A (added) | `var(--color-wardian-success)` |
+| D (deleted) | `var(--color-wardian-error)` |
+| ? (untracked) | `var(--color-wardian-success)` |
+| R/C (renamed/copied) | `var(--color-wardian-processing)` |
+
+Directories inherit amber coloring if any descendant has changes. When git is unavailable (non-git directory), the status map is empty and the explorer renders with no color change.
+
+### AgentConfig: `git_worktree` flag
+
+`git_worktree?: boolean` added to `AgentConfig` in both TypeScript (`src/types/index.ts`) and Rust (`models/agent_config.rs`). The GitPanel reads this flag to determine the active worktree state and writes it via `update_agent_config`.
+
+## Consequences
+
+- **Positive**: Full git workflow (review, stage, commit, push) without leaving Wardian
+- **Positive**: No Windows console flashes from background git polling
+- **Positive**: Explorer provides ambient git context (colored files) without a separate panel
+- **Positive**: Worktree UX is action-first and visible in context rather than hidden in settings
+- **Negative**: Worktree-on-resume has a known architectural limitation (providers bind session identity to CWD); proper fix tracked in Issue #118 (habitat-for-all + junction redirect)
+- **Negative**: Git color coding in the explorer adds a 3-second polling interval per explorer session; if the workspace is a very large repo, `git status --untracked-files=all` may be slow (can be mitigated in future by using `--untracked-files=no`)

--- a/docs/specs/019-session-persistence-policy.md
+++ b/docs/specs/019-session-persistence-policy.md
@@ -136,12 +136,15 @@ OpenCode is the clearest example of why the distinction matters: Wardian can clo
 
 ### Settings
 
-Add settings at two levels:
+Add one global setting for regular interactive agents:
 
-1. **Global workflow default**: default run mode for newly created workflow agent nodes.
-2. **Agent default**: optional preferred inherited run mode when this agent is selected in workflow builder surfaces.
+| Setting | Values | Default |
+| --- | --- | --- |
+| Regular agent sessions | `resume`, `fresh` | `resume` |
 
-The agent-level setting should not override an explicit workflow node choice. Initial implementation may omit these settings and default new workflow nodes to `ephemeral`, with legacy persistent nodes migrating to `inherit_fresh`.
+This setting controls normal visible-agent resume behavior after an agent has been paused or is off. `resume` continues the provider-native session when possible. `fresh` restarts the agent without provider resume flags, reducing provider-context growth for ordinary agent restarts.
+
+Workflow agent nodes do not inherit this global setting. Their behavior remains explicit through `ephemeral`, `inherit_fresh`, and `inherit_resume`, with new workflow nodes defaulting to `ephemeral` and legacy persistent nodes migrating to `inherit_fresh`.
 
 ### Documentation
 

--- a/docs/specs/019-session-persistence-policy.md
+++ b/docs/specs/019-session-persistence-policy.md
@@ -156,6 +156,8 @@ Workflow agent nodes do not inherit this global setting. Their behavior remains 
 
 Claude has one extra runtime constraint: fresh resume must not reuse the old Claude `--session-id`. Wardian keeps the stable Wardian agent ID for UI state, scoped files, and telemetry, but generates a new Claude provider session ID for the fresh launch and then stores that provider ID as the next resumable session. This prevents Claude's "session ID is already in use" error while preserving the user's visible agent identity.
 
+Regular agents also expose a context-menu `Clear` action. `Clear` is a one-shot fresh restart: it ignores the agent's default/fresh/resume setting for that launch, clears Wardian's terminal output buffer, and broadcasts a terminal-clear event so the frontend scrollback cache is discarded too. It does not change the saved per-agent session persistence setting.
+
 ### Documentation
 
 Update user-facing workflow docs to explain:

--- a/docs/specs/019-session-persistence-policy.md
+++ b/docs/specs/019-session-persistence-policy.md
@@ -1,0 +1,168 @@
+# Spec 019: Session Persistence Policy
+
+- **Status:** Proposed
+- **Date:** 2026-04-17
+- **Decider:** User
+
+## Context and Problem Statement
+
+Wardian's provider-native session persistence is useful for interactive agents, but it is too expensive as a default for workflow automation. When workflow runs reuse a provider session, each run can inherit growing context and increase token usage without an explicit user decision.
+
+The existing workflow model also overloads the word "persistent." A persistent workflow agent node can mean "target an existing Wardian agent," "use that agent's provider/runtime configuration," and "resume that provider's conversation history." Those are separate concerns.
+
+Wardian should preserve the ability to resume live agents while making workflow execution fresh by default. Workflows should be able to use an existing agent as a profile template without automatically mutating or extending that live agent's provider session.
+
+## Proposed Decision
+
+### Use One Workflow Agent Run Mode
+
+Wardian will model workflow agent execution with one workflow-facing selector:
+
+| Run mode | Meaning |
+| --- | --- |
+| `ephemeral` | Build a fresh execution from an agent class plus node-specific config. This is the current "temporary" workflow behavior, renamed and clarified. |
+| `inherit_fresh` | Clone provider/runtime settings from an existing Wardian agent, but start a fresh provider session in a workflow-run runtime directory. |
+| `inherit_resume` | Resume the selected agent's provider session and intentionally reuse its mutable runtime directory. |
+
+The backend can still decompose the selected run mode into internal source and persistence concepts, but workflow JSON should not expose a separate `session_persistence` field. This avoids invalid combinations such as `ephemeral + resume`.
+
+### Default Behavior
+
+Defaults should reduce accidental token growth:
+
+| Surface | Default |
+| --- | --- |
+| Interactive agent restart | `resume` |
+| Manual workflow run | `fresh` |
+| Scheduled workflow run | `fresh` |
+| File watcher or listener workflow | `fresh`, unless explicitly configured |
+| OpenClaw or future background-agent runtime | `resume` by design, because the runtime is explicitly long-lived |
+
+This keeps live agents useful while making workflow runs artifact-oriented and reproducible by default.
+
+### Workflow Agent Node UX
+
+The workflow agent node should replace the overloaded `session_type` language with clearer fields:
+
+| Field | Values | Notes |
+| --- | --- | --- |
+| `mode` | `ephemeral`, `inherit_fresh`, `inherit_resume` | Replaces the current user-facing distinction between temporary and persistent. |
+| `agent_class` | class name | Used when `mode = ephemeral`. |
+| `agent_id` | session ID | Used when `mode = inherit_fresh` or `mode = inherit_resume`. |
+
+For backwards compatibility, legacy workflow nodes should be migrated in memory:
+
+| Legacy value | New source | New persistence |
+| --- | --- | --- |
+| `session_type = temporary` | `ephemeral` | fresh provider session |
+| `session_type = persistent` | `inherit_fresh` | fresh provider session |
+
+If preserving exact old behavior is required during migration, persistent legacy nodes can be upgraded to `inherit_resume` behind a one-time compatibility flag. The preferred product behavior is `inherit_fresh`, because the user goal is to stop accidental token growth.
+
+### Backend Execution Context
+
+The Rust backend remains the authority for provider lifecycle decisions. Workflow execution should resolve a backend-owned execution context before launching a provider:
+
+```rust
+pub enum WorkflowAgentMode {
+    Ephemeral,
+    InheritFresh,
+    InheritResume,
+}
+
+pub struct AgentExecutionContext {
+    pub config: AgentConfig,
+    pub mode: WorkflowAgentMode,
+    pub resume_session: Option<String>,
+}
+```
+
+Resolution rules:
+
+1. Determine agent mode from the workflow node.
+2. If `inherit_fresh` or `inherit_resume`, clone the target agent's runtime config.
+3. Apply explicit workflow node overrides such as prompt, output format, timeout, and folder.
+4. If mode is `ephemeral`, build a class/config execution, clear `resume_session`, and use a workflow-run runtime directory.
+5. If mode is `inherit_fresh`, clear `resume_session`, include the source agent as read scope, and use a workflow-run runtime directory.
+6. If mode is `inherit_resume`, pass the provider-native resume ID only when it is valid for that provider and use the source agent's mutable runtime directory.
+7. Persist workflow output as workflow run artifacts, not as implicit provider memory.
+
+`inherit_fresh` runs share the source agent as read scope for instructions, skills, and scoped memory, but receive a separate workflow-run runtime directory. Only `inherit_resume` intentionally reuses the source agent's mutable runtime directory and provider session.
+
+### Startup Prompt Policy
+
+Wardian should treat "introduce yourself" startup prompts as an interactive-agent bootstrap behavior, not as a universal fresh-session behavior.
+
+Workflow-spawned runs should skip introductory prompts:
+
+| Run mode | Startup prompt behavior |
+| --- | --- |
+| `ephemeral` | Do not send an intro prompt. The first provider input is the workflow node prompt. |
+| `inherit_fresh` | Do not send an intro prompt. The run inherits profile scope, not conversational warm-up. |
+| `inherit_resume` | Do not send an intro prompt unless the workflow prompt explicitly asks for that context. |
+
+Regular visible agents may still send an intro prompt on fresh interactive launch when provider behavior benefits from it. Resume launches should skip it.
+
+The launch context should keep these decisions separate:
+
+```rust
+pub enum LaunchSurface {
+    InteractiveAgent,
+    WorkflowNode,
+    ScheduledWorkflow,
+    NativeE2E,
+}
+
+pub enum StartupPromptDecision {
+    SendIntro,
+    SkipIntro,
+}
+```
+
+Provider adapters may expose whether they need an interactive bootstrap prompt for readiness, but headless workflow runs should default to `SkipIntro`. This avoids spending tokens on non-task output and prevents intro text from polluting structured workflow results.
+
+### Provider Semantics
+
+Provider adapters remain responsible for translating a resolved resume ID into provider-specific flags:
+
+| Provider | Resume behavior |
+| --- | --- |
+| Gemini | `--resume <session_id>` only for `inherit_resume`. |
+| Claude | `--resume <session_id>` only for `inherit_resume`; do not resend fresh-session identity on resume. |
+| Codex | `resume <session_id>` or headless resume form only for `inherit_resume`; fresh runs must not use the live provider ID. |
+| OpenCode | `--session <session_id>` only for `inherit_resume`; fresh runs should still receive injected instructions and skill paths through `OPENCODE_CONFIG_CONTENT`. |
+
+OpenCode is the clearest example of why the distinction matters: Wardian can clone OpenCode provider config and injected skills without automatically appending another run to the same OpenCode `sessionID`.
+
+### Settings
+
+Add settings at two levels:
+
+1. **Global workflow default**: default run mode for newly created workflow agent nodes.
+2. **Agent default**: optional preferred inherited run mode when this agent is selected in workflow builder surfaces.
+
+The agent-level setting should not override an explicit workflow node choice. Initial implementation may omit these settings and default new workflow nodes to `ephemeral`, with legacy persistent nodes migrating to `inherit_fresh`.
+
+### Documentation
+
+Update user-facing workflow docs to explain:
+
+- "Agent class" creates a fresh execution from class/config.
+- "Existing agent profile" clones a live agent's settings.
+- "Fresh session" avoids growing provider context.
+- "Resume provider session" is useful for deliberate continuity but can increase token use.
+
+Update developer docs to preserve the key invariant: provider-native resume state is runtime state, not Wardian memory.
+
+Memory read/write behavior is intentionally out of scope for this spec except for one boundary: `inherit_fresh` may read source-agent scoped memory, but it should write workflow artifacts only. Promotion into source-agent memory belongs to [Spec 015](./015-evidence-first-memory.md).
+
+## Consequences
+
+- **Positive**: Workflow runs no longer accidentally consume growing provider context by default.
+- **Positive**: Existing agents can still be used as reusable execution profiles.
+- **Positive**: Interactive agents keep the expected resume behavior.
+- **Positive**: The model aligns with Wardian's evidence-first memory direction by storing workflow artifacts instead of replaying provider transcripts.
+- **Positive**: OpenClaw and future background-agent runtimes get a clear place as explicit long-lived agents.
+- **Negative**: Existing workflows that relied on implicit live-session continuity may need an explicit `resume` setting.
+- **Negative**: The workflow node UI and backend execution paths need migration logic for legacy `session_type` nodes.
+- **Negative**: Fresh workflow runs may lose provider-native context that some users found convenient; that context should be promoted into explicit workflow inputs, memory nodes, or retrieved evidence instead.

--- a/docs/specs/019-session-persistence-policy.md
+++ b/docs/specs/019-session-persistence-policy.md
@@ -144,7 +144,17 @@ Add one global setting for regular interactive agents:
 
 This setting controls normal visible-agent resume behavior after an agent has been paused or is off. `resume` continues the provider-native session when possible. `fresh` restarts the agent without provider resume flags, reducing provider-context growth for ordinary agent restarts.
 
+Each regular agent also has an override:
+
+| Agent setting | Values | Default |
+| --- | --- | --- |
+| Regular Session Resume | `default`, `fresh`, `resume` | `default` |
+
+`default` inherits the global `Regular agent sessions` value. `fresh` and `resume` override the global value for that specific visible agent. This override is intentionally scoped to normal agent resume from Off; workflow agent nodes remain explicit through their own run mode.
+
 Workflow agent nodes do not inherit this global setting. Their behavior remains explicit through `ephemeral`, `inherit_fresh`, and `inherit_resume`, with new workflow nodes defaulting to `ephemeral` and legacy persistent nodes migrating to `inherit_fresh`.
+
+Claude has one extra runtime constraint: fresh resume must not reuse the old Claude `--session-id`. Wardian keeps the stable Wardian agent ID for UI state, scoped files, and telemetry, but generates a new Claude provider session ID for the fresh launch and then stores that provider ID as the next resumable session. This prevents Claude's "session ID is already in use" error while preserving the user's visible agent identity.
 
 ### Documentation
 

--- a/docs/workflows/agent-assignment.md
+++ b/docs/workflows/agent-assignment.md
@@ -40,14 +40,17 @@ For each agent role, the modal shows:
 
 This lets one workflow template be reused across different agent rosters or different scheduled instances.
 
-## Persistent vs Temporary Agent Nodes
+## Agent Run Modes
 
-Agent nodes support two user-facing modes in the builder:
+Agent nodes use one run mode selector:
 
-- **Persistent**: target a real agent session that already exists
-- **Temporary**: choose an agent class and workspace so Wardian can execute against a temporary agent context
+- **Ephemeral**: build a fresh workflow execution from an agent class and workspace. It does not need launch-time agent assignment.
+- **Inherit Fresh**: clone provider, class, workspace, skill, and scoped-memory read configuration from an existing agent, but start a fresh provider session for this workflow run.
+- **Inherit Resume**: continue the selected agent's provider session and mutable runtime state. Use this only when the workflow should deliberately add to that agent's conversation history.
 
-From a user perspective, the important difference is that persistent mode is about targeting an existing agent, while temporary mode is about launching work from a class-based configuration.
+From a user perspective, the important distinction is whether the workflow needs an existing agent. Ephemeral runs do not. Inherited runs do, so they can appear in the Agent Assignments section when no direct agent is already selected.
+
+Workflow-spawned agent runs do not receive an automatic "introduce yourself" startup prompt. The first provider input is the workflow node prompt.
 
 ## Off Agents and Headless Execution
 
@@ -56,7 +59,7 @@ If a target agent is off, Wardian can still execute the workflow through headles
 What users should expect:
 
 - the workflow still attempts to run if the provider supports headless execution
-- role mappings still matter even if the target agent is not currently open in a visible terminal
+- role mappings still matter for inherited runs even if the target agent is not currently open in a visible terminal
 - provider-specific quirks can affect the outcome, especially for structured output or approvals
 
 ## Scheduled Assignment
@@ -79,8 +82,12 @@ Use **roles** when:
 
 Use **direct agent targeting** when:
 
-- the workflow truly belongs to one specific long-lived agent
+- the workflow should inherit from or resume one specific long-lived agent
 - reusability is not important for that automation
+
+Prefer **Inherit Fresh** when you want an existing agent's profile without conversation-history token growth. Reserve **Inherit Resume** for workflows whose purpose is to continue that exact agent session.
+
+The global regular-agent session setting does not change workflow Agent node behavior. Workflow runs follow the node's run mode.
 
 ## Related References
 

--- a/docs/workflows/building-workflows.md
+++ b/docs/workflows/building-workflows.md
@@ -29,7 +29,7 @@ When you click a node, Wardian opens the node settings drawer. That drawer shows
 Examples:
 
 - Scheduled Trigger shows different fields depending on whether you pick `Minutes`, `Hours`, `Daily`, `Weekly`, or `One-Time`.
-- Agent shows different targeting fields depending on whether the session type is `persistent` or `temporary`.
+- Agent shows different targeting fields depending on whether the run mode is `ephemeral`, `inherit_fresh`, or `inherit_resume`.
 - Loop shows different fields for `count` versus `conditional` mode.
 
 ## Connections and Flow
@@ -64,7 +64,7 @@ Wardian opens the run modal when the workflow needs extra launch-time input.
 That usually means one or both of these are true:
 
 - the workflow has a **Manual Trigger** with an input schema
-- the workflow contains **Agent** nodes that need role-to-agent assignments
+- the workflow contains **Agent** nodes in an inherited run mode that need role-to-agent assignments
 
 If neither is needed, the workflow launches immediately based on its trigger type.
 

--- a/docs/workflows/node-reference.md
+++ b/docs/workflows/node-reference.md
@@ -73,14 +73,22 @@ Use it to send a prompt into an agent session or run an agent headlessly when th
 Behavior:
 
 - supports direct targeting or role-based assignment
-- supports `persistent` and `temporary` session modes in the builder
+- supports `ephemeral`, `inherit_fresh`, and `inherit_resume` run modes
 - supports `text` or `json` output formats
-- can require launch-time assignment through the run modal
+- can require launch-time assignment through the run modal when the run mode inherits from an existing agent
+- skips automatic startup or "introduce yourself" prompts for workflow-spawned runs
 
 Common pitfalls:
 
-- leaving a role unmapped, which prevents execution
+- leaving an inherited role unmapped, which prevents execution
+- using `inherit_resume` when you wanted a fresh run with the selected agent's profile
 - assuming JSON mode behaves exactly like an interactive PTY run
+
+Run modes:
+
+- `ephemeral`: use the selected class and workspace for a fresh workflow-run provider session.
+- `inherit_fresh`: clone settings from the selected agent, read that agent's scoped context, and start a fresh workflow-run provider session.
+- `inherit_resume`: continue the selected agent's provider session and runtime directory.
 
 ### Shell Command
 

--- a/e2e/tests/features.spec.ts
+++ b/e2e/tests/features.spec.ts
@@ -116,9 +116,8 @@ test.describe("Wardian Core Feature Tests", () => {
   });
 
   test("14. Grid view container exists", async ({ page }) => {
-    // The grid container should exist even with no agents
-    const gridContainer = page.locator('.flex-1.min-h-full');
-    await expect(gridContainer.first()).toBeAttached();
+    await page.getByRole("button", { name: "Grid" }).click();
+    await expect(page.getByText("No Active Instances")).toBeVisible();
   });
 
   test("15. Watchlist shows empty state message", async ({ page }) => {

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -31,7 +31,7 @@ fn persisted_resume_session_for_provider(
 }
 
 fn provider_uses_generated_session_id(provider_name: &str) -> bool {
-    matches!(provider_name, "claude")
+    matches!(provider_name, "claude" | "codex")
 }
 
 fn restore_runtime_state_after_resume(
@@ -53,6 +53,17 @@ fn restore_runtime_state_after_resume(
         (old_active.log_path.lock(), new_active.log_path.lock())
     {
         *new_path = old_path.clone();
+    }
+}
+
+fn restore_query_count_after_clear(
+    new_active: &mut crate::state::ActiveAgent,
+    old_active: &crate::state::ActiveAgent,
+) {
+    if let (Ok(old_count), Ok(mut new_count)) =
+        (old_active.query_count.lock(), new_active.query_count.lock())
+    {
+        *new_count = *old_count;
     }
 }
 
@@ -408,6 +419,7 @@ pub async fn clear_agent_session(
         );
 
         let mut new_active = manager::spawn_agent(app.clone(), agent.config.clone(), true).await?;
+        restore_query_count_after_clear(&mut new_active, agent);
         if agent.config.provider == "claude" {
             if let Some(fresh_provider_session_id) = agent.config.fresh_provider_session_id.take() {
                 agent.config.resume_session = Some(fresh_provider_session_id);
@@ -506,7 +518,8 @@ pub async fn reorder_agents(
 mod tests {
     use super::{
         persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
-        provider_uses_generated_session_id, restore_runtime_state_after_resume,
+        provider_uses_generated_session_id, restore_query_count_after_clear,
+        restore_runtime_state_after_resume,
     };
     use crate::models::{AgentConfig, AgentSessionPersistenceOverride};
     use crate::state::ActiveAgent;
@@ -552,7 +565,7 @@ mod tests {
     #[test]
     fn claude_keeps_generated_session_ids() {
         assert!(provider_uses_generated_session_id("claude"));
-        assert!(!provider_uses_generated_session_id("codex"));
+        assert!(provider_uses_generated_session_id("codex"));
     }
 
     #[test]
@@ -575,6 +588,22 @@ mod tests {
             new_active.log_path.lock().unwrap().as_deref(),
             Some(std::path::Path::new("C:/tmp/session.json"))
         );
+    }
+
+    #[test]
+    fn clear_preserves_query_count_only() {
+        let old_active = make_test_agent();
+        *old_active.query_count.lock().unwrap() = 7;
+        *old_active.init_timestamp.lock().unwrap() = Some("2026-04-12T17:00:00.000Z".to_string());
+        *old_active.log_path.lock().unwrap() =
+            Some(std::path::PathBuf::from("C:/tmp/session.json"));
+
+        let mut new_active = make_test_agent();
+        restore_query_count_after_clear(&mut new_active, &old_active);
+
+        assert_eq!(*new_active.query_count.lock().unwrap(), 7);
+        assert_eq!(new_active.init_timestamp.lock().unwrap().as_deref(), None);
+        assert_eq!(new_active.log_path.lock().unwrap().as_deref(), None);
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1,5 +1,7 @@
 use crate::manager;
-use crate::models::{AgentConfig, AgentSessionPersistence, AgentTelemetry};
+use crate::models::{
+    AgentConfig, AgentSessionPersistence, AgentSessionPersistenceOverride, AgentTelemetry,
+};
 use crate::state::AppState;
 use tauri::{AppHandle, State};
 
@@ -32,14 +34,24 @@ fn provider_uses_generated_session_id(provider_name: &str) -> bool {
     matches!(provider_name, "claude")
 }
 
-fn restore_runtime_state_after_resume(new_active: &mut crate::state::ActiveAgent, old_active: &crate::state::ActiveAgent) {
-    if let (Ok(old_count), Ok(mut new_count)) = (old_active.query_count.lock(), new_active.query_count.lock()) {
+fn restore_runtime_state_after_resume(
+    new_active: &mut crate::state::ActiveAgent,
+    old_active: &crate::state::ActiveAgent,
+) {
+    if let (Ok(old_count), Ok(mut new_count)) =
+        (old_active.query_count.lock(), new_active.query_count.lock())
+    {
         *new_count = *old_count;
     }
-    if let (Ok(old_ts), Ok(mut new_ts)) = (old_active.init_timestamp.lock(), new_active.init_timestamp.lock()) {
+    if let (Ok(old_ts), Ok(mut new_ts)) = (
+        old_active.init_timestamp.lock(),
+        new_active.init_timestamp.lock(),
+    ) {
         *new_ts = old_ts.clone();
     }
-    if let (Ok(old_path), Ok(mut new_path)) = (old_active.log_path.lock(), new_active.log_path.lock()) {
+    if let (Ok(old_path), Ok(mut new_path)) =
+        (old_active.log_path.lock(), new_active.log_path.lock())
+    {
         *new_path = old_path.clone();
     }
 }
@@ -48,8 +60,18 @@ fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
     config.is_off = false;
 
     let settings = crate::utils::load_shell_settings().unwrap_or_default();
-    if settings.agent_session_persistence == AgentSessionPersistence::Fresh {
+    let resolved_persistence = match config.session_persistence {
+        AgentSessionPersistenceOverride::Default => settings.agent_session_persistence,
+        AgentSessionPersistenceOverride::Fresh => AgentSessionPersistence::Fresh,
+        AgentSessionPersistenceOverride::Resume => AgentSessionPersistence::Resume,
+    };
+
+    config.fresh_provider_session_id = None;
+    if resolved_persistence == AgentSessionPersistence::Fresh {
         config.resume_session = None;
+        if config.provider == "claude" {
+            config.fresh_provider_session_id = Some(uuid::Uuid::new_v4().to_string());
+        }
         return Ok(());
     }
 
@@ -66,8 +88,8 @@ fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
     }
 
     if config.resume_session.is_none() {
-        let should_fallback = config.provider != "opencode"
-            || config.session_id.starts_with("ses_");
+        let should_fallback =
+            config.provider != "opencode" || config.session_id.starts_with("ses_");
         if should_fallback {
             config.resume_session = Some(config.session_id.clone());
         }
@@ -107,7 +129,9 @@ pub async fn spawn_agent(
         } else {
             let cwd = crate::utils::fs::resolve_cwd(&folder, "");
 
-            match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref()).await {
+            match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref())
+                .await
+            {
                 Ok(real_sid) => {
                     manager::log_debug(&format!(
                         "[WARDIAN] Intercepted stream-json session ID for {}: {}",
@@ -274,15 +298,9 @@ pub async fn pause_agent(
                 .map(|s| !s.starts_with("ses_"))
                 .unwrap_or(true)
         {
-            let log_path_snap = agent
-                .log_path
-                .lock()
-                .ok()
-                .and_then(|guard| guard.clone());
+            let log_path_snap = agent.log_path.lock().ok().and_then(|guard| guard.clone());
             if let Some(log_path) = log_path_snap {
-                if let Some(ses_id) =
-                    manager::opencode_extract_created_session_id(&log_path)
-                {
+                if let Some(ses_id) = manager::opencode_extract_created_session_id(&log_path) {
                     agent.config.resume_session = Some(ses_id);
                 }
             }
@@ -322,6 +340,11 @@ pub async fn resume_agent(
         prepare_resume_config(&mut agent.config)?;
         let mut new_active = manager::spawn_agent(app.clone(), agent.config.clone(), true).await?;
         restore_runtime_state_after_resume(&mut new_active, agent);
+        if agent.config.provider == "claude" {
+            if let Some(fresh_provider_session_id) = agent.config.fresh_provider_session_id.take() {
+                agent.config.resume_session = Some(fresh_provider_session_id);
+            }
+        }
 
         // Register new input sender
         if let Some(ref tx) = new_active.stdin_tx {
@@ -421,10 +444,9 @@ pub async fn reorder_agents(
 mod tests {
     use super::{
         persisted_resume_session_for_provider, prepare_resume_config,
-        restore_runtime_state_after_resume,
-        provider_uses_generated_session_id,
+        provider_uses_generated_session_id, restore_runtime_state_after_resume,
     };
-    use crate::models::AgentConfig;
+    use crate::models::{AgentConfig, AgentSessionPersistenceOverride};
     use crate::state::ActiveAgent;
     use std::sync::{Arc, Mutex};
 
@@ -448,6 +470,18 @@ mod tests {
         }
     }
 
+    fn use_isolated_resume_setting() -> (std::sync::MutexGuard<'static, ()>, tempfile::TempDir) {
+        let guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::env::set_var("WARDIAN_HOME", temp.path());
+        crate::utils::save_shell_settings(&crate::utils::ShellSettings {
+            agent_session_persistence: crate::models::AgentSessionPersistence::Resume,
+            ..Default::default()
+        })
+        .expect("save shell settings");
+        (guard, temp)
+    }
+
     #[test]
     fn opencode_uses_provider_session_id_instead_of_generated_uuid() {
         assert!(!provider_uses_generated_session_id("opencode"));
@@ -464,7 +498,8 @@ mod tests {
         let old_active = make_test_agent();
         *old_active.query_count.lock().unwrap() = 3;
         *old_active.init_timestamp.lock().unwrap() = Some("2026-04-12T17:00:00.000Z".to_string());
-        *old_active.log_path.lock().unwrap() = Some(std::path::PathBuf::from("C:/tmp/session.json"));
+        *old_active.log_path.lock().unwrap() =
+            Some(std::path::PathBuf::from("C:/tmp/session.json"));
 
         let mut new_active = make_test_agent();
         restore_runtime_state_after_resume(&mut new_active, &old_active);
@@ -498,6 +533,7 @@ mod tests {
 
     #[test]
     fn opencode_resume_sets_resume_session_and_clears_off() {
+        let (_guard, _temp) = use_isolated_resume_setting();
         // session_id already in ses_xxx format → resume_session inherits it
         let mut config = AgentConfig {
             provider: "opencode".to_string(),
@@ -511,10 +547,12 @@ mod tests {
 
         assert_eq!(config.resume_session.as_deref(), Some("ses_test"));
         assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
     }
 
     #[test]
     fn opencode_resume_with_uuid_session_id_leaves_resume_session_none() {
+        let (_guard, _temp) = use_isolated_resume_setting();
         // session_id is a Wardian UUID (not ses_xxx) → must NOT be used as --session
         let mut config = AgentConfig {
             provider: "opencode".to_string(),
@@ -528,10 +566,12 @@ mod tests {
 
         assert_eq!(config.resume_session, None);
         assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
     }
 
     #[test]
     fn opencode_resume_clears_stale_uuid_resume_session() {
+        let (_guard, _temp) = use_isolated_resume_setting();
         // Stale state: resume_session was previously saved as a UUID (pre-fix)
         let mut config = AgentConfig {
             provider: "opencode".to_string(),
@@ -545,10 +585,12 @@ mod tests {
 
         assert_eq!(config.resume_session, None);
         assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
     }
 
     #[test]
     fn non_opencode_resume_clears_off_and_sets_resume_session() {
+        let (_guard, _temp) = use_isolated_resume_setting();
         let mut config = AgentConfig {
             provider: "gemini".to_string(),
             session_id: "gemini-session".to_string(),
@@ -561,6 +603,7 @@ mod tests {
 
         assert_eq!(config.resume_session.as_deref(), Some("gemini-session"));
         assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
     }
 
     #[test]
@@ -586,6 +629,91 @@ mod tests {
 
         assert_eq!(config.resume_session, None);
         assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn agent_resume_override_fresh_wins_over_global_resume() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::env::set_var("WARDIAN_HOME", temp.path());
+        crate::utils::save_shell_settings(&crate::utils::ShellSettings {
+            agent_session_persistence: crate::models::AgentSessionPersistence::Resume,
+            ..Default::default()
+        })
+        .expect("save shell settings");
+
+        let mut config = AgentConfig {
+            provider: "gemini".to_string(),
+            session_id: "gemini-session".to_string(),
+            resume_session: Some("provider-session".to_string()),
+            session_persistence: AgentSessionPersistenceOverride::Fresh,
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_resume_config(&mut config).expect("prepare resume config");
+
+        assert_eq!(config.resume_session, None);
+        assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn agent_resume_override_resume_wins_over_global_fresh() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::env::set_var("WARDIAN_HOME", temp.path());
+        crate::utils::save_shell_settings(&crate::utils::ShellSettings {
+            agent_session_persistence: crate::models::AgentSessionPersistence::Fresh,
+            ..Default::default()
+        })
+        .expect("save shell settings");
+
+        let mut config = AgentConfig {
+            provider: "gemini".to_string(),
+            session_id: "gemini-session".to_string(),
+            resume_session: None,
+            session_persistence: AgentSessionPersistenceOverride::Resume,
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_resume_config(&mut config).expect("prepare resume config");
+
+        assert_eq!(config.resume_session.as_deref(), Some("gemini-session"));
+        assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn claude_fresh_resume_uses_new_provider_session_without_changing_wardian_id() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::env::set_var("WARDIAN_HOME", temp.path());
+        crate::utils::save_shell_settings(&crate::utils::ShellSettings {
+            agent_session_persistence: crate::models::AgentSessionPersistence::Fresh,
+            ..Default::default()
+        })
+        .expect("save shell settings");
+
+        let mut config = AgentConfig {
+            provider: "claude".to_string(),
+            session_id: "wardian-agent-id".to_string(),
+            resume_session: Some("old-claude-session".to_string()),
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_resume_config(&mut config).expect("prepare resume config");
+
+        assert_eq!(config.session_id, "wardian-agent-id");
+        assert_eq!(config.resume_session, None);
+        assert_ne!(
+            config.fresh_provider_session_id.as_deref(),
+            Some("wardian-agent-id")
+        );
+        assert!(config.fresh_provider_session_id.is_some());
         std::env::remove_var("WARDIAN_HOME");
     }
 }

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1,5 +1,5 @@
 use crate::manager;
-use crate::models::{AgentConfig, AgentTelemetry};
+use crate::models::{AgentConfig, AgentSessionPersistence, AgentTelemetry};
 use crate::state::AppState;
 use tauri::{AppHandle, State};
 
@@ -46,6 +46,12 @@ fn restore_runtime_state_after_resume(new_active: &mut crate::state::ActiveAgent
 
 fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
     config.is_off = false;
+
+    let settings = crate::utils::load_shell_settings().unwrap_or_default();
+    if settings.agent_session_persistence == AgentSessionPersistence::Fresh {
+        config.resume_session = None;
+        return Ok(());
+    }
 
     // For opencode, Wardian uses a UUID as session_id internally, but opencode
     // only recognises real ses_xxx IDs.  Clear any stale UUID stored in
@@ -555,5 +561,31 @@ mod tests {
 
         assert_eq!(config.resume_session.as_deref(), Some("gemini-session"));
         assert!(!config.is_off);
+    }
+
+    #[test]
+    fn global_fresh_session_persistence_resume_clears_resume_session() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::env::set_var("WARDIAN_HOME", temp.path());
+        crate::utils::save_shell_settings(&crate::utils::ShellSettings {
+            agent_session_persistence: crate::models::AgentSessionPersistence::Fresh,
+            ..Default::default()
+        })
+        .expect("save shell settings");
+
+        let mut config = AgentConfig {
+            provider: "gemini".to_string(),
+            session_id: "gemini-session".to_string(),
+            resume_session: Some("provider-session".to_string()),
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_resume_config(&mut config).expect("prepare resume config");
+
+        assert_eq!(config.resume_session, None);
+        assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
     }
 }

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -3,7 +3,7 @@ use crate::models::{
     AgentConfig, AgentSessionPersistence, AgentSessionPersistenceOverride, AgentTelemetry,
 };
 use crate::state::AppState;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, State};
 
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -95,6 +95,16 @@ fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
         }
     }
 
+    Ok(())
+}
+
+fn prepare_clear_config(config: &mut AgentConfig) -> Result<(), String> {
+    config.is_off = false;
+    config.resume_session = None;
+    config.fresh_provider_session_id = None;
+    if config.provider == "claude" {
+        config.fresh_provider_session_id = Some(uuid::Uuid::new_v4().to_string());
+    }
     Ok(())
 }
 
@@ -369,6 +379,58 @@ pub async fn resume_agent(
 }
 
 #[tauri::command]
+pub async fn clear_agent_session(
+    session_id: String,
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    manager::log_debug(&format!(
+        "[WARDIAN] clear_agent_session called for session: {}",
+        session_id
+    ));
+    let mut agents = state.agents.lock().await;
+    let order = state.agent_order.lock().await;
+
+    if let Some(agent) = agents.get_mut(&session_id) {
+        prepare_clear_config(&mut agent.config)?;
+        if let Ok(mut buf) = agent.output_buffer.lock() {
+            buf.clear();
+        }
+        if let Ok(mut title) = agent.terminal_title.lock() {
+            title.clear();
+        }
+        if let Ok(mut status) = agent.current_status.lock() {
+            *status = "Processing...".to_string();
+        }
+        let _ = app.emit(
+            "agent-terminal-cleared",
+            serde_json::json!({ "session_id": session_id }),
+        );
+
+        let mut new_active = manager::spawn_agent(app.clone(), agent.config.clone(), true).await?;
+        if agent.config.provider == "claude" {
+            if let Some(fresh_provider_session_id) = agent.config.fresh_provider_session_id.take() {
+                agent.config.resume_session = Some(fresh_provider_session_id);
+            }
+        }
+
+        if let Some(ref tx) = new_active.stdin_tx {
+            if let Ok(mut senders) = state.input_senders.write() {
+                senders.insert(session_id.clone(), tx.clone());
+            }
+        }
+
+        manager::terminate_active_agent_process(agent);
+        new_active.config = agent.config.clone();
+        let _ = std::mem::replace(agent, new_active);
+        manager::save_state(&app, &agents, &order);
+        Ok(())
+    } else {
+        Err(format!("Agent {} not found", session_id))
+    }
+}
+
+#[tauri::command]
 pub async fn rename_agent(
     session_id: String,
     new_name: String,
@@ -443,7 +505,7 @@ pub async fn reorder_agents(
 #[cfg(test)]
 mod tests {
     use super::{
-        persisted_resume_session_for_provider, prepare_resume_config,
+        persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
         provider_uses_generated_session_id, restore_runtime_state_after_resume,
     };
     use crate::models::{AgentConfig, AgentSessionPersistenceOverride};
@@ -715,5 +777,28 @@ mod tests {
         );
         assert!(config.fresh_provider_session_id.is_some());
         std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn prepare_clear_config_forces_fresh_resume_and_clears_runtime_fields() {
+        let mut config = AgentConfig {
+            provider: "claude".to_string(),
+            session_id: "wardian-agent-id".to_string(),
+            resume_session: Some("old-claude-session".to_string()),
+            session_persistence: AgentSessionPersistenceOverride::Resume,
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_clear_config(&mut config).expect("prepare clear config");
+
+        assert_eq!(config.session_id, "wardian-agent-id");
+        assert_eq!(config.resume_session, None);
+        assert_eq!(
+            config.session_persistence,
+            AgentSessionPersistenceOverride::Resume
+        );
+        assert!(config.fresh_provider_session_id.is_some());
+        assert!(!config.is_off);
     }
 }

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,0 +1,272 @@
+use crate::models::git::{GitFileEntry, GitLogEntry, GitStatusResult};
+use crate::utils::process::new_headless_std_command;
+
+/// Run a git command in the given directory and return stdout as a String.
+///
+/// Uses `new_headless_std_command` so no console window flashes on Windows.
+/// Sets `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS=echo` so git never blocks
+/// waiting for credential input (mirrors VS Code's git extension behaviour).
+fn run_git(cwd: &str, args: &[&str]) -> Result<String, String> {
+    let output = new_headless_std_command("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "echo")
+        .output()
+        .map_err(|e| format!("Failed to execute git: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(stderr.trim().to_string());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Parse `git status --porcelain=v1 -b` output into a GitStatusResult.
+fn parse_porcelain_status(raw: &str) -> GitStatusResult {
+    let mut branch = String::new();
+    let mut ahead: u32 = 0;
+    let mut behind: u32 = 0;
+    let mut files = Vec::new();
+
+    for line in raw.lines() {
+        if let Some(rest) = line.strip_prefix("## ") {
+            // Branch line: "## main...origin/main [ahead 1, behind 2]"
+            let (branch_part, tracking) = match rest.find("...") {
+                Some(idx) => (&rest[..idx], &rest[idx + 3..]),
+                None => (rest, ""),
+            };
+            branch = branch_part.to_string();
+
+            if let Some(bracket_start) = tracking.find('[') {
+                if let Some(bracket_end) = tracking.find(']') {
+                    let info = &tracking[bracket_start + 1..bracket_end];
+                    for part in info.split(',') {
+                        let part = part.trim();
+                        if let Some(n) = part.strip_prefix("ahead ") {
+                            ahead = n.trim().parse().unwrap_or(0);
+                        } else if let Some(n) = part.strip_prefix("behind ") {
+                            behind = n.trim().parse().unwrap_or(0);
+                        }
+                    }
+                }
+            }
+            continue;
+        }
+
+        if line.len() < 4 {
+            continue;
+        }
+
+        let index_status = line.as_bytes()[0] as char;
+        let worktree_status = line.as_bytes()[1] as char;
+        let path = line[3..].to_string();
+
+        // Staged entry (index has a real status, not ' ' or '?')
+        if index_status != ' ' && index_status != '?' {
+            files.push(GitFileEntry {
+                path: path.clone(),
+                status: index_status.to_string(),
+                is_staged: true,
+            });
+        }
+
+        // Unstaged / worktree entry
+        if worktree_status != ' ' {
+            let status = if index_status == '?' {
+                "?".to_string()
+            } else {
+                worktree_status.to_string()
+            };
+            files.push(GitFileEntry {
+                path,
+                status,
+                is_staged: false,
+            });
+        }
+    }
+
+    GitStatusResult {
+        branch,
+        files,
+        ahead,
+        behind,
+    }
+}
+
+#[tauri::command]
+pub async fn git_status(cwd: String) -> Result<GitStatusResult, String> {
+    let raw = run_git(&cwd, &["status", "--porcelain=v1", "-b", "--untracked-files=all"])?;
+    Ok(parse_porcelain_status(&raw))
+}
+
+#[tauri::command]
+pub async fn git_current_branch(cwd: String) -> Result<String, String> {
+    let branch = run_git(&cwd, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    Ok(branch.trim().to_string())
+}
+
+#[tauri::command]
+pub async fn git_log(cwd: String, count: u32) -> Result<Vec<GitLogEntry>, String> {
+    let count_str = format!("-{}", count);
+    let raw = run_git(
+        &cwd,
+        &[
+            "log",
+            &count_str,
+            "--pretty=format:%H%n%s%n%an%n%ai",
+            "--no-color",
+        ],
+    )?;
+
+    let mut entries = Vec::new();
+    let lines: Vec<&str> = raw.lines().collect();
+    // Each entry is 4 lines: hash, message, author, date
+    for chunk in lines.chunks(4) {
+        if chunk.len() == 4 {
+            entries.push(GitLogEntry {
+                hash: chunk[0].to_string(),
+                message: chunk[1].to_string(),
+                author: chunk[2].to_string(),
+                date: chunk[3].to_string(),
+            });
+        }
+    }
+    Ok(entries)
+}
+
+#[tauri::command]
+pub async fn git_diff_file(cwd: String, path: String, staged: bool) -> Result<String, String> {
+    let mut args = vec!["diff", "--no-color"];
+    if staged {
+        args.push("--cached");
+    }
+    args.push("--");
+    args.push(&path);
+    run_git(&cwd, &args)
+}
+
+#[tauri::command]
+pub async fn git_stage(cwd: String, paths: Vec<String>) -> Result<(), String> {
+    let mut args: Vec<&str> = vec!["add", "--"];
+    for p in &paths {
+        args.push(p);
+    }
+    run_git(&cwd, &args)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn git_unstage(cwd: String, paths: Vec<String>) -> Result<(), String> {
+    let mut args: Vec<&str> = vec!["reset", "HEAD", "--"];
+    for p in &paths {
+        args.push(p);
+    }
+    run_git(&cwd, &args)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn git_discard_changes(cwd: String, paths: Vec<String>) -> Result<(), String> {
+    // Separate tracked (checkout) from untracked (clean) files
+    let status_raw = run_git(&cwd, &["status", "--porcelain=v1", "--untracked-files=all"])?;
+    let mut tracked = Vec::new();
+    let mut untracked = Vec::new();
+    let path_set: std::collections::HashSet<&str> = paths.iter().map(|s| s.as_str()).collect();
+
+    for line in status_raw.lines() {
+        if line.len() < 4 {
+            continue;
+        }
+        let file_path = &line[3..];
+        if !path_set.contains(file_path) {
+            continue;
+        }
+        if line.starts_with("??") {
+            untracked.push(file_path.to_string());
+        } else {
+            tracked.push(file_path.to_string());
+        }
+    }
+
+    if !tracked.is_empty() {
+        let mut args: Vec<&str> = vec!["checkout", "--"];
+        for p in &tracked {
+            args.push(p);
+        }
+        run_git(&cwd, &args)?;
+    }
+
+    // Remove untracked files directly
+    for p in &untracked {
+        let full = std::path::Path::new(&cwd).join(p);
+        if full.is_file() {
+            let _ = std::fs::remove_file(&full);
+        } else if full.is_dir() {
+            let _ = std::fs::remove_dir_all(&full);
+        }
+    }
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn git_commit(cwd: String, message: String) -> Result<(), String> {
+    run_git(&cwd, &["commit", "-m", &message])?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn git_pull(cwd: String) -> Result<String, String> {
+    run_git(&cwd, &["pull"])
+}
+
+#[tauri::command]
+pub async fn git_push(cwd: String) -> Result<String, String> {
+    run_git(&cwd, &["push"])
+}
+
+#[tauri::command]
+pub async fn git_create_worktree(
+    cwd: String,
+    path: String,
+    branch: String,
+) -> Result<(), String> {
+    run_git(&cwd, &["worktree", "add", &path, "-b", &branch])?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn git_remove_worktree(cwd: String, path: String) -> Result<(), String> {
+    run_git(&cwd, &["worktree", "remove", &path, "--force"])?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_status_simple() {
+        let raw = "## main...origin/main [ahead 2, behind 1]\n M src/foo.rs\nA  src/bar.rs\n?? new_file.txt\n";
+        let result = parse_porcelain_status(raw);
+        assert_eq!(result.branch, "main");
+        assert_eq!(result.ahead, 2);
+        assert_eq!(result.behind, 1);
+        // Should have: staged A for bar.rs, unstaged M for foo.rs, untracked for new_file.txt
+        assert_eq!(result.files.len(), 3);
+    }
+
+    #[test]
+    fn parse_status_no_tracking() {
+        let raw = "## feature-branch\nMM both.rs\n";
+        let result = parse_porcelain_status(raw);
+        assert_eq!(result.branch, "feature-branch");
+        assert_eq!(result.ahead, 0);
+        assert_eq!(result.behind, 0);
+        // MM = staged M + unstaged M
+        assert_eq!(result.files.len(), 2);
+        assert!(result.files[0].is_staged);
+        assert!(!result.files[1].is_staged);
+    }
+}

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,5 +1,8 @@
 use crate::models::git::{GitFileEntry, GitLogEntry, GitStatusResult};
+use crate::state::AppState;
 use crate::utils::process::new_headless_std_command;
+use notify::Watcher;
+use tauri::{AppHandle, Emitter};
 
 /// Run a git command in the given directory and return stdout as a String.
 ///
@@ -239,6 +242,80 @@ pub async fn git_create_worktree(
 #[tauri::command]
 pub async fn git_remove_worktree(cwd: String, path: String) -> Result<(), String> {
     run_git(&cwd, &["worktree", "remove", &path, "--force"])?;
+    Ok(())
+}
+
+/// Start watching a git repo's index and HEAD for changes.
+/// Emits `git-changed` (payload: cwd string) to the frontend on any change,
+/// debounced to 150 ms so rapid multi-file operations fire a single event.
+/// Replaces any existing watcher for the same path.
+#[tauri::command]
+pub async fn git_watch(
+    cwd: String,
+    app: AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let git_dir = std::path::Path::new(&cwd).join(".git");
+    let index_path = git_dir.join("index");
+    let head_path = git_dir.join("HEAD");
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+
+    let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if res.is_ok() {
+            let _ = tx.send(());
+        }
+    })
+    .map_err(|e| e.to_string())?;
+
+    // Only watch files that exist (non-git dirs won't have these)
+    if index_path.exists() {
+        watcher
+            .watch(&index_path, notify::RecursiveMode::NonRecursive)
+            .map_err(|e| e.to_string())?;
+    }
+    if head_path.exists() {
+        watcher
+            .watch(&head_path, notify::RecursiveMode::NonRecursive)
+            .map_err(|e| e.to_string())?;
+    }
+
+    // Store watcher so it stays alive; dropping the old one automatically stops it
+    state.git_watchers.lock().await.insert(cwd.clone(), watcher);
+
+    // Debounce task: wait for first event, drain rapid follow-ups within 150 ms, then emit
+    let app_handle = app.clone();
+    tokio::spawn(async move {
+        loop {
+            if rx.recv().await.is_none() {
+                break; // watcher dropped (git_unwatch called or new watcher replaced this one)
+            }
+            loop {
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(150),
+                    rx.recv(),
+                )
+                .await
+                {
+                    Ok(Some(_)) => continue, // more events within window, reset timer
+                    Ok(None) => return,       // watcher dropped during debounce
+                    Err(_) => break,          // window elapsed, fire
+                }
+            }
+            let _ = app_handle.emit("git-changed", &cwd);
+        }
+    });
+
+    Ok(())
+}
+
+/// Stop watching a git repo path. Safe to call even if no watcher exists.
+#[tauri::command]
+pub async fn git_unwatch(
+    cwd: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    state.git_watchers.lock().await.remove(&cwd);
     Ok(())
 }
 

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -26,6 +26,14 @@ fn run_git(cwd: &str, args: &[&str]) -> Result<String, String> {
 }
 
 /// Parse `git status --porcelain=v1 -b` output into a GitStatusResult.
+fn parse_porcelain_path(raw_path: &str) -> String {
+    if let Some((_, new_path)) = raw_path.split_once(" -> ") {
+        return new_path.to_string();
+    }
+    raw_path.to_string()
+}
+
+/// Parse `git status --porcelain=v1 -b` output into a GitStatusResult.
 fn parse_porcelain_status(raw: &str) -> GitStatusResult {
     let mut branch = String::new();
     let mut ahead: u32 = 0;
@@ -63,7 +71,7 @@ fn parse_porcelain_status(raw: &str) -> GitStatusResult {
 
         let index_status = line.as_bytes()[0] as char;
         let worktree_status = line.as_bytes()[1] as char;
-        let path = line[3..].to_string();
+        let path = parse_porcelain_path(&line[3..]);
 
         // Staged entry (index has a real status, not ' ' or '?')
         if index_status != ' ' && index_status != '?' {
@@ -181,14 +189,14 @@ pub async fn git_discard_changes(cwd: String, paths: Vec<String>) -> Result<(), 
         if line.len() < 4 {
             continue;
         }
-        let file_path = &line[3..];
-        if !path_set.contains(file_path) {
+        let file_path = parse_porcelain_path(&line[3..]);
+        if !path_set.contains(file_path.as_str()) {
             continue;
         }
         if line.starts_with("??") {
-            untracked.push(file_path.to_string());
+            untracked.push(file_path);
         } else {
-            tracked.push(file_path.to_string());
+            tracked.push(file_path);
         }
     }
 
@@ -345,5 +353,14 @@ mod tests {
         assert_eq!(result.files.len(), 2);
         assert!(result.files[0].is_staged);
         assert!(!result.files[1].is_staged);
+    }
+
+    #[test]
+    fn parse_status_rename_uses_new_path() {
+        let raw = "## main\nR  old/path.rs -> new/path.rs\n";
+        let result = parse_porcelain_status(raw);
+        assert_eq!(result.files.len(), 1);
+        assert_eq!(result.files[0].path, "new/path.rs");
+        assert!(result.files[0].is_staged);
     }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod class;
 pub mod fs;
+pub mod git;
 pub mod library;
 pub mod patch;
 pub mod settings;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,4 +1,5 @@
 use crate::utils::{ShellOption, ShellSettings};
+use crate::models::AgentSessionPersistence;
 
 #[tauri::command]
 pub fn list_available_shells() -> Result<Vec<ShellOption>, String> {
@@ -13,6 +14,13 @@ pub fn load_shell_settings() -> Result<ShellSettings, String> {
 #[tauri::command]
 pub fn save_shell_settings(settings: ShellSettings) -> Result<ShellSettings, String> {
     crate::utils::save_shell_settings(&settings)
+}
+
+#[tauri::command]
+pub fn save_agent_session_persistence(
+    persistence: AgentSessionPersistence,
+) -> Result<ShellSettings, String> {
+    crate::utils::save_agent_session_persistence(persistence)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -302,7 +302,7 @@ pub async fn submit_prompt_to_agent(
         return Ok(());
     }
 
-    submit_prompt_via_sender(&tx, &prompt).await
+    submit_prompt_via_sender(&tx, &prompt, &provider_name).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,7 +162,9 @@ pub fn run() {
             commands::git::git_pull,
             commands::git::git_push,
             commands::git::git_create_worktree,
-            commands::git::git_remove_worktree
+            commands::git::git_remove_worktree,
+            commands::git::git_watch,
+            commands::git::git_unwatch
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,8 +16,8 @@ use tauri::{Emitter, Manager};
 pub fn run() {
     #[cfg(windows)]
     {
-        use windows::core::PCWSTR;
         use windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
+        use windows::core::PCWSTR;
         let aumid: Vec<u16> = "org.wardian.desktop"
             .encode_utf16()
             .chain(std::iter::once(0))
@@ -97,6 +97,7 @@ pub fn run() {
             commands::agent::kill_agent,
             commands::agent::pause_agent,
             commands::agent::resume_agent,
+            commands::agent::clear_agent_session,
             commands::agent::rename_agent,
             commands::agent::reorder_agents,
             commands::agent::update_agent_config,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,7 +150,19 @@ pub fn run() {
             commands::settings::list_available_shells,
             commands::settings::load_shell_settings,
             commands::settings::save_shell_settings,
-            commands::settings::save_opencode_theme
+            commands::settings::save_opencode_theme,
+            commands::git::git_status,
+            commands::git::git_current_branch,
+            commands::git::git_log,
+            commands::git::git_diff_file,
+            commands::git::git_stage,
+            commands::git::git_unstage,
+            commands::git::git_discard_changes,
+            commands::git::git_commit,
+            commands::git::git_pull,
+            commands::git::git_push,
+            commands::git::git_create_worktree,
+            commands::git::git_remove_worktree
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,6 +151,7 @@ pub fn run() {
             commands::settings::list_available_shells,
             commands::settings::load_shell_settings,
             commands::settings::save_shell_settings,
+            commands::settings::save_agent_session_persistence,
             commands::settings::save_opencode_theme,
             commands::git::git_status,
             commands::git::git_current_branch,

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1658,33 +1658,31 @@ pub async fn run_headless_with_options(
         for line in output.lines() {
             if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) {
                 match parsed.get("type").and_then(|v| v.as_str()).unwrap_or("") {
-                    "item.completed" => {
+                    "item.completed"
                         if parsed
                             .get("item")
                             .and_then(|v| v.get("type"))
                             .and_then(|v| v.as_str())
-                            == Some("agent_message")
-                        {
-                            last_message = parsed
-                                .get("item")
-                                .and_then(|v| v.get("text"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
-                        }
+                            == Some("agent_message") =>
+                    {
+                        last_message = parsed
+                            .get("item")
+                            .and_then(|v| v.get("text"))
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
                     }
-                    "event_msg" => {
+                    "event_msg"
                         if parsed
                             .get("payload")
                             .and_then(|v| v.get("type"))
                             .and_then(|v| v.as_str())
-                            == Some("agent_message")
-                        {
-                            last_message = parsed
-                                .get("payload")
-                                .and_then(|v| v.get("message"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
-                        }
+                            == Some("agent_message") =>
+                    {
+                        last_message = parsed
+                            .get("payload")
+                            .and_then(|v| v.get("message"))
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.to_string());
                     }
                     _ => {}
                 }
@@ -2151,10 +2149,8 @@ fn claude_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
                 return Some("Processing...".to_string());
             }
             Some("progress") => return Some("Processing...".to_string()),
-            Some("user") => {
-                if claude_is_real_user_query(line) {
-                    return Some("Processing...".to_string());
-                }
+            Some("user") if claude_is_real_user_query(line) => {
+                return Some("Processing...".to_string());
             }
             _ => {}
         }

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1,7 +1,7 @@
 use crate::models::{AgentClassDefinition, AgentConfig, AgentEvent, AgentProvider, AgentTelemetry};
-use crate::providers::ProviderFactory;
-use crate::providers::claude::{ClaudeUserEventKind, classify_claude_user_event};
+use crate::providers::claude::{classify_claude_user_event, ClaudeUserEventKind};
 use crate::providers::opencode::OpenCodeProvider;
+use crate::providers::ProviderFactory;
 use crate::state::{ActiveAgent, AppState};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::collections::HashMap;
@@ -14,6 +14,10 @@ pub use crate::utils::process::new_headless_command;
 #[cfg(windows)]
 pub use crate::utils::process::{find_wardian_session_process_roots, force_kill_process_tree};
 pub use crate::utils::shell::build_program_launch;
+
+fn session_bootstrap_prompt() -> &'static str {
+    "Introduce yourself"
+}
 
 #[cfg(windows)]
 fn cleanup_stale_session_processes(session_id: &str, provider: &str) {
@@ -1765,7 +1769,7 @@ pub async fn obtain_session_id(
         }
 
         provider_args.push("--json".to_string());
-        provider_args.push("Introduce yourself".to_string());
+        provider_args.push(session_bootstrap_prompt().to_string());
     } else if provider_name == "opencode" {
         provider_args.push("run".to_string());
         if let Some(config) = config {
@@ -1775,7 +1779,7 @@ pub async fn obtain_session_id(
         provider_args.push("json".to_string());
         provider_args.push("--dir".to_string());
         provider_args.push(cwd.to_string_lossy().to_string());
-        provider_args.push("Introduce yourself".to_string());
+        provider_args.push(session_bootstrap_prompt().to_string());
     } else if provider_name == "claude" {
         // --print mode does not accept --input-format stream-json; strip it.
         if let Some(config) = config {
@@ -1788,10 +1792,10 @@ pub async fn obtain_session_id(
             provider_args.push("stream-json".to_string());
         }
         provider_args.push("--print".to_string());
-        provider_args.push("Introduce yourself".to_string());
+        provider_args.push(session_bootstrap_prompt().to_string());
     } else {
         provider_args.push("-p".to_string());
-        provider_args.push("Introduce yourself".to_string());
+        provider_args.push(session_bootstrap_prompt().to_string());
         provider_args.push("-o".to_string());
         provider_args.push("stream-json".to_string());
     }
@@ -2771,8 +2775,8 @@ mod tests {
         interactive_provider_cwd, interactive_provider_launch, migrate_codex_bootstrap_home,
         opencode_interactive_env, opencode_log_path_after, opencode_log_path_in,
         opencode_metrics_from_log, opencode_runtime_config_content,
-        opencode_should_fallback_to_idle, opencode_status_from_title, strip_flag_value_pairs,
-        strip_standalone_flag,
+        opencode_should_fallback_to_idle, opencode_status_from_title, session_bootstrap_prompt,
+        strip_flag_value_pairs, strip_standalone_flag,
     };
     use crate::models::AgentConfig;
     use std::path::Path;
@@ -3283,7 +3287,7 @@ mod tests {
                 "json".to_string(),
                 "--dir".to_string(),
                 "D:/Development/Wardian".to_string(),
-                "Introduce yourself".to_string(),
+                session_bootstrap_prompt().to_string(),
             ],
         )
         .expect("headless launch spec");
@@ -3297,7 +3301,12 @@ mod tests {
         assert_eq!(launch.args[1], "/c");
         assert!(launch.args[2].contains("opencode"));
         assert!(launch.args[2].contains("--format"));
-        assert!(launch.args[2].contains("Introduce yourself"));
+        assert!(launch.args[2].contains(session_bootstrap_prompt()));
+    }
+
+    #[test]
+    fn bootstrap_session_prompt_uses_intro_prompt_for_providers_that_need_bootstrap() {
+        assert_eq!(session_bootstrap_prompt(), "Introduce yourself");
     }
 
     #[test]

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1,4 +1,4 @@
-use crate::models::{AgentClassDefinition, AgentConfig, AgentEvent, AgentTelemetry};
+use crate::models::{AgentClassDefinition, AgentConfig, AgentEvent, AgentProvider, AgentTelemetry};
 use crate::providers::claude::{classify_claude_user_event, ClaudeUserEventKind};
 use crate::providers::opencode::OpenCodeProvider;
 use crate::providers::ProviderFactory;
@@ -115,12 +115,10 @@ fn opencode_status_from_title(title: &str) -> Option<&'static str> {
 }
 
 fn opencode_session_diff_path(session_id: &str) -> std::path::PathBuf {
-    let base = dirs::data_local_dir().or_else(|| {
-        dirs::home_dir().map(|home| home.join(".local").join("share"))
-    });
+    let base = dirs::data_local_dir()
+        .or_else(|| dirs::home_dir().map(|home| home.join(".local").join("share")));
     let base = base.unwrap_or_else(|| std::path::PathBuf::from("."));
-    base
-        .join("opencode")
+    base.join("opencode")
         .join("storage")
         .join("session_diff")
         .join(format!("{session_id}.json"))
@@ -193,7 +191,9 @@ fn extract_terminal_titles(chunk: &str) -> Vec<String> {
                 end += 1;
             }
 
-            let title = String::from_utf8_lossy(&bytes[value_start..end]).trim().to_string();
+            let title = String::from_utf8_lossy(&bytes[value_start..end])
+                .trim()
+                .to_string();
             if !title.is_empty() {
                 titles.push(title);
             }
@@ -1249,7 +1249,10 @@ fn interactive_provider_args(
             provider_args.push(provider_cwd.to_string_lossy().to_string());
         }
         "opencode" => {
-            let target_dir = if provider_cwd.file_name().is_some_and(|name| name == "habitat") {
+            let target_dir = if provider_cwd
+                .file_name()
+                .is_some_and(|name| name == "habitat")
+            {
                 habitat_workspace_cwd(provider_cwd)
             } else {
                 workspace_cwd.to_path_buf()
@@ -1311,7 +1314,6 @@ fn apply_terminal_identity_env(cmd: &mut CommandBuilder) {
     cmd.env("COLORTERM", "truecolor");
     cmd.env("TERM", "xterm-256color");
 }
-
 
 #[cfg(windows)]
 fn quote_cmd_arg(value: &str) -> String {
@@ -1385,55 +1387,45 @@ pub async fn run_headless(
     run_headless_with_config(cwd, prompt, session_id, output_format, provider_name, None).await
 }
 
-pub async fn run_headless_with_config(
-    cwd: &std::path::Path,
-    prompt: &str,
-    session_id: &str,
-    output_format: &str,
+pub struct HeadlessRunOptions<'a> {
+    pub cwd: &'a std::path::Path,
+    pub prompt: &'a str,
+    pub wardian_session_id: &'a str,
+    pub resume_session: Option<&'a str>,
+    pub output_format: &'a str,
+    pub provider_name: &'a str,
+    pub config_override: Option<&'a AgentConfig>,
+}
+
+fn headless_provider_args(
     provider_name: &str,
+    provider: &dyn AgentProvider,
+    provider_cwd: &std::path::Path,
+    prompt: &str,
+    output_format: &str,
+    resume_session: Option<&str>,
     config_override: Option<&AgentConfig>,
-) -> Result<serde_json::Value, String> {
-    use tokio::io::{AsyncBufReadExt, BufReader};
-    let provider = ProviderFactory::resolve(provider_name)?;
-    let habitat_root = prepare_provider_habitat(provider_name, cwd, "", Some(session_id))?;
-    let provider_cwd = cwd.to_path_buf();
-    let normalized_prompt = if provider_name == "opencode" {
-        crate::utils::terminal_input::normalize_prompt_for_terminal_submit(prompt)
-    } else {
-        prompt.to_string()
-    };
-    let persisted_opencode_config = if provider_name == "opencode" {
-        config_override.cloned().or_else(|| persisted_agent_config(session_id))
-    } else {
-        None
-    };
-    let (bin, mut provider_args) = provider.get_executable();
-    let claude_hook = if provider_name == "claude" {
-        ensure_claude_permission_hook(session_id).ok()
-    } else {
-        None
-    };
+) -> Vec<String> {
+    let (_bin, mut provider_args) = provider.get_executable();
     match provider_name {
         "codex" => {
             provider_args.push("--cd".to_string());
             provider_args.push(provider_cwd.to_string_lossy().to_string());
             provider_args.push("exec".to_string());
-            provider_args.push("resume".to_string());
-            provider_args.push(session_id.to_string());
+            if let Some(resume_id) = resume_session.filter(|s| !s.trim().is_empty()) {
+                provider_args.push("resume".to_string());
+                provider_args.push(resume_id.to_string());
+            }
             provider_args.push("--json".to_string());
             provider_args.push(prompt.to_string());
         }
         "claude" => {
-            if let Some(hook) = claude_hook.as_ref() {
-                provider_args.push("--settings".to_string());
-                provider_args.push(hook.settings_arg.clone());
-            }
             provider_args.push("--print".to_string());
             provider_args.push("--output-format".to_string());
             provider_args.push(output_format.to_string());
-            if !session_id.is_empty() {
+            if let Some(resume_id) = resume_session.filter(|s| !s.trim().is_empty()) {
                 provider_args.push("--resume".to_string());
-                provider_args.push(session_id.to_string());
+                provider_args.push(resume_id.to_string());
             }
             provider_args.push(prompt.to_string());
         }
@@ -1443,27 +1435,96 @@ pub async fn run_headless_with_config(
         }
         "opencode" => {
             provider_args.push("run".to_string());
-            if let Some(config) = persisted_opencode_config.as_ref() {
-                provider_args.extend(provider.get_spawn_args(config, !session_id.is_empty()));
-            } else if !session_id.is_empty() {
+            if let Some(config) = config_override {
+                let mut config = config.clone();
+                config.resume_session = resume_session.map(str::to_string);
+                provider_args.extend(provider.get_spawn_args(&config, resume_session.is_some()));
+            } else if let Some(resume_id) = resume_session.filter(|s| !s.trim().is_empty()) {
                 provider_args.push("--session".to_string());
-                provider_args.push(session_id.to_string());
+                provider_args.push(resume_id.to_string());
             }
             provider_args.push("--format".to_string());
             provider_args.push("json".to_string());
             provider_args.push("--dir".to_string());
             provider_args.push(provider_cwd.to_string_lossy().to_string());
-            provider_args.push(normalized_prompt.clone());
+            provider_args
+                .push(crate::utils::terminal_input::normalize_prompt_for_terminal_submit(prompt));
         }
         _ => {
             provider_args.push("-p".to_string());
             provider_args.push(prompt.to_string());
             provider_args.push("--output-format".to_string());
             provider_args.push(output_format.to_string());
-            if !session_id.is_empty() {
+            if let Some(resume_id) = resume_session.filter(|s| !s.trim().is_empty()) {
                 provider_args.push("--resume".to_string());
-                provider_args.push(session_id.to_string());
+                provider_args.push(resume_id.to_string());
             }
+        }
+    }
+    provider_args
+}
+
+pub async fn run_headless_with_config(
+    cwd: &std::path::Path,
+    prompt: &str,
+    session_id: &str,
+    output_format: &str,
+    provider_name: &str,
+    config_override: Option<&AgentConfig>,
+) -> Result<serde_json::Value, String> {
+    run_headless_with_options(HeadlessRunOptions {
+        cwd,
+        prompt,
+        wardian_session_id: session_id,
+        resume_session: (!session_id.trim().is_empty()).then_some(session_id),
+        output_format,
+        provider_name,
+        config_override,
+    })
+    .await
+}
+
+pub async fn run_headless_with_options(
+    options: HeadlessRunOptions<'_>,
+) -> Result<serde_json::Value, String> {
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    let cwd = options.cwd;
+    let prompt = options.prompt;
+    let wardian_session_id = options.wardian_session_id;
+    let resume_session = options.resume_session;
+    let output_format = options.output_format;
+    let provider_name = options.provider_name;
+    let config_override = options.config_override;
+    let provider = ProviderFactory::resolve(provider_name)?;
+    let habitat_root = prepare_provider_habitat(provider_name, cwd, "", Some(wardian_session_id))?;
+    let provider_cwd = cwd.to_path_buf();
+    let persisted_opencode_config = if provider_name == "opencode" {
+        config_override
+            .cloned()
+            .or_else(|| persisted_agent_config(wardian_session_id))
+    } else {
+        None
+    };
+    let (bin, _) = provider.get_executable();
+    let claude_hook = if provider_name == "claude" {
+        ensure_claude_permission_hook(wardian_session_id).ok()
+    } else {
+        None
+    };
+
+    let mut provider_args = headless_provider_args(
+        provider_name,
+        provider.as_ref(),
+        &provider_cwd,
+        prompt,
+        output_format,
+        resume_session,
+        persisted_opencode_config.as_ref(),
+    );
+    if let Some(hook) = claude_hook.as_ref() {
+        if provider_name == "claude" {
+            provider_args.insert(0, hook.settings_arg.clone());
+            provider_args.insert(0, "--settings".to_string());
         }
     }
 
@@ -1483,10 +1544,15 @@ pub async fn run_headless_with_config(
             .as_ref()
             .map(|config| config.agent_class.as_str())
             .unwrap_or("");
+        let opencode_scope_session = if resume_session.is_some() {
+            resume_session
+        } else {
+            (!wardian_session_id.trim().is_empty()).then_some(wardian_session_id)
+        };
         for (key, value) in opencode_env(
             &provider_cwd,
             class_name,
-            (!session_id.is_empty()).then_some(session_id),
+            opencode_scope_session,
             persisted_opencode_config.as_ref(),
         )? {
             cmd.env(key, value);
@@ -1510,7 +1576,7 @@ pub async fn run_headless_with_config(
     log_debug(&format!(
         "[Wardian] run_headless: provider={}, session_id={}, cwd={}, prompt_len={}, output_format={}",
         provider_name,
-        if session_id.is_empty() { "<none>" } else { session_id },
+        if wardian_session_id.is_empty() { "<none>" } else { wardian_session_id },
         cwd.display(),
         prompt.len(),
         output_format
@@ -1611,7 +1677,7 @@ pub async fn run_headless_with_config(
 
         if output_format == "json" {
             Ok(serde_json::json!({
-                "thread_id": session_id,
+                "thread_id": wardian_session_id,
                 "response": last_message.unwrap_or_default(),
                 "raw": output,
             }))
@@ -1623,7 +1689,7 @@ pub async fn run_headless_with_config(
 
         if output_format == "json" {
             Ok(serde_json::json!({
-                "session_id": summary.session_id.unwrap_or_else(|| session_id.to_string()),
+                "session_id": summary.session_id.unwrap_or_else(|| wardian_session_id.to_string()),
                 "response": summary.last_text.clone().unwrap_or_default(),
                 "raw": output,
             }))
@@ -1675,7 +1741,8 @@ pub async fn obtain_session_id(
         provider_args.push("exec".to_string());
 
         if let Some(config) = config {
-            let spawn_args = strip_flag_value_pairs(provider.get_spawn_args(config, false), "--add-dir");
+            let spawn_args =
+                strip_flag_value_pairs(provider.get_spawn_args(config, false), "--add-dir");
             provider_args.extend(strip_standalone_flag(spawn_args, "--no-alt-screen"));
             if config.codex_skip_git_repo_check.unwrap_or(true) {
                 provider_args.push("--skip-git-repo-check".to_string());
@@ -1700,10 +1767,8 @@ pub async fn obtain_session_id(
     } else if provider_name == "claude" {
         // --print mode does not accept --input-format stream-json; strip it.
         if let Some(config) = config {
-            let spawn_args = strip_flag_value_pairs(
-                provider.get_spawn_args(config, false),
-                "--input-format",
-            );
+            let spawn_args =
+                strip_flag_value_pairs(provider.get_spawn_args(config, false), "--input-format");
             provider_args.extend(spawn_args);
         } else {
             provider_args.push("--verbose".to_string());
@@ -1791,7 +1856,9 @@ pub async fn obtain_session_id(
                         if let Some(start) = trimmed.find('{') {
                             let json_part = &trimmed[start..];
                             if provider_name == "opencode" {
-                                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_part) {
+                                if let Ok(parsed) =
+                                    serde_json::from_str::<serde_json::Value>(json_part)
+                                {
                                     if session_id.is_none() {
                                         session_id = parsed
                                             .get("sessionID")
@@ -1988,24 +2055,21 @@ pub fn latest_codex_session_index_entry(
 
     let content = std::fs::read_to_string(&index_path)
         .map_err(|e| format!("Failed to read Codex session index: {}", e))?;
-    let latest = content
-        .lines()
-        .rev()
-        .find_map(|line| {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                return None;
-            }
+    let latest = content.lines().rev().find_map(|line| {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
 
-            let parsed: serde_json::Value = serde_json::from_str(trimmed).ok()?;
-            let session_id = parsed.get("id")?.as_str()?.trim();
-            let updated_at = parsed.get("updated_at")?.as_str()?.trim();
-            if session_id.is_empty() || updated_at.is_empty() {
-                return None;
-            }
+        let parsed: serde_json::Value = serde_json::from_str(trimmed).ok()?;
+        let session_id = parsed.get("id")?.as_str()?.trim();
+        let updated_at = parsed.get("updated_at")?.as_str()?.trim();
+        if session_id.is_empty() || updated_at.is_empty() {
+            return None;
+        }
 
-            Some((session_id.to_string(), updated_at.to_string()))
-        });
+        Some((session_id.to_string(), updated_at.to_string()))
+    });
 
     Ok(latest)
 }
@@ -2090,7 +2154,6 @@ struct OpenCodeLogMetrics {
     init_timestamp: Option<String>,
     status: Option<String>,
 }
-
 
 /// Find the newest OpenCode log file whose filesystem mtime is at or after
 /// `spawn_time`.  OpenCode creates one log file per process invocation using
@@ -2691,12 +2754,13 @@ pub async fn kill_all_agents(state: &AppState) {
 mod tests {
     use super::{
         claude_permission_hook_matches_session, claude_status_from_log,
-        codex_bootstrap_launch_context, finalize_interactive_spawn_args, headless_provider_launch,
-        extract_terminal_titles, opencode_should_fallback_to_idle, opencode_status_from_title,
-        interactive_provider_args, interactive_provider_cwd, interactive_provider_launch,
-        migrate_codex_bootstrap_home, opencode_interactive_env, opencode_log_path_after,
-        opencode_log_path_in, opencode_metrics_from_log, opencode_runtime_config_content,
-        strip_flag_value_pairs, strip_standalone_flag,
+        codex_bootstrap_launch_context, extract_terminal_titles, finalize_interactive_spawn_args,
+        headless_provider_args, headless_provider_launch, interactive_provider_args,
+        interactive_provider_cwd, interactive_provider_launch, migrate_codex_bootstrap_home,
+        opencode_interactive_env, opencode_log_path_after, opencode_log_path_in,
+        opencode_metrics_from_log, opencode_runtime_config_content,
+        opencode_should_fallback_to_idle, opencode_status_from_title, strip_flag_value_pairs,
+        strip_standalone_flag,
     };
     use crate::models::AgentConfig;
     use std::path::Path;
@@ -2714,7 +2778,10 @@ mod tests {
     #[test]
     fn opencode_title_maps_to_status() {
         assert_eq!(opencode_status_from_title("OpenCode"), Some("Idle"));
-        assert_eq!(opencode_status_from_title("OC | Working"), Some("Processing..."));
+        assert_eq!(
+            opencode_status_from_title("OC | Working"),
+            Some("Processing...")
+        );
         assert_eq!(
             opencode_status_from_title("OC | Action Required: approve tool"),
             Some("Action Needed")
@@ -2727,7 +2794,11 @@ mod tests {
         let now = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(10);
         let last = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(3);
 
-        assert!(opencode_should_fallback_to_idle("Processing...", Some(last), now));
+        assert!(opencode_should_fallback_to_idle(
+            "Processing...",
+            Some(last),
+            now
+        ));
         assert!(!opencode_should_fallback_to_idle("Idle", Some(last), now));
     }
 
@@ -2953,8 +3024,8 @@ mod tests {
         let server_log = log_dir.join("2026-04-12T100002.log");
         std::fs::write(&server_log, "server session events").expect("write server");
 
-        let found = opencode_log_path_after(&log_dir, spawn_time)
-            .expect("should find a log after spawn");
+        let found =
+            opencode_log_path_after(&log_dir, spawn_time).expect("should find a log after spawn");
 
         assert_eq!(
             found, server_log,
@@ -3024,10 +3095,7 @@ mod tests {
 
         let args = interactive_provider_args("opencode", workspace_cwd, workspace_cwd, Vec::new());
 
-        assert_eq!(
-            args,
-            vec!["D:/Development/Wardian".to_string()]
-        );
+        assert_eq!(args, vec!["D:/Development/Wardian".to_string()]);
     }
     #[test]
     fn strip_flag_value_pairs_removes_all_add_dir_arguments() {
@@ -3221,6 +3289,65 @@ mod tests {
     }
 
     #[test]
+    fn codex_fresh_headless_args_omit_resume_subcommand() {
+        let provider = crate::providers::ProviderFactory::resolve("codex").unwrap();
+        let args = headless_provider_args(
+            "codex",
+            provider.as_ref(),
+            Path::new("D:/Development/Wardian"),
+            "task",
+            "json",
+            None,
+            None,
+        );
+
+        assert!(args.contains(&"exec".to_string()));
+        assert!(!args.contains(&"resume".to_string()));
+        assert!(!args.contains(&"ses_source".to_string()));
+    }
+
+    #[test]
+    fn claude_fresh_headless_args_omit_resume_flag() {
+        let provider = crate::providers::ProviderFactory::resolve("claude").unwrap();
+        let args = headless_provider_args(
+            "claude",
+            provider.as_ref(),
+            Path::new("D:/Development/Wardian"),
+            "task",
+            "text",
+            None,
+            None,
+        );
+
+        assert!(args.contains(&"--print".to_string()));
+        assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn opencode_fresh_headless_args_omit_session_flag_but_keep_config() {
+        let provider = crate::providers::ProviderFactory::resolve("opencode").unwrap();
+        let config = AgentConfig {
+            opencode_agent: Some("build".into()),
+            ..Default::default()
+        };
+
+        let args = headless_provider_args(
+            "opencode",
+            provider.as_ref(),
+            Path::new("D:/Development/Wardian"),
+            "task",
+            "text",
+            None,
+            Some(&config),
+        );
+
+        assert!(args.contains(&"run".to_string()));
+        assert!(args.contains(&"--agent".to_string()));
+        assert!(args.contains(&"build".to_string()));
+        assert!(!args.contains(&"--session".to_string()));
+    }
+
+    #[test]
     fn opencode_interactive_launch_bypasses_shell_wrapper() {
         let launch = interactive_provider_launch(
             "opencode",
@@ -3308,7 +3435,8 @@ mod tests {
         provider_args.push("--cd".to_string());
         provider_args.push("D:/Development/Wardian".to_string());
         provider_args.push("exec".to_string());
-        let spawn_args = strip_flag_value_pairs(provider.get_spawn_args(&config, false), "--add-dir");
+        let spawn_args =
+            strip_flag_value_pairs(provider.get_spawn_args(&config, false), "--add-dir");
         provider_args.extend(strip_standalone_flag(spawn_args, "--no-alt-screen"));
         if config.codex_skip_git_repo_check.unwrap_or(true) {
             provider_args.push("--skip-git-repo-check".to_string());
@@ -3337,10 +3465,7 @@ mod tests {
 
         assert_eq!(
             args,
-            vec![
-                "--resume".to_string(),
-                "claude-session".to_string(),
-            ]
+            vec!["--resume".to_string(), "claude-session".to_string(),]
         );
     }
 
@@ -3362,5 +3487,4 @@ mod tests {
             ]
         );
     }
-
 }

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1,7 +1,7 @@
 use crate::models::{AgentClassDefinition, AgentConfig, AgentEvent, AgentProvider, AgentTelemetry};
-use crate::providers::claude::{classify_claude_user_event, ClaudeUserEventKind};
-use crate::providers::opencode::OpenCodeProvider;
 use crate::providers::ProviderFactory;
+use crate::providers::claude::{ClaudeUserEventKind, classify_claude_user_event};
+use crate::providers::opencode::OpenCodeProvider;
 use crate::state::{ActiveAgent, AppState};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::collections::HashMap;
@@ -903,6 +903,14 @@ pub async fn spawn_agent(
                 {
                     sessions.push(resume_session.to_string());
                 }
+                if let Some(fresh_provider_session_id) = config
+                    .fresh_provider_session_id
+                    .as_ref()
+                    .map(|sid| sid.trim())
+                    .filter(|sid| !sid.is_empty() && *sid != config.session_id)
+                {
+                    sessions.push(fresh_provider_session_id.to_string());
+                }
                 sessions
             };
             let hook_current_status = current_status.clone();
@@ -1576,7 +1584,11 @@ pub async fn run_headless_with_options(
     log_debug(&format!(
         "[Wardian] run_headless: provider={}, session_id={}, cwd={}, prompt_len={}, output_format={}",
         provider_name,
-        if wardian_session_id.is_empty() { "<none>" } else { wardian_session_id },
+        if wardian_session_id.is_empty() {
+            "<none>"
+        } else {
+            wardian_session_id
+        },
         cwd.display(),
         prompt.len(),
         output_format
@@ -2081,7 +2093,7 @@ fn codex_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
         match payload_type {
             "exec_approval_request" => return Some("Action Needed".to_string()),
             "task_started" | "agent_message" | "exec_command_begin" | "exec_command_start" => {
-                return Some("Processing...".to_string())
+                return Some("Processing...".to_string());
             }
             "task_complete" => return Some("Idle".to_string()),
             _ => {}

--- a/src-tauri/src/models/agent_config.rs
+++ b/src-tauri/src/models/agent_config.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use super::AgentSessionPersistenceOverride;
+
 fn default_provider() -> String {
     "claude".to_string()
 }
@@ -47,6 +49,10 @@ pub struct AgentConfig {
     pub output_format: Option<String>,
     #[serde(default)]
     pub custom_args: Option<String>,
+    #[serde(default)]
+    pub session_persistence: AgentSessionPersistenceOverride,
+    #[serde(default, skip)]
+    pub fresh_provider_session_id: Option<String>,
 
     // Claude-specific fields
     #[serde(default)]
@@ -100,6 +106,7 @@ pub struct AgentClassDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::AgentSessionPersistenceOverride;
 
     #[test]
     fn agent_config_serde_roundtrip() {
@@ -120,6 +127,16 @@ mod tests {
         assert_eq!(config.folder, deserialized.folder);
         assert_eq!(config.resume_session, deserialized.resume_session);
         assert_eq!(config.is_off, deserialized.is_off);
+    }
+
+    #[test]
+    fn agent_config_defaults_regular_session_persistence_to_global_default() {
+        let config: AgentConfig = serde_json::from_str(r#"{"session_id":"abc-123"}"#).unwrap();
+
+        assert_eq!(
+            config.session_persistence,
+            AgentSessionPersistenceOverride::Default
+        );
     }
 
     #[test]

--- a/src-tauri/src/models/git.rs
+++ b/src-tauri/src/models/git.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitFileEntry {
+    pub path: String,
+    /// Status code: "M", "A", "D", "R", "C", "U", "?"
+    pub status: String,
+    pub is_staged: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitStatusResult {
+    pub branch: String,
+    pub files: Vec<GitFileEntry>,
+    pub ahead: u32,
+    pub behind: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitLogEntry {
+    pub hash: String,
+    pub message: String,
+    pub author: String,
+    pub date: String,
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -12,5 +12,8 @@ pub use agent_telemetry::AgentTelemetry;
 pub use fs::*;
 pub use library::*;
 pub use provider::{AgentEvent, AgentProvider};
-pub use session_policy::{AgentExecutionPolicy, AgentSessionPersistence, WorkflowAgentMode};
+pub use session_policy::{
+    AgentExecutionPolicy, AgentSessionPersistence, AgentSessionPersistenceOverride,
+    WorkflowAgentMode,
+};
 pub use workflow::*;

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_config;
 pub mod agent_telemetry;
 pub mod fs;
+pub mod git;
 pub mod library;
 pub mod provider;
 pub mod workflow;

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod fs;
 pub mod git;
 pub mod library;
 pub mod provider;
+pub mod session_policy;
 pub mod workflow;
 
 pub use agent_config::{AgentClassDefinition, AgentConfig};
@@ -11,4 +12,5 @@ pub use agent_telemetry::AgentTelemetry;
 pub use fs::*;
 pub use library::*;
 pub use provider::{AgentEvent, AgentProvider};
+pub use session_policy::{AgentExecutionPolicy, AgentSessionPersistence, WorkflowAgentMode};
 pub use workflow::*;

--- a/src-tauri/src/models/session_policy.rs
+++ b/src-tauri/src/models/session_policy.rs
@@ -16,6 +16,15 @@ pub enum AgentSessionPersistence {
     Resume,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentSessionPersistenceOverride {
+    #[default]
+    Default,
+    Fresh,
+    Resume,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AgentExecutionPolicy {
     pub mode: WorkflowAgentMode,

--- a/src-tauri/src/models/session_policy.rs
+++ b/src-tauri/src/models/session_policy.rs
@@ -1,0 +1,79 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowAgentMode {
+    Ephemeral,
+    InheritFresh,
+    InheritResume,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentSessionPersistence {
+    Fresh,
+    #[default]
+    Resume,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AgentExecutionPolicy {
+    pub mode: WorkflowAgentMode,
+}
+
+impl AgentExecutionPolicy {
+    pub fn from_legacy_session_type(
+        legacy_session_type: Option<&str>,
+        explicit_mode: Option<&str>,
+    ) -> Self {
+        if let Some(mode) = explicit_mode.and_then(parse_workflow_agent_mode) {
+            return Self { mode };
+        }
+
+        let mode = match legacy_session_type {
+            Some("temporary") => WorkflowAgentMode::Ephemeral,
+            Some("persistent") => WorkflowAgentMode::InheritFresh,
+            _ => WorkflowAgentMode::Ephemeral,
+        };
+
+        Self { mode }
+    }
+}
+
+pub fn parse_workflow_agent_mode(value: &str) -> Option<WorkflowAgentMode> {
+    match value {
+        "ephemeral" => Some(WorkflowAgentMode::Ephemeral),
+        "inherit_fresh" => Some(WorkflowAgentMode::InheritFresh),
+        "inherit_resume" => Some(WorkflowAgentMode::InheritResume),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_temporary_maps_to_ephemeral() {
+        let resolved = AgentExecutionPolicy::from_legacy_session_type(Some("temporary"), None);
+
+        assert_eq!(resolved.mode, WorkflowAgentMode::Ephemeral);
+    }
+
+    #[test]
+    fn legacy_persistent_maps_to_inherit_fresh() {
+        let resolved = AgentExecutionPolicy::from_legacy_session_type(Some("persistent"), None);
+
+        assert_eq!(resolved.mode, WorkflowAgentMode::InheritFresh);
+    }
+
+    #[test]
+    fn explicit_mode_wins_over_legacy_session_type() {
+        let resolved = AgentExecutionPolicy::from_legacy_session_type(
+            Some("persistent"),
+            Some("inherit_resume"),
+        );
+
+        assert_eq!(resolved.mode, WorkflowAgentMode::InheritResume);
+    }
+}

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -1,5 +1,5 @@
-use crate::models::provider::{AgentEvent, AgentProvider};
 use crate::models::AgentConfig;
+use crate::models::provider::{AgentEvent, AgentProvider};
 
 /// The concrete `AgentProvider` implementation for Claude Code CLI.
 pub struct ClaudeProvider;
@@ -200,9 +200,14 @@ impl AgentProvider for ClaudeProvider {
         }
 
         // Only set fresh-session identity on non-resume launches.
-        if !is_resume && !config.session_id.trim().is_empty() {
+        let fresh_session_id = config
+            .fresh_provider_session_id
+            .as_deref()
+            .unwrap_or(config.session_id.as_str())
+            .trim();
+        if !is_resume && !fresh_session_id.is_empty() {
             args.push("--session-id".into());
-            args.push(config.session_id.clone());
+            args.push(fresh_session_id.to_string());
         }
         if !is_resume && !config.session_name.trim().is_empty() {
             args.push("--name".into());
@@ -609,5 +614,19 @@ mod tests {
         let args = p.get_spawn_args(&config, false);
         assert!(args.contains(&"--session-id".to_string()));
         assert!(args.contains(&"019d331a-0500-7592-969f-8f437886f42b".to_string()));
+    }
+
+    #[test]
+    fn fresh_spawn_prefers_transient_provider_session_id() {
+        let p = make_provider();
+        let config = AgentConfig {
+            session_id: "stable-wardian-id".into(),
+            fresh_provider_session_id: Some("fresh-claude-id".into()),
+            ..Default::default()
+        };
+        let args = p.get_spawn_args(&config, false);
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(args.contains(&"fresh-claude-id".to_string()));
+        assert!(!args.contains(&"stable-wardian-id".to_string()));
     }
 }

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -17,6 +17,8 @@ pub struct AppState {
     pub workflow_runs: Mutex<HashMap<String, Vec<tauri::async_runtime::JoinHandle<()>>>>,
     pub triggers_paused: std::sync::atomic::AtomicBool,
     pub scheduler_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    // Active git repo watchers keyed by workspace path
+    pub git_watchers: Mutex<HashMap<String, notify::RecommendedWatcher>>,
 }
 
 impl AppState {
@@ -38,6 +40,7 @@ impl Default for AppState {
             workflow_runs: Mutex::new(HashMap::new()),
             triggers_paused: std::sync::atomic::AtomicBool::new(false),
             scheduler_handle: Mutex::new(None),
+            git_watchers: Mutex::new(HashMap::new()),
         }
     }
 }

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -71,6 +71,15 @@ pub fn save_shell_settings(settings: &ShellSettings) -> Result<ShellSettings, St
     save_shell_settings_to_path(&path, settings)
 }
 
+pub fn save_agent_session_persistence(
+    persistence: AgentSessionPersistence,
+) -> Result<ShellSettings, String> {
+    let path = shell_settings_path()?;
+    let mut settings = load_shell_settings_from_path(&path).unwrap_or_default();
+    settings.agent_session_persistence = persistence;
+    save_shell_settings_to_path(&path, &settings)
+}
+
 pub fn build_shell_command(command: &str) -> Result<ShellLaunchSpec, String> {
     let settings = load_shell_settings().unwrap_or_default();
     let available = list_available_shells();

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -1,4 +1,5 @@
 use crate::utils::get_wardian_home;
+use crate::models::AgentSessionPersistence;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -21,6 +22,8 @@ pub struct ShellSettings {
     pub custom_executable: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_args: Option<String>,
+    #[serde(default)]
+    pub agent_session_persistence: AgentSessionPersistence,
 }
 
 impl Default for ShellSettings {
@@ -29,6 +32,7 @@ impl Default for ShellSettings {
             shell_id: "auto".to_string(),
             custom_executable: None,
             custom_args: None,
+            agent_session_persistence: AgentSessionPersistence::Resume,
         }
     }
 }
@@ -701,6 +705,7 @@ mod tests {
             shell_id: "custom".to_string(),
             custom_executable: Some("C:/Program Files/PowerShell/7/pwsh.exe".to_string()),
             custom_args: Some("-NoProfile -Command".to_string()),
+            ..Default::default()
         };
 
         let saved = save_shell_settings_to_path(&path, &settings).expect("save settings");
@@ -720,6 +725,7 @@ mod tests {
                 "/bin/bash".to_string()
             }),
             custom_args: None,
+            ..Default::default()
         };
 
         let spec = build_shell_command_with_settings("echo hello", &settings, &[])
@@ -756,6 +762,7 @@ mod tests {
                 shell_id: "pwsh".to_string(),
                 custom_executable: None,
                 custom_args: None,
+                ..Default::default()
             },
             &available,
         )
@@ -789,6 +796,7 @@ mod tests {
                 shell_id: "pwsh".to_string(),
                 custom_executable: None,
                 custom_args: None,
+                ..Default::default()
             },
             &available,
         )
@@ -869,6 +877,7 @@ mod tests {
                 shell_id: "git-bash".to_string(),
                 custom_executable: None,
                 custom_args: None,
+                ..Default::default()
             },
             &available,
         )
@@ -909,6 +918,7 @@ mod tests {
                 shell_id: "git-bash".to_string(),
                 custom_executable: None,
                 custom_args: None,
+                ..Default::default()
             },
             &available,
         )
@@ -944,6 +954,7 @@ mod tests {
                 shell_id: "wsl".to_string(),
                 custom_executable: None,
                 custom_args: None,
+                ..Default::default()
             },
             &available,
         )

--- a/src-tauri/src/utils/terminal_input.rs
+++ b/src-tauri/src/utils/terminal_input.rs
@@ -10,6 +10,7 @@ pub fn normalize_prompt_for_terminal_submit(prompt: &str) -> String {
 pub async fn submit_prompt_via_sender(
     tx: &Sender<Vec<u8>>,
     prompt: &str,
+    provider_name: &str,
 ) -> Result<(), String> {
     let normalized = normalize_prompt_for_terminal_submit(prompt);
     if normalized.is_empty() {
@@ -22,7 +23,13 @@ pub async fn submit_prompt_via_sender(
 
     tokio::time::sleep(std::time::Duration::from_millis(TERMINAL_SUBMIT_DELAY_MS)).await;
 
-    tx.send(TERMINAL_SUBMIT_KEY.to_vec())
+    let submit_key = if provider_name == "codex" {
+        b"\x1b\r".as_slice()
+    } else {
+        TERMINAL_SUBMIT_KEY
+    };
+
+    tx.send(submit_key.to_vec())
         .await
         .map_err(|e| format!("Failed to send prompt submit key: {}", e))?;
 
@@ -45,7 +52,7 @@ mod tests {
     async fn submit_prompt_sends_text_then_submit_key() {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
 
-        submit_prompt_via_sender(&tx, "hello\nworld")
+        submit_prompt_via_sender(&tx, "hello\nworld", "gemini")
             .await
             .expect("submit prompt");
 

--- a/src-tauri/src/workflow_engine/agent_execution.rs
+++ b/src-tauri/src/workflow_engine/agent_execution.rs
@@ -1,0 +1,202 @@
+use crate::models::{AgentConfig, AgentExecutionPolicy, WorkflowAgentMode};
+
+#[derive(Debug, Clone)]
+pub struct AgentExecutionContext {
+    pub config: AgentConfig,
+    pub mode: WorkflowAgentMode,
+    pub source_agent_id: Option<String>,
+    pub execution_session_id: String,
+    pub resume_session: Option<String>,
+    pub use_source_runtime: bool,
+}
+
+fn workflow_execution_session_id(workflow_run_id: &str, node_id: &str) -> String {
+    format!("workflow-{}-{}", workflow_run_id, node_id)
+}
+
+pub fn resolve_agent_execution_context(
+    node_id: &str,
+    node_config: &serde_json::Map<String, serde_json::Value>,
+    target_agent: Option<&AgentConfig>,
+    workflow_run_id: &str,
+) -> Result<AgentExecutionContext, String> {
+    let legacy_session_type = node_config.get("session_type").and_then(|v| v.as_str());
+    let explicit_mode = node_config.get("mode").and_then(|v| v.as_str());
+    let mut mode =
+        AgentExecutionPolicy::from_legacy_session_type(legacy_session_type, explicit_mode).mode;
+    if explicit_mode.is_none()
+        && legacy_session_type.is_none()
+        && mode == WorkflowAgentMode::Ephemeral
+        && target_agent.is_some()
+    {
+        mode = WorkflowAgentMode::InheritFresh;
+    }
+    let execution_session_id = workflow_execution_session_id(workflow_run_id, node_id);
+
+    let mut config = match mode {
+        WorkflowAgentMode::Ephemeral => {
+            let agent_class = node_config
+                .get("agent_class")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let folder = node_config
+                .get("folder")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            AgentConfig {
+                session_id: execution_session_id.clone(),
+                session_name: format!("Workflow {}", node_id),
+                agent_class,
+                folder,
+                resume_session: None,
+                is_off: true,
+                ..Default::default()
+            }
+        }
+        WorkflowAgentMode::InheritFresh | WorkflowAgentMode::InheritResume => {
+            target_agent.cloned().ok_or_else(|| {
+                "inherit_fresh and inherit_resume require an agent_id or role mapping".to_string()
+            })?
+        }
+    };
+
+    if let Some(output_format) = node_config.get("output_format").and_then(|v| v.as_str()) {
+        config.output_format = Some(output_format.to_string());
+    }
+    if let Some(folder) = node_config.get("folder").and_then(|v| v.as_str()) {
+        if !folder.trim().is_empty() {
+            config.folder = folder.to_string();
+        }
+    }
+    if let Some(provider) = node_config.get("provider").and_then(|v| v.as_str()) {
+        if !provider.trim().is_empty() {
+            config.provider = provider.to_string();
+        }
+    }
+
+    let source_agent_id = target_agent.map(|agent| agent.session_id.clone());
+    let resume_session = match mode {
+        WorkflowAgentMode::InheritResume => config
+            .resume_session
+            .clone()
+            .or_else(|| (!config.session_id.trim().is_empty()).then(|| config.session_id.clone())),
+        WorkflowAgentMode::Ephemeral | WorkflowAgentMode::InheritFresh => {
+            config.session_id = execution_session_id.clone();
+            config.resume_session = None;
+            None
+        }
+    };
+
+    Ok(AgentExecutionContext {
+        config,
+        mode,
+        source_agent_id,
+        execution_session_id,
+        resume_session,
+        use_source_runtime: mode == WorkflowAgentMode::InheritResume,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn source_agent() -> AgentConfig {
+        AgentConfig {
+            session_id: "agent-123".into(),
+            session_name: "Source Agent".into(),
+            agent_class: "Coder".into(),
+            folder: "D:/Development/Wardian".into(),
+            provider: "opencode".into(),
+            resume_session: Some("ses_source".into()),
+            system_include_directories: Some(vec!["source-scope".into()]),
+            include_directories: Some(vec!["user-scope".into()]),
+            ..Default::default()
+        }
+    }
+
+    fn object(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+        value.as_object().expect("object").clone()
+    }
+
+    #[test]
+    fn ephemeral_never_uses_resume_session() {
+        let config = object(json!({
+            "mode": "ephemeral",
+            "agent_class": "Coder",
+            "folder": "D:/Development/Wardian"
+        }));
+
+        let ctx =
+            resolve_agent_execution_context("node-1", &config, None, "run-1").expect("context");
+
+        assert_eq!(ctx.mode, WorkflowAgentMode::Ephemeral);
+        assert_eq!(ctx.config.session_id, "workflow-run-1-node-1");
+        assert_eq!(ctx.config.resume_session, None);
+        assert_eq!(ctx.resume_session, None);
+        assert!(!ctx.use_source_runtime);
+    }
+
+    #[test]
+    fn inherit_fresh_clones_provider_settings_but_clears_resume_session() {
+        let config = object(json!({ "mode": "inherit_fresh" }));
+
+        let ctx =
+            resolve_agent_execution_context("node-1", &config, Some(&source_agent()), "run-1")
+                .expect("context");
+
+        assert_eq!(ctx.mode, WorkflowAgentMode::InheritFresh);
+        assert_eq!(ctx.config.provider, "opencode");
+        assert_eq!(ctx.config.agent_class, "Coder");
+        assert_eq!(ctx.config.session_id, "workflow-run-1-node-1");
+        assert_eq!(ctx.config.resume_session, None);
+        assert_eq!(ctx.resume_session, None);
+        assert_eq!(ctx.source_agent_id.as_deref(), Some("agent-123"));
+        assert_eq!(
+            ctx.config.system_include_directories.as_deref(),
+            Some(&["source-scope".to_string()][..])
+        );
+        assert!(!ctx.use_source_runtime);
+    }
+
+    #[test]
+    fn inherit_resume_keeps_valid_resume_session() {
+        let config = object(json!({ "mode": "inherit_resume" }));
+
+        let ctx =
+            resolve_agent_execution_context("node-1", &config, Some(&source_agent()), "run-1")
+                .expect("context");
+
+        assert_eq!(ctx.mode, WorkflowAgentMode::InheritResume);
+        assert_eq!(ctx.config.session_id, "agent-123");
+        assert_eq!(ctx.resume_session.as_deref(), Some("ses_source"));
+        assert!(ctx.use_source_runtime);
+    }
+
+    #[test]
+    fn missing_mode_for_workflow_resolves_to_ephemeral() {
+        let config = object(json!({ "agent_class": "Coder" }));
+
+        let ctx =
+            resolve_agent_execution_context("node-1", &config, None, "run-1").expect("context");
+
+        assert_eq!(ctx.mode, WorkflowAgentMode::Ephemeral);
+    }
+
+    #[test]
+    fn legacy_direct_agent_without_mode_resolves_to_inherit_fresh() {
+        let config = object(json!({ "agent_id": "agent-123" }));
+
+        let ctx =
+            resolve_agent_execution_context("node-1", &config, Some(&source_agent()), "run-1")
+                .expect("context");
+
+        assert_eq!(ctx.mode, WorkflowAgentMode::InheritFresh);
+        assert_eq!(ctx.config.session_id, "workflow-run-1-node-1");
+        assert_eq!(ctx.resume_session, None);
+    }
+
+}

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -2076,7 +2076,7 @@ pub async fn run_workflow(
                                 } else {
                                     if let Err(err) =
                                         crate::utils::terminal_input::submit_prompt_via_sender(
-                                            &tx, &prompt,
+                                            &tx, &prompt, &provider_name
                                         )
                                         .await
                                     {

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_execution;
 mod migrate;
 
 use crate::manager::log_debug;
@@ -1775,6 +1776,11 @@ pub async fn run_workflow(
                     } else {
                         direct_id
                     };
+                    let mode = crate::models::AgentExecutionPolicy::from_legacy_session_type(
+                        node.config.get("session_type").and_then(|v| v.as_str()),
+                        node.config.get("mode").and_then(|v| v.as_str()),
+                    )
+                    .mode;
 
                     let mut prompt = node
                         .config
@@ -1784,46 +1790,62 @@ pub async fn run_workflow(
                         .to_string();
                     prompt = interpolate_string(&prompt, &registry);
 
-                    if agent_id.is_empty() {
+                    if agent_id.is_empty() && mode != crate::models::WorkflowAgentMode::Ephemeral {
                         node_error = Some(if !role.is_empty() {
                             format!("Role '{}' not mapped to an agent. Set role_mappings before running.", role)
                         } else {
                             "Missing agent_id or role".to_string()
                         });
                     } else {
-                        // Resolve provider name from live agent state or saved config
-                        let provider_name = {
+                        let target_agent_config = if agent_id.is_empty() {
+                            None
+                        } else {
                             let state = app.state::<crate::state::AppState>();
                             let agents_map = state.agents.lock().await;
                             if let Some(agent) = agents_map.get(agent_id) {
-                                agent.config.provider.clone()
-                            } else {
-                                // Fallback: read from persisted state
-                                let mut found = "gemini".to_string();
-                                if let Some(home) = get_wardian_home() {
-                                    if let Ok(data) =
-                                        std::fs::read_to_string(home.join("wardian_state.json"))
+                                Some(agent.config.clone())
+                            } else if let Some(home) = get_wardian_home() {
+                                if let Ok(data) =
+                                    std::fs::read_to_string(home.join("wardian_state.json"))
+                                {
+                                    if let Ok(configs) =
+                                        serde_json::from_str::<Vec<crate::models::AgentConfig>>(
+                                            &data,
+                                        )
                                     {
-                                        if let Ok(configs) =
-                                            serde_json::from_str::<Vec<crate::models::AgentConfig>>(
-                                                &data,
-                                            )
-                                        {
-                                            if let Some(cfg) =
-                                                configs.iter().find(|c| c.session_id == agent_id)
-                                            {
-                                                found = cfg.provider.clone();
-                                            }
-                                        }
+                                        configs.into_iter().find(|c| c.session_id == agent_id)
+                                    } else {
+                                        None
                                     }
+                                } else {
+                                    None
                                 }
-                                found
+                            } else {
+                                None
                             }
                         };
+                        let node_config = node
+                            .config
+                            .as_object()
+                            .cloned()
+                            .unwrap_or_default();
+                        let exec_ctx = match agent_execution::resolve_agent_execution_context(
+                            &node.id,
+                            &node_config,
+                            target_agent_config.as_ref(),
+                            &run_instance_id,
+                        ) {
+                            Ok(ctx) => Some(ctx),
+                            Err(err) => {
+                                node_error = Some(err);
+                                None
+                            }
+                        };
+                        if let Some(exec_ctx) = exec_ctx {
+                        let provider_name = exec_ctx.config.provider.clone();
                         let output_format = node
                             .config
                             .get("output_format")
-                            .or_else(|| node.config.get("mode"))
                             .and_then(|v| v.as_str())
                             .unwrap_or("text");
 
@@ -1860,14 +1882,46 @@ pub async fn run_workflow(
                         ));
 
                         // 1. Resolve CWD logic (Shared between modes)
-                        let folder = node
-                            .config
-                            .get("folder")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("");
-                        let cwd = crate::utils::fs::resolve_cwd(folder, agent_id);
+                        let cwd = crate::utils::fs::resolve_cwd(
+                            &exec_ctx.config.folder,
+                            &exec_ctx.execution_session_id,
+                        );
 
-                        if output_format == "json" {
+                        if exec_ctx.mode != crate::models::WorkflowAgentMode::InheritResume {
+                            let run_result = tokio::time::timeout(
+                                std::time::Duration::from_millis(timeout_ms),
+                                crate::manager::run_headless_with_options(
+                                    crate::manager::HeadlessRunOptions {
+                                        cwd: &cwd,
+                                        prompt: &prompt,
+                                        wardian_session_id: &exec_ctx.execution_session_id,
+                                        resume_session: None,
+                                        output_format,
+                                        provider_name: &provider_name,
+                                        config_override: Some(&exec_ctx.config),
+                                    },
+                                ),
+                            )
+                            .await;
+
+                            let run_result = match run_result {
+                                Ok(res) => res,
+                                Err(_) => Err(format!("Agent timeout ({}ms)", timeout_ms)),
+                            };
+
+                            match run_result {
+                                Ok(data) => {
+                                    output_payload = flatten_headless_response(data);
+                                }
+                                Err(e) => {
+                                    log_debug(&format!(
+                                        "[Wardian] Fresh workflow agent run failed: {}",
+                                        e
+                                    ));
+                                    node_error = Some(e);
+                                }
+                            }
+                        } else if output_format == "json" {
                             // --- HEADLESS JSON MODE (Always kills PTY for clean structured output) ---
                             let state = app.state::<crate::state::AppState>();
                             let mut was_online = false;
@@ -1898,13 +1952,16 @@ pub async fn run_workflow(
 
                             let run_result = tokio::time::timeout(
                                 std::time::Duration::from_millis(timeout_ms),
-                                crate::manager::run_headless_with_config(
-                                    &cwd,
-                                    &prompt,
-                                    agent_id,
-                                    output_format,
-                                    &provider_name,
-                                    agent_cfg.as_ref(),
+                                crate::manager::run_headless_with_options(
+                                    crate::manager::HeadlessRunOptions {
+                                        cwd: &cwd,
+                                        prompt: &prompt,
+                                        wardian_session_id: &exec_ctx.execution_session_id,
+                                        resume_session: exec_ctx.resume_session.as_deref(),
+                                        output_format,
+                                        provider_name: &provider_name,
+                                        config_override: Some(&exec_ctx.config),
+                                    },
                                 ),
                             )
                             .await;
@@ -1985,13 +2042,16 @@ pub async fn run_workflow(
                                 if provider_name == "opencode" {
                                     let run_result = tokio::time::timeout(
                                         std::time::Duration::from_millis(timeout_ms),
-                                        crate::manager::run_headless_with_config(
-                                            &cwd,
-                                            &prompt,
-                                            agent_id,
-                                            output_format,
-                                            &provider_name,
-                                            None,
+                                        crate::manager::run_headless_with_options(
+                                            crate::manager::HeadlessRunOptions {
+                                                cwd: &cwd,
+                                                prompt: &prompt,
+                                                wardian_session_id: &exec_ctx.execution_session_id,
+                                                resume_session: exec_ctx.resume_session.as_deref(),
+                                                output_format,
+                                                provider_name: &provider_name,
+                                                config_override: Some(&exec_ctx.config),
+                                            },
                                         ),
                                     )
                                     .await;
@@ -2079,13 +2139,16 @@ pub async fn run_workflow(
                                 let _ = app.emit("agents-updated", ());
                                 let run_result = tokio::time::timeout(
                                     std::time::Duration::from_millis(timeout_ms),
-                                    crate::manager::run_headless_with_config(
-                                        &cwd,
-                                        &prompt,
-                                        agent_id,
-                                        output_format,
-                                        &provider_name,
-                                        None,
+                                    crate::manager::run_headless_with_options(
+                                        crate::manager::HeadlessRunOptions {
+                                            cwd: &cwd,
+                                            prompt: &prompt,
+                                            wardian_session_id: &exec_ctx.execution_session_id,
+                                            resume_session: exec_ctx.resume_session.as_deref(),
+                                            output_format,
+                                            provider_name: &provider_name,
+                                            config_override: Some(&exec_ctx.config),
+                                        },
                                     ),
                                 )
                                 .await;
@@ -2119,6 +2182,7 @@ pub async fn run_workflow(
                                 let _ = app.emit("agents-updated", ());
                             }
                         }
+                    }
                     }
                 }
                 "communication" | "notify" => {

--- a/src/components/AdvancedSettings.test.tsx
+++ b/src/components/AdvancedSettings.test.tsx
@@ -21,4 +21,21 @@ describe("AdvancedSettings", () => {
     expect(updateField).toHaveBeenCalledWith("opencode_agent", "build");
   });
 
+  it("edits regular session persistence from advanced settings", () => {
+    const updateField = vi.fn();
+
+    render(
+      <AdvancedSettings
+        config={{ provider: "claude", session_persistence: "default" }}
+        updateField={updateField}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced Settings" }));
+    fireEvent.change(screen.getByLabelText("Regular Session Resume"), {
+      target: { value: "fresh" },
+    });
+
+    expect(updateField).toHaveBeenCalledWith("session_persistence", "fresh");
+  });
 });

--- a/src/components/AdvancedSettings.test.tsx
+++ b/src/components/AdvancedSettings.test.tsx
@@ -38,4 +38,23 @@ describe("AdvancedSettings", () => {
 
     expect(updateField).toHaveBeenCalledWith("session_persistence", "fresh");
   });
+
+  it("places regular session resume outside provider parameters", () => {
+    const updateField = vi.fn();
+    const { container } = render(
+      <AdvancedSettings
+        config={{ provider: "claude", session_persistence: "default" }}
+        updateField={updateField}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced Settings" }));
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Regular Session Resume")).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf("Provider Parameters")).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf("Regular Session Resume")).toBeLessThan(
+      text.indexOf("Provider Parameters"),
+    );
+  });
 });

--- a/src/components/AdvancedSettings.test.tsx
+++ b/src/components/AdvancedSettings.test.tsx
@@ -20,4 +20,5 @@ describe("AdvancedSettings", () => {
 
     expect(updateField).toHaveBeenCalledWith("opencode_agent", "build");
   });
+
 });

--- a/src/components/AdvancedSettings.tsx
+++ b/src/components/AdvancedSettings.tsx
@@ -34,6 +34,20 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
 
       {showAdvanced && (
         <div className="flex flex-col gap-4 pt-2">
+          <div>
+              <label htmlFor="regular-session-resume" className="block text-[10px] font-bold text-muted-neutral mb-1">Regular Session Resume</label>
+              <select
+              id="regular-session-resume"
+              className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
+              value={config.session_persistence || "default"}
+              onChange={(e) => updateField("session_persistence", e.target.value as AgentConfig["session_persistence"])}
+              >
+                  <option value="default">Use global default</option>
+                  <option value="fresh">Start fresh on resume</option>
+                  <option value="resume">Resume provider session</option>
+              </select>
+          </div>
+
           {/* Gemini CLI Properties */}
           <div className="flex flex-col gap-4">
               <h4 className="text-[10px] font-bold text-muted-neutral tracking-wide mb-1 border-b border-wardian-border pb-1">Provider Parameters</h4>
@@ -63,20 +77,6 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                       </label>
                     </>
                   )}
-              </div>
-
-              <div>
-                  <label htmlFor="regular-session-resume" className="block text-[10px] font-bold text-muted-neutral mb-1">Regular Session Resume</label>
-                  <select
-                  id="regular-session-resume"
-                  className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
-                  value={config.session_persistence || "default"}
-                  onChange={(e) => updateField("session_persistence", e.target.value as AgentConfig["session_persistence"])}
-                  >
-                      <option value="default">Use global default</option>
-                      <option value="fresh">Start fresh on resume</option>
-                      <option value="resume">Resume provider session</option>
-                  </select>
               </div>
 
               <div>

--- a/src/components/AdvancedSettings.tsx
+++ b/src/components/AdvancedSettings.tsx
@@ -66,6 +66,20 @@ export const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
               </div>
 
               <div>
+                  <label htmlFor="regular-session-resume" className="block text-[10px] font-bold text-muted-neutral mb-1">Regular Session Resume</label>
+                  <select
+                  id="regular-session-resume"
+                  className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
+                  value={config.session_persistence || "default"}
+                  onChange={(e) => updateField("session_persistence", e.target.value as AgentConfig["session_persistence"])}
+                  >
+                      <option value="default">Use global default</option>
+                      <option value="fresh">Start fresh on resume</option>
+                      <option value="resume">Resume provider session</option>
+                  </select>
+              </div>
+
+              <div>
                   <label className="block text-[10px] font-bold text-muted-neutral mb-1">Model Override</label>
                   <input
                   className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-1.5 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -15,7 +15,6 @@ export interface AgentContextMenuProps {
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
   onDelete: (agentId: string) => void;
-  onResetLayout: () => void;
   onClose: () => void;
 }
 
@@ -32,7 +31,6 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   onAddToList,
   onRemoveFromList,
   onDelete,
-  onResetLayout,
   onClose,
 }) => {
   const [subMenuListId, setSubMenuListId] = useState<string | null>(null);
@@ -166,17 +164,6 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       )}
 
       <div className="context-menu-divider" />
-
-      <button
-        className="context-menu-item"
-        onClick={() => {
-          onResetLayout();
-          onClose();
-        }}
-      >
-        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
-        Reset Grid Layout
-      </button>
 
       <button
         className="context-menu-item text-wardian-error hover:!bg-wardian-error/20"

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -12,6 +12,7 @@ export interface AgentContextMenuProps {
   onQuery: (agentId: string) => void;
   onPause: (agentId: string) => void;
   onRestart: (agentId: string) => void;
+  onClear: (agentId: string) => void;
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
   onDelete: (agentId: string) => void;
@@ -28,6 +29,7 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   onQuery,
   onPause,
   onRestart,
+  onClear,
   onAddToList,
   onRemoveFromList,
   onDelete,
@@ -101,6 +103,17 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
         {offAgentIds.has(agentId) ? 'Start' : 'Restart'}
+      </button>
+      <button
+        data-testid="context-clear"
+        className="context-menu-item"
+        onClick={() => {
+          onClear(agentId);
+          onClose();
+        }}
+      >
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 7h16M10 11v6m4-6v6M6 7l1 13a2 2 0 002 2h6a2 2 0 002-2l1-13M9 7V4h6v3" /></svg>
+        Clear
       </button>
 
       <div className="context-menu-divider" />

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -112,7 +112,7 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
           onClose();
         }}
       >
-        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 7h16M10 11v6m4-6v6M6 7l1 13a2 2 0 002 2h6a2 2 0 002-2l1-13M9 7V4h6v3" /></svg>
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 15l8-8a2 2 0 012.8 0l4.2 4.2a2 2 0 010 2.8l-5 5H8l-4-4zM13 19h7" /></svg>
         Clear
       </button>
 

--- a/src/features/agents/ConfigureAgentPanel.tsx
+++ b/src/features/agents/ConfigureAgentPanel.tsx
@@ -142,6 +142,21 @@ export const ConfigureAgentPanel: React.FC<Props> = ({
             </select>
           </div>
           <div>
+            <label className="block text-[10px] font-bold text-muted-neutral mb-1">Regular Session Resume</label>
+            <select
+              className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
+              value={config.session_persistence || "default"}
+              onChange={(e) => updateField("session_persistence", e.target.value as AgentConfig["session_persistence"])}
+            >
+              <option value="default">Use global default</option>
+              <option value="fresh">Start fresh on resume</option>
+              <option value="resume">Resume provider session</option>
+            </select>
+            <p className="mt-1 text-[10px] text-muted-neutral leading-relaxed">
+              Applies when this regular visible agent is resumed from Off. Workflow agent nodes use their own run mode.
+            </p>
+          </div>
+          <div>
             <div className="flex justify-between items-center mb-1">
               <label className="block text-[10px] font-bold text-muted-neutral">Session ID</label>
               <button 

--- a/src/features/agents/ConfigureAgentPanel.tsx
+++ b/src/features/agents/ConfigureAgentPanel.tsx
@@ -142,21 +142,6 @@ export const ConfigureAgentPanel: React.FC<Props> = ({
             </select>
           </div>
           <div>
-            <label className="block text-[10px] font-bold text-muted-neutral mb-1">Regular Session Resume</label>
-            <select
-              className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
-              value={config.session_persistence || "default"}
-              onChange={(e) => updateField("session_persistence", e.target.value as AgentConfig["session_persistence"])}
-            >
-              <option value="default">Use global default</option>
-              <option value="fresh">Start fresh on resume</option>
-              <option value="resume">Resume provider session</option>
-            </select>
-            <p className="mt-1 text-[10px] text-muted-neutral leading-relaxed">
-              Applies when this regular visible agent is resumed from Off. Workflow agent nodes use their own run mode.
-            </p>
-          </div>
-          <div>
             <div className="flex justify-between items-center mb-1">
               <label className="block text-[10px] font-bold text-muted-neutral">Session ID</label>
               <button 

--- a/src/features/agents/configUtils.test.ts
+++ b/src/features/agents/configUtils.test.ts
@@ -52,4 +52,10 @@ describe("requiresRestart", () => {
         const config2: AgentConfig = { ...baseConfig, system_include_directories: ["/new"] };
         expect(requiresRestart(config1, config2)).toBe(true);
     });
+
+    it("does not require restart when regular session persistence changes", () => {
+        const config1: AgentConfig = { ...baseConfig, session_persistence: "default" };
+        const config2: AgentConfig = { ...baseConfig, session_persistence: "fresh" };
+        expect(requiresRestart(config1, config2)).toBe(false);
+    });
 });

--- a/src/features/agents/configUtils.ts
+++ b/src/features/agents/configUtils.ts
@@ -8,7 +8,7 @@ export function requiresRestart(oldConfig: AgentConfig, newConfig: AgentConfig):
   const keys = Object.keys(newConfig) as (keyof AgentConfig)[];
   
   for (const key of keys) {
-    if (key === "session_name" || key === "session_id") continue;
+    if (key === "session_name" || key === "session_id" || key === "session_persistence") continue;
     
     const oldVal = oldConfig[key];
     const newVal = newConfig[key];

--- a/src/features/explorer/ExplorerPanel.tsx
+++ b/src/features/explorer/ExplorerPanel.tsx
@@ -3,6 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { FileTree, FileNode } from './FileTree';
 import { useConfirm } from '../../components/ConfirmDialog';
+import { GitStatusResult } from '../../types';
 
 interface ExplorerPanelProps {
   selectedAgentIds: Set<string>;
@@ -11,7 +12,8 @@ interface ExplorerPanelProps {
 export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }) => {
   const confirm = useConfirm();
   const [rootPath, setRootPath] = useState<string | null>(null);
-  
+  const [gitStatusMap, setGitStatusMap] = useState<Record<string, string>>({});
+
   // Context Menu State
   const [menuPos, setMenuPos] = useState<{x: number, y: number} | null>(null);
   const [activeNode, setActiveNode] = useState<FileNode | null>(null);
@@ -34,6 +36,28 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }
     };
     fetchPath();
   }, [selectedAgentId]);
+
+  useEffect(() => {
+    if (!rootPath) return;
+    let isMounted = true;
+    const poll = async () => {
+      try {
+        const result = await invoke<GitStatusResult>('git_status', { cwd: rootPath });
+        if (!isMounted) return;
+        const map: Record<string, string> = {};
+        for (const f of result.files) {
+          const key = f.path.replace(/\\/g, '/');
+          if (!map[key] || f.is_staged) map[key] = f.status;
+        }
+        setGitStatusMap(map);
+      } catch {
+        if (isMounted) setGitStatusMap({});
+      }
+    };
+    poll();
+    const id = setInterval(poll, 3000);
+    return () => { isMounted = false; clearInterval(id); };
+  }, [rootPath]);
 
   useEffect(() => {
     const handleClick = () => setMenuPos(null);
@@ -111,10 +135,12 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }
       
       <div className="flex-1 overflow-auto w-full relative min-h-0 -mx-3 px-3">
         {rootPath ? (
-          <FileTree 
+          <FileTree
             key={refreshKey}
-            path={rootPath} 
-            onContextMenu={handleContextMenu} 
+            path={rootPath}
+            onContextMenu={handleContextMenu}
+            gitStatusMap={gitStatusMap}
+            explorerRoot={rootPath}
           />
         ) : (
           <div className="text-sm text-wardian-text-muted animate-pulse border border-transparent">Mapping directory...</div>

--- a/src/features/explorer/ExplorerPanel.tsx
+++ b/src/features/explorer/ExplorerPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { FileTree, FileNode } from './FileTree';
@@ -13,6 +13,21 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }
   const confirm = useConfirm();
   const [rootPath, setRootPath] = useState<string | null>(null);
   const [gitStatusMap, setGitStatusMap] = useState<Record<string, string>>({});
+  const changedDirectories = useMemo(() => {
+    const directories = new Set<string>();
+    for (const filePath of Object.keys(gitStatusMap)) {
+      const segments = filePath.split('/').filter(Boolean);
+      if (segments.length <= 1) {
+        continue;
+      }
+      let prefix = '';
+      for (let i = 0; i < segments.length - 1; i++) {
+        prefix = prefix ? `${prefix}/${segments[i]}` : segments[i];
+        directories.add(prefix);
+      }
+    }
+    return directories;
+  }, [gitStatusMap]);
 
   // Context Menu State
   const [menuPos, setMenuPos] = useState<{x: number, y: number} | null>(null);
@@ -140,6 +155,7 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }
             path={rootPath}
             onContextMenu={handleContextMenu}
             gitStatusMap={gitStatusMap}
+            changedDirectories={changedDirectories}
             explorerRoot={rootPath}
           />
         ) : (

--- a/src/features/explorer/FileTree.tsx
+++ b/src/features/explorer/FileTree.tsx
@@ -132,7 +132,7 @@ export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMen
               </span>
 
               <span
-                className={`truncate flex-1 ${!gitColor ? (node.is_dir ? 'text-wardian-text font-medium' : 'text-wardian-text-muted group-hover:text-wardian-text') : ''} transition-colors`}
+                className={`truncate flex-1 ${node.is_dir ? 'font-medium' : ''} ${!gitColor ? (node.is_dir ? 'text-wardian-text' : 'text-wardian-text-muted group-hover:text-wardian-text') : ''} transition-colors`}
                 style={gitColor ? { color: gitColor } : undefined}
               >
                 {node.name}

--- a/src/features/explorer/FileTree.tsx
+++ b/src/features/explorer/FileTree.tsx
@@ -15,6 +15,7 @@ export interface FileTreeProps {
   onContextMenu?: (e: React.MouseEvent, node: FileNode) => void;
   depth?: number;
   gitStatusMap?: Record<string, string>;
+  changedDirectories?: Set<string>;
   explorerRoot?: string;
 }
 
@@ -45,7 +46,7 @@ const getFileIcon = (extension: string | null) => {
   return <FileText className="w-4 h-4 text-wardian-text-muted shrink-0" />;
 }
 
-export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMenu, depth = 0, gitStatusMap, explorerRoot }) => {
+export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMenu, depth = 0, gitStatusMap, changedDirectories, explorerRoot }) => {
   const [nodes, setNodes] = useState<FileNode[]>([]);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(false);
@@ -101,8 +102,7 @@ export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMen
       {nodes.map(node => {
         const relPath = explorerRoot ? toRelativePath(node.path, explorerRoot) : '';
         const fileStatus = gitStatusMap?.[relPath];
-        const dirHasChanges = node.is_dir && gitStatusMap &&
-          Object.keys(gitStatusMap).some(k => k.startsWith(relPath + '/'));
+        const dirHasChanges = node.is_dir && relPath !== '' && changedDirectories?.has(relPath);
         const gitColor = fileStatus
           ? GIT_STATUS_COLORS[fileStatus]
           : dirHasChanges ? GIT_STATUS_COLORS['M'] : undefined;
@@ -152,6 +152,7 @@ export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMen
                 onSelect={onSelect}
                 onContextMenu={onContextMenu}
                 gitStatusMap={gitStatusMap}
+                changedDirectories={changedDirectories}
                 explorerRoot={explorerRoot}
               />
             )}

--- a/src/features/explorer/FileTree.tsx
+++ b/src/features/explorer/FileTree.tsx
@@ -14,6 +14,23 @@ export interface FileTreeProps {
   onSelect?: (path: string, is_dir: boolean) => void;
   onContextMenu?: (e: React.MouseEvent, node: FileNode) => void;
   depth?: number;
+  gitStatusMap?: Record<string, string>;
+  explorerRoot?: string;
+}
+
+const GIT_STATUS_COLORS: Record<string, string> = {
+  M: 'var(--color-wardian-warning)',
+  A: 'var(--color-wardian-success)',
+  D: 'var(--color-wardian-error)',
+  R: 'var(--color-wardian-warning)',
+  C: 'var(--color-wardian-processing)',
+  '?': 'var(--color-wardian-success)',
+};
+
+function toRelativePath(nodePath: string, root: string): string {
+  const n = nodePath.replace(/\\/g, '/');
+  const r = root.replace(/\\/g, '/').replace(/\/$/, '');
+  return n.startsWith(r) ? n.slice(r.length).replace(/^\//, '') : n;
 }
 
 const getFileIcon = (extension: string | null) => {
@@ -28,7 +45,7 @@ const getFileIcon = (extension: string | null) => {
   return <FileText className="w-4 h-4 text-wardian-text-muted shrink-0" />;
 }
 
-export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMenu, depth = 0 }) => {
+export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMenu, depth = 0, gitStatusMap, explorerRoot }) => {
   const [nodes, setNodes] = useState<FileNode[]>([]);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(false);
@@ -81,45 +98,66 @@ export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMen
 
   return (
     <div className={`flex flex-col ${depth === 0 ? 'w-full h-full' : ''}`}>
-      {nodes.map(node => (
-        <React.Fragment key={node.path}>
-          <div 
-            className="flex items-center shrink-0 gap-1.5 py-[2px] pr-2 hover:bg-wardian-card-bg-muted cursor-pointer rounded-md text-[13px] whitespace-nowrap overflow-hidden select-none group w-full"
-            style={{ paddingLeft: `${(depth * 14) + 2}px` }}
-            onClick={(e) => handleClick(e, node)}
-            onContextMenu={(e) => onContextMenu && onContextMenu(e, node)}
-          >
-            {node.is_dir ? (
-              <span className="text-wardian-text-muted cursor-pointer hover:text-wardian-text shrink-0 flex items-center justify-center w-4 h-4" onClick={(e) => { e.stopPropagation(); toggleFolder(node.path); }}>
-                {expanded[node.path] ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-              </span>
-            ) : (
-              <span className="w-4 h-4 shrink-0 inline-block" />
-            )}
-            
-            <span className="text-wardian-text-muted flex items-center shrink-0">
-              {node.is_dir ? (
-                <Folder className={`w-4 h-4 ${expanded[node.path] ? 'fill-wardian-accent/20 text-wardian-accent' : 'text-wardian-processing'}`} />
-              ) : (
-                getFileIcon(node.extension)
-              )}
-            </span>
-            
-            <span className={`truncate flex-1 ${node.is_dir ? 'text-wardian-text font-medium' : 'text-wardian-text-muted group-hover:text-wardian-text'} transition-colors`}>
-              {node.name}
-            </span>
-          </div>
+      {nodes.map(node => {
+        const relPath = explorerRoot ? toRelativePath(node.path, explorerRoot) : '';
+        const fileStatus = gitStatusMap?.[relPath];
+        const dirHasChanges = node.is_dir && gitStatusMap &&
+          Object.keys(gitStatusMap).some(k => k.startsWith(relPath + '/'));
+        const gitColor = fileStatus
+          ? GIT_STATUS_COLORS[fileStatus]
+          : dirHasChanges ? GIT_STATUS_COLORS['M'] : undefined;
 
-          {node.is_dir && expanded[node.path] && (
-            <FileTree 
-              path={node.path} 
-              depth={depth + 1} 
-              onSelect={onSelect} 
-              onContextMenu={onContextMenu} 
-            />
-          )}
-        </React.Fragment>
-      ))}
+        return (
+          <React.Fragment key={node.path}>
+            <div
+              className="flex items-center shrink-0 gap-1.5 py-[2px] pr-2 hover:bg-wardian-card-bg-muted cursor-pointer rounded-md text-[13px] whitespace-nowrap overflow-hidden select-none group w-full"
+              style={{ paddingLeft: `${(depth * 14) + 2}px` }}
+              onClick={(e) => handleClick(e, node)}
+              onContextMenu={(e) => onContextMenu && onContextMenu(e, node)}
+            >
+              {node.is_dir ? (
+                <span className="text-wardian-text-muted cursor-pointer hover:text-wardian-text shrink-0 flex items-center justify-center w-4 h-4" onClick={(e) => { e.stopPropagation(); toggleFolder(node.path); }}>
+                  {expanded[node.path] ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                </span>
+              ) : (
+                <span className="w-4 h-4 shrink-0 inline-block" />
+              )}
+
+              <span className="text-wardian-text-muted flex items-center shrink-0">
+                {node.is_dir ? (
+                  <Folder className={`w-4 h-4 ${expanded[node.path] ? 'fill-wardian-accent/20 text-wardian-accent' : 'text-wardian-processing'}`} />
+                ) : (
+                  getFileIcon(node.extension)
+                )}
+              </span>
+
+              <span
+                className={`truncate flex-1 ${!gitColor ? (node.is_dir ? 'text-wardian-text font-medium' : 'text-wardian-text-muted group-hover:text-wardian-text') : ''} transition-colors`}
+                style={gitColor ? { color: gitColor } : undefined}
+              >
+                {node.name}
+              </span>
+
+              {fileStatus && (
+                <span className="shrink-0 text-[10px] font-bold ml-1 opacity-80" style={{ color: gitColor }}>
+                  {fileStatus}
+                </span>
+              )}
+            </div>
+
+            {node.is_dir && expanded[node.path] && (
+              <FileTree
+                path={node.path}
+                depth={depth + 1}
+                onSelect={onSelect}
+                onContextMenu={onContextMenu}
+                gitStatusMap={gitStatusMap}
+                explorerRoot={explorerRoot}
+              />
+            )}
+          </React.Fragment>
+        );
+      })}
     </div>
   );
 };

--- a/src/features/git/GitDiffView.tsx
+++ b/src/features/git/GitDiffView.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+
+interface GitDiffViewProps {
+  diff: string;
+  filePath: string;
+  onClose: () => void;
+}
+
+export const GitDiffView: React.FC<GitDiffViewProps> = ({ diff, filePath, onClose }) => {
+  const lines = diff.split("\n");
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] bg-black/60 flex items-center justify-center p-8 backdrop-blur-sm animate-in fade-in"
+      onClick={onClose}
+    >
+      <div
+        className="bg-wardian-card border border-wardian-border shadow-2xl rounded-2xl w-full max-w-4xl max-h-[90vh] flex flex-col font-mono text-sm overflow-hidden animate-in zoom-in-95 duration-200"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center p-4 border-b border-wardian-border shrink-0 bg-wardian-bg/50">
+          <h3 className="font-bold text-lg text-[var(--color-wardian-accent)] truncate flex-1 mr-4">
+            {filePath}
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-[var(--color-wardian-text-muted)] hover:text-wardian-error font-bold transition-colors w-8 h-8 flex items-center justify-center rounded-md hover:bg-wardian-error/10"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="p-0 overflow-y-auto flex-1 bg-wardian-bg/30 cursor-text">
+          {diff.trim() ? (
+            <pre className="text-xs leading-relaxed">
+              {lines.map((line, i) => {
+                let lineClass = "px-4 py-0";
+                let lineStyle: React.CSSProperties = {};
+                if (line.startsWith("+") && !line.startsWith("+++")) {
+                  lineStyle = {
+                    backgroundColor: "color-mix(in srgb, var(--color-wardian-success), transparent 90%)",
+                    color: "var(--color-wardian-success)",
+                  };
+                } else if (line.startsWith("-") && !line.startsWith("---")) {
+                  lineStyle = {
+                    backgroundColor: "color-mix(in srgb, var(--color-wardian-error), transparent 90%)",
+                    color: "var(--color-wardian-error)",
+                  };
+                } else if (line.startsWith("@@")) {
+                  lineStyle = {
+                    backgroundColor: "color-mix(in srgb, var(--color-wardian-processing), transparent 90%)",
+                    color: "var(--color-wardian-processing)",
+                  };
+                } else {
+                  lineClass += " text-primary";
+                }
+                return (
+                  <div key={i} className={lineClass} style={lineStyle}>
+                    {line}
+                  </div>
+                );
+              })}
+            </pre>
+          ) : (
+            <div className="p-6 text-[var(--color-wardian-text-muted)] italic">
+              No differences to display.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/git/GitFileList.tsx
+++ b/src/features/git/GitFileList.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { GitFileEntry } from "../../types";
+
+interface GitFileListProps {
+  files: GitFileEntry[];
+  onStage?: (path: string) => void;
+  onUnstage?: (path: string) => void;
+  onDiscard?: (path: string) => void;
+  onDiff?: (path: string, staged: boolean) => void;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  M: "text-[var(--color-wardian-warning)]",
+  A: "text-[var(--color-wardian-success)]",
+  D: "text-[var(--color-wardian-error)]",
+  R: "text-[var(--color-wardian-processing)]",
+  C: "text-[var(--color-wardian-processing)]",
+  U: "text-[var(--color-wardian-warning)]",
+  "?": "text-[var(--color-wardian-text-muted)]",
+};
+
+export const GitFileList: React.FC<GitFileListProps> = ({
+  files,
+  onStage,
+  onUnstage,
+  onDiscard,
+  onDiff,
+}) => {
+  if (files.length === 0) return null;
+
+  return (
+    <ul className="flex flex-col gap-0.5">
+      {files.map((file, i) => {
+        const colorClass = STATUS_COLORS[file.status] || "text-primary";
+        const filename = file.path.split("/").pop() || file.path;
+        const dir = file.path.includes("/")
+          ? file.path.substring(0, file.path.lastIndexOf("/"))
+          : "";
+
+        return (
+          <li
+            key={`${file.path}-${file.is_staged}-${i}`}
+            className="flex items-center gap-1.5 px-1.5 py-1 rounded hover:bg-wardian-card-bg-muted group text-xs"
+          >
+            <button
+              className="flex-1 min-w-0 text-left truncate text-primary hover:underline cursor-pointer"
+              title={file.path}
+              onClick={() => onDiff?.(file.path, file.is_staged)}
+            >
+              <span>{filename}</span>
+              {dir && (
+                <span className="ml-1.5 text-[var(--color-wardian-text-muted)]">{dir}</span>
+              )}
+            </button>
+            <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+              {file.is_staged && onUnstage && (
+                <button
+                  className="p-0.5 rounded hover:bg-wardian-card text-[var(--color-wardian-text-muted)] hover:text-primary transition-colors"
+                  title="Unstage"
+                  onClick={() => onUnstage(file.path)}
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20 12H4" />
+                  </svg>
+                </button>
+              )}
+              {!file.is_staged && onStage && (
+                <button
+                  className="p-0.5 rounded hover:bg-wardian-card text-[var(--color-wardian-text-muted)] hover:text-primary transition-colors"
+                  title="Stage"
+                  onClick={() => onStage(file.path)}
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+                  </svg>
+                </button>
+              )}
+              {!file.is_staged && onDiscard && file.status !== "?" && (
+                <button
+                  className="p-0.5 rounded hover:bg-[color-mix(in_srgb,var(--color-wardian-error),transparent_80%)] text-[var(--color-wardian-text-muted)] hover:text-[var(--color-wardian-error)] transition-colors"
+                  title="Discard Changes"
+                  onClick={() => onDiscard(file.path)}
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 10h10a8 8 0 018 8v2M3 10l6 6m-6-6l6-6" />
+                  </svg>
+                </button>
+              )}
+            </div>
+            <span className={`font-mono font-bold w-4 text-center shrink-0 ${colorClass}`}>
+              {file.status}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};

--- a/src/features/git/GitPanel.tsx
+++ b/src/features/git/GitPanel.tsx
@@ -1,0 +1,483 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { AgentConfig, GitStatusResult } from "../../types";
+import { GitFileList } from "./GitFileList";
+import { GitDiffView } from "./GitDiffView";
+import { useConfirm } from "../../components/ConfirmDialog";
+
+interface GitPanelProps {
+  selectedAgentIds: Set<string>;
+  agents: AgentConfig[];
+  onAgentsUpdated: () => void;
+  telemetry: Record<string, import("../../types").AgentTelemetry>;
+}
+
+export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, onAgentsUpdated, telemetry }) => {
+  const confirm = useConfirm();
+  const [rootPath, setRootPath] = useState<string | null>(null);
+  const [status, setStatus] = useState<GitStatusResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [commitMsg, setCommitMsg] = useState("");
+  const [diffContent, setDiffContent] = useState<string | null>(null);
+  const [diffFilePath, setDiffFilePath] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+
+  // Collapsible sections
+  const [stagedOpen, setStagedOpen] = useState(true);
+  const [changesOpen, setChangesOpen] = useState(true);
+  const [untrackedOpen, setUntrackedOpen] = useState(true);
+
+  const selectedAgentId = selectedAgentIds.size === 1 ? Array.from(selectedAgentIds)[0] : null;
+  const selectedAgent = agents.find((a) => a.session_id === selectedAgentId) ?? null;
+  // Branch starts with "wardian/" when the agent is actively running inside a worktree
+  const isWorktreeActive = status?.branch?.startsWith("wardian/") ?? false;
+  const isAgentRunning = (telemetry[selectedAgentId ?? ""]?.current_status ?? "Off") !== "Off";
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Resolve the agent's working directory
+  useEffect(() => {
+    const fetchPath = async () => {
+      if (!selectedAgentId) {
+        setRootPath(null);
+        return;
+      }
+      try {
+        const path = await invoke<string>("get_explorer_root", { sessionId: selectedAgentId });
+        setRootPath(path);
+      } catch {
+        setRootPath(null);
+      }
+    };
+    fetchPath();
+  }, [selectedAgentId]);
+
+  // Fetch git status
+  const refreshStatus = useCallback(async () => {
+    if (!rootPath) return;
+    try {
+      const result = await invoke<GitStatusResult>("git_status", { cwd: rootPath });
+      setStatus(result);
+      setError(null);
+    } catch (err) {
+      setStatus(null);
+      setError(String(err));
+    }
+  }, [rootPath]);
+
+  // Poll status every 3 seconds
+  useEffect(() => {
+    refreshStatus();
+    pollRef.current = setInterval(refreshStatus, 3000);
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [refreshStatus]);
+
+  // File operations
+  const handleStage = async (path: string) => {
+    if (!rootPath) return;
+    try {
+      await invoke("git_stage", { cwd: rootPath, paths: [path] });
+      await refreshStatus();
+    } catch (err) {
+      console.error("Stage failed:", err);
+    }
+  };
+
+  const handleUnstage = async (path: string) => {
+    if (!rootPath) return;
+    try {
+      await invoke("git_unstage", { cwd: rootPath, paths: [path] });
+      await refreshStatus();
+    } catch (err) {
+      console.error("Unstage failed:", err);
+    }
+  };
+
+  const handleDiscard = async (path: string) => {
+    if (!rootPath) return;
+    if (!(await confirm(`Discard changes to ${path}?`))) return;
+    try {
+      await invoke("git_discard_changes", { cwd: rootPath, paths: [path] });
+      await refreshStatus();
+    } catch (err) {
+      console.error("Discard failed:", err);
+    }
+  };
+
+  const handleDiff = async (path: string, staged: boolean) => {
+    if (!rootPath) return;
+    try {
+      const diff = await invoke<string>("git_diff_file", { cwd: rootPath, path, staged });
+      setDiffContent(diff);
+      setDiffFilePath(path);
+    } catch (err) {
+      console.error("Diff failed:", err);
+    }
+  };
+
+  // Stage all / Unstage all
+  const handleStageAll = async () => {
+    if (!rootPath || !status) return;
+    const unstaged = status.files.filter((f) => !f.is_staged).map((f) => f.path);
+    if (unstaged.length === 0) return;
+    try {
+      await invoke("git_stage", { cwd: rootPath, paths: unstaged });
+      await refreshStatus();
+    } catch (err) {
+      console.error("Stage all failed:", err);
+    }
+  };
+
+  const handleUnstageAll = async () => {
+    if (!rootPath || !status) return;
+    const staged = status.files.filter((f) => f.is_staged).map((f) => f.path);
+    if (staged.length === 0) return;
+    try {
+      await invoke("git_unstage", { cwd: rootPath, paths: staged });
+      await refreshStatus();
+    } catch (err) {
+      console.error("Unstage all failed:", err);
+    }
+  };
+
+  // Commit
+  const handleCommit = async () => {
+    if (!rootPath || !commitMsg.trim()) return;
+    setLoading(true);
+    try {
+      await invoke("git_commit", { cwd: rootPath, message: commitMsg.trim() });
+      setCommitMsg("");
+      await refreshStatus();
+    } catch (err) {
+      console.error("Commit failed:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Worktree action — updates config then restarts agent if it's running
+  const [worktreeLoading, setWorktreeLoading] = useState(false);
+  const handleWorktreeAction = async (enable: boolean) => {
+    if (!selectedAgent || !selectedAgentId) return;
+    setWorktreeLoading(true);
+    try {
+      await invoke("update_agent_config", { newConfig: { ...selectedAgent, git_worktree: enable } });
+      onAgentsUpdated();
+      if (isAgentRunning) {
+        await invoke("resume_agent", { sessionId: selectedAgentId });
+      }
+    } finally {
+      setWorktreeLoading(false);
+    }
+  };
+
+  // Pull / Push
+  const handlePull = async () => {
+    if (!rootPath) return;
+    setSyncing(true);
+    try {
+      await invoke<string>("git_pull", { cwd: rootPath });
+      await refreshStatus();
+    } catch (err) {
+      console.error("Pull failed:", err);
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const handlePush = async () => {
+    if (!rootPath) return;
+    setSyncing(true);
+    try {
+      await invoke<string>("git_push", { cwd: rootPath });
+      await refreshStatus();
+    } catch (err) {
+      console.error("Push failed:", err);
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  // No agent selected
+  if (!selectedAgentId) {
+    return (
+      <div className="flex flex-col h-full w-full">
+        <h2 className="text-xl font-bold text-primary tracking-tight mb-4">Source Control</h2>
+        <div className="flex flex-col items-center justify-center flex-1 text-center p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <div className="w-16 h-16 mb-4 text-gray-700/40">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M6 3v12M18 9a3 3 0 11-6 0 3 3 0 016 0zM6 21a3 3 0 110-6 3 3 0 010 6z" />
+            </svg>
+          </div>
+          <p className="text-xs text-muted italic">Select an agent to view source control.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Not a git repo or error
+  if (error) {
+    return (
+      <div className="flex flex-col h-full w-full">
+        <h2 className="text-xl font-bold text-primary tracking-tight mb-4">Source Control</h2>
+        <div className="flex flex-col items-center justify-center flex-1 text-center p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+          <div className="w-16 h-16 mb-4 text-gray-700/40">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M6 3v12M18 9a3 3 0 11-6 0 3 3 0 016 0zM6 21a3 3 0 110-6 3 3 0 010 6z" />
+            </svg>
+          </div>
+          <h3 className="text-sm font-bold text-primary mb-2 tracking-wide">Not a Git Repository</h3>
+          <p className="text-xs text-muted italic px-4">The agent's workspace is not initialized as a git repository.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading initial status
+  if (!status) {
+    return (
+      <div className="flex flex-col h-full w-full">
+        <h2 className="text-xl font-bold text-primary tracking-tight mb-4">Source Control</h2>
+        <div className="text-sm text-[var(--color-wardian-text-muted)] animate-pulse px-1">Loading git status...</div>
+      </div>
+    );
+  }
+
+  const stagedFiles = status.files.filter((f) => f.is_staged);
+  const unstagedTracked = status.files.filter((f) => !f.is_staged && f.status !== "?");
+  const untrackedFiles = status.files.filter((f) => !f.is_staged && f.status === "?");
+  const hasStagedFiles = stagedFiles.length > 0;
+
+  return (
+    <div className="flex flex-col h-full w-full relative">
+      <h2 className="text-xl font-bold text-primary tracking-tight mb-2">Source Control</h2>
+
+      {/* Branch bar */}
+      <div className="flex items-center gap-2 py-1.5 mb-3 border-b border-wardian-border/30">
+        <svg className="w-4 h-4 text-[var(--color-wardian-accent)] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 3v12M18 9a3 3 0 11-6 0 3 3 0 016 0zM6 21a3 3 0 110-6 3 3 0 010 6z" />
+        </svg>
+        <span className="text-xs font-semibold text-primary truncate">{status.branch}</span>
+        {status.ahead > 0 && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-[color-mix(in_srgb,var(--color-wardian-success),transparent_80%)] text-[var(--color-wardian-success)] font-mono">↑{status.ahead}</span>
+        )}
+        {status.behind > 0 && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-[color-mix(in_srgb,var(--color-wardian-warning),transparent_80%)] text-[var(--color-wardian-warning)] font-mono">↓{status.behind}</span>
+        )}
+        <div className="flex-1" />
+        <button
+          onClick={handlePull}
+          disabled={syncing}
+          className="p-1 rounded hover:bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] hover:text-primary transition-colors disabled:opacity-40"
+          title="Pull"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+          </svg>
+        </button>
+        <button
+          onClick={handlePush}
+          disabled={syncing}
+          className="p-1 rounded hover:bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] hover:text-primary transition-colors disabled:opacity-40"
+          title="Push"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Worktree action row */}
+      <div className="mb-3">
+        {isWorktreeActive ? (
+          <div className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-[color-mix(in_srgb,var(--color-wardian-processing),transparent_88%)] border border-[color-mix(in_srgb,var(--color-wardian-processing),transparent_70%)]">
+            <svg className="w-3.5 h-3.5 text-[var(--color-wardian-processing)] shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="7" cy="5" r="2" fill="none" /><circle cx="7" cy="19" r="2" fill="none" /><circle cx="17" cy="12" r="2" fill="none" />
+              <line x1="7" y1="7" x2="7" y2="17" /><path fill="none" d="M7 17 C7 13 17 13 17 12" />
+            </svg>
+            <span className="text-[11px] font-mono text-[var(--color-wardian-processing)] truncate flex-1">{status.branch}</span>
+            <button
+              onClick={() => handleWorktreeAction(false)}
+              disabled={worktreeLoading}
+              className="text-[var(--color-wardian-processing)] hover:text-[var(--color-wardian-error)] transition-colors disabled:opacity-40 shrink-0"
+              title="Remove worktree — restarts agent on main branch"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        ) : (
+          <button
+            onClick={() => handleWorktreeAction(true)}
+            disabled={worktreeLoading}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg border border-dashed border-wardian-border text-[var(--color-wardian-text-muted)] hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)] transition-colors group disabled:opacity-40"
+          >
+            <svg className="w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="7" cy="5" r="2" fill="none" /><circle cx="7" cy="19" r="2" fill="none" /><circle cx="17" cy="12" r="2" fill="none" />
+              <line x1="7" y1="7" x2="7" y2="17" /><path fill="none" d="M7 17 C7 13 17 13 17 12" />
+            </svg>
+            <span className="text-[11px]">{worktreeLoading ? "Applying…" : "+ Worktree"}</span>
+          </button>
+        )}
+      </div>
+
+      {/* Commit box — at top, matching VS Code layout */}
+      <div className="pb-3 mb-1 border-b border-wardian-border/30 flex flex-col gap-2">
+        <textarea
+          className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-xs text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors h-16 resize-none placeholder:text-[var(--color-wardian-text-muted)]"
+          placeholder="Message (Ctrl+Enter to commit)"
+          value={commitMsg}
+          onChange={(e) => setCommitMsg(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+              e.preventDefault();
+              handleCommit();
+            }
+          }}
+        />
+        <button
+          onClick={handleCommit}
+          disabled={loading || !commitMsg.trim() || !hasStagedFiles}
+          className="w-full py-1.5 rounded text-xs font-bold transition-colors bg-[var(--color-wardian-accent)] text-black hover:opacity-90 disabled:opacity-30 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+          </svg>
+          {loading ? "Committing..." : "Commit"}
+        </button>
+      </div>
+
+      {/* Scrollable content */}
+      <div className="flex-1 overflow-y-auto no-scrollbar min-h-0 flex flex-col gap-2">
+        {/* Staged Changes */}
+        {stagedFiles.length > 0 && (
+          <section>
+            <button
+              onClick={() => setStagedOpen(!stagedOpen)}
+              className="flex items-center gap-1.5 w-full text-left py-1 group"
+            >
+              <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${stagedOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Staged Changes</span>
+              <div className="flex-1" />
+              <button
+                onClick={(e) => { e.stopPropagation(); handleUnstageAll(); }}
+                className="p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-wardian-card text-[var(--color-wardian-text-muted)] hover:text-primary transition-all"
+                title="Unstage All"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20 12H4" />
+                </svg>
+              </button>
+              <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
+                {stagedFiles.length}
+              </span>
+            </button>
+            {stagedOpen && (
+              <GitFileList
+                files={stagedFiles}
+                onUnstage={handleUnstage}
+                onDiff={handleDiff}
+              />
+            )}
+          </section>
+        )}
+
+        {/* Changes (unstaged tracked) */}
+        {unstagedTracked.length > 0 && (
+          <section>
+            <button
+              onClick={() => setChangesOpen(!changesOpen)}
+              className="flex items-center gap-1.5 w-full text-left py-1 group"
+            >
+              <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${changesOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Changes</span>
+              <div className="flex-1" />
+              <button
+                onClick={(e) => { e.stopPropagation(); handleStageAll(); }}
+                className="p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-wardian-card text-[var(--color-wardian-text-muted)] hover:text-primary transition-all"
+                title="Stage All"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+                </svg>
+              </button>
+              <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
+                {unstagedTracked.length}
+              </span>
+            </button>
+            {changesOpen && (
+              <GitFileList
+                files={unstagedTracked}
+                onStage={handleStage}
+                onDiscard={handleDiscard}
+                onDiff={handleDiff}
+              />
+            )}
+          </section>
+        )}
+
+        {/* Untracked Files */}
+        {untrackedFiles.length > 0 && (
+          <section>
+            <button
+              onClick={() => setUntrackedOpen(!untrackedOpen)}
+              className="flex items-center gap-1.5 w-full text-left py-1 group"
+            >
+              <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${untrackedOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Untracked</span>
+              <div className="flex-1" />
+              <button
+                onClick={(e) => { e.stopPropagation(); handleStageAll(); }}
+                className="p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-wardian-card text-[var(--color-wardian-text-muted)] hover:text-primary transition-all"
+                title="Stage All Untracked"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+                </svg>
+              </button>
+              <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
+                {untrackedFiles.length}
+              </span>
+            </button>
+            {untrackedOpen && (
+              <GitFileList
+                files={untrackedFiles}
+                onStage={handleStage}
+                onDiff={handleDiff}
+              />
+            )}
+          </section>
+        )}
+
+        {/* Clean state */}
+        {status.files.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <svg className="w-10 h-10 mb-3 text-[var(--color-wardian-success)]/40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M5 13l4 4L19 7" />
+            </svg>
+            <p className="text-xs text-muted italic">Working tree clean</p>
+          </div>
+        )}
+      </div>
+
+      {/* Diff overlay */}
+      {diffContent !== null && (
+        <GitDiffView
+          diff={diffContent}
+          filePath={diffFilePath}
+          onClose={() => setDiffContent(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/features/git/GitPanel.tsx
+++ b/src/features/git/GitPanel.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { AgentConfig, GitStatusResult } from "../../types";
+import { listen } from "@tauri-apps/api/event";
+import { AgentConfig, GitStatusResult, GitLogEntry } from "../../types";
 import { GitFileList } from "./GitFileList";
 import { GitDiffView } from "./GitDiffView";
 import { useConfirm } from "../../components/ConfirmDialog";
@@ -27,6 +28,10 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
   const [stagedOpen, setStagedOpen] = useState(true);
   const [changesOpen, setChangesOpen] = useState(true);
   const [untrackedOpen, setUntrackedOpen] = useState(true);
+  const [historyOpen, setHistoryOpen] = useState(true);
+
+  // Commit history
+  const [history, setHistory] = useState<GitLogEntry[]>([]);
 
   const selectedAgentId = selectedAgentIds.size === 1 ? Array.from(selectedAgentIds)[0] : null;
   const selectedAgent = agents.find((a) => a.session_id === selectedAgentId) ?? null;
@@ -34,7 +39,6 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
   const isWorktreeActive = status?.branch?.startsWith("wardian/") ?? false;
   const isAgentRunning = (telemetry[selectedAgentId ?? ""]?.current_status ?? "Off") !== "Off";
 
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Resolve the agent's working directory
   useEffect(() => {
@@ -66,14 +70,38 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
     }
   }, [rootPath]);
 
-  // Poll status every 3 seconds
+  // Fetch commit history when root changes or after a commit
+  const refreshHistory = useCallback(async () => {
+    if (!rootPath) return;
+    try {
+      const log = await invoke<GitLogEntry[]>("git_log", { cwd: rootPath, count: 50 });
+      setHistory(log);
+    } catch {
+      setHistory([]);
+    }
+  }, [rootPath]);
+
+  // Watch .git/index + .git/HEAD via FSWatcher; refresh on change event
   useEffect(() => {
+    if (!rootPath) return;
+
     refreshStatus();
-    pollRef.current = setInterval(refreshStatus, 3000);
+    refreshHistory();
+
+    invoke("git_watch", { cwd: rootPath }).catch(() => {});
+
+    const unlistenPromise = listen<string>("git-changed", (event) => {
+      if (event.payload === rootPath) {
+        refreshStatus();
+        refreshHistory();
+      }
+    });
+
     return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
+      invoke("git_unwatch", { cwd: rootPath }).catch(() => {});
+      unlistenPromise.then((fn) => fn());
     };
-  }, [refreshStatus]);
+  }, [rootPath, refreshStatus, refreshHistory]);
 
   // File operations
   const handleStage = async (path: string) => {
@@ -151,6 +179,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
       await invoke("git_commit", { cwd: rootPath, message: commitMsg.trim() });
       setCommitMsg("");
       await refreshStatus();
+      await refreshHistory();
     } catch (err) {
       console.error("Commit failed:", err);
     } finally {
@@ -208,8 +237,9 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
         <h2 className="text-xl font-bold text-primary tracking-tight mb-4">Source Control</h2>
         <div className="flex flex-col items-center justify-center flex-1 text-center p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
           <div className="w-16 h-16 mb-4 text-gray-700/40">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M6 3v12M18 9a3 3 0 11-6 0 3 3 0 016 0zM6 21a3 3 0 110-6 3 3 0 010 6z" />
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="7" cy="5" r="2" style={{fill:'none'}} /><circle cx="7" cy="19" r="2" style={{fill:'none'}} /><circle cx="17" cy="12" r="2" style={{fill:'none'}} />
+              <line x1="7" y1="7" x2="7" y2="17" /><path style={{fill:'none'}} d="M7 17 C7 13 17 13 17 12" />
             </svg>
           </div>
           <p className="text-xs text-muted italic">Select an agent to view source control.</p>
@@ -225,8 +255,9 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
         <h2 className="text-xl font-bold text-primary tracking-tight mb-4">Source Control</h2>
         <div className="flex flex-col items-center justify-center flex-1 text-center p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
           <div className="w-16 h-16 mb-4 text-gray-700/40">
-            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M6 3v12M18 9a3 3 0 11-6 0 3 3 0 016 0zM6 21a3 3 0 110-6 3 3 0 010 6z" />
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="7" cy="5" r="2" style={{fill:'none'}} /><circle cx="7" cy="19" r="2" style={{fill:'none'}} /><circle cx="17" cy="12" r="2" style={{fill:'none'}} />
+              <line x1="7" y1="7" x2="7" y2="17" /><path style={{fill:'none'}} d="M7 17 C7 13 17 13 17 12" />
             </svg>
           </div>
           <h3 className="text-sm font-bold text-primary mb-2 tracking-wide">Not a Git Repository</h3>
@@ -257,8 +288,9 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
 
       {/* Branch bar */}
       <div className="flex items-center gap-2 py-1.5 mb-3 border-b border-wardian-border/30">
-        <svg className="w-4 h-4 text-[var(--color-wardian-accent)] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 3v12M18 9a3 3 0 11-6 0 3 3 0 016 0zM6 21a3 3 0 110-6 3 3 0 010 6z" />
+        <svg className="w-4 h-4 text-[var(--color-wardian-accent)] shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="7" cy="5" r="2" style={{fill:'none'}} /><circle cx="7" cy="19" r="2" style={{fill:'none'}} /><circle cx="17" cy="12" r="2" style={{fill:'none'}} />
+          <line x1="7" y1="7" x2="7" y2="17" /><path style={{fill:'none'}} d="M7 17 C7 13 17 13 17 12" />
         </svg>
         <span className="text-xs font-semibold text-primary truncate">{status.branch}</span>
         {status.ahead > 0 && (
@@ -467,6 +499,39 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
             </svg>
             <p className="text-xs text-muted italic">Working tree clean</p>
           </div>
+        )}
+
+        {/* Commit History */}
+        {history.length > 0 && (
+          <section className="mt-1 border-t border-wardian-border/30 pt-2">
+            <button
+              onClick={() => setHistoryOpen(!historyOpen)}
+              className="flex items-center gap-1.5 w-full text-left py-1"
+            >
+              <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${historyOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+              </svg>
+              <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">History</span>
+              <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
+                {history.length}
+              </span>
+            </button>
+            {historyOpen && (
+              <div className="flex flex-col">
+                {history.map((entry, i) => (
+                  <div key={entry.hash} className="flex items-center gap-2 py-[3px] px-1 hover:bg-wardian-card-bg-muted rounded group cursor-default">
+                    <div className="relative flex flex-col items-center shrink-0" style={{ width: 12 }}>
+                      {i > 0 && <div className="absolute top-0 left-1/2 -translate-x-1/2 w-px bg-wardian-border/50" style={{ height: '50%' }} />}
+                      <div className={`w-2 h-2 rounded-full border shrink-0 z-10 ${i === 0 ? 'bg-[var(--color-wardian-accent)] border-[var(--color-wardian-accent)]' : 'bg-transparent border-[var(--color-wardian-text-muted)]'}`} />
+                      {i < history.length - 1 && <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-px bg-wardian-border/50" style={{ height: '50%' }} />}
+                    </div>
+                    <span className="text-[11px] text-primary truncate flex-1 leading-snug">{entry.message}</span>
+                    <span className="text-[9px] font-mono text-[var(--color-wardian-text-muted)] shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">{entry.hash.slice(0, 7)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
         )}
       </div>
 

--- a/src/features/git/GitPanel.tsx
+++ b/src/features/git/GitPanel.tsx
@@ -35,6 +35,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
 
   const selectedAgentId = selectedAgentIds.size === 1 ? Array.from(selectedAgentIds)[0] : null;
   const selectedAgent = agents.find((a) => a.session_id === selectedAgentId) ?? null;
+  const isNotGitRepoError = (error ?? "").toLowerCase().includes("not a git repository");
   // Branch starts with "wardian/" when the agent is actively running inside a worktree
   const isWorktreeActive = status?.branch?.startsWith("wardian/") ?? false;
   const isAgentRunning = (telemetry[selectedAgentId ?? ""]?.current_status ?? "Off") !== "Off";
@@ -260,8 +261,14 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
               <line x1="7" y1="7" x2="7" y2="17" /><path style={{fill:'none'}} d="M7 17 C7 13 17 13 17 12" />
             </svg>
           </div>
-          <h3 className="text-sm font-bold text-primary mb-2 tracking-wide">Not a Git Repository</h3>
-          <p className="text-xs text-muted italic px-4">The agent's workspace is not initialized as a git repository.</p>
+          <h3 className="text-sm font-bold text-primary mb-2 tracking-wide">
+            {isNotGitRepoError ? "Not a Git Repository" : "Unable to Load Source Control"}
+          </h3>
+          <p className="text-xs text-muted italic px-4">
+            {isNotGitRepoError
+              ? "The agent's workspace is not initialized as a git repository."
+              : error}
+          </p>
         </div>
       </div>
     );

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -95,7 +95,45 @@ describe('SettingsPanel', () => {
       });
     });
 
-    expect(await screen.findByText('Runtime settings updated.')).toBeInTheDocument();
+    expect(await screen.findByText('Shell settings updated.')).toBeInTheDocument();
+  });
+
+  it('shows the auto-selected shell when default shell is auto', async () => {
+    mockInvoke.mockImplementation(async (command, args) => {
+      switch (command) {
+        case 'load_shell_settings':
+          return {
+            shell_id: 'auto',
+            custom_executable: null,
+            custom_args: null,
+            agent_session_persistence: 'resume',
+          };
+        case 'list_available_shells':
+          return [
+            {
+              id: 'cmd',
+              label: 'Command Prompt',
+              executable: 'C:/Windows/System32/cmd.exe',
+              default_args: ['/C'],
+            },
+            {
+              id: 'pwsh',
+              label: 'PowerShell 7',
+              executable: 'C:/Program Files/PowerShell/7/pwsh.exe',
+              default_args: ['-NoProfile', '-Command'],
+            },
+          ];
+        case 'save_shell_settings':
+          return (args as { settings?: unknown } | undefined)?.settings;
+        default:
+          return null;
+      }
+    });
+
+    render(<SettingsPanel />);
+
+    expect(await screen.findByText('Auto: PowerShell 7')).toBeInTheDocument();
+    expect(screen.getByText('C:/Program Files/PowerShell/7/pwsh.exe')).toBeInTheDocument();
   });
 
   it('saves global regular agent session persistence through tauri', async () => {
@@ -116,5 +154,8 @@ describe('SettingsPanel', () => {
         },
       });
     });
+
+    expect(await screen.findByText('Agent runtime updated.')).toBeInTheDocument();
+    expect(screen.queryByText('Shell settings updated.')).not.toBeInTheDocument();
   });
 });

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -16,6 +16,7 @@ describe('SettingsPanel', () => {
       shell_id: 'auto',
       custom_executable: '',
       custom_args: '',
+      agent_session_persistence: 'resume',
       available_shells: [],
       shell_settings_loaded: false,
       shells_loaded: false,
@@ -28,6 +29,7 @@ describe('SettingsPanel', () => {
             shell_id: 'pwsh',
             custom_executable: null,
             custom_args: null,
+            agent_session_persistence: 'resume',
           };
         case 'list_available_shells':
           return [
@@ -88,10 +90,31 @@ describe('SettingsPanel', () => {
           shell_id: 'custom',
           custom_executable: 'C:/Tools/custom-shell.exe',
           custom_args: '--command',
+          agent_session_persistence: 'resume',
         },
       });
     });
 
-    expect(await screen.findByText('Default shell updated.')).toBeInTheDocument();
+    expect(await screen.findByText('Runtime settings updated.')).toBeInTheDocument();
+  });
+
+  it('saves global regular agent session persistence through tauri', async () => {
+    render(<SettingsPanel />);
+
+    const select = await screen.findByLabelText('Regular agent sessions');
+    fireEvent.change(select, { target: { value: 'fresh' } });
+
+    fireEvent.click(screen.getByText('Save Agent Runtime'));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('save_shell_settings', {
+        settings: {
+          shell_id: 'pwsh',
+          custom_executable: null,
+          custom_args: null,
+          agent_session_persistence: 'fresh',
+        },
+      });
+    });
   });
 });

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -48,6 +48,13 @@ describe('SettingsPanel', () => {
           ];
         case 'save_shell_settings':
           return (args as { settings?: unknown } | undefined)?.settings;
+        case 'save_agent_session_persistence':
+          return {
+            shell_id: 'pwsh',
+            custom_executable: null,
+            custom_args: null,
+            agent_session_persistence: (args as { persistence?: 'fresh' | 'resume' } | undefined)?.persistence ?? 'resume',
+          };
         case 'run_gemini_patch':
           return 'ok';
         default:
@@ -125,6 +132,13 @@ describe('SettingsPanel', () => {
           ];
         case 'save_shell_settings':
           return (args as { settings?: unknown } | undefined)?.settings;
+        case 'save_agent_session_persistence':
+          return {
+            shell_id: 'auto',
+            custom_executable: null,
+            custom_args: null,
+            agent_session_persistence: (args as { persistence?: 'fresh' | 'resume' } | undefined)?.persistence ?? 'resume',
+          };
         default:
           return null;
       }
@@ -145,17 +159,13 @@ describe('SettingsPanel', () => {
     fireEvent.click(screen.getByText('Save Agent Runtime'));
 
     await waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith('save_shell_settings', {
-        settings: {
-          shell_id: 'pwsh',
-          custom_executable: null,
-          custom_args: null,
-          agent_session_persistence: 'fresh',
-        },
+      expect(mockInvoke).toHaveBeenCalledWith('save_agent_session_persistence', {
+        persistence: 'fresh',
       });
     });
 
     expect(await screen.findByText('Agent runtime updated.')).toBeInTheDocument();
     expect(screen.queryByText('Shell settings updated.')).not.toBeInTheDocument();
+    expect(mockInvoke).not.toHaveBeenCalledWith('save_shell_settings', expect.anything());
   });
 });

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -13,12 +13,14 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     shell_id,
     custom_executable,
     custom_args,
+    agent_session_persistence,
     available_shells,
     shell_settings_loaded,
     shells_loaded,
     setShellId,
     setCustomExecutable,
     setCustomArgs,
+    setAgentSessionPersistence,
     loadShellSettings,
     loadAvailableShells,
     saveShellSettings,
@@ -60,7 +62,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     try {
       await saveShellSettings();
       setShellStatus("success");
-      setShellMessage("Default shell updated.");
+      setShellMessage("Runtime settings updated.");
       setTimeout(() => {
         setShellStatus("idle");
         setShellMessage("");
@@ -132,6 +134,42 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
             <p className="text-[10px] text-muted-neutral leading-relaxed">
               <span className="text-[var(--color-wardian-accent)] font-bold">NOTE:</span> For complete terminal synchronization, update the gemini CLI theme as well, and then restart the application.
             </p>
+          </div>
+        </div>
+
+        <div className="border-t border-wardian-border pt-6">
+          <h3 className="text-[10px] font-bold text-muted-neutral tracking-wide mb-4">Agent Runtime</h3>
+
+          <div className="bg-wardian-card-bg-muted border border-wardian-light/50 rounded-xl p-4 flex flex-col gap-3">
+            <label className="text-sm font-bold text-primary" htmlFor="agent-session-persistence">
+              Regular agent sessions
+            </label>
+            <select
+              id="agent-session-persistence"
+              value={agent_session_persistence}
+              onChange={(e) => setAgentSessionPersistence(e.target.value as 'fresh' | 'resume')}
+              className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+            >
+              <option value="resume">Resume provider session</option>
+              <option value="fresh">Start fresh on resume</option>
+            </select>
+            <p className="text-[10px] text-muted-neutral leading-relaxed">
+              Applies when regular visible agents are resumed from Off. Workflow agent nodes use their own run mode.
+            </p>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleSaveShell}
+                disabled={!shell_settings_loaded || shellStatus === 'saving'}
+                className={`px-4 py-2 text-xs font-bold rounded-lg border transition-all whitespace-nowrap ${
+                  shellStatus === 'saving'
+                    ? 'bg-wardian-border text-muted border-transparent cursor-not-allowed'
+                    : 'bg-wardian-bg border-wardian-light text-primary hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]'
+                }`}
+              >
+                {shellStatus === 'saving' ? 'Saving...' : 'Save Agent Runtime'}
+              </button>
+            </div>
           </div>
         </div>
 
@@ -272,4 +310,3 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     </div>
   );
 };
-

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -37,6 +37,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     loadShellSettings,
     loadAvailableShells,
     saveShellSettings,
+    saveAgentSessionPersistence,
   } = useSettingsStore();
   const [patchStatus, setPatchStatus] = useState<"idle" | "running" | "success" | "error">("idle");
   const [patchMessage, setPatchMessage] = useState("");
@@ -92,7 +93,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     setAgentRuntimeStatus("saving");
     setAgentRuntimeMessage("");
     try {
-      await saveShellSettings();
+      await saveAgentSessionPersistence();
       setAgentRuntimeStatus("success");
       setAgentRuntimeMessage("Agent runtime updated.");
       setTimeout(() => {

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -4,6 +4,19 @@ import { useSettingsStore } from "../../store/useSettingsStore";
 
 interface SettingsPanelProps {}
 
+const windowsAutoShellIds = ['pwsh', 'powershell', 'cmd', 'git-bash', 'wsl', 'bash'];
+const posixAutoShellIds = ['zsh', 'bash', 'sh', 'fish'];
+
+const resolveAutoShell = <T extends { id: string }>(availableShells: T[]) => {
+  const hasWindowsShell = availableShells.some((option) =>
+    ['pwsh', 'powershell', 'cmd', 'git-bash', 'wsl'].includes(option.id),
+  );
+  const preferredIds = hasWindowsShell ? windowsAutoShellIds : posixAutoShellIds;
+  return preferredIds
+    .map((id) => availableShells.find((option) => option.id === id))
+    .find((option) => option !== undefined) ?? availableShells[0];
+};
+
 export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
   const {
     theme,
@@ -29,6 +42,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
   const [patchMessage, setPatchMessage] = useState("");
   const [shellStatus, setShellStatus] = useState<"idle" | "saving" | "success" | "error">("idle");
   const [shellMessage, setShellMessage] = useState("");
+  const [agentRuntimeStatus, setAgentRuntimeStatus] = useState<"idle" | "saving" | "success" | "error">("idle");
+  const [agentRuntimeMessage, setAgentRuntimeMessage] = useState("");
 
   useEffect(() => {
     if (!shell_settings_loaded) {
@@ -62,7 +77,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     try {
       await saveShellSettings();
       setShellStatus("success");
-      setShellMessage("Runtime settings updated.");
+      setShellMessage("Shell settings updated.");
       setTimeout(() => {
         setShellStatus("idle");
         setShellMessage("");
@@ -73,7 +88,26 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     }
   };
 
+  const handleSaveAgentRuntime = async () => {
+    setAgentRuntimeStatus("saving");
+    setAgentRuntimeMessage("");
+    try {
+      await saveShellSettings();
+      setAgentRuntimeStatus("success");
+      setAgentRuntimeMessage("Agent runtime updated.");
+      setTimeout(() => {
+        setAgentRuntimeStatus("idle");
+        setAgentRuntimeMessage("");
+      }, 4000);
+    } catch (e: unknown) {
+      setAgentRuntimeStatus("error");
+      setAgentRuntimeMessage(`Agent runtime update failed: ${String(e)}`);
+    }
+  };
+
   const selectedShell = available_shells.find((option) => option.id === shell_id);
+  const autoSelectedShell = resolveAutoShell(available_shells);
+  const displayedShell = shell_id === 'auto' ? autoSelectedShell : selectedShell;
 
   return (
     <div data-testid="settings-panel" className="flex flex-col h-full">
@@ -159,17 +193,25 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
             <div className="flex justify-end">
               <button
                 type="button"
-                onClick={handleSaveShell}
-                disabled={!shell_settings_loaded || shellStatus === 'saving'}
+                onClick={handleSaveAgentRuntime}
+                disabled={!shell_settings_loaded || agentRuntimeStatus === 'saving'}
                 className={`px-4 py-2 text-xs font-bold rounded-lg border transition-all whitespace-nowrap ${
-                  shellStatus === 'saving'
+                  agentRuntimeStatus === 'saving'
                     ? 'bg-wardian-border text-muted border-transparent cursor-not-allowed'
                     : 'bg-wardian-bg border-wardian-light text-primary hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]'
                 }`}
               >
-                {shellStatus === 'saving' ? 'Saving...' : 'Save Agent Runtime'}
+                {agentRuntimeStatus === 'saving' ? 'Saving...' : 'Save Agent Runtime'}
               </button>
             </div>
+            {agentRuntimeMessage && (
+              <div className={`p-2 mt-1 rounded border text-xs font-medium text-left ${
+                agentRuntimeStatus === 'success' ? 'bg-cyan-500/10 border-cyan-500/20 text-cyan-400' :
+                'bg-red-500/10 border-red-500/20 text-red-400'
+              }`}>
+                {agentRuntimeMessage}
+              </div>
+            )}
           </div>
         </div>
 
@@ -225,11 +267,13 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
             ) : (
               <div className="rounded-lg border border-wardian-border bg-wardian-bg px-3 py-2">
                 <p className="text-[11px] font-bold text-primary">
-                  {shell_id === 'auto' ? 'Wardian will choose the best available shell for this system.' : selectedShell?.label ?? 'Loading shell details...'}
+                  {shell_id === 'auto'
+                    ? (displayedShell ? `Auto: ${displayedShell.label}` : 'Auto: detecting shell...')
+                    : displayedShell?.label ?? 'Loading shell details...'}
                 </p>
-                {shell_id !== 'auto' && selectedShell && (
+                {displayedShell && (
                   <p className="text-[10px] text-muted-neutral mt-1 break-all">
-                    {selectedShell.executable}
+                    {displayedShell.executable}
                   </p>
                 )}
               </div>

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -53,6 +53,7 @@ type TerminalSessionEntry = {
   recentWritePreviews: string[];
   opencodeFocusReported: boolean;
   outputReadyUnlisten: (() => void) | null;
+  terminalClearedUnlisten: (() => void) | null;
   provider?: string;
   currentTheme: typeof DARK_TERM_THEME;
   renderer: TerminalRendererEntry | null;
@@ -202,6 +203,7 @@ function disposeTerminalSession(sessionId: string) {
 
   entry.disposed = true;
   entry.outputReadyUnlisten?.();
+  entry.terminalClearedUnlisten?.();
   const renderer = entry.renderer;
   if (renderer?.resizeTimeout) {
     clearTimeout(renderer.resizeTimeout);
@@ -212,6 +214,34 @@ function disposeTerminalSession(sessionId: string) {
   entry.parserSerializeAddon.dispose();
   entry.parser.dispose();
   terminalSessionMap.delete(sessionId);
+}
+
+function clearTerminalSession(sessionId: string) {
+  const entry = terminalSessionMap.get(sessionId);
+  if (!entry || entry.disposed) {
+    return;
+  }
+
+  entry.recentWritePreviews = [];
+  entry.latestTitle = null;
+  entry.lastHomeRedrawLines = null;
+  entry.homeRedrawScrollbackSeen?.clear();
+  entry.transientHomeRedrawActive = false;
+  entry.pendingResizeRedrawSuppression = false;
+  entry.existingScrollbackLines = undefined;
+  const parserWithReset = entry.parser as HeadlessTerminal & { reset?: () => void };
+  if (typeof parserWithReset.reset === "function") {
+    parserWithReset.reset();
+  } else {
+    entry.parser.write("\u001bc");
+  }
+  const rendererTerm = entry.renderer?.term as (Terminal & { reset?: () => void; clear?: () => void }) | undefined;
+  if (typeof rendererTerm?.reset === "function") {
+    rendererTerm.reset();
+  } else if (typeof rendererTerm?.clear === "function") {
+    rendererTerm.clear();
+  }
+  entry.titleHandlerRef.current?.("");
 }
 
 async function reportTerminalSize(sessionId: string, entry: TerminalSessionEntry, cols: number, rows: number) {
@@ -378,6 +408,7 @@ async function getOrCreateTerminalSession(sessionId: string, provider?: string) 
     recentWritePreviews: [],
     opencodeFocusReported: false,
     outputReadyUnlisten: null,
+    terminalClearedUnlisten: null,
     provider,
     currentTheme: DARK_TERM_THEME,
     renderer: null,
@@ -395,6 +426,21 @@ async function getOrCreateTerminalSession(sessionId: string, provider?: string) 
   };
 
   terminalSessionMap.set(sessionId, entry);
+
+  void listen<{ session_id?: string }>("agent-terminal-cleared", (event) => {
+    if (event.payload?.session_id !== sessionId) {
+      return;
+    }
+    clearTerminalSession(sessionId);
+  }).then((unlisten) => {
+    if (entry.disposed) {
+      unlisten();
+      return;
+    }
+    entry.terminalClearedUnlisten = unlisten;
+  }).catch((error) => {
+    console.warn("agent-terminal-cleared listen error:", error);
+  });
 
   void listen<{ session_id?: string }>("agent-pty-output-ready", (event) => {
     if (event.payload?.session_id !== sessionId) {

--- a/src/features/workflows/WorkflowNode.tsx
+++ b/src/features/workflows/WorkflowNode.tsx
@@ -104,10 +104,12 @@ export const WorkflowNode = memo(({ id, data, selected }: NodeProps<Node<{ label
 
   const incomingEdges = edges.filter(e => e.target === id);
   const isWaitNode = type === 'wait';
+  const legacySessionType = data.config?.session_type;
+  const agentRunMode = data.config?.mode || (legacySessionType === 'persistent' ? 'inherit_fresh' : 'ephemeral');
 
   // Hard Sync Check (Amber Warning)
   const targetAgent = agents?.find(a => a.session_id === data.config?.agent_id);
-  const isPersistent = data.config?.session_type === 'persistent';
+  const isPersistent = agentRunMode === 'inherit_resume';
   
   // A Hard Sync (Restart) is required if the agent is already online but parameters differ
   const needsRestart = targetAgent && !targetAgent.is_off && (
@@ -185,19 +187,23 @@ export const WorkflowNode = memo(({ id, data, selected }: NodeProps<Node<{ label
           {resolveVariables(data.label)}
         </div>
 
+        {type === 'agent' && agentRunMode === 'inherit_resume' && (
+          <div className="rounded border border-[var(--color-wardian-warning)]/40 bg-[color-mix(in_srgb,var(--color-wardian-warning),transparent_90%)] px-2 py-1 text-[10px] leading-snug text-[var(--color-wardian-text)]">
+            Resumes the selected agent conversation. Token use can grow with each workflow run.
+          </div>
+        )}
 
         {/* Dynamic Fields */}
         {blockDef?.fields && blockDef.fields.length > 0 && (
           <div className="flex flex-col gap-2 pt-2 border-t border-[var(--color-wardian-border)]">
             {blockDef.fields.map(field => {
               const val = data.config?.[field.name] || '';
-              const sessionType = data.config?.session_type || 'persistent';
 
               // Conditional visibility for Agent fields
               if (type === 'agent') {
-                if (field.name === 'agent_id' && sessionType === 'temporary') return null;
-                if (field.name === 'agent_class' && sessionType === 'persistent') return null;
-                if (field.name === 'folder' && sessionType === 'persistent') return null;
+                if (field.name === 'agent_id' && agentRunMode === 'ephemeral') return null;
+                if (field.name === 'agent_class' && agentRunMode !== 'ephemeral') return null;
+                if (field.name === 'folder' && agentRunMode !== 'ephemeral') return null;
                 
                 const outputFormat = data.config?.output_format || 'text';
                 if (field.name === 'json_schema' && outputFormat !== 'json') return null;

--- a/src/features/workflows/blockLibrary.test.ts
+++ b/src/features/workflows/blockLibrary.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { BLOCK_LIBRARY } from './blockLibrary';
+
+describe('workflow block library', () => {
+  it('exposes exactly the three supported agent run modes', () => {
+    const agentBlock = BLOCK_LIBRARY.find((block) => block.type === 'agent');
+    const modeField = agentBlock?.fields?.find((field) => field.name === 'mode');
+
+    expect(modeField?.options).toEqual(['ephemeral', 'inherit_fresh', 'inherit_resume']);
+  });
+
+  it('does not expose legacy session_type or session_persistence fields for agent nodes', () => {
+    const agentBlock = BLOCK_LIBRARY.find((block) => block.type === 'agent');
+    const fieldNames = [
+      ...(agentBlock?.fields || []),
+      ...(agentBlock?.advancedFields || []),
+    ].map((field) => field.name);
+
+    expect(fieldNames).not.toContain('session_type');
+    expect(fieldNames).not.toContain('session_persistence');
+  });
+});

--- a/src/features/workflows/blockLibrary.ts
+++ b/src/features/workflows/blockLibrary.ts
@@ -89,7 +89,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
       { name: 'agent_id', label: 'Target Agent', type: 'select', placeholder: 'Select Agent' },
       { name: 'agent_class', label: 'Agent Class', type: 'select', placeholder: 'Select Class' },
       { name: 'prompt', label: 'Prompt Template', type: 'textarea', placeholder: 'Analyze {{nodes.step1.output}}', required: true },
-      { name: 'session_type', label: 'Session Type', type: 'select', options: ['persistent', 'temporary'], default: 'persistent' },
+      { name: 'mode', label: 'Run Mode', type: 'select', options: ['ephemeral', 'inherit_fresh', 'inherit_resume'], default: 'ephemeral' },
       { name: 'folder', label: 'Workspace Folder', type: 'text', placeholder: 'C:\\path\\to\\project' },
       { name: 'output_format', label: 'Output Format', type: 'select', options: ['text', 'json'], default: 'text' },
       { name: 'json_schema', label: 'JSON Schema', type: 'schema', placeholder: '{ "type": "object" }' }

--- a/src/features/workflows/workflowLaunch.test.ts
+++ b/src/features/workflows/workflowLaunch.test.ts
@@ -146,6 +146,16 @@ describe('workflowLaunch', () => {
     expect(normalized.nodes[0].config.mode).toBe('inherit_resume');
   });
 
+  it('falls back to legacy mapping when workflow mode value is invalid', () => {
+    const config = normalizeWorkflowAgentConfig({
+      mode: 'broken-mode',
+      session_type: 'persistent',
+      agent_id: 'agent-123',
+    });
+
+    expect(config.mode).toBe('inherit_fresh');
+  });
+
   it('preserves existing role mappings and role assignments while adding missing mappings', () => {
     const workflow: WorkflowDefinition = {
       ...baseWorkflow,

--- a/src/features/workflows/workflowLaunch.test.ts
+++ b/src/features/workflows/workflowLaunch.test.ts
@@ -4,6 +4,7 @@ import {
   buildScheduledRunFromWorkflow,
   getWorkflowLaunchKind,
   getWorkflowRoleTargets,
+  normalizeWorkflowAgentConfig,
   normalizeWorkflowForLaunch,
   setWorkflowTriggerStatus,
   synthesizeWorkflowRole,
@@ -75,6 +76,74 @@ describe('workflowLaunch', () => {
       },
     ]);
     expect(workflowNeedsRunConfig(workflow, false)).toBe(true);
+  });
+
+  it('does not create run modal role targets for ephemeral agent nodes', () => {
+    const workflow: WorkflowDefinition = {
+      ...baseWorkflow,
+      nodes: [
+        { id: 'agent-1', type: 'agent', name: 'Scratch Agent', config: { mode: 'ephemeral', agent_class: 'Coder' } },
+      ],
+    };
+
+    expect(getWorkflowRoleTargets(workflow)).toEqual([]);
+    expect(workflowNeedsRunConfig(workflow, false)).toBe(false);
+  });
+
+  it('treats legacy temporary agent nodes as ephemeral for run config needs', () => {
+    const workflow: WorkflowDefinition = {
+      ...baseWorkflow,
+      nodes: [
+        { id: 'agent-1', type: 'agent', name: 'Temporary Agent', config: { session_type: 'temporary', agent_id: 'agent-123' } },
+      ],
+    };
+
+    expect(getWorkflowRoleTargets(workflow)).toEqual([]);
+    expect(workflowNeedsRunConfig(workflow, false)).toBe(false);
+  });
+
+  it('maps legacy temporary agent nodes to ephemeral mode', () => {
+    const config = normalizeWorkflowAgentConfig({ session_type: 'temporary', agent_class: 'Coder' });
+
+    expect(config).toMatchObject({
+      session_type: 'temporary',
+      mode: 'ephemeral',
+      agent_class: 'Coder',
+    });
+    expect(config).not.toHaveProperty('session_persistence');
+  });
+
+  it('maps legacy persistent agent nodes to inherit_fresh mode', () => {
+    const config = normalizeWorkflowAgentConfig({ session_type: 'persistent', agent_id: 'agent-123' });
+
+    expect(config).toMatchObject({
+      session_type: 'persistent',
+      mode: 'inherit_fresh',
+      agent_id: 'agent-123',
+    });
+    expect(config).not.toHaveProperty('session_persistence');
+  });
+
+  it('maps legacy direct agent nodes without session_type to inherit_fresh mode', () => {
+    const config = normalizeWorkflowAgentConfig({ agent_id: 'agent-123' });
+
+    expect(config).toMatchObject({
+      mode: 'inherit_fresh',
+      agent_id: 'agent-123',
+    });
+  });
+
+  it('preserves explicit workflow agent mode during launch normalization', () => {
+    const workflow: WorkflowDefinition = {
+      ...baseWorkflow,
+      nodes: [
+        { id: 'agent-1', type: 'agent', name: 'Resume Agent', config: { session_type: 'persistent', mode: 'inherit_resume', agent_id: 'agent-123' } },
+      ],
+    };
+
+    const normalized = normalizeWorkflowForLaunch(workflow);
+
+    expect(normalized.nodes[0].config.mode).toBe('inherit_resume');
   });
 
   it('preserves existing role mappings and role assignments while adding missing mappings', () => {

--- a/src/features/workflows/workflowLaunch.ts
+++ b/src/features/workflows/workflowLaunch.ts
@@ -8,6 +8,33 @@ export interface WorkflowRoleTarget {
   nodeName: string;
 }
 
+export function normalizeWorkflowAgentConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...config };
+
+  if (typeof normalized.mode !== 'string') {
+    if (normalized.session_type === 'temporary') {
+      normalized.mode = 'ephemeral';
+    } else if (normalized.session_type === 'persistent') {
+      normalized.mode = 'inherit_fresh';
+    } else if (
+      (typeof normalized.agent_id === 'string' && normalized.agent_id.trim().length > 0) ||
+      (typeof normalized.role === 'string' && normalized.role.trim().length > 0)
+    ) {
+      normalized.mode = 'inherit_fresh';
+    }
+  }
+
+  return normalized;
+}
+
+function workflowAgentNeedsInheritedAgent(config: Record<string, unknown> | undefined): boolean {
+  if (!config) {
+    return false;
+  }
+
+  return normalizeWorkflowAgentConfig(config).mode !== 'ephemeral';
+}
+
 function isTriggerNode(node: WorkflowNode): boolean {
   return node.type === 'trigger';
 }
@@ -33,7 +60,9 @@ export function normalizeWorkflowForLaunch(workflow: WorkflowDefinition): Workfl
       return node;
     }
 
-    const config = typeof node.config === 'object' && node.config !== null ? { ...node.config } : {};
+    const config = normalizeWorkflowAgentConfig(
+      typeof node.config === 'object' && node.config !== null ? node.config : {}
+    );
     const role = typeof config.role === 'string' && config.role.trim().length > 0
       ? config.role
       : synthesizeWorkflowRole(node);
@@ -41,7 +70,7 @@ export function normalizeWorkflowForLaunch(workflow: WorkflowDefinition): Workfl
     config.role = role;
 
     const agentId = typeof config.agent_id === 'string' ? config.agent_id : '';
-    if (agentId && !roleMappings[role]) {
+    if (agentId && config.mode !== 'ephemeral' && !roleMappings[role]) {
       roleMappings[role] = agentId;
     }
 
@@ -74,7 +103,7 @@ export function getWorkflowRoleTargets(workflow: WorkflowDefinition): WorkflowRo
   const normalized = normalizeWorkflowForLaunch(workflow);
 
   return normalized.nodes
-    .filter((node) => node.type === 'agent')
+    .filter((node) => node.type === 'agent' && workflowAgentNeedsInheritedAgent(node.config))
     .map((node) => ({
       role: String(node.config?.role || synthesizeWorkflowRole(node)),
       defaultAgentId: typeof node.config?.agent_id === 'string' ? node.config.agent_id : '',
@@ -217,4 +246,3 @@ export function buildScheduledRunFromWorkflow(workflow: WorkflowDefinition): Sch
     is_paused: false,
   };
 }
-

--- a/src/features/workflows/workflowLaunch.ts
+++ b/src/features/workflows/workflowLaunch.ts
@@ -8,8 +8,13 @@ export interface WorkflowRoleTarget {
   nodeName: string;
 }
 
+const validWorkflowModes = new Set(['ephemeral', 'inherit_fresh', 'inherit_resume']);
+
 export function normalizeWorkflowAgentConfig(config: Record<string, unknown>): Record<string, unknown> {
   const normalized = { ...config };
+  if (typeof normalized.mode === 'string' && !validWorkflowModes.has(normalized.mode)) {
+    delete normalized.mode;
+  }
 
   if (typeof normalized.mode !== 'string') {
     if (normalized.session_type === 'temporary') {

--- a/src/layout/SidebarContentPane.tsx
+++ b/src/layout/SidebarContentPane.tsx
@@ -8,6 +8,7 @@ import { CommandPanel } from "../features/commands/CommandPanel";
 import { SettingsPanel } from "../features/settings/SettingsPanel";
 import { WorkflowSidebar } from "../features/workflows/WorkflowSidebar";
 import { ExplorerPanel } from "../features/explorer/ExplorerPanel";
+import { GitPanel } from "../features/git/GitPanel";
 
 interface SidebarContentPaneProps {
   activeTab: SidebarTab;
@@ -45,6 +46,15 @@ interface SidebarContentPaneProps {
         <div className="px-4 py-6 flex-1 overflow-y-auto no-scrollbar min-w-[var(--sidebar-content-width)] flex flex-col min-h-0 h-full">
         {activeTab === "explorer" && (
           <ExplorerPanel selectedAgentIds={selectedAgentIds} />
+        )}
+
+        {activeTab === "git" && (
+          <GitPanel
+            selectedAgentIds={selectedAgentIds}
+            agents={agents}
+            onAgentsUpdated={onAgentsUpdated}
+            telemetry={telemetry}
+          />
         )}
 
         {activeTab === "agent-config" && (

--- a/src/layout/SidebarIconRail.tsx
+++ b/src/layout/SidebarIconRail.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Folder } from "lucide-react";
 
-export type SidebarTab = "explorer" | "agent-config" | "command" | "classes" | "workflows" | "ssh" | "settings";
+export type SidebarTab = "explorer" | "git" | "agent-config" | "command" | "classes" | "workflows" | "ssh" | "settings";
 
 interface SidebarIconRailProps {
   activeTab: SidebarTab;
@@ -29,6 +29,22 @@ export const SidebarIconRail: React.FC<SidebarIconRailProps> = ({
       >
         {activeTab === "explorer" && <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-[var(--color-wardian-accent)] rounded-r-full" />}
         <Folder className="w-6 h-6 group-hover:scale-110 transition-transform" strokeWidth={2} />
+      </button>
+
+      <button
+        data-testid="sidebar-tab-git"
+        onClick={() => handleTabClick("git")}
+        className={`relative p-3 rounded-xl transition-all group ${activeTab === "git" ? "bg-wardian-card-bg-muted text-[var(--color-wardian-accent)]" : "text-muted-neutral hover:text-bright-neutral"}`}
+        title="Source Control"
+      >
+        {activeTab === "git" && <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-[var(--color-wardian-accent)] rounded-r-full" />}
+        <svg className="w-6 h-6 group-hover:scale-110 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="7" cy="5" r="2" fill="none" />
+          <circle cx="7" cy="19" r="2" fill="none" />
+          <circle cx="17" cy="12" r="2" fill="none" />
+          <line x1="7" y1="7" x2="7" y2="17" />
+          <path fill="none" d="M7 17 C7 13 17 13 17 12" />
+        </svg>
       </button>
 
       <button

--- a/src/layout/SidebarIconRail.tsx
+++ b/src/layout/SidebarIconRail.tsx
@@ -39,11 +39,11 @@ export const SidebarIconRail: React.FC<SidebarIconRailProps> = ({
       >
         {activeTab === "git" && <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-[var(--color-wardian-accent)] rounded-r-full" />}
         <svg className="w-6 h-6 group-hover:scale-110 transition-transform" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="7" cy="5" r="2" fill="none" />
-          <circle cx="7" cy="19" r="2" fill="none" />
-          <circle cx="17" cy="12" r="2" fill="none" />
+          <circle cx="7" cy="5" r="2" style={{fill:'none'}} />
+          <circle cx="7" cy="19" r="2" style={{fill:'none'}} />
+          <circle cx="17" cy="12" r="2" style={{fill:'none'}} />
           <line x1="7" y1="7" x2="7" y2="17" />
-          <path fill="none" d="M7 17 C7 13 17 13 17 12" />
+          <path style={{fill:'none'}} d="M7 17 C7 13 17 13 17 12" />
         </svg>
       </button>
 

--- a/src/layout/watchlist/AgentWatchlist.test.tsx
+++ b/src/layout/watchlist/AgentWatchlist.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import AgentWatchlist from './AgentWatchlist';
 import type { AgentConfig, AgentTelemetry } from '../../types';
 import type { Watchlist } from './types';
@@ -27,6 +27,7 @@ describe('AgentWatchlist', () => {
   const mockOnQuery = vi.fn();
   const mockOnPause = vi.fn();
   const mockOnRestart = vi.fn();
+  const mockOnClear = vi.fn();
   const mockOnDelete = vi.fn();
   const mockOnActiveListChange = vi.fn();
   const mockOnWatchlistsChange = vi.fn(async () => {});
@@ -59,6 +60,7 @@ describe('AgentWatchlist', () => {
     onQuery: mockOnQuery,
     onPause: mockOnPause,
     onRestart: mockOnRestart,
+    onClear: mockOnClear,
     onDelete: mockOnDelete,
     onAddToList: vi.fn(),
     onRemoveFromList: vi.fn(),
@@ -99,7 +101,18 @@ describe('AgentWatchlist', () => {
     expect(screen.getByText('Rename')).toBeInTheDocument();
     expect(screen.getByText('Pause')).toBeInTheDocument();
     expect(screen.getByText('Restart')).toBeInTheDocument();
+    expect(within(screen.getByTestId('agent-context-menu')).getByRole('button', { name: 'Clear' })).toBeInTheDocument();
     expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('triggers onClear action from the context menu', async () => {
+    render(<AgentWatchlist {...defaultProps} />);
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row');
+
+    fireEvent.contextMenu(agentRow!);
+    fireEvent.click(within(screen.getByTestId('agent-context-menu')).getByRole('button', { name: 'Clear' }));
+
+    expect(mockOnClear).toHaveBeenCalledWith('agent-1');
   });
 
   it('disables Pause for already off agents', async () => {

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -24,6 +24,7 @@ interface AgentWatchlistProps {
   onQuery: (agentId: string) => void;
   onPause: (agentId: string) => void;
   onRestart: (agentId: string) => void;
+  onClear: (agentId: string) => void;
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
   onDelete: (agentId: string) => void;
@@ -48,6 +49,7 @@ export default function AgentWatchlist({
   onQuery,
   onPause,
   onRestart,
+  onClear,
   onAddToList,
   onRemoveFromList,
   onDelete,
@@ -483,6 +485,7 @@ export default function AgentWatchlist({
           onQuery={onQuery}
           onPause={onPause}
           onRestart={onRestart}
+          onClear={onClear}
           onAddToList={(listId, agentId) => {
             onAddToList(listId, agentId);
             setContextMenu(p => ({ ...p, visible: false }));

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -9,7 +9,6 @@ import {
 } from "./watchlistUtils";
 import { deriveCurrentThought, getStatusColorClass, getAgentStatusLabel, getAgentStatusTextClass } from "../../utils/statusUtils";
 import { AgentContextMenu } from "../../../src/components/AgentContextMenu";
-import { useLayoutStore } from "../../store/useLayoutStore";
 
 interface AgentWatchlistProps {
   agents: AgentConfig[];
@@ -58,7 +57,6 @@ export default function AgentWatchlist({
   onActiveListChange,
   onWatchlistsChange,
 }: AgentWatchlistProps) {
-  const { resetLayout } = useLayoutStore();
   // ── Search State ───────────────────────────────────────────────────
   const [searchTerm, setSearchTerm] = useState("");
   const [draggedAgentId, setDraggedAgentId] = useState<string | null>(null);
@@ -494,7 +492,6 @@ export default function AgentWatchlist({
             setContextMenu(p => ({ ...p, visible: false }));
           }}
           onDelete={onDelete}
-          onResetLayout={resetLayout}
           onClose={() => setContextMenu(p => ({ ...p, visible: false }))}
         />
       )}

--- a/src/store/useSettingsStore.ts
+++ b/src/store/useSettingsStore.ts
@@ -9,6 +9,7 @@ interface SettingsState {
   shell_id: string;
   custom_executable: string;
   custom_args: string;
+  agent_session_persistence: 'fresh' | 'resume';
   available_shells: ShellOption[];
   shell_settings_loaded: boolean;
   shells_loaded: boolean;
@@ -17,6 +18,7 @@ interface SettingsState {
   setShellId: (shellId: string) => void;
   setCustomExecutable: (value: string) => void;
   setCustomArgs: (value: string) => void;
+  setAgentSessionPersistence: (value: 'fresh' | 'resume') => void;
   loadShellSettings: () => Promise<void>;
   loadAvailableShells: () => Promise<void>;
   saveShellSettings: () => Promise<void>;
@@ -26,6 +28,7 @@ const DEFAULT_SHELL_SETTINGS: ShellSettings = {
   shell_id: 'auto',
   custom_executable: null,
   custom_args: null,
+  agent_session_persistence: 'resume',
 };
 
 export const useSettingsStore = create<SettingsState>()(
@@ -36,6 +39,7 @@ export const useSettingsStore = create<SettingsState>()(
       shell_id: DEFAULT_SHELL_SETTINGS.shell_id,
       custom_executable: DEFAULT_SHELL_SETTINGS.custom_executable ?? '',
       custom_args: DEFAULT_SHELL_SETTINGS.custom_args ?? '',
+      agent_session_persistence: DEFAULT_SHELL_SETTINGS.agent_session_persistence,
       available_shells: [],
       shell_settings_loaded: false,
       shells_loaded: false,
@@ -44,6 +48,7 @@ export const useSettingsStore = create<SettingsState>()(
       setShellId: (shell_id) => set({ shell_id }),
       setCustomExecutable: (custom_executable) => set({ custom_executable }),
       setCustomArgs: (custom_args) => set({ custom_args }),
+      setAgentSessionPersistence: (agent_session_persistence) => set({ agent_session_persistence }),
       loadShellSettings: async () => {
         try {
           const settings = await invoke<ShellSettings>('load_shell_settings');
@@ -51,6 +56,7 @@ export const useSettingsStore = create<SettingsState>()(
             shell_id: settings.shell_id,
             custom_executable: settings.custom_executable ?? '',
             custom_args: settings.custom_args ?? '',
+            agent_session_persistence: settings.agent_session_persistence ?? DEFAULT_SHELL_SETTINGS.agent_session_persistence,
             shell_settings_loaded: true,
           });
         } catch (error) {
@@ -59,6 +65,7 @@ export const useSettingsStore = create<SettingsState>()(
             shell_id: DEFAULT_SHELL_SETTINGS.shell_id,
             custom_executable: '',
             custom_args: '',
+            agent_session_persistence: DEFAULT_SHELL_SETTINGS.agent_session_persistence,
             shell_settings_loaded: true,
           });
         }
@@ -77,12 +84,14 @@ export const useSettingsStore = create<SettingsState>()(
           shell_id: get().shell_id,
           custom_executable: get().custom_executable.trim() || null,
           custom_args: get().custom_args.trim() || null,
+          agent_session_persistence: get().agent_session_persistence,
         };
         const saved = await invoke<ShellSettings>('save_shell_settings', { settings });
         set({
           shell_id: saved.shell_id,
           custom_executable: saved.custom_executable ?? '',
           custom_args: saved.custom_args ?? '',
+          agent_session_persistence: saved.agent_session_persistence ?? DEFAULT_SHELL_SETTINGS.agent_session_persistence,
           shell_settings_loaded: true,
         });
       },

--- a/src/store/useSettingsStore.ts
+++ b/src/store/useSettingsStore.ts
@@ -22,6 +22,7 @@ interface SettingsState {
   loadShellSettings: () => Promise<void>;
   loadAvailableShells: () => Promise<void>;
   saveShellSettings: () => Promise<void>;
+  saveAgentSessionPersistence: () => Promise<void>;
 }
 
 const DEFAULT_SHELL_SETTINGS: ShellSettings = {
@@ -87,6 +88,18 @@ export const useSettingsStore = create<SettingsState>()(
           agent_session_persistence: get().agent_session_persistence,
         };
         const saved = await invoke<ShellSettings>('save_shell_settings', { settings });
+        set({
+          shell_id: saved.shell_id,
+          custom_executable: saved.custom_executable ?? '',
+          custom_args: saved.custom_args ?? '',
+          agent_session_persistence: saved.agent_session_persistence ?? DEFAULT_SHELL_SETTINGS.agent_session_persistence,
+          shell_settings_loaded: true,
+        });
+      },
+      saveAgentSessionPersistence: async () => {
+        const saved = await invoke<ShellSettings>('save_agent_session_persistence', {
+          persistence: get().agent_session_persistence,
+        });
         set({
           shell_id: saved.shell_id,
           custom_executable: saved.custom_executable ?? '',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export interface AgentConfig {
     screen_reader?: boolean;
     output_format?: "text" | "json" | "stream-json";
     custom_args?: string;
+    session_persistence?: "default" | "fresh" | "resume";
 
     // Claude-specific fields
     permission_mode?: "default" | "plan" | "auto-accept";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,7 @@ export interface AgentConfig {
 
     // Git isolation
     git_worktree?: boolean;
+
 }
 
 export interface GitFileEntry {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,29 @@ export interface AgentConfig {
     // OpenCode-specific fields
     opencode_agent?: string;
     opencode_port?: number;
+
+    // Git isolation
+    git_worktree?: boolean;
+}
+
+export interface GitFileEntry {
+    path: string;
+    status: string;
+    is_staged: boolean;
+}
+
+export interface GitStatusResult {
+    branch: string;
+    files: GitFileEntry[];
+    ahead: number;
+    behind: number;
+}
+
+export interface GitLogEntry {
+    hash: string;
+    message: string;
+    author: string;
+    date: string;
 }
 
 export * from "./workflow";

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -9,4 +9,5 @@ export interface ShellSettings {
   shell_id: string;
   custom_executable: string | null;
   custom_args: string | null;
+  agent_session_persistence: 'fresh' | 'resume';
 }

--- a/src/types/types.test.ts
+++ b/src/types/types.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { AgentConfig, AgentTelemetry, AgentClassDefinition, AgentOutputPayload, AgentJsonEvent } from "./index";
+import type { WorkflowAgentMode, WorkflowNode } from "./workflow";
 
 describe("TypeScript Interface Shape Tests", () => {
   describe("AgentConfig", () => {
@@ -36,6 +37,28 @@ describe("TypeScript Interface Shape Tests", () => {
         is_off: false,
       };
       expect(config.resume_session).toBeUndefined();
+    });
+
+  });
+
+  describe("WorkflowAgentMode", () => {
+    it("accepts the three workflow agent run modes", () => {
+      const modes: WorkflowAgentMode[] = ["ephemeral", "inherit_fresh", "inherit_resume"];
+
+      expect(modes).toEqual(["ephemeral", "inherit_fresh", "inherit_resume"]);
+    });
+
+    it("accepts workflow agent nodes without a separate session persistence field", () => {
+      const node: WorkflowNode = {
+        id: "agent-1",
+        type: "agent",
+        config: {
+          mode: "inherit_resume",
+          agent_id: "agent-123",
+        },
+      };
+
+      expect(node.config.mode).toBe("inherit_resume");
     });
   });
 

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -15,6 +15,8 @@ export type NodeType =
 
 export type NodeStatus = 'idle' | 'processing' | 'completed' | 'failed' | 'blocked';
 
+export type WorkflowAgentMode = 'ephemeral' | 'inherit_fresh' | 'inherit_resume';
+
 export interface NodeDependency {
   node_id: string;
   port: string;
@@ -29,6 +31,19 @@ export interface WorkflowNode {
   dependencies?: NodeDependency[];
   // For UI state tracking
   position?: { x: number; y: number };
+}
+
+export interface WorkflowAgentNodeConfig {
+  mode?: WorkflowAgentMode;
+  /** Legacy field retained for migration from older saved workflows. */
+  session_type?: 'temporary' | 'persistent';
+  agent_id?: string;
+  agent_class?: string;
+  folder?: string;
+  prompt?: string;
+  output_format?: 'text' | 'json';
+  json_schema?: Record<string, unknown>;
+  timeout_ms?: number | string;
 }
 
 export interface WorkflowSettings {

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -440,6 +440,22 @@ function AppBody() {
     }
   };
 
+  const onClear = async (id: string) => {
+    try {
+      await invoke('clear_agent_session', { sessionId: id });
+      setCurrentThoughts(prev => ({ ...prev, [id]: "" }));
+      setTerminalTitles(prev => ({ ...prev, [id]: "" }));
+      setOffAgentIds(prev => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      fetchAgents();
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   const onDelete = async (id: string) => {
     if (await confirm('Delete this agent?')) {
       try {
@@ -537,6 +553,7 @@ function AppBody() {
                 onQuery={(id) => { const el = document.getElementById(`agent-card-${id}`); if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' }); }}
                 onPause={onPause}
                 onRestart={onRestart}
+                onClear={onClear}
                 onMouseEnterCard={handleMouseEnterCard}
                 onMouseUp={handleMouseUp}
                 onMouseDown={handleMouseDown}
@@ -595,6 +612,7 @@ function AppBody() {
           onQuery={(id) => { const el = document.getElementById(`agent-card-${id}`); if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' }); }}
           onPause={onPause}
           onRestart={onRestart}
+          onClear={onClear}
           onDelete={onDelete}
           onAddToList={handleAddToList}
           onRemoveFromList={handleRemoveFromList}

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -47,6 +47,7 @@ function renderGrid(maximizedAgentId: string | null, filteredAgents: AgentConfig
       onQuery={vi.fn()}
       onPause={vi.fn()}
       onRestart={vi.fn()}
+      onClear={vi.fn()}
     />
   );
 }

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -58,7 +58,7 @@ describe('GridView maximize behavior', () => {
     const card = screen.getByTestId('terminal-agent-1').closest('#agent-card-agent-1');
     expect(card?.className).toContain('fixed');
     expect(card?.className).toContain('inset-0');
-    expect(card?.className).toContain('z-50');
+    expect(card?.className).toContain('z-[100]');
   });
 
   it('falls back to the filtered grid when the maximized agent is no longer visible', () => {

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -52,13 +52,13 @@ function renderGrid(maximizedAgentId: string | null, filteredAgents: AgentConfig
 }
 
 describe('GridView maximize behavior', () => {
-  it('maximized terminals use fixed positioning for full-screen overlay', () => {
+  it('maximized terminals fill the grid container', () => {
     renderGrid('agent-1');
 
     const card = screen.getByTestId('terminal-agent-1').closest('#agent-card-agent-1');
-    expect(card?.className).toContain('fixed');
-    expect(card?.className).toContain('inset-0');
-    expect(card?.className).toContain('z-[100]');
+    expect(card?.className).toContain('h-full');
+    expect(card?.className).toContain('w-full');
+    expect(card?.className).not.toContain('fixed');
   });
 
   it('falls back to the filtered grid when the maximized agent is no longer visible', () => {

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -125,7 +125,6 @@ export const GridView: React.FC<GridViewProps> = ({
     gap: (isMaximized || isMobile) ? '0' : '8px',
     background: 'transparent',
     padding: (isMaximized || isMobile) ? '0' : '8px',
-    // Removed the excessive paddingBottom: '200px'
     height: (isMaximized || isMobile) ? '100%' : 'auto',
   };
 
@@ -172,7 +171,7 @@ export const GridView: React.FC<GridViewProps> = ({
             onMouseEnter={() => onMouseEnterCard(agentId)}
             onDragStart={(e) => e.preventDefault()}
             onMouseUp={() => onMouseUp()}
-            className={`bg-[var(--color-wardian-card)] overflow-hidden flex flex-col shadow-lg relative ${isAgentMaximized ? 'fixed inset-0 z-[100] rounded-none border-none transition-none h-screen w-screen' : 'transition-all rounded-xl border border-wardian-border ' + (isSelected || draggedAgentId === agentId || dragOverAgentId === agentId ? 'ring-1 ring-[var(--color-wardian-accent)]/50 shadow-wardian-accent z-10' : '')} ${draggedAgentId === agentId && !isAgentMaximized ? 'opacity-50 scale-[0.98]' : ''}`}
+            className={`bg-[var(--color-wardian-card)] overflow-hidden flex flex-col shadow-lg relative ${isAgentMaximized ? 'h-full w-full rounded-none border-none transition-none z-10' : 'transition-all rounded-xl border border-wardian-border ' + (isSelected || draggedAgentId === agentId || dragOverAgentId === agentId ? 'ring-1 ring-[var(--color-wardian-accent)]/50 shadow-wardian-accent z-10' : '')} ${draggedAgentId === agentId && !isAgentMaximized ? 'opacity-50 scale-[0.98]' : ''}`}
           >
             <div 
               onMouseEnter={() => onMouseEnterCard(agentId)}

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -5,6 +5,7 @@ import type { Watchlist } from "../layout/watchlist/types";
 import { AgentContextMenu } from "../components/AgentContextMenu";
 import { useLayoutStore } from "../store/useLayoutStore";
 import { useGridResize } from "../features/grid/useGridResize";
+import { ContextMenu, ContextMenuItem } from "../components/ContextMenu";
 
 interface GridViewProps {
   filteredAgents: AgentConfig[];
@@ -76,6 +77,17 @@ export const GridView: React.FC<GridViewProps> = ({
   const { isResizing, startResize, guidePos, resizeType } = useGridResize(containerRef);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
 
+  const [bgContextMenu, setBgContextMenu] = useState<{ x: number; y: number; visible: boolean }>({
+    x: 0, y: 0, visible: false
+  });
+
+  const handleBackgroundContextMenu = (e: React.MouseEvent) => {
+    // Only trigger if we click the grid background itself (gaps/padding)
+    if (e.target !== containerRef.current) return;
+    e.preventDefault();
+    setBgContextMenu({ x: e.clientX, y: e.clientY, visible: true });
+  };
+
   useEffect(() => {
     const handleResize = () => setWindowWidth(window.innerWidth);
     window.addEventListener('resize', handleResize);
@@ -109,17 +121,27 @@ export const GridView: React.FC<GridViewProps> = ({
     gridTemplateColumns: (isMaximized || isMobile) 
       ? '1fr' 
       : layout.column_tracks.map(t => `${t}fr`).join(' '),
-    gridAutoRows: `${layout.row_height}px`,
-    gap: (isMaximized || isMobile) ? '16px' : '8px',
+    gridAutoRows: (isMaximized || isMobile) ? '100%' : `${layout.row_height}px`,
+    gap: (isMaximized || isMobile) ? '0' : '8px',
     background: 'transparent',
-    padding: (isMaximized || isMobile) ? '16px' : '8px',
-    paddingBottom: '200px',
+    padding: (isMaximized || isMobile) ? '0' : '8px',
+    // Removed the excessive paddingBottom: '200px'
+    height: (isMaximized || isMobile) ? '100%' : 'auto',
   };
+
+  const bgMenuItems: ContextMenuItem[] = [
+    {
+      label: "Reset Grid Layout",
+      onClick: resetLayout,
+      icon: <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
+    }
+  ];
 
   return (
     <div 
       ref={containerRef}
       style={gridStyle}
+      onContextMenu={handleBackgroundContextMenu}
       className={`w-full relative ${isResizing ? 'cursor-col-resize' : ''}`}
     >
       {visibleAgents.map((agent: AgentConfig, _idx: number) => {
@@ -150,13 +172,13 @@ export const GridView: React.FC<GridViewProps> = ({
             onMouseEnter={() => onMouseEnterCard(agentId)}
             onDragStart={(e) => e.preventDefault()}
             onMouseUp={() => onMouseUp()}
-            className={`bg-[var(--color-wardian-card)] overflow-hidden flex flex-col shadow-lg relative ${isAgentMaximized ? 'fixed inset-0 z-50 rounded-none border-none transition-none' : 'transition-all rounded-xl border border-wardian-border ' + (isSelected || draggedAgentId === agentId || dragOverAgentId === agentId ? 'ring-1 ring-[var(--color-wardian-accent)]/50 shadow-wardian-accent z-10' : '')} ${draggedAgentId === agentId && !isAgentMaximized ? 'opacity-50 scale-[0.98]' : ''}`}
+            className={`bg-[var(--color-wardian-card)] overflow-hidden flex flex-col shadow-lg relative ${isAgentMaximized ? 'fixed inset-0 z-[100] rounded-none border-none transition-none h-screen w-screen' : 'transition-all rounded-xl border border-wardian-border ' + (isSelected || draggedAgentId === agentId || dragOverAgentId === agentId ? 'ring-1 ring-[var(--color-wardian-accent)]/50 shadow-wardian-accent z-10' : '')} ${draggedAgentId === agentId && !isAgentMaximized ? 'opacity-50 scale-[0.98]' : ''}`}
           >
             <div 
               onMouseEnter={() => onMouseEnterCard(agentId)}
               onMouseDown={(e) => { if (e.button === 0) onMouseDown(agentId); }}
               onClick={(e) => { e.stopPropagation(); if (!isAgentMaximized) onCardClick(e, agentId); }}
-              onContextMenu={(e) => { if (!isAgentMaximized) handleContextMenu(e, agentId); }}
+              onContextMenu={(e) => handleContextMenu(e, agentId)}
               className={`p-4 border-b border-wardian-light justify-between items-center group transition-colors cursor-grab active:cursor-grabbing select-none flex ${isSelected ? 'bg-[var(--color-wardian-accent)]/5' : 'bg-[var(--color-wardian-sidebar-primary)]'}`}
             >
               <div className="flex items-center gap-3">
@@ -280,8 +302,16 @@ export const GridView: React.FC<GridViewProps> = ({
           onAddToList={onAddToList}
           onRemoveFromList={onRemoveFromList}
           onDelete={onDelete}
-          onResetLayout={resetLayout}
           onClose={() => setContextMenu({ ...contextMenu, visible: false })}
+        />
+      )}
+
+      {bgContextMenu.visible && (
+        <ContextMenu
+          x={bgContextMenu.x}
+          y={bgContextMenu.y}
+          items={bgMenuItems}
+          onClose={() => setBgContextMenu({ ...bgContextMenu, visible: false })}
         />
       )}
 

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -38,6 +38,7 @@ interface GridViewProps {
   onQuery: (agentId: string) => void;
   onPause: (agentId: string) => void;
   onRestart: (agentId: string) => void;
+  onClear: (agentId: string) => void;
 }
 
 export const GridView: React.FC<GridViewProps> = ({
@@ -71,6 +72,7 @@ export const GridView: React.FC<GridViewProps> = ({
   onQuery,
   onPause,
   onRestart,
+  onClear,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { layout, resetLayout } = useLayoutStore();
@@ -298,6 +300,7 @@ export const GridView: React.FC<GridViewProps> = ({
           onQuery={onQuery}
           onPause={onPause}
           onRestart={onRestart}
+          onClear={onClear}
           onAddToList={onAddToList}
           onRemoveFromList={onRemoveFromList}
           onDelete={onDelete}


### PR DESCRIPTION
## Description
This PR refines agent session persistence behavior, introduces a new integrated Source Control panel, and implements several UX improvements for settings and terminal management.

## Key Changes

### ≡ƒô┬ Source Control Integration (Spec 018)
- **New Git Panel:** Integrated git status, staging, committing, and worktree management in the sidebar.
- **Ambient Git Context:** The Explorer now highlights modified/added/deleted files based on git status.
- **Cross-Platform Safety:** Background git commands use `CREATE_NO_WINDOW` on Windows to prevent console flashes.
- **Git Watcher:** Added a debounced file system watcher (`notify` crate) to keep the UI in sync with external git changes.

### ≡ƒöä Session Persistence Policy (Spec 019)
- **Granular Control:** Introduced `AgentSessionPersistenceOverride` allowing per-agent overrides of the global `fresh`/`resume` default.
- **Workflow Optimization:** Workflow runs now default to `fresh` (non-resuming) to prevent accidental token context growth.
- **Fresh Resume for Claude/Codex:** Wardian now generates a new provider-native session ID for "fresh" starts while maintaining the stable Wardian Agent ID, avoiding "session ID in use" errors.
- **Headless Bootstrap Skip:** Workflow-spawned agents now skip the "Introduce yourself" bootstrap prompt to save tokens and keep output structured.

### ≡ƒæ« Agent Management & UX
- **Clear Action:** New "Clear" context menu action to force a fresh provider launch and clear both backend buffers and frontend scrollback.
- **Settings Feedback:** Split settings save feedback into distinct shell and runtime statuses.
- **Codex Stabilization:** Codex now follows the same generated-session-ID pattern as Claude, avoiding unnecessary bootstrap prompts.

### ≡ƒô║ Documentation & Specs
- Added **Spec 015: Evidence-First Memory** (design constraints for future memory model).
- Added **Spec 018: Source Control Panel**.
- Added **Spec 019: Session Persistence Policy**.

## Verification
- `npm run lint` & `npm run test`
- `cargo clippy` & `cargo test`
- Manual verification of Git staging/committing and PTY persistence overrides.