### PR TITLE
feat(watchlists): add agent teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Wardian is a governance layer for AI orchestration. It centralizes PTY managemen
 
 ## Quick Start
 
-Ensure you have Rust, Node.js (v18+), and a supported provider CLI (e.g. `@google/gemini-cli` or `@anthropic-ai/claude-code`) installed.
+Ensure you have Rust, Node.js (v18+), and at least one supported provider CLI installed, such as `@google/gemini-cli`, `@anthropic-ai/claude-code`, `@openai/codex`, or `opencode`.
 
 ```bash
 git clone https://github.com/tangemicioglu/Wardian.git
@@ -65,7 +65,7 @@ Wardian abstracts the differences between varied agent runtimes into a unified i
 | **Gemini CLI**  | ✅ Stable  | Patched skill discovery; stream-based turn detection.    |
 | **Claude Code** | ✅ Stable  | Custom permission hooks; explicit session ID management. |
 | **Codex**       | 🧪 Beta    | Habitat-based state migration; bootstrap isolation.      |
-| **OpenCode**    | 📅 Planned | TBD.                                                     |
+| **OpenCode**    | 🧪 Beta    | Real-workspace runtime config injection.                |
 | **OpenClaw**    | 📅 Planned | TBD.                                                     |
 
 > See [Provider Runtime Notes](docs/providers.md) for a deep dive into provider-specific discovery and lifecycle management.
@@ -166,7 +166,7 @@ Wardian is built with a focus on modularity, thread safety, and separation of co
 
 1. **Rust**: Install [rustup.rs](https://rustup.rs/) (latest stable).
 2. **Node.js**: Ensure Node.js (v18+) is installed.
-3. **Agent CLIs**: Install supported providers globally (e.g., `npm install -g @google/gemini-cli`) and ensure they are successfully authenticated in your terminal first.
+3. **Agent CLIs**: Install supported providers globally (e.g., `npm install -g @google/gemini-cli @anthropic-ai/claude-code @openai/codex`) and install the OpenCode CLI separately if you plan to use that beta provider. Ensure each provider is successfully authenticated in your terminal first.
 4. **Clone & Install**:
    ```bash
    git clone https://github.com/tangemicioglu/Wardian.git

--- a/docs/guide/watchlists.md
+++ b/docs/guide/watchlists.md
@@ -4,7 +4,7 @@ The **Agent Watchlist** (Right Sidebar) is your primary high-fidelity tool for m
 
 ## 🕵️ Real-Time Monitoring
 
-### 1. Status Indicators
+### Status Indicators
 Every agent in the watchlist has a distinct status light:
 - **Emerald (Idle)**: Ready for a new task.
 - **Cyan (Processing)**: Currently executing or thinking.
@@ -12,8 +12,26 @@ Every agent in the watchlist has a distinct status light:
 - **Gray (Off)**: Session is paused or hibernating.
 - **Red (Error)**: Encountered a fatal process error.
 
-### 2. Live Thought Bubbles
+### Live Thought Bubbles
 Wardian captures the agent's internal telemetry and displays it as a "Thought Bubble" next to the agent's name. This allows you to see what the agent is currently working on without reading the full terminal log.
+
+## 📊 Customizable Columns
+
+Click the **gear icon** (⚙) in the watchlist header to open the column picker. Each column can be toggled on or off independently:
+
+| Column | Default | Description |
+|---|---|---|
+| Status | On | Current agent status label |
+| Query Count | On | Number of prompts sent this session |
+| Uptime | Off | Time since the agent process started |
+| Provider / Model | Off | Provider name and model identifier |
+| Last Queried | On | Time elapsed since the last prompt was sent |
+
+### Sorting
+Click any column header to sort by that column. Clicking again cycles through ascending → descending → unsorted. The **Agent** column header sorts alphabetically by name. Sorting applies on top of your custom watchlist order; drag-to-reorder still works when no sort is active.
+
+### Persistence
+Column visibility and sort state are saved to `~/.wardian/watchlists/prefs.json` and restored on next launch.
 
 ## 🗂️ Organizing with Watchlists
 As your swarm grows, a single list becomes difficult to manage. Wardian allows you to group agents into custom **Watchlists**.
@@ -25,7 +43,7 @@ As your swarm grows, a single list becomes difficult to manage. Wardian allows y
 
 ### Managing Agents
 - **Reordering**: Drag and drop agent cards within a watchlist to prioritize your view.
-- **Filtering**: Click a watchlist tab to focus only on that group of agents. 
+- **Filtering**: Click a watchlist tab to focus only on that group of agents.
 - **Bulk Selection**: Use `Ctrl+Click` to select multiple agents within a watchlist for broadcast commands.
 
 ## 🖱️ Remote Management

--- a/docs/specs/020-agent-teams-and-bulk-actions.md
+++ b/docs/specs/020-agent-teams-and-bulk-actions.md
@@ -1,0 +1,147 @@
+# Spec 020: Agent Teams and Bulk Actions
+
+- **Status:** Proposed
+- **Date:** 2026-04-19
+- **Decider:** User
+
+## Context and Problem Statement
+
+Wardian already supports multi-select in the Watchlist through Ctrl-click and Shift-click, but the actions exposed through the agent context menu still mostly behave as single-agent actions. Users also need a way to group related agents into teams so the Roster, Dashboard, and Grid can present cooperating agents as a unified command-center unit.
+
+Issue 76 requests a global Team primitive with visual grouping, unified movement, team-level bulk actions, named teams, dynamic membership, and persistence in watchlist state. The key design constraint is that teams are global, and their member sequence should stay synchronized across watchlists rather than becoming local per watchlist.
+
+## Proposed Decision
+
+Wardian will model teams as global records persisted with watchlist state. Watchlists will store ordered entries that can point either to a solo agent or to a team. Existing flat watchlists will be migrated in memory and saved back in the new shape after the first change.
+
+### Data Model
+
+```ts
+export interface AgentTeam {
+  id: string;
+  name: string;
+  agentIds: string[];
+}
+
+export type WatchlistEntry =
+  | { type: "agent"; agentId: string }
+  | { type: "team"; teamId: string };
+
+export interface Watchlist {
+  id: string;
+  name: string;
+  entries: WatchlistEntry[];
+}
+
+export interface WatchlistState {
+  version: 2;
+  watchlists: Watchlist[];
+  teams: AgentTeam[];
+}
+```
+
+The loader will continue accepting the current persisted format:
+
+```ts
+Array<{ id: string; name: string; agentIds: string[] }>
+```
+
+Legacy watchlists load as version 1 data and are normalized to version 2 in the frontend state.
+
+### Team Invariants
+
+- An agent can belong to at most one team.
+- Teams are global across Wardian, not scoped to a watchlist.
+- Team member order is stored once in `AgentTeam.agentIds`.
+- Watchlists never render partial teams.
+- If a watchlist contains any member of a team, that watchlist normalizes to a team entry and shows the full team.
+- Ungrouping a team deletes only the team record. It does not delete agents.
+- Deleting agents remains a separate destructive action with confirmation.
+
+### Roster Interaction Model
+
+Team creation is low-friction:
+
+- Selecting multiple agents and right-clicking opens a bulk menu with `Create Team`.
+- `Create Team` immediately creates `Team N` from the selected agents.
+- Renaming is available from the team header context menu.
+
+Membership is drag-driven:
+
+- Drag a solo agent onto a team block or header to add the agent to the team.
+- Drag a member out of a team block to remove the agent from the team and place it as a solo entry near the team block.
+- Drag members within a team block to reorder the global team member sequence.
+- Drag the team header or block to move the team as a unit.
+
+Team header actions:
+
+- `Rename Team`
+- `Query Team`
+- `Pause Team`
+- `Start Team`, `Restart Team`, or `Restart / Start Team` depending on member states
+- `Clear Team`
+- `Ungroup Team`
+
+The team header should use Wardian theme variables and a distinct border or background to make the group visually legible without introducing hardcoded colors.
+
+### Bulk Context Menu
+
+Right-click target resolution:
+
+- If multiple agents are selected and the right-click target is inside that selection, the menu applies to the selected set.
+- If the right-click target is outside the current selection, selection changes to that target and the normal single-target menu appears.
+- If the target is a team header, the resolved action target is the team's member IDs.
+- If the selected set includes teams and solo agents, actions resolve to the unique agent IDs represented by that selection.
+
+Bulk menu behavior:
+
+- `Rename` is disabled for multi-agent selections.
+- `Query` applies to all resolved target agents.
+- `Clear` applies to all resolved target agents.
+- `Delete` applies to all resolved target agents and requires confirmation such as `Delete 4 agents?`.
+- `Pause` pauses running agents and skips agents already Off.
+- `Start` starts Off agents and skips running agents.
+- `Restart` restarts running agents and starts Off agents.
+- Mixed state labels may use `Restart / Start Selected` to make the behavior explicit.
+- `Add to List` shows lists where at least one target agent is missing and adds all missing targets.
+- `Remove from List` shows lists where at least one target agent is present and removes all present targets.
+
+These operations are intentionally idempotent for mixed list membership.
+
+### Dashboard and Grid Rendering
+
+The Roster is the primary editing surface for teams. Dashboard and Grid should consume the same normalized display model so team grouping remains recognizable across views.
+
+Phase 1 rendering:
+
+- Roster renders full team blocks with headers and nested member rows.
+- Dashboard renders a team band/header followed by full member rows.
+- Grid renders team grouping as a visual wrapper or header around the member cards when layout constraints allow it.
+
+Dashboard and Grid do not need to expose the full membership editing surface in phase 1. They should respect global team order and bulk action resolution.
+
+### Persistence
+
+The backend `watchlist` commands currently store raw JSON under `watchlists/index.json`. That can remain the storage boundary for phase 1, but the frontend should own explicit TypeScript normalization helpers instead of spreading raw-shape checks through components.
+
+The save path should write version 2 state:
+
+```json
+{
+  "version": 2,
+  "watchlists": [],
+  "teams": []
+}
+```
+
+The load path should accept both version 2 objects and legacy arrays.
+
+## Consequences
+
+- **Positive**: Teams become a global command-center primitive rather than a local visual trick.
+- **Positive**: Full team inclusion avoids confusing partial-team drag and reorder rules.
+- **Positive**: Bulk execution reuses one target-resolution model for selected agents, team headers, and future group actions.
+- **Positive**: Existing backend storage can stay simple because schema normalization is handled at the frontend boundary.
+- **Negative**: Watchlists can no longer intentionally show only part of a team.
+- **Negative**: Migrating from flat watchlists to entry-based watchlists touches several UI paths at once.
+- **Negative**: Full team inclusion may surprise users who expected a narrowly curated watchlist after adding one team member.

--- a/src-tauri/src/commands/watchlist.rs
+++ b/src-tauri/src/commands/watchlist.rs
@@ -1,20 +1,21 @@
 use tauri::AppHandle;
 
 #[tauri::command]
-pub async fn load_watchlists(_app: AppHandle) -> Result<Vec<serde_json::Value>, String> {
+pub async fn load_watchlists(_app: AppHandle) -> Result<serde_json::Value, String> {
     if let Some(app_dir) = crate::utils::fs::get_wardian_home() {
         let path = app_dir.join("watchlists/index.json");
         if let Ok(data) = std::fs::read_to_string(&path) {
-            let parsed: Vec<serde_json::Value> = serde_json::from_str(&data).unwrap_or_default();
+            let parsed: serde_json::Value =
+                serde_json::from_str(&data).unwrap_or_else(|_| serde_json::json!([]));
             return Ok(parsed);
         }
     }
-    Ok(Vec::new())
+    Ok(serde_json::json!([]))
 }
 
 #[tauri::command]
 pub async fn save_watchlists(
-    watchlists: Vec<serde_json::Value>,
+    watchlists: serde_json::Value,
     _app: AppHandle,
 ) -> Result<(), String> {
     let app_dir = crate::utils::fs::get_wardian_home()

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -1,14 +1,19 @@
 import React, { useState, useRef, useEffect } from "react";
-import type { Watchlist } from "../layout/watchlist/types";
+import type { AgentTeam, Watchlist } from "../layout/watchlist/types";
 import { getListsContainingAgent, getListsNotContainingAgent } from "../layout/watchlist/watchlistUtils";
 
 export interface AgentContextMenuProps {
   x: number;
   y: number;
   agentId: string;
+  agentIds?: string[];
+  teams?: AgentTeam[];
+  menuKind?: "agent" | "team";
+  teamId?: string;
   offAgentIds: Set<string>;
   watchlists: Watchlist[];
   onInitiateRename: (agentId: string) => void;
+  onInitiateTeamRename?: (teamId: string) => void;
   onQuery: (agentId: string) => void;
   onPause: (agentId: string) => void;
   onRestart: (agentId: string) => void;
@@ -16,6 +21,8 @@ export interface AgentContextMenuProps {
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
   onDelete: (agentId: string) => void;
+  onCreateTeam?: (agentIds: string[]) => void;
+  onUngroupTeam?: (teamId: string) => void;
   onClose: () => void;
 }
 
@@ -23,9 +30,14 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   x,
   y,
   agentId,
+  agentIds,
+  teams = [],
+  menuKind = "agent",
+  teamId,
   offAgentIds,
   watchlists,
   onInitiateRename,
+  onInitiateTeamRename,
   onQuery,
   onPause,
   onRestart,
@@ -33,10 +45,22 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   onAddToList,
   onRemoveFromList,
   onDelete,
+  onCreateTeam,
+  onUngroupTeam,
   onClose,
 }) => {
   const [subMenuListId, setSubMenuListId] = useState<string | null>(null);
   const contextMenuRef = useRef<HTMLDivElement>(null);
+  const targetAgentIds = agentIds?.length ? agentIds : [agentId];
+  const isTeam = menuKind === "team";
+  const isBulk = targetAgentIds.length > 1;
+  const allTargetsOff = targetAgentIds.every((id) => offAgentIds.has(id));
+  const anyTargetOff = targetAgentIds.some((id) => offAgentIds.has(id));
+  const anyTargetRunning = targetAgentIds.some((id) => !offAgentIds.has(id));
+
+  const forEachTarget = (handler: (id: string) => void) => {
+    for (const id of targetAgentIds) handler(id);
+  };
 
   useEffect(() => {
     const handleClick = () => onClose();
@@ -58,84 +82,120 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); }}
     >
       <button
-        className="context-menu-item"
+        className={`context-menu-item ${isBulk && !isTeam ? 'opacity-50 cursor-not-allowed' : ''}`}
+        disabled={isBulk && !isTeam}
         onClick={() => {
+          if (isTeam && teamId) {
+            onInitiateTeamRename?.(teamId);
+            onClose();
+            return;
+          }
+          if (isBulk) return;
           onInitiateRename(agentId);
           onClose();
         }}
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
-        Rename
+        {isTeam ? 'Rename Team' : 'Rename'}
       </button>
       <button
         className="context-menu-item"
         onClick={() => {
-          onQuery(agentId);
+          forEachTarget(onQuery);
           onClose();
         }}
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" /></svg>
-        Query
+        {isTeam ? 'Query Team' : isBulk ? 'Query Selected' : 'Query'}
       </button>
 
       <div className="context-menu-divider" />
 
+      {!isTeam && onCreateTeam && (
+        <button
+          className="context-menu-item"
+          onClick={() => {
+            onCreateTeam(targetAgentIds);
+            onClose();
+          }}
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m0-4a4 4 0 100-8 4 4 0 000 8zm8 0a4 4 0 100-8 4 4 0 000 8z" /></svg>
+          Create Team
+        </button>
+      )}
+
+      {!isTeam && onCreateTeam && <div className="context-menu-divider" />}
+
       <button
         data-testid="context-pause"
-        className={`context-menu-item ${offAgentIds.has(agentId) ? 'opacity-50 cursor-not-allowed' : ''}`}
-        disabled={offAgentIds.has(agentId)}
+        className={`context-menu-item ${!anyTargetRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
+        disabled={!anyTargetRunning}
         onClick={() => {
-          if (offAgentIds.has(agentId)) return;
-          onPause(agentId);
+          if (!anyTargetRunning) return;
+          forEachTarget((id) => { if (!offAgentIds.has(id)) onPause(id); });
           onClose();
         }}
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 9v6m4-6v6m7-3a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-        Pause
+        {isTeam ? 'Pause Team' : isBulk ? 'Pause Selected' : 'Pause'}
       </button>
       <button
         data-testid="context-start"
         className="context-menu-item"
         onClick={() => {
-          onRestart(agentId);
+          forEachTarget(onRestart);
           onClose();
         }}
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" /></svg>
-        {offAgentIds.has(agentId) ? 'Start' : 'Restart'}
+        {isTeam
+          ? anyTargetOff && anyTargetRunning
+            ? 'Restart / Start Team'
+            : allTargetsOff
+              ? 'Start Team'
+              : 'Restart Team'
+          : isBulk
+          ? anyTargetOff && anyTargetRunning
+            ? 'Restart / Start Selected'
+            : allTargetsOff
+              ? 'Start Selected'
+              : 'Restart Selected'
+          : offAgentIds.has(agentId) ? 'Start' : 'Restart'}
       </button>
       <button
         data-testid="context-clear"
         className="context-menu-item"
         onClick={() => {
-          onClear(agentId);
+          forEachTarget(onClear);
           onClose();
         }}
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 15l8-8a2 2 0 012.8 0l4.2 4.2a2 2 0 010 2.8l-5 5H8l-4-4zM13 19h7" /></svg>
-        Clear
+        {isTeam ? 'Clear Team' : isBulk ? 'Clear Selected' : 'Clear'}
       </button>
 
       <div className="context-menu-divider" />
 
-      {getListsNotContainingAgent(watchlists, agentId).length > 0 && (
+      {watchlists.some((list) => targetAgentIds.some((id) => getListsNotContainingAgent([list], id, teams).length > 0)) && (
         <div className="context-menu-submenu">
           <button
             className="context-menu-item"
             onMouseEnter={() => setSubMenuListId("add")}
           >
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" /></svg>
-            Add to List
+            {isTeam ? 'Add Team to List' : isBulk ? 'Add Selected to List' : 'Add to List'}
             <svg className="w-3 h-3 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" /></svg>
           </button>
           {subMenuListId === "add" && (
             <div className={`context-submenu ${x > window.innerWidth / 2 ? 'flip-left' : ''}`}>
-              {getListsNotContainingAgent(watchlists, agentId).map((l, i) => (
+              {watchlists
+                .filter((list) => targetAgentIds.some((id) => getListsNotContainingAgent([list], id, teams).length > 0))
+                .map((l, i) => (
                 <button
                   key={l.id}
                   className="context-menu-item"
                   onClick={() => {
-                    onAddToList(l.id, agentId);
+                    forEachTarget((id) => onAddToList(l.id, id));
                     onClose();
                   }}
                 >
@@ -147,24 +207,26 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
         </div>
       )}
 
-      {getListsContainingAgent(watchlists, agentId).length > 0 && (
+      {watchlists.some((list) => targetAgentIds.some((id) => getListsContainingAgent([list], id, teams).length > 0)) && (
         <div className="context-menu-submenu">
           <button
             className="context-menu-item text-wardian-error"
             onMouseEnter={() => setSubMenuListId("remove")}
           >
             <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M20 12H4" /></svg>
-            Remove from List
+            {isTeam ? 'Remove Team from List' : isBulk ? 'Remove Selected from List' : 'Remove from List'}
             <svg className="w-3 h-3 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" /></svg>
           </button>
           {subMenuListId === "remove" && (
             <div className={`context-submenu ${x > window.innerWidth / 2 ? 'flip-left' : ''}`}>
-              {getListsContainingAgent(watchlists, agentId).map((l, i) => (
+              {watchlists
+                .filter((list) => targetAgentIds.some((id) => getListsContainingAgent([list], id, teams).length > 0))
+                .map((l, i) => (
                 <button
                   key={l.id}
                   className="context-menu-item"
                   onClick={() => {
-                    onRemoveFromList(l.id, agentId);
+                    forEachTarget((id) => onRemoveFromList(l.id, id));
                     onClose();
                   }}
                 >
@@ -178,15 +240,29 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
 
       <div className="context-menu-divider" />
 
+      {isTeam && teamId && onUngroupTeam && (
+        <button
+          className="context-menu-item"
+          onClick={() => {
+            onUngroupTeam(teamId);
+            onClose();
+          }}
+        >
+          Ungroup Team
+        </button>
+      )}
+
+      {isTeam && <div className="context-menu-divider" />}
+
       <button
         className="context-menu-item text-wardian-error hover:!bg-wardian-error/20"
         onClick={() => {
-          onDelete(agentId);
+          forEachTarget(onDelete);
           onClose();
         }}
       >
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" /></svg>
-        Delete
+        {isTeam ? 'Delete Team' : isBulk ? 'Delete Selected' : 'Delete'}
       </button>
     </div>
   );

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -20,6 +20,8 @@ export interface AgentContextMenuProps {
   onClear: (agentId: string) => void;
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
+  onAddAgentsToList?: (listId: string, agentIds: string[]) => void;
+  onRemoveAgentsFromList?: (listId: string, agentIds: string[]) => void;
   onDelete: (agentId: string) => void;
   onCreateTeam?: (agentIds: string[]) => void;
   onUngroupTeam?: (teamId: string) => void;
@@ -44,6 +46,8 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   onClear,
   onAddToList,
   onRemoveFromList,
+  onAddAgentsToList,
+  onRemoveAgentsFromList,
   onDelete,
   onCreateTeam,
   onUngroupTeam,
@@ -195,7 +199,8 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
                   key={l.id}
                   className="context-menu-item"
                   onClick={() => {
-                    forEachTarget((id) => onAddToList(l.id, id));
+                    if (onAddAgentsToList) onAddAgentsToList(l.id, targetAgentIds);
+                    else forEachTarget((id) => onAddToList(l.id, id));
                     onClose();
                   }}
                 >
@@ -226,7 +231,8 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
                   key={l.id}
                   className="context-menu-item"
                   onClick={() => {
-                    forEachTarget((id) => onRemoveFromList(l.id, id));
+                    if (onRemoveAgentsFromList) onRemoveAgentsFromList(l.id, targetAgentIds);
+                    else forEachTarget((id) => onRemoveFromList(l.id, id));
                     onClose();
                   }}
                 >

--- a/src/features/explorer/ExplorerPanel.test.tsx
+++ b/src/features/explorer/ExplorerPanel.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { invoke } from '@tauri-apps/api/core';
+import { ExplorerPanel } from './ExplorerPanel';
+
+vi.mock('./FileTree', () => ({
+  FileTree: ({ path }: { path: string }) => <div data-testid="file-tree">{path}</div>,
+}));
+
+describe('ExplorerPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the current explorer root in the local file system', async () => {
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\.wardian';
+      if (command === 'git_status') return { files: [] };
+      return null;
+    });
+
+    render(<ExplorerPanel selectedAgentIds={new Set()} />);
+
+    const openButton = await screen.findByRole('button', { name: 'Open in local file system' });
+    await userEvent.click(openButton);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('reveal_in_explorer', {
+        path: 'C:\\Users\\test\\.wardian',
+      });
+    });
+  });
+});

--- a/src/features/explorer/ExplorerPanel.test.tsx
+++ b/src/features/explorer/ExplorerPanel.test.tsx
@@ -23,6 +23,9 @@ describe('ExplorerPanel', () => {
     render(<ExplorerPanel selectedAgentIds={new Set()} />);
 
     const openButton = await screen.findByRole('button', { name: 'Open in local file system' });
+    expect(openButton).toBeInTheDocument();
+    expect(screen.queryByText('Open')).not.toBeInTheDocument();
+
     await userEvent.click(openButton);
 
     await waitFor(() => {

--- a/src/features/explorer/ExplorerPanel.tsx
+++ b/src/features/explorer/ExplorerPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { writeText } from '@tauri-apps/plugin-clipboard-manager';
+import { FolderOpen } from 'lucide-react';
 import { FileTree, FileNode } from './FileTree';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { GitStatusResult } from '../../types';
@@ -159,9 +160,9 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }
             aria-label="Open in local file system"
             title="Open in local file system"
             onClick={handleOpenRoot}
-            className="shrink-0 rounded-md border border-wardian-border px-2 py-1 text-[11px] font-bold text-muted hover:text-primary hover:bg-wardian-card-bg-muted transition-colors"
+            className="shrink-0 rounded-md border border-wardian-border p-1 text-muted hover:text-primary hover:bg-wardian-card-bg-muted transition-colors"
           >
-            Open
+            <FolderOpen aria-hidden="true" size={14} strokeWidth={2} />
           </button>
         </div>
       )}

--- a/src/features/explorer/ExplorerPanel.tsx
+++ b/src/features/explorer/ExplorerPanel.tsx
@@ -104,6 +104,15 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }
     setMenuPos(null);
   };
 
+  const handleOpenRoot = async () => {
+    if (!rootPath) return;
+    try {
+      await invoke('reveal_in_explorer', { path: rootPath });
+    } catch (err) {
+      console.error("Open explorer root failed:", err);
+    }
+  };
+
   const handlePreview = async () => {
     if (activeNode && !activeNode.is_dir) {
       try {
@@ -142,9 +151,18 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds }
       
       {rootPath && (
         <div className="flex items-center gap-1.5 py-1 mb-2 border-b border-wardian-border/30 w-full group">
-          <span className="label-small text-[12px] font-mono text-muted-neutral group-hover:text-primary select-all truncate transition-colors" title={rootPath}>
+          <span className="label-small text-[12px] font-mono text-muted-neutral group-hover:text-primary select-all truncate transition-colors flex-1 min-w-0" title={rootPath}>
             {rootPath}
           </span>
+          <button
+            type="button"
+            aria-label="Open in local file system"
+            title="Open in local file system"
+            onClick={handleOpenRoot}
+            className="shrink-0 rounded-md border border-wardian-border px-2 py-1 text-[11px] font-bold text-muted hover:text-primary hover:bg-wardian-card-bg-muted transition-colors"
+          >
+            Open
+          </button>
         </div>
       )}
       

--- a/src/layout/watchlist/AgentWatchlist.test.tsx
+++ b/src/layout/watchlist/AgentWatchlist.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
 import AgentWatchlist from './AgentWatchlist';
 import type { AgentConfig, AgentTelemetry } from '../../types';
 import type { Watchlist, WatchlistPrefs, AgentInteractions } from './types';
@@ -29,6 +29,12 @@ describe('AgentWatchlist', () => {
   const mockOnRestart = vi.fn();
   const mockOnClear = vi.fn();
   const mockOnDelete = vi.fn();
+  const mockOnCreateTeam = vi.fn();
+  const mockOnUngroupTeam = vi.fn();
+  const mockOnAddAgentToTeam = vi.fn();
+  const mockOnRemoveAgentFromTeam = vi.fn();
+  const mockOnRenameTeam = vi.fn(async () => {});
+  const mockOnReorderTeamMember = vi.fn();
   const mockOnActiveListChange = vi.fn();
   const mockOnWatchlistsChange = vi.fn(async () => {});
 
@@ -62,6 +68,12 @@ describe('AgentWatchlist', () => {
     onRestart: mockOnRestart,
     onClear: mockOnClear,
     onDelete: mockOnDelete,
+    onCreateTeam: mockOnCreateTeam,
+    onUngroupTeam: mockOnUngroupTeam,
+    onAddAgentToTeam: mockOnAddAgentToTeam,
+    onRemoveAgentFromTeam: mockOnRemoveAgentFromTeam,
+    onRenameTeam: mockOnRenameTeam,
+    onReorderTeamMember: mockOnReorderTeamMember,
     onAddToList: vi.fn(),
     onRemoveFromList: vi.fn(),
     collapsed: false,
@@ -85,6 +97,23 @@ describe('AgentWatchlist', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  const setRect = (element: Element, top: number, height: number) => {
+    Object.defineProperty(element, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        top,
+        bottom: top + height,
+        left: 0,
+        right: 240,
+        width: 240,
+        height,
+        x: 0,
+        y: top,
+        toJSON: () => {},
+      }),
+    });
+  };
 
   it('renders agent rows correctly', () => {
     render(<AgentWatchlist {...defaultProps} />);
@@ -124,6 +153,470 @@ describe('AgentWatchlist', () => {
     fireEvent.click(within(screen.getByTestId('agent-context-menu')).getByRole('button', { name: 'Clear' }));
 
     expect(mockOnClear).toHaveBeenCalledWith('agent-1');
+  });
+
+  it('uses a bulk context menu when right-clicking inside a multi-selection', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        selectedAgentIds={new Set(['agent-1', 'agent-2'])}
+      />
+    );
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row');
+
+    fireEvent.contextMenu(agentRow!);
+
+    const menu = screen.getByTestId('agent-context-menu');
+    expect(within(menu).getByRole('button', { name: 'Rename' })).toBeDisabled();
+    expect(within(menu).getByRole('button', { name: 'Clear Selected' })).toBeInTheDocument();
+
+    fireEvent.click(within(menu).getByRole('button', { name: 'Clear Selected' }));
+
+    expect(mockOnClear).toHaveBeenCalledWith('agent-1');
+    expect(mockOnClear).toHaveBeenCalledWith('agent-2');
+  });
+
+  it('offers team creation for a multi-selection', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        selectedAgentIds={new Set(['agent-1', 'agent-2'])}
+      />
+    );
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row');
+
+    fireEvent.contextMenu(agentRow!);
+    fireEvent.click(screen.getByRole('button', { name: 'Create Team' }));
+
+    expect(mockOnCreateTeam).toHaveBeenCalledWith(['agent-1', 'agent-2']);
+  });
+
+  it('offers team creation for a single-agent context menu', async () => {
+    render(<AgentWatchlist {...defaultProps} />);
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row');
+
+    fireEvent.contextMenu(agentRow!);
+    fireEvent.click(screen.getByRole('button', { name: 'Create Team' }));
+
+    expect(mockOnCreateTeam).toHaveBeenCalledWith(['agent-1']);
+  });
+
+  it('renders global teams as grouped blocks with team header actions', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    expect(screen.getByText('Core Dev Swarm')).toBeInTheDocument();
+    const teamBlock = screen.getByTestId('team-block-team-1');
+    expect(within(teamBlock).getByText('Alpha')).toBeInTheDocument();
+    expect(within(teamBlock).getByText('Beta')).toBeInTheDocument();
+
+    fireEvent.contextMenu(screen.getByTestId('team-header-team-1'));
+    fireEvent.click(screen.getByRole('button', { name: 'Ungroup Team' }));
+
+    expect(mockOnUngroupTeam).toHaveBeenCalledWith('team-1');
+  });
+
+  it('applies normal context actions to every team member from the team menu', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByTestId('team-header-team-1'));
+
+    const menu = screen.getByTestId('agent-context-menu');
+    expect(within(menu).getByRole('button', { name: 'Rename Team' })).toBeInTheDocument();
+    fireEvent.click(within(menu).getByRole('button', { name: 'Query Team' }));
+
+    expect(mockOnQuery).toHaveBeenCalledWith('agent-1');
+    expect(mockOnQuery).toHaveBeenCalledWith('agent-2');
+  });
+
+  it('renames a team from the team context menu', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByTestId('team-header-team-1'));
+    fireEvent.click(screen.getByRole('button', { name: 'Rename Team' }));
+    const input = screen.getByDisplayValue('Core Dev Swarm');
+    fireEvent.change(input, { target: { value: 'Ops Team' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(mockOnRenameTeam).toHaveBeenCalledWith('team-1', 'Ops Team'));
+  });
+
+  it('includes list actions in the team context menu', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        watchlists={[
+          { id: 'all', name: 'All Agents', entries: [{ type: 'team', teamId: 'team-1' }] },
+          { id: 'later', name: 'Later', entries: [] },
+        ]}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.contextMenu(screen.getByTestId('team-header-team-1'));
+
+    const addButton = screen.getByRole('button', { name: 'Add Team to List' });
+    fireEvent.mouseEnter(addButton);
+    fireEvent.click(screen.getByRole('button', { name: '1. Later' }));
+
+    expect(defaultProps.onAddToList).toHaveBeenCalledWith('later', 'agent-1');
+    expect(defaultProps.onAddToList).toHaveBeenCalledWith('later', 'agent-2');
+  });
+
+  it('renders team blocks even when a sort is active', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        prefs={{ ...defaultPrefs, sort: { column_id: 'agent_name', direction: 'asc' } }}
+        onPrefsChange={mockOnPrefsChange}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    expect(screen.getByTestId('team-block-team-1')).toBeInTheDocument();
+    expect(screen.getByText('Core Dev Swarm')).toBeInTheDocument();
+  });
+
+  it('adds a dragged solo agent to a team when dropped on the team header', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByText('Gamma').closest('.watchlist-row')!);
+    fireEvent.mouseUp(screen.getByTestId('team-header-team-1'));
+
+    expect(mockOnAddAgentToTeam).toHaveBeenCalledWith('team-1', 'agent-3');
+  });
+
+  it('moves a dragged team member to another team when dropped on that team header', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        teams={[
+          { id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] },
+          { id: 'team-2', name: 'Support Swarm', agentIds: ['agent-3'] },
+        ]}
+      />
+    );
+
+    fireEvent.mouseDown(within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!);
+    fireEvent.mouseUp(screen.getByTestId('team-header-team-2'));
+
+    expect(mockOnAddAgentToTeam).toHaveBeenCalledWith('team-2', 'agent-1');
+  });
+
+  it('reorders team members within the team', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.mouseDown(within(screen.getByTestId('team-block-team-1')).getByText('Beta').closest('.watchlist-row')!);
+    fireEvent.mouseUp(within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!);
+
+    expect(mockOnReorderTeamMember).toHaveBeenCalledWith('team-1', 'agent-2', 'agent-1', 'before');
+    expect(mockOnAddAgentToTeam).not.toHaveBeenCalled();
+  });
+
+  it('reorders a team member after another member when dropped on the lower half', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+    const alphaRow = within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!;
+    const betaRow = within(screen.getByTestId('team-block-team-1')).getByText('Beta').closest('.watchlist-row')!;
+    setRect(betaRow, 100, 40);
+
+    fireEvent.mouseDown(alphaRow);
+    fireEvent.mouseMove(betaRow, { clientY: 135 });
+    fireEvent.mouseUp(betaRow, { clientY: 135 });
+
+    expect(mockOnReorderTeamMember).toHaveBeenCalledWith('team-1', 'agent-1', 'agent-2', 'after');
+  });
+
+  it('adds a solo agent to a team when dropped on a team member row', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByText('Gamma').closest('.watchlist-row')!);
+    fireEvent.mouseUp(within(screen.getByTestId('team-block-team-1')).getByText('Beta').closest('.watchlist-row')!);
+
+    expect(mockOnAddAgentToTeam).toHaveBeenCalledWith('team-1', 'agent-3');
+    expect(mockOnReorderAgents).not.toHaveBeenCalled();
+  });
+
+  it('adds a solo watchlist row to a team when dropped on a team member row', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        watchlists={[
+          {
+            id: 'today',
+            name: 'Today',
+            entries: [
+              { type: 'agent', agentId: 'agent-3' },
+              { type: 'team', teamId: 'team-1' },
+            ],
+          },
+        ]}
+        activeListId="today"
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByText('Gamma').closest('.watchlist-row')!);
+    fireEvent.mouseUp(within(screen.getByTestId('team-block-team-1')).getByText('Beta').closest('.watchlist-row')!);
+
+    expect(mockOnAddAgentToTeam).toHaveBeenCalledWith('team-1', 'agent-3');
+    expect(mockOnWatchlistsChange).not.toHaveBeenCalled();
+  });
+
+  it('highlights the whole team block when a solo agent is dragged over a team member row', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByText('Gamma').closest('.watchlist-row')!);
+    fireEvent.mouseEnter(within(screen.getByTestId('team-block-team-1')).getByText('Beta').closest('.watchlist-row')!);
+
+    expect(screen.getByTestId('team-block-team-1')).toHaveClass('team-drop-inside');
+  });
+
+  it('places a solo agent before a team when dropped on the upper edge of the team', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+    const beforeZone = screen.getByTestId('team-drop-before-team-1');
+
+    fireEvent.mouseDown(screen.getByText('Gamma').closest('.watchlist-row')!);
+    fireEvent.mouseEnter(beforeZone);
+    fireEvent.mouseUp(beforeZone);
+
+    expect(mockOnAddAgentToTeam).not.toHaveBeenCalled();
+    expect(mockOnReorderAgents).toHaveBeenCalledWith(['agent-3', 'agent-1', 'agent-2']);
+  });
+
+  it('reorders team blocks inside a watchlist', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        watchlists={[
+          {
+            id: 'today',
+            name: 'Today',
+            entries: [{ type: 'team', teamId: 'team-1' }, { type: 'team', teamId: 'team-2' }],
+          },
+        ]}
+        activeListId="today"
+        teams={[
+          { id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1'] },
+          { id: 'team-2', name: 'Support Swarm', agentIds: ['agent-2'] },
+        ]}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByTestId('team-header-team-2'));
+    fireEvent.mouseEnter(screen.getByTestId('team-header-team-1'));
+    fireEvent.mouseUp(screen.getByTestId('team-header-team-1'));
+
+    await waitFor(() => expect(mockOnWatchlistsChange).toHaveBeenCalledWith([
+      {
+        id: 'today',
+        name: 'Today',
+        agentIds: [],
+        entries: [{ type: 'team', teamId: 'team-2' }, { type: 'team', teamId: 'team-1' }],
+      },
+    ]));
+  });
+
+  it('reorders a team when dropped on another teams member row', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        watchlists={[
+          {
+            id: 'today',
+            name: 'Today',
+            entries: [{ type: 'team', teamId: 'team-1' }, { type: 'team', teamId: 'team-2' }],
+          },
+        ]}
+        activeListId="today"
+        teams={[
+          { id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1'] },
+          { id: 'team-2', name: 'Support Swarm', agentIds: ['agent-2'] },
+        ]}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByTestId('team-header-team-2'));
+    fireEvent.mouseEnter(within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!);
+    fireEvent.mouseUp(within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!);
+
+    await waitFor(() => expect(mockOnWatchlistsChange).toHaveBeenCalledWith([
+      {
+        id: 'today',
+        name: 'Today',
+        agentIds: [],
+        entries: [{ type: 'team', teamId: 'team-2' }, { type: 'team', teamId: 'team-1' }],
+      },
+    ]));
+  });
+
+  it('reorders a team relative to a solo row inside a watchlist', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        watchlists={[
+          {
+            id: 'today',
+            name: 'Today',
+            entries: [
+              { type: 'agent', agentId: 'agent-3' },
+              { type: 'team', teamId: 'team-1' },
+            ],
+          },
+        ]}
+        activeListId="today"
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByTestId('team-header-team-1'));
+    fireEvent.mouseEnter(screen.getByText('Gamma').closest('.watchlist-row')!);
+    fireEvent.mouseUp(screen.getByText('Gamma').closest('.watchlist-row')!);
+
+    await waitFor(() => expect(mockOnWatchlistsChange).toHaveBeenCalledWith([
+      {
+        id: 'today',
+        name: 'Today',
+        agentIds: ['agent-3'],
+        entries: [
+          { type: 'team', teamId: 'team-1' },
+          { type: 'agent', agentId: 'agent-3' },
+        ],
+      },
+    ]));
+  });
+
+  it('removes a dragged team member from its team when dropped on a solo row', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.mouseDown(within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!);
+    fireEvent.mouseEnter(screen.getByText('Gamma').closest('.watchlist-row')!);
+    fireEvent.mouseUp(screen.getByText('Gamma').closest('.watchlist-row')!);
+
+    expect(mockOnRemoveAgentFromTeam).toHaveBeenCalledWith('team-1', 'agent-1', 'agent-3', 'before');
+  });
+
+  it('keeps a team member below the remaining team when dragged out in All Agents', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+
+    fireEvent.mouseDown(within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!);
+    fireEvent.mouseUp(screen.getByText('Gamma').closest('.watchlist-row')!);
+
+    expect(mockOnRemoveAgentFromTeam).toHaveBeenCalledWith('team-1', 'agent-1', 'agent-3', 'before');
+    expect(mockOnReorderAgents).toHaveBeenCalledWith(['agent-2', 'agent-1', 'agent-3']);
+  });
+
+  it('switches to single-agent context when right-clicking outside a multi-selection', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        selectedAgentIds={new Set(['agent-1'])}
+      />
+    );
+    const betaRow = screen.getByText('Beta').closest('.watchlist-row');
+
+    fireEvent.contextMenu(betaRow!);
+
+    expect(mockOnSelectionChange).toHaveBeenCalledWith(new Set(['agent-2']));
+    expect(screen.getByRole('button', { name: 'Rename' })).not.toBeDisabled();
   });
 
   it('disables Pause for already off agents', async () => {

--- a/src/layout/watchlist/AgentWatchlist.test.tsx
+++ b/src/layout/watchlist/AgentWatchlist.test.tsx
@@ -29,10 +29,13 @@ describe('AgentWatchlist', () => {
   const mockOnRestart = vi.fn();
   const mockOnClear = vi.fn();
   const mockOnDelete = vi.fn();
+  const mockOnAddAgentsToList = vi.fn();
+  const mockOnRemoveAgentsFromList = vi.fn();
   const mockOnCreateTeam = vi.fn();
   const mockOnUngroupTeam = vi.fn();
   const mockOnAddAgentToTeam = vi.fn();
   const mockOnRemoveAgentFromTeam = vi.fn();
+  const mockOnRemoveAgentFromTeamAtEntry = vi.fn();
   const mockOnRenameTeam = vi.fn(async () => {});
   const mockOnReorderTeamMember = vi.fn();
   const mockOnActiveListChange = vi.fn();
@@ -76,6 +79,9 @@ describe('AgentWatchlist', () => {
     onReorderTeamMember: mockOnReorderTeamMember,
     onAddToList: vi.fn(),
     onRemoveFromList: vi.fn(),
+    onAddAgentsToList: mockOnAddAgentsToList,
+    onRemoveAgentsFromList: mockOnRemoveAgentsFromList,
+    onRemoveAgentFromTeamAtEntry: mockOnRemoveAgentFromTeamAtEntry,
     collapsed: false,
     watchlists: sampleWatchlists,
     activeListId: 'all',
@@ -273,8 +279,36 @@ describe('AgentWatchlist', () => {
     fireEvent.mouseEnter(addButton);
     fireEvent.click(screen.getByRole('button', { name: '1. Later' }));
 
-    expect(defaultProps.onAddToList).toHaveBeenCalledWith('later', 'agent-1');
-    expect(defaultProps.onAddToList).toHaveBeenCalledWith('later', 'agent-2');
+    expect(mockOnAddAgentsToList).toHaveBeenCalledWith('later', ['agent-1', 'agent-2']);
+    expect(defaultProps.onAddToList).not.toHaveBeenCalled();
+  });
+
+  it('batches list additions and removals from a multi-selection context menu', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        selectedAgentIds={new Set(['agent-1', 'agent-2'])}
+        watchlists={[
+          { id: 'inbox', name: 'Inbox', entries: [{ type: 'agent', agentId: 'agent-1' }, { type: 'agent', agentId: 'agent-2' }] },
+          { id: 'later', name: 'Later', entries: [] },
+        ]}
+      />
+    );
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row')!;
+
+    fireEvent.contextMenu(agentRow);
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Add Selected to List' }));
+    fireEvent.click(screen.getByRole('button', { name: '1. Later' }));
+
+    expect(mockOnAddAgentsToList).toHaveBeenCalledWith('later', ['agent-1', 'agent-2']);
+    expect(defaultProps.onAddToList).not.toHaveBeenCalled();
+
+    fireEvent.contextMenu(agentRow);
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Remove Selected from List' }));
+    fireEvent.click(screen.getByRole('button', { name: '1. Inbox' }));
+
+    expect(mockOnRemoveAgentsFromList).toHaveBeenCalledWith('inbox', ['agent-1', 'agent-2']);
+    expect(defaultProps.onRemoveFromList).not.toHaveBeenCalled();
   });
 
   it('renders team blocks even when a sort is active', async () => {
@@ -582,6 +616,38 @@ describe('AgentWatchlist', () => {
     fireEvent.mouseUp(screen.getByText('Gamma').closest('.watchlist-row')!);
 
     expect(mockOnRemoveAgentFromTeam).toHaveBeenCalledWith('team-1', 'agent-1', 'agent-3', 'before');
+  });
+
+  it('extracts a team member to a team edge in a watchlist with one atomic callback', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        watchlists={[
+          {
+            id: 'today',
+            name: 'Today',
+            entries: [{ type: 'team', teamId: 'team-1' }],
+          },
+        ]}
+        activeListId="today"
+        teams={[{ id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] }]}
+      />
+    );
+    const beforeZone = screen.getByTestId('team-drop-before-team-1');
+
+    fireEvent.mouseDown(within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!);
+    fireEvent.mouseEnter(beforeZone);
+    fireEvent.mouseUp(beforeZone);
+
+    expect(mockOnRemoveAgentFromTeamAtEntry).toHaveBeenCalledWith(
+      'team-1',
+      'agent-1',
+      { type: 'team', teamId: 'team-1' },
+      'before',
+      'today',
+    );
+    expect(mockOnRemoveAgentFromTeam).not.toHaveBeenCalled();
+    expect(mockOnWatchlistsChange).not.toHaveBeenCalled();
   });
 
   it('keeps a team member below the remaining team when dragged out in All Agents', async () => {

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { AgentConfig, AgentTelemetry } from "../../types";
-import type { Watchlist, ContextMenuState, WatchlistPrefs, AgentInteractions, SortableColumnId, OptionalColumnId, AgentTeam, WatchlistDisplayItem } from "./types";
+import type { Watchlist, ContextMenuState, WatchlistPrefs, AgentInteractions, SortableColumnId, OptionalColumnId, AgentTeam, WatchlistDisplayItem, WatchlistEntry } from "./types";
 import { DEFAULT_WATCHLIST_PREFS } from "./types";
 
 const COLUMN_WIDTHS: Record<OptionalColumnId, string> = {
@@ -74,12 +74,15 @@ interface AgentWatchlistProps {
   onClear: (agentId: string) => void;
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
+  onAddAgentsToList?: (listId: string, agentIds: string[]) => void;
+  onRemoveAgentsFromList?: (listId: string, agentIds: string[]) => void;
   onDelete: (agentId: string) => void;
   onCreateTeam?: (agentIds: string[]) => void;
   onUngroupTeam?: (teamId: string) => void;
   onRenameTeam?: (teamId: string, newName: string) => Promise<void>;
   onAddAgentToTeam?: (teamId: string, agentId: string) => void;
   onRemoveAgentFromTeam?: (teamId: string, agentId: string, targetAgentId?: string, position?: DropPosition) => void;
+  onRemoveAgentFromTeamAtEntry?: (teamId: string, agentId: string, targetEntry: WatchlistEntry, position: DropPosition, targetListId: string) => void;
   onReorderTeamMember?: (teamId: string, draggedAgentId: string, targetAgentId: string, position?: DropPosition) => void;
   collapsed: boolean;
   watchlists: Watchlist[];
@@ -109,12 +112,15 @@ export default function AgentWatchlist({
   onClear,
   onAddToList,
   onRemoveFromList,
+  onAddAgentsToList,
+  onRemoveAgentsFromList,
   onDelete,
   onCreateTeam,
   onUngroupTeam,
   onRenameTeam,
   onAddAgentToTeam,
   onRemoveAgentFromTeam,
+  onRemoveAgentFromTeamAtEntry,
   onReorderTeamMember,
   collapsed,
   watchlists,
@@ -464,9 +470,25 @@ export default function AgentWatchlist({
           wasDragging.current = true;
         }
       } else if (target.type === "team" && target.position !== "inside") {
-        if (sourceTeam) onRemoveAgentFromTeam?.(sourceTeam.id, draggedAgentId);
-        if (activeListId === "all") insertAgentAroundTeam(draggedAgentId, target.teamId, target.position);
-        else await moveAgentEntryInActiveList(draggedAgentId, target);
+        if (sourceTeam) {
+          if (activeListId !== "all" && onRemoveAgentFromTeamAtEntry) {
+            onRemoveAgentFromTeamAtEntry(
+              sourceTeam.id,
+              draggedAgentId,
+              { type: "team", teamId: target.teamId },
+              target.position,
+              activeListId,
+            );
+          } else {
+            onRemoveAgentFromTeam?.(sourceTeam.id, draggedAgentId);
+            if (activeListId === "all") insertAgentAroundTeam(draggedAgentId, target.teamId, target.position);
+            else await moveAgentEntryInActiveList(draggedAgentId, target);
+          }
+        } else if (activeListId === "all") {
+          insertAgentAroundTeam(draggedAgentId, target.teamId, target.position);
+        } else {
+          await moveAgentEntryInActiveList(draggedAgentId, target);
+        }
         wasDragging.current = true;
       } else if (target.type === "agent" && sourceTeam?.agentIds.includes(target.agentId)) {
         onReorderTeamMember?.(sourceTeam.id, draggedAgentId, target.agentId, target.position);
@@ -985,6 +1007,14 @@ export default function AgentWatchlist({
             onRemoveFromList(listId, agentId);
             setContextMenu(p => ({ ...p, visible: false }));
           }}
+          onAddAgentsToList={onAddAgentsToList ? (listId, ids) => {
+            onAddAgentsToList(listId, ids);
+            setContextMenu(p => ({ ...p, visible: false }));
+          } : undefined}
+          onRemoveAgentsFromList={onRemoveAgentsFromList ? (listId, ids) => {
+            onRemoveAgentsFromList(listId, ids);
+            setContextMenu(p => ({ ...p, visible: false }));
+          } : undefined}
           onDelete={onDelete}
           onCreateTeam={onCreateTeam}
           onClose={() => setContextMenu(p => ({ ...p, visible: false }))}
@@ -1023,6 +1053,14 @@ export default function AgentWatchlist({
               onRemoveFromList(listId, id);
               setTeamContextMenu((p) => ({ ...p, visible: false }));
             }}
+            onAddAgentsToList={onAddAgentsToList ? (listId, ids) => {
+              onAddAgentsToList(listId, ids);
+              setTeamContextMenu((p) => ({ ...p, visible: false }));
+            } : undefined}
+            onRemoveAgentsFromList={onRemoveAgentsFromList ? (listId, ids) => {
+              onRemoveAgentsFromList(listId, ids);
+              setTeamContextMenu((p) => ({ ...p, visible: false }));
+            } : undefined}
             onDelete={onDelete}
             onUngroupTeam={(id) => {
               onUngroupTeam?.(id);

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import type { AgentConfig, AgentTelemetry } from "../../types";
-import type { Watchlist, ContextMenuState, WatchlistPrefs, AgentInteractions, SortableColumnId, OptionalColumnId } from "./types";
+import type { Watchlist, ContextMenuState, WatchlistPrefs, AgentInteractions, SortableColumnId, OptionalColumnId, AgentTeam, WatchlistDisplayItem } from "./types";
 import { DEFAULT_WATCHLIST_PREFS } from "./types";
 
 const COLUMN_WIDTHS: Record<OptionalColumnId, string> = {
@@ -11,18 +11,29 @@ const COLUMN_WIDTHS: Record<OptionalColumnId, string> = {
   last_queried:   '32px',
 };
 import {
-  reorderWithinList,
   filterAgents,
-  getAgentsForList,
   createWatchlist,
   formatUptime,
   formatRelativeTime,
   cycleSort,
   sortAgents,
+  getDisplayItemsForList,
+  flattenDisplayItems,
+  getWatchlistEntries,
 } from "./watchlistUtils";
 import { deriveCurrentThought, getStatusColorClass, getAgentStatusLabel, getAgentStatusTextClass } from "../../utils/statusUtils";
 import { AgentContextMenu } from "../../../src/components/AgentContextMenu";
 import { ColumnPicker } from "./ColumnPicker";
+
+type DragSource =
+  | { type: "agent"; agentId: string }
+  | { type: "team"; teamId: string };
+
+type DropPosition = "before" | "after";
+
+type DropTarget =
+  | { type: "agent"; agentId: string; position: DropPosition }
+  | { type: "team"; teamId: string; position: "before" | "inside" | "after" };
 
 function SortableHeader({ columnId, sort, onSort, label }: {
   columnId: SortableColumnId;
@@ -64,6 +75,12 @@ interface AgentWatchlistProps {
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
   onDelete: (agentId: string) => void;
+  onCreateTeam?: (agentIds: string[]) => void;
+  onUngroupTeam?: (teamId: string) => void;
+  onRenameTeam?: (teamId: string, newName: string) => Promise<void>;
+  onAddAgentToTeam?: (teamId: string, agentId: string) => void;
+  onRemoveAgentFromTeam?: (teamId: string, agentId: string, targetAgentId?: string, position?: DropPosition) => void;
+  onReorderTeamMember?: (teamId: string, draggedAgentId: string, targetAgentId: string, position?: DropPosition) => void;
   collapsed: boolean;
   watchlists: Watchlist[];
   activeListId: string;
@@ -72,6 +89,7 @@ interface AgentWatchlistProps {
   prefs?: WatchlistPrefs;
   onPrefsChange?: (prefs: WatchlistPrefs) => void;
   interactions?: AgentInteractions;
+  teams?: AgentTeam[];
 }
 
 export default function AgentWatchlist({
@@ -92,6 +110,12 @@ export default function AgentWatchlist({
   onAddToList,
   onRemoveFromList,
   onDelete,
+  onCreateTeam,
+  onUngroupTeam,
+  onRenameTeam,
+  onAddAgentToTeam,
+  onRemoveAgentFromTeam,
+  onReorderTeamMember,
   collapsed,
   watchlists,
   activeListId,
@@ -100,6 +124,7 @@ export default function AgentWatchlist({
   prefs = DEFAULT_WATCHLIST_PREFS,
   onPrefsChange,
   interactions = {},
+  teams = [],
 }: AgentWatchlistProps) {
   // ── Column picker state ────────────────────────────────────────────
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -107,21 +132,30 @@ export default function AgentWatchlist({
   // ── Search State ───────────────────────────────────────────────────
   const [searchTerm, setSearchTerm] = useState("");
   const [draggedAgentId, setDraggedAgentId] = useState<string | null>(null);
-  const [dragOverAgentId, setDragOverAgentId] = useState<string | null>(null);
+  const [draggedTeamId, setDraggedTeamId] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>({
     visible: false,
     x: 0,
     y: 0,
     agentId: null,
+    agentIds: undefined,
   });
   const [editingListId, setEditingListId] = useState<string | null>(null);
   const [editingListName, setEditingListName] = useState("");
   const [tabContextMenu, setTabContextMenu] = useState<{ visible: boolean; x: number; y: number; listId: string | null }>({
     visible: false, x: 0, y: 0, listId: null,
   });
+  const [teamContextMenu, setTeamContextMenu] = useState<{ visible: boolean; x: number; y: number; teamId: string | null }>({
+    visible: false, x: 0, y: 0, teamId: null,
+  });
   const [editingAgentId, setEditingAgentId] = useState<string | null>(null);
   const [editingAgentName, setEditingAgentName] = useState("");
+  const [editingTeamId, setEditingTeamId] = useState<string | null>(null);
+  const [editingTeamName, setEditingTeamName] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
+  const dragSourceRef = useRef<DragSource | null>(null);
+  const dropTargetRef = useRef<DropTarget | null>(null);
+  const [dropTarget, setDropTargetState] = useState<DropTarget | null>(null);
   const wasDragging = useRef(false);
   const lastSelectedIdRef = useRef<string | null>(null);
   const lastClickRef = useRef<{ id: string; time: number } | null>(null);
@@ -141,11 +175,11 @@ export default function AgentWatchlist({
     const validIds = new Set(agents.map((a) => a.session_id));
     const pruned = watchlists.map((wl) => ({
       ...wl,
-      agentIds: wl.agentIds.filter((id: string) => validIds.has(id)),
+      entries: getWatchlistEntries(wl).filter((entry) => entry.type === "team" || validIds.has(entry.agentId)),
     }));
     // Only persist if something actually changed
     const changed = pruned.some(
-      (wl, i) => wl.agentIds.length !== watchlists[i]?.agentIds.length
+      (wl, i) => getWatchlistEntries(wl).length !== getWatchlistEntries(watchlists[i]).length
     );
     if (changed) {
       persistWatchlists(pruned);
@@ -168,8 +202,46 @@ export default function AgentWatchlist({
       ? null
       : watchlists.find((l) => l.id === activeListId) || null;
 
-  const listAgents = getAgentsForList(agents, activeList);
-  const displayedAgents = filterAgents(listAgents, searchTerm);
+  const baseDisplayItems = getDisplayItemsForList(agents, activeList, teams);
+  const filteredDisplayItems = baseDisplayItems
+    .map((item): WatchlistDisplayItem | null => {
+      if (!searchTerm.trim()) return item;
+      const term = searchTerm.toLowerCase();
+      if (item.type === "team") {
+        const matchingAgents = filterAgents(item.agents, searchTerm);
+        if (item.team.name.toLowerCase().includes(term) || matchingAgents.length > 0) {
+          return { ...item, agents: matchingAgents.length > 0 ? matchingAgents : item.agents };
+        }
+        return null;
+      }
+      return filterAgents([item.agent], searchTerm).length > 0 ? item : null;
+    })
+    .filter((item): item is WatchlistDisplayItem => Boolean(item));
+  const unsortedDisplayedAgents = flattenDisplayItems(filteredDisplayItems);
+  const sortedDisplayedAgents = sortAgents(unsortedDisplayedAgents, prefs.sort, telemetry, interactions);
+  const sortedAgentRanks = new Map(sortedDisplayedAgents.map((agent, index) => [agent.session_id, index]));
+  const sortedDisplayItems = prefs.sort
+    ? [...filteredDisplayItems]
+        .map((item) => {
+          if (item.type === "agent") return item;
+          return {
+            ...item,
+            agents: [...item.agents].sort(
+              (a, b) => (sortedAgentRanks.get(a.session_id) ?? 0) - (sortedAgentRanks.get(b.session_id) ?? 0),
+            ),
+          };
+        })
+        .sort((a, b) => {
+          const aRank = a.type === "agent"
+            ? sortedAgentRanks.get(a.agent.session_id) ?? 0
+            : Math.min(...a.agents.map((agent) => sortedAgentRanks.get(agent.session_id) ?? 0));
+          const bRank = b.type === "agent"
+            ? sortedAgentRanks.get(b.agent.session_id) ?? 0
+            : Math.min(...b.agents.map((agent) => sortedAgentRanks.get(agent.session_id) ?? 0));
+          return aRank - bRank;
+        })
+    : filteredDisplayItems;
+  const displayedAgents = flattenDisplayItems(sortedDisplayItems);
 
   // ── Handlers ───────────────────────────────────────────────────────
   const handleCreateList = async () => {
@@ -209,6 +281,20 @@ export default function AgentWatchlist({
     setEditingAgentId(null);
   };
 
+  const handleRenameTeamCommit = async (teamId: string) => {
+    if (isRenaming || !editingTeamId) return;
+    const trimmed = editingTeamName.trim();
+    if (trimmed) {
+      setIsRenaming(true);
+      try {
+        await onRenameTeam?.(teamId, trimmed);
+      } finally {
+        setIsRenaming(false);
+      }
+    }
+    setEditingTeamId(null);
+  };
+
   const handleTabContextMenu = (e: React.MouseEvent, listId: string) => {
     e.preventDefault();
     e.stopPropagation();
@@ -220,55 +306,229 @@ export default function AgentWatchlist({
 
   // ── Mouse-based Drag & Drop (WebView2-compatible) ──────────────────
   const handleMouseDown = (agentId: string) => {
+    dragSourceRef.current = { type: "agent", agentId };
     setDraggedAgentId(agentId);
+    setDraggedTeamId(null);
   };
 
-  const handleMouseEnterRow = (agentId: string) => {
-    if (draggedAgentId && draggedAgentId !== agentId) {
-      setDragOverAgentId(agentId);
+  const setDropTarget = (target: DropTarget | null) => {
+    dropTargetRef.current = target;
+    setDropTargetState(target);
+  };
+
+  const resetDragState = () => {
+    dragSourceRef.current = null;
+    setDropTarget(null);
+    setDraggedAgentId(null);
+    setDraggedTeamId(null);
+  };
+
+  const rowDropPosition = (e: React.MouseEvent): DropPosition => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (rect.height <= 0) return "before";
+    return e.clientY < rect.top + rect.height / 2 ? "before" : "after";
+  };
+
+  const teamDropPosition = (e: React.MouseEvent): "before" | "inside" | "after" => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (rect.height <= 0) return "inside";
+    const ratio = (e.clientY - rect.top) / rect.height;
+    if (ratio < 0.25) return "before";
+    if (ratio > 0.75) return "after";
+    return "inside";
+  };
+
+  const targetTeamForAgent = (agentId: string) => teams.find((team) => team.agentIds.includes(agentId));
+
+  const updateAgentRowDropTarget = (targetAgentId: string, e?: React.MouseEvent) => {
+    const source = dragSourceRef.current;
+    const targetTeam = targetTeamForAgent(targetAgentId);
+    const position = e ? rowDropPosition(e) : "before";
+
+    if (source?.type === "team") {
+      setDropTarget(targetTeam ? { type: "team", teamId: targetTeam.id, position } : { type: "agent", agentId: targetAgentId, position });
+      return;
+    }
+
+    if (source?.type === "agent") {
+      const sourceTeam = targetTeamForAgent(source.agentId);
+      if (targetTeam && sourceTeam?.id === targetTeam.id) {
+        setDropTarget(source.agentId === targetAgentId ? null : { type: "agent", agentId: targetAgentId, position });
+        return;
+      }
+      if (targetTeam) {
+        const teamPosition = e ? teamDropPosition(e) : "inside";
+        setDropTarget({ type: "team", teamId: targetTeam.id, position: teamPosition });
+        return;
+      }
+      setDropTarget(source.agentId === targetAgentId ? null : { type: "agent", agentId: targetAgentId, position });
     }
   };
 
-  const handleMouseUp = async () => {
-    if (draggedAgentId && dragOverAgentId && draggedAgentId !== dragOverAgentId) {
-      if (activeListId === "all") {
+  const handleMouseEnterRow = (agentId: string, e: React.MouseEvent) => {
+    updateAgentRowDropTarget(agentId, e);
+  };
+
+  const insertAgentAroundTeam = (draggedAgentId: string, teamId: string, position: "before" | "after") => {
+    const team = teams.find((candidate) => candidate.id === teamId);
+    if (!team) return;
+    const newOrder = agents.map((agent) => agent.session_id).filter((id) => id !== draggedAgentId);
+    const indexes = team.agentIds.map((id) => newOrder.indexOf(id)).filter((index) => index !== -1);
+    if (indexes.length === 0) return;
+    const targetIndex = position === "before" ? Math.min(...indexes) : Math.max(...indexes) + 1;
+    newOrder.splice(targetIndex, 0, draggedAgentId);
+    onReorderAgents(newOrder);
+  };
+
+  const updateActiveEntries = async (nextEntries: ReturnType<typeof getWatchlistEntries>) => {
+    if (!activeList) return;
+    await persistWatchlists(watchlists.map((list) =>
+      list.id === activeList.id
+        ? { ...list, entries: nextEntries, agentIds: nextEntries.filter((entry) => entry.type === "agent").map((entry) => entry.agentId) }
+        : list,
+    ));
+  };
+
+  const moveAgentEntryInActiveList = async (draggedAgentId: string, target: DropTarget) => {
+    if (!activeList) return;
+    const entries = getWatchlistEntries(activeList);
+    const fromIndex = entries.findIndex((entry) => entry.type === "agent" && entry.agentId === draggedAgentId);
+    const toIndex = entries.findIndex((entry) => {
+      if (target.type === "agent") return entry.type === "agent" && entry.agentId === target.agentId;
+      return entry.type === "team" && entry.teamId === target.teamId;
+    });
+    if (fromIndex === -1 || toIndex === -1) return;
+    const nextEntries = [...entries];
+    const [dragged] = nextEntries.splice(fromIndex, 1);
+    const adjustedTargetIndex = nextEntries.findIndex((entry) => {
+      if (target.type === "agent") return entry.type === "agent" && entry.agentId === target.agentId;
+      return entry.type === "team" && entry.teamId === target.teamId;
+    });
+    const insertIndex = adjustedTargetIndex + (target.position === "after" ? 1 : 0);
+    nextEntries.splice(insertIndex, 0, dragged);
+    await updateActiveEntries(nextEntries);
+  };
+
+  const moveTeamEntry = async (draggedTeamId: string, target: DropTarget) => {
+    if (activeListId === "all") {
+      const draggedTeam = teams.find((team) => team.id === draggedTeamId);
+      if (!draggedTeam) return;
+      const draggedIds = new Set(draggedTeam.agentIds);
+      const remaining = agents.map((agent) => agent.session_id).filter((id) => !draggedIds.has(id));
+      let targetIndex = -1;
+      if (target.type === "team") {
+        const targetTeam = teams.find((team) => team.id === target.teamId);
+        const indexes = targetTeam?.agentIds.map((id) => remaining.indexOf(id)).filter((index) => index !== -1) ?? [];
+        if (indexes.length > 0) targetIndex = target.position === "after" ? Math.max(...indexes) + 1 : Math.min(...indexes);
+      } else {
+        const rowIndex = remaining.indexOf(target.agentId);
+        if (rowIndex !== -1) targetIndex = rowIndex + (target.position === "after" ? 1 : 0);
+      }
+      if (targetIndex === -1) return;
+      const newOrder = [...remaining];
+      newOrder.splice(targetIndex, 0, ...draggedTeam.agentIds);
+      onReorderAgents(newOrder);
+      return;
+    }
+
+    if (!activeList) return;
+    const entries = getWatchlistEntries(activeList);
+    const fromIndex = entries.findIndex((entry) => entry.type === "team" && entry.teamId === draggedTeamId);
+    const toIndex = entries.findIndex((entry) => {
+      if (target.type === "team") return entry.type === "team" && entry.teamId === target.teamId;
+      return entry.type === "agent" && entry.agentId === target.agentId;
+    });
+    if (fromIndex === -1 || toIndex === -1) return;
+    const nextEntries = [...entries];
+    const [moved] = nextEntries.splice(fromIndex, 1);
+    const adjustedTargetIndex = nextEntries.findIndex((entry) => {
+      if (target.type === "team") return entry.type === "team" && entry.teamId === target.teamId;
+      return entry.type === "agent" && entry.agentId === target.agentId;
+    });
+    const insertIndex = adjustedTargetIndex + (target.position === "after" ? 1 : 0);
+    nextEntries.splice(insertIndex, 0, moved);
+    await updateActiveEntries(nextEntries);
+  };
+
+  const handleMouseUp = async (target = dropTargetRef.current) => {
+    const source = dragSourceRef.current;
+    if (source?.type === "team" && target) {
+      await moveTeamEntry(source.teamId, target);
+      wasDragging.current = true;
+    } else if (source?.type === "agent" && target) {
+      const draggedAgentId = source.agentId;
+      const sourceTeam = targetTeamForAgent(draggedAgentId);
+      if (target.type === "team" && target.position === "inside") {
+        if (!sourceTeam || sourceTeam.id !== target.teamId) {
+          onAddAgentToTeam?.(target.teamId, draggedAgentId);
+          wasDragging.current = true;
+        }
+      } else if (target.type === "team" && target.position !== "inside") {
+        if (sourceTeam) onRemoveAgentFromTeam?.(sourceTeam.id, draggedAgentId);
+        if (activeListId === "all") insertAgentAroundTeam(draggedAgentId, target.teamId, target.position);
+        else await moveAgentEntryInActiveList(draggedAgentId, target);
+        wasDragging.current = true;
+      } else if (target.type === "agent" && sourceTeam?.agentIds.includes(target.agentId)) {
+        onReorderTeamMember?.(sourceTeam.id, draggedAgentId, target.agentId, target.position);
+        wasDragging.current = true;
+      } else if (target.type === "agent" && sourceTeam) {
+        onRemoveAgentFromTeam?.(sourceTeam.id, draggedAgentId, target.agentId, target.position);
+        if (activeListId === "all") {
+          const remaining = agents.map((agent) => agent.session_id).filter((id) => id !== draggedAgentId);
+          const targetIndex = remaining.indexOf(target.agentId);
+          if (targetIndex !== -1) {
+            const newOrder = [...remaining];
+            newOrder.splice(targetIndex + (target.position === "after" ? 1 : 0), 0, draggedAgentId);
+            onReorderAgents(newOrder);
+          }
+        }
+        wasDragging.current = true;
+      } else if (target.type === "agent" && activeListId === "all") {
         const fromIndex = agents.findIndex(a => a.session_id === draggedAgentId);
-        const toIndex = agents.findIndex(a => a.session_id === dragOverAgentId);
+        const toIndex = agents.findIndex(a => a.session_id === target.agentId);
         if (fromIndex !== -1 && toIndex !== -1) {
           const newOrder = [...agents.map(a => a.session_id)];
           const [dragged] = newOrder.splice(fromIndex, 1);
-          newOrder.splice(toIndex, 0, dragged);
+          const adjustedTargetIndex = newOrder.indexOf(target.agentId);
+          newOrder.splice(adjustedTargetIndex + (target.position === "after" ? 1 : 0), 0, dragged);
           onReorderAgents(newOrder);
           wasDragging.current = true;
         }
-      } else if (activeList) {
-        const fromIndex = activeList.agentIds.indexOf(draggedAgentId);
-        const toIndex = activeList.agentIds.indexOf(dragOverAgentId);
-        if (fromIndex !== -1 && toIndex !== -1) {
-          const reordered = reorderWithinList(activeList.agentIds, fromIndex, toIndex);
-          const updated = watchlists.map((l) =>
-            l.id === activeList.id ? { ...l, agentIds: reordered } : l,
-          );
-          await persistWatchlists(updated);
-          wasDragging.current = true;
-        }
+      } else if (target.type === "agent") {
+        await moveAgentEntryInActiveList(draggedAgentId, target);
+        wasDragging.current = true;
       }
     }
+    resetDragState();
+  };
+
+  const handleTeamMouseDown = (teamId: string) => {
+    dragSourceRef.current = { type: "team", teamId };
+    setDraggedTeamId(teamId);
     setDraggedAgentId(null);
-    setDragOverAgentId(null);
+  };
+
+  const handleTeamDropZone = (teamId: string, position: "before" | "inside" | "after") => {
+    const source = dragSourceRef.current;
+    if (!source) return;
+    if (source.type === "team" && source.teamId === teamId) return;
+    if (source.type === "agent") {
+      const team = teams.find((candidate) => candidate.id === teamId);
+      if (!team || (position === "inside" && team.agentIds.includes(source.agentId))) return;
+    }
+    setDropTarget({ type: "team", teamId, position });
   };
 
   // Cancel drag if mouse leaves the list area
   useEffect(() => {
     const cancelDrag = () => {
-      if (draggedAgentId) {
-        setDraggedAgentId(null);
-        setDragOverAgentId(null);
+      if (dragSourceRef.current) {
+        resetDragState();
       }
     };
     window.addEventListener("mouseup", cancelDrag);
     return () => window.removeEventListener("mouseup", cancelDrag);
-  }, [draggedAgentId]);
+  }, [draggedAgentId, draggedTeamId]);
 
   const handleContextMenu = (e: React.MouseEvent, agentId: string) => {
     e.preventDefault();
@@ -276,7 +536,29 @@ export default function AgentWatchlist({
     const menuW = 200, menuH = 280;
     const x = Math.min(e.clientX, window.innerWidth - menuW - 8);
     const y = Math.min(e.clientY, window.innerHeight - menuH - 8);
-    setContextMenu({ visible: true, x, y, agentId });
+    const isInsideMultiSelection = selectedAgentIds.size > 1 && selectedAgentIds.has(agentId);
+    if (!isInsideMultiSelection && !selectedAgentIds.has(agentId)) {
+      onSelectionChange(new Set([agentId]));
+    }
+    setContextMenu({
+      visible: true,
+      x,
+      y,
+      agentId,
+      agentIds: isInsideMultiSelection ? Array.from(selectedAgentIds) : [agentId],
+    });
+  };
+
+  const handleTeamContextMenu = (e: React.MouseEvent, teamId: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const menuW = 200, menuH = 160;
+    setTeamContextMenu({
+      visible: true,
+      x: Math.min(e.clientX, window.innerWidth - menuW - 8),
+      y: Math.min(e.clientY, window.innerHeight - menuH - 8),
+      teamId,
+    });
   };
 
   // ── Status derivation helper ───────────────────────────────────────
@@ -298,8 +580,151 @@ export default function AgentWatchlist({
   const colFragment = visibleCols.map(c => COLUMN_WIDTHS[c.id]).join(' ');
   const gridTemplate = `auto minmax(50px, 1fr)${colFragment ? ' ' + colFragment : ''}`;
 
-  // ── Sorted agents ──────────────────────────────────────────────────
-  const sortedAgents = sortAgents(displayedAgents, prefs.sort, telemetry, interactions);
+  const renderAgentRow = (agent: AgentConfig, options: { nested?: boolean } = {}) => {
+    const agentId = agent.session_id;
+    const isSelected = selectedAgentIds.has(agentId);
+    const { status, thought } = getAgentStatus(agentId);
+    const statusColor = getStatusColorClass(status);
+    const metrics = telemetry[agentId];
+    const team = teams.find((candidate) => candidate.agentIds.includes(agentId));
+    const isDragTarget = dropTarget?.type === "agent" && dropTarget.agentId === agentId && draggedAgentId !== agentId;
+    const isBeingDragged = draggedAgentId === agentId;
+    const isNestedTeamDropTarget = options.nested && dropTarget?.type === "team" && team?.id === dropTarget.teamId;
+
+    return (
+      <div
+        key={agentId}
+        onMouseDown={() => handleMouseDown(agentId)}
+        onMouseEnter={(e) => { e.stopPropagation(); handleMouseEnterRow(agentId, e); }}
+        onMouseMove={(e) => { e.stopPropagation(); updateAgentRowDropTarget(agentId, e); }}
+        onMouseUp={(e) => {
+          e.stopPropagation();
+          updateAgentRowDropTarget(agentId, e);
+          handleMouseUp();
+        }}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (wasDragging.current) { wasDragging.current = false; return; }
+
+          const now = Date.now();
+          const DOUBLE_CLICK_TOLERANCE = 450;
+          const isDoubleClick = lastClickRef.current &&
+                               lastClickRef.current.id === agentId &&
+                               (now - lastClickRef.current.time) < DOUBLE_CLICK_TOLERANCE;
+
+          lastClickRef.current = { id: agentId, time: now };
+
+          if (e.shiftKey && lastSelectedIdRef.current) {
+            const currentIndex = displayedAgents.findIndex(a => a.session_id === agentId);
+            const lastIndex = displayedAgents.findIndex(a => a.session_id === lastSelectedIdRef.current);
+
+            if (currentIndex !== -1 && lastIndex !== -1) {
+              const start = Math.min(currentIndex, lastIndex);
+              const end = Math.max(currentIndex, lastIndex);
+              const rangeIds = displayedAgents.slice(start, end + 1).map(a => a.session_id);
+
+              const next = (e.ctrlKey || e.metaKey)
+                ? new Set([...selectedAgentIds, ...rangeIds])
+                : new Set(rangeIds);
+
+              onSelectionChange(next);
+              return;
+            }
+          }
+
+          if (e.ctrlKey || e.metaKey) {
+            const next = new Set(selectedAgentIds);
+            if (next.has(agentId)) next.delete(agentId);
+            else next.add(agentId);
+            onSelectionChange(next);
+            lastSelectedIdRef.current = agentId;
+          } else {
+            if (selectedAgentIds.has(agentId) && selectedAgentIds.size === 1) {
+              if (!isDoubleClick) {
+                onSelectionChange(new Set());
+                lastSelectedIdRef.current = null;
+              } else {
+                onAgentClick(agentId);
+                onSelectionChange(new Set([agentId]));
+                lastSelectedIdRef.current = agentId;
+              }
+            } else {
+              onSelectionChange(new Set([agentId]));
+              lastSelectedIdRef.current = agentId;
+            }
+          }
+        }}
+        onContextMenu={(e) => handleContextMenu(e, agentId)}
+        className={`watchlist-row ${isSelected ? "selected" : ""} ${isDragTarget ? `drag-over-${dropTarget?.type === "agent" ? dropTarget.position : "before"}` : ""} ${isNestedTeamDropTarget ? "bg-[var(--color-wardian-accent)]/10" : ""} ${isBeingDragged ? "opacity-50" : ""} ${options.nested ? "ml-2 border-l border-wardian-border/40" : ""} select-none`}
+        style={{ cursor: "grab", gridTemplateColumns: gridTemplate }}
+      >
+        <div className={`w-2 h-2 rounded-full flex-shrink-0 ${statusColor}`} />
+        <div className="flex-1 min-w-0">
+          {editingAgentId === agentId ? (
+            <input
+              className="text-xs font-bold text-primary bg-transparent border-b border-[var(--color-wardian-accent)] focus:outline-none w-full"
+              autoFocus
+              value={editingAgentName}
+              onChange={(e) => setEditingAgentName(e.target.value)}
+              onBlur={() => handleRenameAgentCommit(agentId)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleRenameAgentCommit(agentId);
+                }
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setEditingAgentId(null);
+                }
+                e.stopPropagation();
+              }}
+              onClick={e => e.stopPropagation()}
+              onMouseDown={e => e.stopPropagation()}
+            />
+          ) : (
+            <p className="text-xs font-bold truncate text-bright-neutral">
+              {agent.session_name}
+            </p>
+          )}
+          <p className="text-[10px] text-primary/50 font-medium truncate tracking-wide">
+            {agent.agent_class}
+          </p>
+        </div>
+        {prefs.columns.filter(c => c.visible).map(col => {
+          if (col.id === 'status_label') return (
+            <span key="status_label" className={`text-[9px] truncate max-w-[60px] ${getAgentStatusTextClass(status)}`}>
+              {getAgentStatusLabel(status, thought)}
+            </span>
+          );
+          if (col.id === 'query_count') return (
+            <span key="query_count" className="text-[9px] text-muted-neutral tabular-nums w-4 text-right">
+              {metrics?.query_count ?? "–"}
+            </span>
+          );
+          if (col.id === 'uptime') return (
+            <span key="uptime" className="label-small tabular-nums text-muted">
+              {formatUptime(metrics?.init_timestamp ?? null)}
+            </span>
+          );
+          if (col.id === 'provider_model') {
+            const provider = agent.provider ?? '–';
+            const model = agent.model ? ` · ${agent.model}` : '';
+            return (
+              <span key="provider_model" className="label-small text-muted truncate overflow-hidden">
+                {provider}{model}
+              </span>
+            );
+          }
+          if (col.id === 'last_queried') return (
+            <span key="last_queried" className="label-small tabular-nums text-muted">
+              {formatRelativeTime(interactions[agentId])}
+            </span>
+          );
+          return null;
+        })}
+      </div>
+    );
+  };
 
   // ── Render ─────────────────────────────────────────────────────────
   return (
@@ -414,146 +839,95 @@ export default function AgentWatchlist({
           className="flex-1 overflow-y-auto no-scrollbar"
           onClick={() => onSelectionChange(new Set())}
         >
-          {sortedAgents.map((agent) => {
-            const agentId = agent.session_id;
-            const isSelected = selectedAgentIds.has(agentId);
-            const { status, thought } = getAgentStatus(agentId);
-            const statusColor = getStatusColorClass(status);
-            const metrics = telemetry[agentId];
-            const isDragTarget = dragOverAgentId === agentId && draggedAgentId !== null && draggedAgentId !== agentId;
-            const isBeingDragged = draggedAgentId === agentId;
-
-            return (
-              <div
-                key={agentId}
-                onMouseDown={() => handleMouseDown(agentId)}
-                onMouseEnter={() => handleMouseEnterRow(agentId)}
-                onMouseUp={(e) => { e.stopPropagation(); handleMouseUp(); }}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (wasDragging.current) { wasDragging.current = false; return; }
-
-                  const now = Date.now();
-                  const DOUBLE_CLICK_TOLERANCE = 450;
-                  const isDoubleClick = lastClickRef.current &&
-                                       lastClickRef.current.id === agentId &&
-                                       (now - lastClickRef.current.time) < DOUBLE_CLICK_TOLERANCE;
-
-                  lastClickRef.current = { id: agentId, time: now };
-
-                  if (e.shiftKey && lastSelectedIdRef.current) {
-                    const currentIndex = displayedAgents.findIndex(a => a.session_id === agentId);
-                    const lastIndex = displayedAgents.findIndex(a => a.session_id === lastSelectedIdRef.current);
-
-                    if (currentIndex !== -1 && lastIndex !== -1) {
-                      const start = Math.min(currentIndex, lastIndex);
-                      const end = Math.max(currentIndex, lastIndex);
-                      const rangeIds = displayedAgents.slice(start, end + 1).map(a => a.session_id);
-
-                      const next = (e.ctrlKey || e.metaKey)
-                        ? new Set([...selectedAgentIds, ...rangeIds])
-                        : new Set(rangeIds);
-
-                      onSelectionChange(next);
-                      return;
-                    }
-                  }
-
-                  if (e.ctrlKey || e.metaKey) {
-                    const next = new Set(selectedAgentIds);
-                    if (next.has(agentId)) next.delete(agentId);
-                    else next.add(agentId);
-                    onSelectionChange(next);
-                    lastSelectedIdRef.current = agentId;
-                  } else {
-                    // Selection logic
-                    if (selectedAgentIds.has(agentId) && selectedAgentIds.size === 1) {
-                      if (!isDoubleClick) {
-                        onSelectionChange(new Set());
-                        lastSelectedIdRef.current = null;
-                      } else {
-                        // Double click -> Ensure it stays selected and scroll
-                        onAgentClick(agentId);
-                        onSelectionChange(new Set([agentId])); // Safety re-assert
-                        lastSelectedIdRef.current = agentId;
-                      }
-                    } else {
-                      onSelectionChange(new Set([agentId]));
-                      lastSelectedIdRef.current = agentId;
-                    }
-                  }
-                }}
-                onContextMenu={(e) => handleContextMenu(e, agentId)}
-                className={`watchlist-row ${isSelected ? "selected" : ""} ${isDragTarget ? "drag-over" : ""} ${isBeingDragged ? "opacity-50" : ""} select-none`}
-                style={{ cursor: activeListId !== "all" ? "grab" : "pointer", gridTemplateColumns: gridTemplate }}
-              >
-                <div className={`w-2 h-2 rounded-full flex-shrink-0 ${statusColor}`} />
-                <div className="flex-1 min-w-0">
-                  {editingAgentId === agentId ? (
-                    <input
-                      className="text-xs font-bold text-primary bg-transparent border-b border-[var(--color-wardian-accent)] focus:outline-none w-full"
-                      autoFocus
-                      value={editingAgentName}
-                      onChange={(e) => setEditingAgentName(e.target.value)}
-                      onBlur={() => handleRenameAgentCommit(agentId)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          handleRenameAgentCommit(agentId);
-                        }
-                        if (e.key === 'Escape') {
-                          e.preventDefault();
-                          setEditingAgentId(null);
-                        }
+          {teams.length === 0
+            ? displayedAgents.map((agent) => renderAgentRow(agent))
+            : sortedDisplayItems.map((item) => {
+                if (item.type === "agent") return renderAgentRow(item.agent);
+                return (
+                  <div
+                    key={item.team.id}
+                    data-testid={`team-block-${item.team.id}`}
+                    className={`mb-2 rounded-lg border border-wardian-border bg-wardian-card-bg-muted/40 overflow-hidden ${dropTarget?.type === "team" && dropTarget.teamId === item.team.id ? `team-drop-${dropTarget.position}` : ""}`}
+                    onMouseEnter={() => handleTeamDropZone(item.team.id, "inside")}
+                    onMouseMove={() => handleTeamDropZone(item.team.id, "inside")}
+                    onMouseUp={(e) => {
+                      e.stopPropagation();
+                      handleMouseUp();
+                    }}
+                  >
+                    <div
+                      data-testid={`team-drop-before-${item.team.id}`}
+                      className="team-edge-drop-zone"
+                      onMouseEnter={(e) => { e.stopPropagation(); handleTeamDropZone(item.team.id, "before"); }}
+                      onMouseMove={(e) => { e.stopPropagation(); handleTeamDropZone(item.team.id, "before"); }}
+                      onMouseUp={(e) => {
                         e.stopPropagation();
+                        handleTeamDropZone(item.team.id, "before");
+                        handleMouseUp();
                       }}
-                      onClick={e => e.stopPropagation()}
-                      onMouseDown={e => e.stopPropagation()}
                     />
-                  ) : (
-                    <p className="text-xs font-bold truncate text-bright-neutral">
-                      {agent.session_name}
-                    </p>
-                  )}
-                  <p className="text-[10px] text-primary/50 font-medium truncate tracking-wide">
-                    {agent.agent_class}
-                  </p>
-                </div>
-                {prefs.columns.filter(c => c.visible).map(col => {
-                  if (col.id === 'status_label') return (
-                    <span key="status_label" className={`text-[9px] truncate max-w-[60px] ${getAgentStatusTextClass(status)}`}>
-                      {getAgentStatusLabel(status, thought)}
-                    </span>
-                  );
-                  if (col.id === 'query_count') return (
-                    <span key="query_count" className="text-[9px] text-muted-neutral tabular-nums w-4 text-right">
-                      {metrics?.query_count ?? "–"}
-                    </span>
-                  );
-                  if (col.id === 'uptime') return (
-                    <span key="uptime" className="label-small tabular-nums text-muted">
-                      {formatUptime(metrics?.init_timestamp ?? null)}
-                    </span>
-                  );
-                  if (col.id === 'provider_model') {
-                    const provider = agent.provider ?? '–';
-                    const model = agent.model ? ` · ${agent.model}` : '';
-                    return (
-                      <span key="provider_model" className="label-small text-muted truncate overflow-hidden">
-                        {provider}{model}
-                      </span>
-                    );
-                  }
-                  if (col.id === 'last_queried') return (
-                    <span key="last_queried" className="label-small tabular-nums text-muted">
-                      {formatRelativeTime(interactions[agentId])}
-                    </span>
-                  );
-                  return null;
-                })}
-              </div>
-            );
-          })}
+                    <div
+                      data-testid={`team-header-${item.team.id}`}
+                      className="px-2 py-1.5 border-b border-wardian-border/60 bg-wardian-card-bg-muted cursor-grab"
+                      onMouseDown={() => handleTeamMouseDown(item.team.id)}
+                      onMouseEnter={(e) => { e.stopPropagation(); handleTeamDropZone(item.team.id, "inside"); }}
+                      onMouseMove={(e) => { e.stopPropagation(); handleTeamDropZone(item.team.id, "inside"); }}
+                      onContextMenu={(e) => handleTeamContextMenu(e, item.team.id)}
+                      onMouseUp={(e) => {
+                        e.stopPropagation();
+                        handleTeamDropZone(item.team.id, "inside");
+                        handleMouseUp();
+                      }}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onSelectionChange(new Set(item.agents.map((agent) => agent.session_id)));
+                      }}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        {editingTeamId === item.team.id ? (
+                          <input
+                            className="text-xs font-bold text-primary bg-transparent border-b border-[var(--color-wardian-accent)] focus:outline-none min-w-0 flex-1"
+                            autoFocus
+                            value={editingTeamName}
+                            onChange={(e) => setEditingTeamName(e.target.value)}
+                            onBlur={() => handleRenameTeamCommit(item.team.id)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.preventDefault();
+                                handleRenameTeamCommit(item.team.id);
+                              }
+                              if (e.key === 'Escape') {
+                                e.preventDefault();
+                                setEditingTeamId(null);
+                              }
+                              e.stopPropagation();
+                            }}
+                            onClick={(e) => e.stopPropagation()}
+                            onMouseDown={(e) => e.stopPropagation()}
+                          />
+                        ) : (
+                          <span className="text-xs font-bold text-primary truncate">{item.team.name}</span>
+                        )}
+                        <span className="label-small !tracking-normal">{item.agents.length} agents</span>
+                      </div>
+                    </div>
+                    <div className="py-1">
+                      {item.agents.map((agent) => renderAgentRow(agent, { nested: true }))}
+                    </div>
+                    <div
+                      data-testid={`team-drop-after-${item.team.id}`}
+                      className="team-edge-drop-zone"
+                      onMouseEnter={(e) => { e.stopPropagation(); handleTeamDropZone(item.team.id, "after"); }}
+                      onMouseMove={(e) => { e.stopPropagation(); handleTeamDropZone(item.team.id, "after"); }}
+                      onMouseUp={(e) => {
+                        e.stopPropagation();
+                        handleTeamDropZone(item.team.id, "after");
+                        handleMouseUp();
+                      }}
+                    />
+                  </div>
+                );
+              })}
 
           {displayedAgents.length === 0 && (
             <div className="py-8 text-center text-muted-neutral text-xs">
@@ -590,6 +964,8 @@ export default function AgentWatchlist({
           x={contextMenu.x}
           y={contextMenu.y}
           agentId={contextMenu.agentId}
+          agentIds={contextMenu.agentIds}
+          teams={teams}
           offAgentIds={offAgentIds}
           watchlists={watchlists}
           onInitiateRename={(id) => {
@@ -610,9 +986,52 @@ export default function AgentWatchlist({
             setContextMenu(p => ({ ...p, visible: false }));
           }}
           onDelete={onDelete}
+          onCreateTeam={onCreateTeam}
           onClose={() => setContextMenu(p => ({ ...p, visible: false }))}
         />
       )}
+
+      {teamContextMenu.visible && teamContextMenu.teamId && (() => {
+        const team = teams.find((candidate) => candidate.id === teamContextMenu.teamId);
+        if (!team || team.agentIds.length === 0) return null;
+        return (
+          <AgentContextMenu
+            x={teamContextMenu.x}
+            y={teamContextMenu.y}
+            agentId={team.agentIds[0]}
+            agentIds={team.agentIds}
+            teams={teams}
+            menuKind="team"
+            teamId={team.id}
+            offAgentIds={offAgentIds}
+            watchlists={watchlists}
+            onInitiateRename={() => {}}
+            onInitiateTeamRename={() => {
+              setEditingTeamId(team.id);
+              setEditingTeamName(team.name);
+              setTeamContextMenu((p) => ({ ...p, visible: false }));
+            }}
+            onQuery={onQuery}
+            onPause={onPause}
+            onRestart={onRestart}
+            onClear={onClear}
+            onAddToList={(listId, id) => {
+              onAddToList(listId, id);
+              setTeamContextMenu((p) => ({ ...p, visible: false }));
+            }}
+            onRemoveFromList={(listId, id) => {
+              onRemoveFromList(listId, id);
+              setTeamContextMenu((p) => ({ ...p, visible: false }));
+            }}
+            onDelete={onDelete}
+            onUngroupTeam={(id) => {
+              onUngroupTeam?.(id);
+              setTeamContextMenu((p) => ({ ...p, visible: false }));
+            }}
+            onClose={() => setTeamContextMenu((p) => ({ ...p, visible: false }))}
+          />
+        );
+      })()}
 
       {/* ── Tab Context Menu (right-click on watchlist tab) ──── */}
       {tabContextMenu.visible && tabContextMenu.listId && (

--- a/src/layout/watchlist/types.ts
+++ b/src/layout/watchlist/types.ts
@@ -1,8 +1,29 @@
 export interface Watchlist {
   id: string;
   name: string;
+  entries?: WatchlistEntry[];
+  agentIds?: string[];
+}
+
+export interface AgentTeam {
+  id: string;
+  name: string;
   agentIds: string[];
 }
+
+export type WatchlistEntry =
+  | { type: "agent"; agentId: string }
+  | { type: "team"; teamId: string };
+
+export interface WatchlistState {
+  version: 2;
+  watchlists: Watchlist[];
+  teams: AgentTeam[];
+}
+
+export type WatchlistDisplayItem =
+  | { type: "agent"; agent: import("../../types").AgentConfig }
+  | { type: "team"; team: AgentTeam; agents: import("../../types").AgentConfig[] };
 
 /**
  * Context menu action types available for agent rows.
@@ -22,6 +43,7 @@ export interface ContextMenuState {
   x: number;
   y: number;
   agentId: string | null;
+  agentIds?: string[];
 }
 
 // All toggleable columns (status_label and query_count are on by default)

--- a/src/layout/watchlist/watchlistUtils.test.ts
+++ b/src/layout/watchlist/watchlistUtils.test.ts
@@ -12,8 +12,18 @@ import {
   formatRelativeTime,
   cycleSort,
   sortAgents,
+  normalizeWatchlistState,
+  getWatchlistEntries,
+  getDisplayItemsForList,
+  addAgentsToList,
+  removeAgentsFromList,
+  createTeamFromAgents,
+  ungroupTeam,
+  addAgentToTeam,
+  removeAgentFromTeam,
+  reorderTeamMember,
 } from "./watchlistUtils";
-import type { Watchlist, WatchlistPrefs } from "./types";
+import type { Watchlist, WatchlistPrefs, WatchlistState } from "./types";
 import type { AgentConfig, AgentTelemetry } from "../../types";
 
 // ── reorderWithinList ──────────────────────────────────────────────────
@@ -48,6 +58,315 @@ describe("reorderWithinList", () => {
     const copy = [...original];
     reorderWithinList(original, 0, 2);
     expect(original).toEqual(copy);
+  });
+});
+
+// ── team-aware watchlist state ─────────────────────────────────────────
+
+describe("normalizeWatchlistState", () => {
+  it("migrates legacy watchlist arrays into versioned state", () => {
+    const state = normalizeWatchlistState([
+      { id: "l1", name: "List 1", agentIds: ["a", "b"] },
+    ]);
+
+    expect(state).toEqual({
+      version: 2,
+      teams: [],
+      watchlists: [
+        {
+          id: "l1",
+          name: "List 1",
+          entries: [
+            { type: "agent", agentId: "a" },
+            { type: "agent", agentId: "b" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("normalizes watchlists to full team inclusion", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b", "c"] }],
+      watchlists: [
+        {
+          id: "today",
+          name: "Today",
+          entries: [{ type: "agent", agentId: "b" }, { type: "agent", agentId: "x" }],
+        },
+      ],
+    });
+
+    expect(getWatchlistEntries(state.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "x" },
+    ]);
+  });
+
+  it("normalizes snake_case persisted team and entry fields", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agent_ids: ["a", "b"] }],
+      watchlists: [
+        {
+          id: "l1",
+          name: "List 1",
+          entries: [{ type: "team", team_id: "team-1" }],
+        },
+      ],
+    });
+
+    expect(state.teams).toEqual([{ id: "team-1", name: "Core", agentIds: ["a", "b"] }]);
+    expect(getWatchlistEntries(state.watchlists[0])).toEqual([{ type: "team", teamId: "team-1" }]);
+  });
+
+  it("normalizes legacy snake_case agent_ids lists", () => {
+    const state = normalizeWatchlistState([
+      { id: "l1", name: "List 1", agent_ids: ["a", "b"] },
+    ]);
+
+    expect(getWatchlistEntries(state.watchlists[0])).toEqual([
+      { type: "agent", agentId: "a" },
+      { type: "agent", agentId: "b" },
+    ]);
+  });
+});
+
+describe("team display helpers", () => {
+  const agents: AgentConfig[] = [
+    { session_id: "a", session_name: "Alpha", agent_class: "Coder", folder: "", is_off: false },
+    { session_id: "b", session_name: "Beta", agent_class: "QA", folder: "", is_off: false },
+    { session_id: "c", session_name: "Gamma", agent_class: "Coder", folder: "", is_off: false },
+    { session_id: "x", session_name: "Solo", agent_class: "Coder", folder: "", is_off: false },
+  ];
+  const state: WatchlistState = normalizeWatchlistState({
+    version: 2,
+    teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b", "c"] }],
+    watchlists: [
+      {
+        id: "today",
+        name: "Today",
+        entries: [{ type: "team", teamId: "team-1" }, { type: "agent", agentId: "x" }],
+      },
+    ],
+  });
+
+  it("returns grouped display items and full team members", () => {
+    const items = getDisplayItemsForList(agents, state.watchlists[0], state.teams);
+
+    expect(items).toEqual([
+      { type: "team", team: state.teams[0], agents: [agents[0], agents[1], agents[2]] },
+      { type: "agent", agent: agents[3] },
+    ]);
+  });
+
+  it("bulk-adds selected agents by converting team members to team entries", () => {
+    const updated = addAgentsToList(state.watchlists[0], ["b", "x"], state.teams);
+
+    expect(getWatchlistEntries(updated)).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "x" },
+    ]);
+  });
+
+  it("bulk-removes selected agents and removes the whole team when a member is removed", () => {
+    const updated = removeAgentsFromList(state.watchlists[0], ["b"], state.teams);
+
+    expect(getWatchlistEntries(updated)).toEqual([{ type: "agent", agentId: "x" }]);
+  });
+});
+
+describe("team mutations", () => {
+  it("creates a default-named global team from selected agents", () => {
+    const state = normalizeWatchlistState([
+      { id: "l1", name: "List 1", agentIds: ["a", "b", "c"] },
+    ]);
+
+    const next = createTeamFromAgents(state, "team-1", ["a", "b"]);
+
+    expect(next.teams).toEqual([{ id: "team-1", name: "Team 1", agentIds: ["a", "b"] }]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "c" },
+    ]);
+  });
+
+  it("creates a one-agent team", () => {
+    const state = normalizeWatchlistState([
+      { id: "l1", name: "List 1", agentIds: ["a", "b"] },
+    ]);
+
+    const next = createTeamFromAgents(state, "team-1", ["a"]);
+
+    expect(next.teams).toEqual([{ id: "team-1", name: "Team 1", agentIds: ["a"] }]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "b" },
+    ]);
+  });
+
+  it("moves only selected members out of existing teams when creating a new team", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b"] }],
+      watchlists: [
+        {
+          id: "l1",
+          name: "List 1",
+          entries: [{ type: "team", teamId: "team-1" }, { type: "agent", agentId: "c" }],
+        },
+      ],
+    });
+
+    const next = createTeamFromAgents(state, "team-2", ["a", "c"]);
+
+    expect(next.teams).toEqual([
+      { id: "team-1", name: "Core", agentIds: ["b"] },
+      { id: "team-2", name: "Team 2", agentIds: ["a", "c"] },
+    ]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "team", teamId: "team-2" },
+    ]);
+  });
+
+  it("ungroups a team back into solo entries anywhere the team appears", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b"] }],
+      watchlists: [{ id: "l1", name: "List 1", entries: [{ type: "team", teamId: "team-1" }] }],
+    });
+
+    const next = ungroupTeam(state, "team-1");
+
+    expect(next.teams).toEqual([]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "agent", agentId: "a" },
+      { type: "agent", agentId: "b" },
+    ]);
+  });
+
+  it("adds a solo agent to a team and normalizes watchlists to the full team", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a"] }],
+      watchlists: [{ id: "l1", name: "List 1", entries: [{ type: "team", teamId: "team-1" }, { type: "agent", agentId: "b" }] }],
+    });
+
+    const next = addAgentToTeam(state, "team-1", "b");
+
+    expect(next.teams[0].agentIds).toEqual(["a", "b"]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([{ type: "team", teamId: "team-1" }]);
+  });
+
+  it("removes a member from a team and keeps the removed agent near the team", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b"] }],
+      watchlists: [{ id: "l1", name: "List 1", entries: [{ type: "team", teamId: "team-1" }] }],
+    });
+
+    const next = removeAgentFromTeam(state, "team-1", "b");
+
+    expect(next.teams[0].agentIds).toEqual(["a"]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "b" },
+    ]);
+  });
+
+  it("removes a member from a team and places it at the drop target in a watchlist", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b"] }],
+      watchlists: [
+        {
+          id: "l1",
+          name: "List 1",
+          entries: [{ type: "team", teamId: "team-1" }, { type: "agent", agentId: "x" }],
+        },
+      ],
+    });
+
+    const next = removeAgentFromTeam(state, "team-1", "a", "x");
+
+    expect(next.teams[0].agentIds).toEqual(["b"]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "a" },
+      { type: "agent", agentId: "x" },
+    ]);
+  });
+
+  it("moves a member between teams without deleting unselected teammates", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [
+        { id: "team-1", name: "Core", agentIds: ["a", "b"] },
+        { id: "team-2", name: "Support", agentIds: ["c"] },
+      ],
+      watchlists: [{ id: "l1", name: "List 1", entries: [{ type: "team", teamId: "team-1" }, { type: "team", teamId: "team-2" }] }],
+    });
+
+    const next = addAgentToTeam(state, "team-2", "a");
+
+    expect(next.teams).toEqual([
+      { id: "team-1", name: "Core", agentIds: ["b"] },
+      { id: "team-2", name: "Support", agentIds: ["c", "a"] },
+    ]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "team", teamId: "team-2" },
+    ]);
+  });
+
+  it("reorders members within a team", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b", "c"] }],
+      watchlists: [{ id: "l1", name: "List 1", entries: [{ type: "team", teamId: "team-1" }] }],
+    });
+
+    const next = reorderTeamMember(state, "team-1", "c", "a");
+
+    expect(next.teams[0].agentIds).toEqual(["c", "a", "b"]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([{ type: "team", teamId: "team-1" }]);
+  });
+
+  it("reorders a team member after the target member", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b", "c"] }],
+      watchlists: [{ id: "l1", name: "List 1", entries: [{ type: "team", teamId: "team-1" }] }],
+    });
+
+    const next = reorderTeamMember(state, "team-1", "a", "c", "after");
+
+    expect(next.teams[0].agentIds).toEqual(["b", "c", "a"]);
+  });
+
+  it("removes a team member after the target solo agent", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b"] }],
+      watchlists: [
+        {
+          id: "l1",
+          name: "List 1",
+          entries: [{ type: "team", teamId: "team-1" }, { type: "agent", agentId: "c" }],
+        },
+      ],
+    });
+
+    const next = removeAgentFromTeam(state, "team-1", "a", "c", "after");
+
+    expect(next.teams[0].agentIds).toEqual(["b"]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "c" },
+      { type: "agent", agentId: "a" },
+    ]);
   });
 });
 

--- a/src/layout/watchlist/watchlistUtils.test.ts
+++ b/src/layout/watchlist/watchlistUtils.test.ts
@@ -21,9 +21,10 @@ import {
   ungroupTeam,
   addAgentToTeam,
   removeAgentFromTeam,
+  removeAgentFromTeamAtEntry,
   reorderTeamMember,
 } from "./watchlistUtils";
-import type { Watchlist, WatchlistPrefs, WatchlistState } from "./types";
+import type { Watchlist, WatchlistEntry, WatchlistPrefs, WatchlistState } from "./types";
 import type { AgentConfig, AgentTelemetry } from "../../types";
 
 // ── reorderWithinList ──────────────────────────────────────────────────
@@ -168,6 +169,18 @@ describe("team display helpers", () => {
       { type: "team", teamId: "team-1" },
       { type: "agent", agentId: "x" },
     ]);
+  });
+
+  it("detects duplicate entries by fields instead of object serialization order", () => {
+    const list: Watchlist = {
+      id: "l1",
+      name: "List 1",
+      entries: [{ agentId: "x", type: "agent" } as unknown as WatchlistEntry],
+    };
+
+    const updated = addAgentsToList(list, ["x"], []);
+
+    expect(getWatchlistEntries(updated)).toEqual([{ type: "agent", agentId: "x" }]);
   });
 
   it("bulk-removes selected agents and removes the whole team when a member is removed", () => {
@@ -365,6 +378,36 @@ describe("team mutations", () => {
     expect(getWatchlistEntries(next.watchlists[0])).toEqual([
       { type: "team", teamId: "team-1" },
       { type: "agent", agentId: "c" },
+      { type: "agent", agentId: "a" },
+    ]);
+  });
+
+  it("removes a member from a team and places it before a team entry in one watchlist mutation", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b"] }],
+      watchlists: [
+        { id: "today", name: "Today", entries: [{ type: "team", teamId: "team-1" }] },
+        { id: "later", name: "Later", entries: [{ type: "team", teamId: "team-1" }] },
+      ],
+    });
+
+    const next = removeAgentFromTeamAtEntry(
+      state,
+      "team-1",
+      "a",
+      { type: "team", teamId: "team-1" },
+      "before",
+      "today",
+    );
+
+    expect(next.teams[0].agentIds).toEqual(["b"]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "agent", agentId: "a" },
+      { type: "team", teamId: "team-1" },
+    ]);
+    expect(getWatchlistEntries(next.watchlists[1])).toEqual([
+      { type: "team", teamId: "team-1" },
       { type: "agent", agentId: "a" },
     ]);
   });

--- a/src/layout/watchlist/watchlistUtils.ts
+++ b/src/layout/watchlist/watchlistUtils.ts
@@ -55,6 +55,13 @@ function dedupeEntries(entries: WatchlistEntry[]): WatchlistEntry[] {
   });
 }
 
+function sameWatchlistEntry(a: WatchlistEntry, b: WatchlistEntry): boolean {
+  if (a.type !== b.type) return false;
+  if (a.type === "team" && b.type === "team") return a.teamId === b.teamId;
+  if (a.type === "agent" && b.type === "agent") return a.agentId === b.agentId;
+  return false;
+}
+
 export function getWatchlistEntries(list: Watchlist): WatchlistEntry[] {
   const rawEntries = (list as Watchlist & { entries?: unknown }).entries;
   if (Array.isArray(rawEntries)) {
@@ -192,7 +199,7 @@ export function addAgentsToList(
   for (const agentId of agentIds) {
     const team = teamForAgent(teams, agentId);
     const entry: WatchlistEntry = team ? { type: "team", teamId: team.id } : { type: "agent", agentId };
-    if (!next.some((existing) => JSON.stringify(existing) === JSON.stringify(entry))) {
+    if (!next.some((existing) => sameWatchlistEntry(existing, entry))) {
       next.push(entry);
     }
   }
@@ -494,6 +501,67 @@ export function removeAgentFromTeam(
         });
 
         return inserted ? nextEntries : [...baseEntries, { type: "agent", agentId }];
+      })(),
+    })),
+  });
+}
+
+export function removeAgentFromTeamAtEntry(
+  state: WatchlistState,
+  teamId: string,
+  agentId: string,
+  targetEntry: WatchlistEntry,
+  position: "before" | "after",
+  targetListId: string,
+): WatchlistState {
+  const team = state.teams.find((candidate) => candidate.id === teamId);
+  if (!team || !team.agentIds.includes(agentId)) return state;
+  const remainingTeamMembers = team.agentIds.filter((id) => id !== agentId);
+  const teams = state.teams
+    .map((candidate) =>
+      candidate.id === teamId
+        ? { ...candidate, agentIds: remainingTeamMembers }
+        : candidate,
+    )
+    .filter((candidate) => candidate.agentIds.length > 0);
+
+  const removedAgentEntry: WatchlistEntry = { type: "agent", agentId };
+  return normalizeWatchlistState({
+    version: 2,
+    teams,
+    watchlists: state.watchlists.map((list) => ({
+      ...list,
+      entries: (() => {
+        const originalEntries = getWatchlistEntries(list);
+        const baseEntries = originalEntries.flatMap((entry): WatchlistEntry[] => {
+          if (entry.type === "team" && entry.teamId === teamId) {
+            return remainingTeamMembers.length > 0 ? [{ type: "team", teamId }] : [];
+          }
+          if (entry.type === "agent" && entry.agentId === agentId) return [];
+          return [entry];
+        });
+
+        if (list.id !== targetListId) {
+          let inserted = false;
+          const nextEntries = originalEntries.flatMap((entry): WatchlistEntry[] => {
+            if (entry.type === "team" && entry.teamId === teamId) {
+              inserted = true;
+              const teamEntry = remainingTeamMembers.length > 0 ? [{ type: "team" as const, teamId }] : [];
+              return [...teamEntry, removedAgentEntry];
+            }
+            if (entry.type === "agent" && entry.agentId === agentId) return [];
+            return [entry];
+          });
+          return inserted ? nextEntries : baseEntries;
+        }
+
+        let inserted = false;
+        const nextEntries = baseEntries.flatMap((entry): WatchlistEntry[] => {
+          if (!sameWatchlistEntry(entry, targetEntry)) return [entry];
+          inserted = true;
+          return position === "after" ? [entry, removedAgentEntry] : [removedAgentEntry, entry];
+        });
+        return inserted ? nextEntries : [...baseEntries, removedAgentEntry];
       })(),
     })),
   });

--- a/src/layout/watchlist/watchlistUtils.ts
+++ b/src/layout/watchlist/watchlistUtils.ts
@@ -1,5 +1,146 @@
-import type { Watchlist, AgentInteractions, SortableColumnId, WatchlistPrefs } from "./types";
+import type {
+  Watchlist,
+  AgentInteractions,
+  SortableColumnId,
+  WatchlistPrefs,
+  AgentTeam,
+  WatchlistEntry,
+  WatchlistState,
+  WatchlistDisplayItem,
+} from "./types";
 import type { AgentConfig, AgentTelemetry } from "../../types";
+
+function isWatchlistState(value: unknown): value is WatchlistState {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      (value as { version?: unknown }).version === 2 &&
+      Array.isArray((value as { watchlists?: unknown }).watchlists) &&
+      Array.isArray((value as { teams?: unknown }).teams),
+  );
+}
+
+function normalizeTeam(value: unknown): AgentTeam | null {
+  if (!value || typeof value !== "object") return null;
+  const team = value as { id?: unknown; name?: unknown; agentIds?: unknown; agent_ids?: unknown };
+  const rawAgentIds = Array.isArray(team.agentIds)
+    ? team.agentIds
+    : Array.isArray(team.agent_ids)
+      ? team.agent_ids
+      : [];
+  if (typeof team.id !== "string") return null;
+  return {
+    id: team.id,
+    name: typeof team.name === "string" ? team.name : "Team",
+    agentIds: rawAgentIds.filter((id): id is string => typeof id === "string"),
+  };
+}
+
+function teamForAgent(teams: AgentTeam[], agentId: string): AgentTeam | undefined {
+  return teams.find((team) => team.agentIds.includes(agentId));
+}
+
+function dedupeEntries(entries: WatchlistEntry[]): WatchlistEntry[] {
+  const seenAgents = new Set<string>();
+  const seenTeams = new Set<string>();
+  return entries.filter((entry) => {
+    if (entry.type === "team") {
+      if (seenTeams.has(entry.teamId)) return false;
+      seenTeams.add(entry.teamId);
+      return true;
+    }
+    if (seenAgents.has(entry.agentId)) return false;
+    seenAgents.add(entry.agentId);
+    return true;
+  });
+}
+
+export function getWatchlistEntries(list: Watchlist): WatchlistEntry[] {
+  const rawEntries = (list as Watchlist & { entries?: unknown }).entries;
+  if (Array.isArray(rawEntries)) {
+    return rawEntries.flatMap((entry): WatchlistEntry[] => {
+      if (!entry || typeof entry !== "object") return [];
+      const candidate = entry as { type?: unknown; agentId?: unknown; agent_id?: unknown; teamId?: unknown; team_id?: unknown };
+      if (candidate.type === "team") {
+        const teamId = typeof candidate.teamId === "string" ? candidate.teamId : candidate.team_id;
+        return typeof teamId === "string" ? [{ type: "team", teamId }] : [];
+      }
+      if (candidate.type === "agent") {
+        const agentId = typeof candidate.agentId === "string" ? candidate.agentId : candidate.agent_id;
+        return typeof agentId === "string" ? [{ type: "agent", agentId }] : [];
+      }
+      return [];
+    });
+  }
+  const rawAgentIds = Array.isArray(list.agentIds)
+    ? list.agentIds
+    : Array.isArray((list as Watchlist & { agent_ids?: unknown }).agent_ids)
+      ? (list as Watchlist & { agent_ids: unknown[] }).agent_ids
+      : [];
+  return rawAgentIds
+    .filter((agentId): agentId is string => typeof agentId === "string")
+    .map((agentId) => ({ type: "agent", agentId }));
+}
+
+export function normalizeWatchlistEntries(
+  entries: WatchlistEntry[],
+  teams: AgentTeam[],
+): WatchlistEntry[] {
+  const teamIdsFromMembers = new Set<string>();
+  for (const entry of entries) {
+    if (entry.type !== "agent") continue;
+    const team = teamForAgent(teams, entry.agentId);
+    if (team) teamIdsFromMembers.add(team.id);
+  }
+
+  const normalized = entries.flatMap((entry): WatchlistEntry[] => {
+    if (entry.type === "team") return [entry];
+    const team = teamForAgent(teams, entry.agentId);
+    if (team) return [{ type: "team", teamId: team.id }];
+    return [entry];
+  });
+
+  return dedupeEntries(normalized).filter((entry) => {
+    if (entry.type === "agent") {
+      return !teams.some((team) => team.agentIds.includes(entry.agentId));
+    }
+    return teamIdsFromMembers.has(entry.teamId) || teams.some((team) => team.id === entry.teamId);
+  });
+}
+
+export function normalizeWatchlistState(input: unknown): WatchlistState {
+  const state: WatchlistState = isWatchlistState(input)
+    ? {
+        version: 2,
+        teams: input.teams.map(normalizeTeam).filter((team): team is AgentTeam => Boolean(team)),
+        watchlists: input.watchlists,
+      }
+    : {
+        version: 2,
+        teams: [],
+        watchlists: Array.isArray(input)
+          ? (input as Watchlist[]).map((list) => ({
+              id: list.id,
+              name: list.name,
+              entries: getWatchlistEntries(list),
+            }))
+          : [],
+      };
+
+  return {
+    version: 2,
+    teams: state.teams,
+    watchlists: state.watchlists.map((list) => ({
+      id: list.id,
+      name: list.name,
+      entries: normalizeWatchlistEntries(getWatchlistEntries(list), state.teams),
+    })),
+  };
+}
+
+export function flattenDisplayItems(items: WatchlistDisplayItem[]): AgentConfig[] {
+  return items.flatMap((item) => (item.type === "team" ? item.agents : [item.agent]));
+}
 
 /**
  * Reorders items within a list by moving an item from one index to another.
@@ -30,10 +171,33 @@ export function reorderWithinList(
  * Returns a new watchlist with the agent appended.
  */
 export function addAgentToList(list: Watchlist, agentId: string): Watchlist {
-  if (list.agentIds.includes(agentId)) {
+  const entries = getWatchlistEntries(list);
+  if (entries.some((entry) => entry.type === "agent" && entry.agentId === agentId)) {
     return list;
   }
-  return { ...list, agentIds: [...list.agentIds, agentId] };
+  return {
+    ...list,
+    agentIds: list.agentIds ? [...list.agentIds, agentId] : undefined,
+    entries: [...entries, { type: "agent", agentId }],
+  };
+}
+
+export function addAgentsToList(
+  list: Watchlist,
+  agentIds: string[],
+  teams: AgentTeam[] = [],
+): Watchlist {
+  const current = getWatchlistEntries(list);
+  const next = [...current];
+  for (const agentId of agentIds) {
+    const team = teamForAgent(teams, agentId);
+    const entry: WatchlistEntry = team ? { type: "team", teamId: team.id } : { type: "agent", agentId };
+    if (!next.some((existing) => JSON.stringify(existing) === JSON.stringify(entry))) {
+      next.push(entry);
+    }
+  }
+  const entries = normalizeWatchlistEntries(next, teams);
+  return { ...list, agentIds: entries.filter((entry) => entry.type === "agent").map((entry) => entry.agentId), entries };
 }
 
 /**
@@ -44,7 +208,28 @@ export function removeAgentFromList(
   list: Watchlist,
   agentId: string,
 ): Watchlist {
-  return { ...list, agentIds: list.agentIds.filter((id) => id !== agentId) };
+  return removeAgentsFromList(list, [agentId]);
+}
+
+export function removeAgentsFromList(
+  list: Watchlist,
+  agentIds: string[],
+  teams: AgentTeam[] = [],
+): Watchlist {
+  const ids = new Set(agentIds);
+  const teamIdsToRemove = new Set(
+    teams.filter((team) => team.agentIds.some((id) => ids.has(id))).map((team) => team.id),
+  );
+  const entries = getWatchlistEntries(list).filter((entry) => {
+    if (entry.type === "team") return !teamIdsToRemove.has(entry.teamId);
+    return !ids.has(entry.agentId) && !teamIdsToRemove.has(teamForAgent(teams, entry.agentId)?.id ?? "");
+  });
+  const normalized = normalizeWatchlistEntries(entries, teams);
+  return {
+    ...list,
+    agentIds: normalized.filter((entry) => entry.type === "agent").map((entry) => entry.agentId),
+    entries: normalized,
+  };
 }
 
 /**
@@ -70,12 +255,52 @@ export function filterAgents(
 export function getAgentsForList(
   agents: AgentConfig[],
   list: Watchlist | null,
+  teams: AgentTeam[] = [],
 ): AgentConfig[] {
   if (!list) return agents;
+  return flattenDisplayItems(getDisplayItemsForList(agents, list, teams));
+}
+
+export function getDisplayItemsForList(
+  agents: AgentConfig[],
+  list: Watchlist | null,
+  teams: AgentTeam[],
+): WatchlistDisplayItem[] {
+  if (!list) {
+    const emittedTeams = new Set<string>();
+    const items: WatchlistDisplayItem[] = [];
+    for (const agent of agents) {
+      const team = teamForAgent(teams, agent.session_id);
+      if (!team) {
+        items.push({ type: "agent", agent });
+        continue;
+      }
+      if (emittedTeams.has(team.id)) continue;
+      emittedTeams.add(team.id);
+      const teamAgents = team.agentIds
+        .map((id) => agents.find((candidate) => candidate.session_id === id))
+        .filter((candidate): candidate is AgentConfig => Boolean(candidate));
+      if (teamAgents.length > 0) items.push({ type: "team", team, agents: teamAgents });
+    }
+    return items;
+  }
+
   const agentMap = new Map(agents.map((a) => [a.session_id, a]));
-  return list.agentIds
-    .map((id) => agentMap.get(id))
-    .filter((a): a is AgentConfig => a !== undefined);
+  const teamMap = new Map(teams.map((team) => [team.id, team]));
+  return normalizeWatchlistEntries(getWatchlistEntries(list), teams)
+    .map((entry): WatchlistDisplayItem | null => {
+      if (entry.type === "team") {
+        const team = teamMap.get(entry.teamId);
+        if (!team) return null;
+        const teamAgents = team.agentIds
+          .map((id) => agentMap.get(id))
+          .filter((agent): agent is AgentConfig => Boolean(agent));
+        return teamAgents.length > 0 ? { type: "team", team, agents: teamAgents } : null;
+      }
+      const agent = agentMap.get(entry.agentId);
+      return agent ? { type: "agent", agent } : null;
+    })
+    .filter((item): item is WatchlistDisplayItem => Boolean(item));
 }
 
 /**
@@ -90,6 +315,7 @@ export function createWatchlist(
     id,
     name: `List ${nextNumber}`,
     agentIds: [],
+    entries: [],
   };
 }
 
@@ -99,8 +325,16 @@ export function createWatchlist(
 export function getListsContainingAgent(
   lists: Watchlist[],
   agentId: string,
+  teams: AgentTeam[] = [],
 ): Watchlist[] {
-  return lists.filter((l) => l.agentIds.includes(agentId));
+  return lists.filter((l) => {
+    const entries = normalizeWatchlistEntries(getWatchlistEntries(l), teams);
+    return entries.some((entry) => {
+      if (entry.type === "agent") return entry.agentId === agentId;
+      const team = teams.find((candidate) => candidate.id === entry.teamId);
+      return Boolean(team?.agentIds.includes(agentId));
+    });
+  });
 }
 
 /**
@@ -109,8 +343,184 @@ export function getListsContainingAgent(
 export function getListsNotContainingAgent(
   lists: Watchlist[],
   agentId: string,
+  teams: AgentTeam[] = [],
 ): Watchlist[] {
-  return lists.filter((l) => !l.agentIds.includes(agentId));
+  return lists.filter((l) => !getListsContainingAgent([l], agentId, teams).length);
+}
+
+export function createTeamFromAgents(
+  state: WatchlistState,
+  teamId: string,
+  agentIds: string[],
+): WatchlistState {
+  const selected = [...new Set(agentIds)];
+  const selectedSet = new Set(selected);
+  const nextTeamNumber = state.teams.length + 1;
+  const remainingTeams = state.teams
+    .map((team) => ({ ...team, agentIds: team.agentIds.filter((agentId) => !selectedSet.has(agentId)) }))
+    .filter((team) => team.agentIds.length > 0);
+  const nextTeams = [
+    ...remainingTeams,
+    { id: teamId, name: `Team ${nextTeamNumber}`, agentIds: selected },
+  ];
+  return normalizeWatchlistState({
+    version: 2,
+    teams: nextTeams,
+    watchlists: state.watchlists.map((list) => {
+      const entries = getWatchlistEntries(list);
+      let inserted = false;
+      const nextEntries = entries.flatMap((entry): WatchlistEntry[] => {
+        if (entry.type === "team") {
+          const oldTeam = state.teams.find((team) => team.id === entry.teamId);
+          if (!oldTeam?.agentIds.some((agentId) => selectedSet.has(agentId))) return [entry];
+          const result: WatchlistEntry[] = [];
+          if (oldTeam.agentIds.some((agentId) => !selectedSet.has(agentId))) {
+            result.push(entry);
+          }
+          if (!inserted) {
+            result.push({ type: "team", teamId });
+            inserted = true;
+          }
+          return result;
+        }
+        if (selectedSet.has(entry.agentId)) {
+          if (inserted) return [];
+          inserted = true;
+          return [{ type: "team", teamId }];
+        }
+        return [entry];
+      });
+      return { ...list, entries: inserted ? nextEntries : entries };
+    }),
+  });
+}
+
+export function ungroupTeam(state: WatchlistState, teamId: string): WatchlistState {
+  const team = state.teams.find((candidate) => candidate.id === teamId);
+  if (!team) return state;
+  const teams = state.teams.filter((candidate) => candidate.id !== teamId);
+  return normalizeWatchlistState({
+    version: 2,
+    teams,
+    watchlists: state.watchlists.map((list) => ({
+      ...list,
+      entries: getWatchlistEntries(list).flatMap((entry): WatchlistEntry[] => {
+        if (entry.type === "team" && entry.teamId === teamId) {
+          return team.agentIds.map((agentId) => ({ type: "agent", agentId }));
+        }
+        return [entry];
+      }),
+    })),
+  });
+}
+
+export function addAgentToTeam(
+  state: WatchlistState,
+  teamId: string,
+  agentId: string,
+): WatchlistState {
+  const teams = state.teams
+    .map((team) => {
+      const withoutAgent = team.agentIds.filter((id) => id !== agentId);
+      if (team.id !== teamId) return { ...team, agentIds: withoutAgent };
+      return {
+        ...team,
+        agentIds: withoutAgent.includes(agentId) ? withoutAgent : [...withoutAgent, agentId],
+      };
+    })
+    .filter((team) => team.agentIds.length > 0);
+
+  return normalizeWatchlistState({
+    version: 2,
+    teams,
+    watchlists: state.watchlists.map((list) => ({
+      ...list,
+      entries: getWatchlistEntries(list).map((entry) => {
+        if (entry.type === "agent" && entry.agentId === agentId) {
+          return { type: "team" as const, teamId };
+        }
+        return entry;
+      }),
+    })),
+  });
+}
+
+export function removeAgentFromTeam(
+  state: WatchlistState,
+  teamId: string,
+  agentId: string,
+  targetAgentId?: string,
+  position: "before" | "after" = "before",
+): WatchlistState {
+  const team = state.teams.find((candidate) => candidate.id === teamId);
+  if (!team || !team.agentIds.includes(agentId)) return state;
+  const remainingTeamMembers = team.agentIds.filter((id) => id !== agentId);
+  const teams = state.teams
+    .map((candidate) =>
+      candidate.id === teamId
+        ? { ...candidate, agentIds: remainingTeamMembers }
+        : candidate,
+    )
+    .filter((candidate) => candidate.agentIds.length > 0);
+
+  return normalizeWatchlistState({
+    version: 2,
+    teams,
+    watchlists: state.watchlists.map((list) => ({
+      ...list,
+      entries: (() => {
+        let inserted = false;
+        const baseEntries = getWatchlistEntries(list).flatMap((entry): WatchlistEntry[] => {
+          if (entry.type === "team" && entry.teamId === teamId) {
+            const teamEntry = remainingTeamMembers.length > 0 ? [{ type: "team" as const, teamId }] : [];
+            if (!targetAgentId) {
+              inserted = true;
+              return [...teamEntry, { type: "agent", agentId }];
+            }
+            return teamEntry;
+          }
+          if (entry.type === "agent" && entry.agentId === agentId) return [];
+          return [entry];
+        });
+
+        if (!targetAgentId) return baseEntries;
+
+        const nextEntries = baseEntries.flatMap((entry): WatchlistEntry[] => {
+          if (entry.type === "agent" && entry.agentId === targetAgentId) {
+            inserted = true;
+            return position === "after" ? [entry, { type: "agent", agentId }] : [{ type: "agent", agentId }, entry];
+          }
+          return [entry];
+        });
+
+        return inserted ? nextEntries : [...baseEntries, { type: "agent", agentId }];
+      })(),
+    })),
+  });
+}
+
+export function reorderTeamMember(
+  state: WatchlistState,
+  teamId: string,
+  draggedAgentId: string,
+  targetAgentId: string,
+  position: "before" | "after" = "before",
+): WatchlistState {
+  return normalizeWatchlistState({
+    version: 2,
+    teams: state.teams.map((team) => {
+      if (team.id !== teamId) return team;
+      const fromIndex = team.agentIds.indexOf(draggedAgentId);
+      const toIndex = team.agentIds.indexOf(targetAgentId);
+      if (fromIndex === -1 || toIndex === -1) return team;
+      const nextAgentIds = team.agentIds.filter((id) => id !== draggedAgentId);
+      const targetIndex = nextAgentIds.indexOf(targetAgentId);
+      if (targetIndex === -1) return team;
+      nextAgentIds.splice(targetIndex + (position === "after" ? 1 : 0), 0, draggedAgentId);
+      return { ...team, agentIds: nextAgentIds };
+    }),
+    watchlists: state.watchlists,
+  });
 }
 
 export function formatUptime(initTimestamp: string | null): string {

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -480,8 +480,26 @@
   background: rgba(16, 185, 129, 0.08);
   border-color: rgba(16, 185, 129, 0.3);
 }
-.watchlist-row.drag-over {
+.watchlist-row.drag-over-before {
   border-top: 2px solid var(--color-wardian-accent);
+}
+.watchlist-row.drag-over-after {
+  border-bottom: 2px solid var(--color-wardian-accent);
+}
+.team-drop-inside {
+  box-shadow: 0 0 0 1px var(--color-wardian-accent);
+}
+.team-drop-before {
+  border-top-color: var(--color-wardian-accent);
+  box-shadow: 0 -2px 0 0 var(--color-wardian-accent);
+}
+.team-drop-after {
+  border-bottom-color: var(--color-wardian-accent);
+  box-shadow: 0 2px 0 0 var(--color-wardian-accent);
+}
+.team-edge-drop-zone {
+  height: 8px;
+  margin: -1px 0;
 }
 
 /* ── Context Menu ─────────────────────────────────────── */

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -28,14 +28,21 @@ const mockInvoke = vi.mocked(invoke);
 
 // Helper to set up mock return values for the initial load
 let currentAgents: AgentConfig[] = [];
+let currentWatchlists: unknown = [];
 function setupDefaultMocks(agents: AgentConfig[] = [], classes: AgentClassDefinition[] = []) {
   currentAgents = [...agents];
+  currentWatchlists = [];
   mockInvoke.mockImplementation(async (cmd: any, args?: any) => {
     switch (cmd) {
       case "list_agents":
         return currentAgents;
       case "list_agent_classes":
         return classes;
+      case "load_watchlists":
+        return currentWatchlists;
+      case "save_watchlists":
+        currentWatchlists = args?.watchlists;
+        return null;
       case "pause_agent":
         if (args?.sessionId) {
           currentAgents = currentAgents.map(a => 
@@ -62,12 +69,23 @@ function setupDefaultMocks(agents: AgentConfig[] = [], classes: AgentClassDefini
         return [];
       case "get_library_tree":
         return { type: "Folder", path: "", name: "Root", children: [] };
+      case "list_deployed_skills":
+        return [];
       case "load_workflow_library":
         return { folders: [], rootWorkflowIds: [] };
       default:
         return null;
     }
   });
+}
+
+function setupDefaultMocksWithWatchlists(
+  agents: AgentConfig[],
+  classes: AgentClassDefinition[],
+  watchlists: unknown,
+) {
+  setupDefaultMocks(agents, classes);
+  currentWatchlists = watchlists;
 }
 
 const defaultClasses: AgentClassDefinition[] = [
@@ -257,6 +275,70 @@ describe("Agent Watchlist Sidebar", () => {
       expect(screen.getByText("Agent")).toBeInTheDocument();
       expect(screen.getByText("Status")).toBeInTheDocument();
       expect(screen.getByText("Qry")).toBeInTheDocument();
+    });
+  });
+
+  it("loads versioned team watchlist state into the roster", async () => {
+    setupDefaultMocksWithWatchlists(sampleAgents, defaultClasses, {
+      version: 2,
+      teams: [{ id: "team-1", name: "Core Dev Swarm", agentIds: ["agent-1", "agent-2"] }],
+      watchlists: [],
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    expect(await screen.findByText("Core Dev Swarm")).toBeInTheDocument();
+  });
+
+  it("renders team members in the main grid when a watchlist contains a team entry", async () => {
+    setupDefaultMocksWithWatchlists(sampleAgents, defaultClasses, {
+      version: 2,
+      teams: [{ id: "team-1", name: "Core Dev Swarm", agentIds: ["agent-1", "agent-2"] }],
+      watchlists: [
+        {
+          id: "today",
+          name: "Today",
+          entries: [{ type: "team", teamId: "team-1" }],
+        },
+      ],
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByTitle("Today"));
+
+    await waitFor(() => {
+      const cards = screen.getAllByTestId("agent-card");
+      expect(cards).toHaveLength(2);
+      expect(screen.getAllByText("Alpha").length).toBeGreaterThanOrEqual(2);
+      expect(screen.getAllByText("Beta").length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("renders team members in the main grid from snake_case persisted team state", async () => {
+    setupDefaultMocksWithWatchlists(sampleAgents, defaultClasses, {
+      version: 2,
+      teams: [{ id: "team-1", name: "Core Dev Swarm", agent_ids: ["agent-1", "agent-2"] }],
+      watchlists: [
+        {
+          id: "today",
+          name: "Today",
+          entries: [{ type: "team", team_id: "team-1" }],
+        },
+      ],
+    });
+    await act(async () => {
+      render(<App />);
+    });
+
+    fireEvent.click(await screen.findByTitle("Today"));
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("agent-card")).toHaveLength(2);
+      expect(screen.getAllByText("Alpha").length).toBeGreaterThanOrEqual(2);
+      expect(screen.getAllByText("Beta").length).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -6,8 +6,18 @@ import "../styles/App.css";
 
 import AgentWatchlist from "../layout/watchlist/AgentWatchlist";
 import { classifyJsonEvent, deriveCurrentThought, getStatusColorClass } from "../utils/statusUtils";
-import { getAgentsForList, addAgentToList, removeAgentFromList } from "../layout/watchlist/watchlistUtils";
-import type { Watchlist, WatchlistPrefs, AgentInteractions } from "../layout/watchlist/types";
+import {
+  getAgentsForList,
+  addAgentsToList,
+  removeAgentsFromList,
+  normalizeWatchlistState,
+  createTeamFromAgents,
+  ungroupTeam,
+  addAgentToTeam,
+  removeAgentFromTeam,
+  reorderTeamMember,
+} from "../layout/watchlist/watchlistUtils";
+import type { Watchlist, WatchlistPrefs, AgentInteractions, AgentTeam, WatchlistState } from "../layout/watchlist/types";
 import { DEFAULT_WATCHLIST_PREFS } from "../layout/watchlist/types";
 
 import { ErrorBoundary } from "../components/ErrorBoundary";
@@ -120,6 +130,7 @@ function AppBody() {
   const { theme } = useSettingsStore();
 
   const [watchlists, setWatchlists] = useState<Watchlist[]>([]);
+  const [teams, setTeams] = useState<AgentTeam[]>([]);
   const [activeListId, setActiveListId] = useState<string>("all");
   const [watchlistPrefs, setWatchlistPrefs] = useState<WatchlistPrefs>(DEFAULT_WATCHLIST_PREFS);
   const [agentInteractions, setAgentInteractions] = useState<AgentInteractions>({});
@@ -156,8 +167,10 @@ function AppBody() {
   useEffect(() => {
     (async () => {
       try {
-        const data = await invoke<Watchlist[]>("load_watchlists");
-        if (data && data.length > 0) setWatchlists(data);
+        const data = await invoke<unknown>("load_watchlists");
+        const state = normalizeWatchlistState(data);
+        setWatchlists(state.watchlists);
+        setTeams(state.teams);
       } catch { /* first run */ }
 
       try {
@@ -184,12 +197,18 @@ function AppBody() {
     }
   }, []);
 
-  const persistWatchlists = useCallback(async (lists: Watchlist[]) => {
-    setWatchlists(lists);
+  const persistWatchlistState = useCallback(async (state: WatchlistState) => {
+    const normalized = normalizeWatchlistState(state);
+    setWatchlists(normalized.watchlists);
+    setTeams(normalized.teams);
     try {
-      await invoke("save_watchlists", { watchlists: lists });
+      await invoke("save_watchlists", { watchlists: normalized });
     } catch { /* non-critical */ }
   }, []);
+
+  const persistWatchlists = useCallback(async (lists: Watchlist[]) => {
+    await persistWatchlistState({ version: 2, watchlists: lists, teams });
+  }, [persistWatchlistState, teams]);
 
   const persistWatchlistPrefs = useCallback(async (prefs: WatchlistPrefs) => {
     setWatchlistPrefs(prefs);
@@ -200,20 +219,53 @@ function AppBody() {
 
   const handleAddToList = async (listId: string, agentId: string) => {
     const updated = watchlists.map((l) =>
-      l.id === listId ? addAgentToList(l, agentId) : l,
+      l.id === listId ? addAgentsToList(l, [agentId], teams) : l,
     );
     await persistWatchlists(updated);
   };
 
   const handleRemoveFromList = async (listId: string, agentId: string) => {
     const updated = watchlists.map((l) =>
-      l.id === listId ? removeAgentFromList(l, agentId) : l,
+      l.id === listId ? removeAgentsFromList(l, [agentId], teams) : l,
     );
     await persistWatchlists(updated);
   };
 
+  const handleCreateTeam = async (agentIds: string[]) => {
+    const next = createTeamFromAgents(
+      { version: 2, watchlists, teams },
+      crypto.randomUUID(),
+      agentIds,
+    );
+    await persistWatchlistState(next);
+  };
+
+  const handleUngroupTeam = async (teamId: string) => {
+    await persistWatchlistState(ungroupTeam({ version: 2, watchlists, teams }, teamId));
+  };
+
+  const handleRenameTeam = async (teamId: string, newName: string) => {
+    await persistWatchlistState({
+      version: 2,
+      watchlists,
+      teams: teams.map((team) => team.id === teamId ? { ...team, name: newName } : team),
+    });
+  };
+
+  const handleAddAgentToTeam = async (teamId: string, agentId: string) => {
+    await persistWatchlistState(addAgentToTeam({ version: 2, watchlists, teams }, teamId, agentId));
+  };
+
+  const handleRemoveAgentFromTeam = async (teamId: string, agentId: string, targetAgentId?: string, position: "before" | "after" = "before") => {
+    await persistWatchlistState(removeAgentFromTeam({ version: 2, watchlists, teams }, teamId, agentId, targetAgentId, position));
+  };
+
+  const handleReorderTeamMember = async (teamId: string, draggedAgentId: string, targetAgentId: string, position: "before" | "after" = "before") => {
+    await persistWatchlistState(reorderTeamMember({ version: 2, watchlists, teams }, teamId, draggedAgentId, targetAgentId, position));
+  };
+
   const activeList = activeListId === "all" ? null : watchlists.find(l => l.id === activeListId) || null;
-  const filteredAgents = getAgentsForList(agents, activeList);
+  const filteredAgents = getAgentsForList(agents, activeList, teams);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: light)");
@@ -304,7 +356,7 @@ function AppBody() {
         newDisplayList.splice(toIndex, 0, draggedItem);
         const newOrder = newDisplayList.map(a => a.session_id);
         if (activeListId !== 'all') {
-          const updatedWatchlists = watchlists.map(l => l.id === activeListId ? { ...l, agentIds: newOrder } : l);
+          const updatedWatchlists = watchlists.map(l => l.id === activeListId ? { ...l, entries: newOrder.map(agentId => ({ type: "agent" as const, agentId })) } : l);
           await persistWatchlists(updatedWatchlists);
         } else {
           setAgents(newDisplayList);
@@ -591,8 +643,8 @@ function AppBody() {
                 editingAgentId={editingAgentId}
                 tempName={tempName}
                 theme={theme}
-                watchlists={watchlists}
-                onAddToList={handleAddToList}
+          watchlists={watchlists}
+          onAddToList={handleAddToList}
                 onRemoveFromList={handleRemoveFromList}
                 onQuery={(id) => { const el = document.getElementById(`agent-card-${id}`); if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' }); }}
                 onPause={onPause}
@@ -665,6 +717,13 @@ function AppBody() {
           activeListId={activeListId}
           onActiveListChange={setActiveListId}
           onWatchlistsChange={persistWatchlists}
+          teams={teams}
+          onCreateTeam={handleCreateTeam}
+          onUngroupTeam={handleUngroupTeam}
+          onRenameTeam={handleRenameTeam}
+          onAddAgentToTeam={handleAddAgentToTeam}
+          onRemoveAgentFromTeam={handleRemoveAgentFromTeam}
+          onReorderTeamMember={handleReorderTeamMember}
           prefs={watchlistPrefs}
           onPrefsChange={persistWatchlistPrefs}
           interactions={agentInteractions}

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -15,9 +15,10 @@ import {
   ungroupTeam,
   addAgentToTeam,
   removeAgentFromTeam,
+  removeAgentFromTeamAtEntry,
   reorderTeamMember,
 } from "../layout/watchlist/watchlistUtils";
-import type { Watchlist, WatchlistPrefs, AgentInteractions, AgentTeam, WatchlistState } from "../layout/watchlist/types";
+import type { Watchlist, WatchlistPrefs, AgentInteractions, AgentTeam, WatchlistState, WatchlistEntry } from "../layout/watchlist/types";
 import { DEFAULT_WATCHLIST_PREFS } from "../layout/watchlist/types";
 
 import { ErrorBoundary } from "../components/ErrorBoundary";
@@ -218,15 +219,23 @@ function AppBody() {
   }, []);
 
   const handleAddToList = async (listId: string, agentId: string) => {
+    await handleAddAgentsToList(listId, [agentId]);
+  };
+
+  const handleAddAgentsToList = async (listId: string, agentIds: string[]) => {
     const updated = watchlists.map((l) =>
-      l.id === listId ? addAgentsToList(l, [agentId], teams) : l,
+      l.id === listId ? addAgentsToList(l, agentIds, teams) : l,
     );
     await persistWatchlists(updated);
   };
 
   const handleRemoveFromList = async (listId: string, agentId: string) => {
+    await handleRemoveAgentsFromList(listId, [agentId]);
+  };
+
+  const handleRemoveAgentsFromList = async (listId: string, agentIds: string[]) => {
     const updated = watchlists.map((l) =>
-      l.id === listId ? removeAgentsFromList(l, [agentId], teams) : l,
+      l.id === listId ? removeAgentsFromList(l, agentIds, teams) : l,
     );
     await persistWatchlists(updated);
   };
@@ -258,6 +267,23 @@ function AppBody() {
 
   const handleRemoveAgentFromTeam = async (teamId: string, agentId: string, targetAgentId?: string, position: "before" | "after" = "before") => {
     await persistWatchlistState(removeAgentFromTeam({ version: 2, watchlists, teams }, teamId, agentId, targetAgentId, position));
+  };
+
+  const handleRemoveAgentFromTeamAtEntry = async (
+    teamId: string,
+    agentId: string,
+    targetEntry: WatchlistEntry,
+    position: "before" | "after",
+    targetListId: string,
+  ) => {
+    await persistWatchlistState(removeAgentFromTeamAtEntry(
+      { version: 2, watchlists, teams },
+      teamId,
+      agentId,
+      targetEntry,
+      position,
+      targetListId,
+    ));
   };
 
   const handleReorderTeamMember = async (teamId: string, draggedAgentId: string, targetAgentId: string, position: "before" | "after" = "before") => {
@@ -712,6 +738,8 @@ function AppBody() {
           onDelete={onDelete}
           onAddToList={handleAddToList}
           onRemoveFromList={handleRemoveFromList}
+          onAddAgentsToList={handleAddAgentsToList}
+          onRemoveAgentsFromList={handleRemoveAgentsFromList}
           collapsed={rightCollapsed}
           watchlists={watchlists}
           activeListId={activeListId}
@@ -723,6 +751,7 @@ function AppBody() {
           onRenameTeam={handleRenameTeam}
           onAddAgentToTeam={handleAddAgentToTeam}
           onRemoveAgentFromTeam={handleRemoveAgentFromTeam}
+          onRemoveAgentFromTeamAtEntry={handleRemoveAgentFromTeamAtEntry}
           onReorderTeamMember={handleReorderTeamMember}
           prefs={watchlistPrefs}
           onPrefsChange={persistWatchlistPrefs}

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -53,6 +53,21 @@ function renderGrid(maximizedAgentId: string | null, filteredAgents: AgentConfig
 }
 
 describe('GridView maximize behavior', () => {
+  it('does not size each mobile card to the full viewport height', () => {
+    const originalWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 });
+
+    const { container } = renderGrid(null);
+
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.gridTemplateColumns).toBe('1fr');
+    expect(root.style.gridAutoRows).not.toBe('100%');
+    expect(screen.getByTestId('terminal-agent-1')).toBeInTheDocument();
+    expect(screen.getByTestId('terminal-agent-2')).toBeInTheDocument();
+
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth });
+  });
+
   it('maximized terminals fill the grid container', () => {
     renderGrid('agent-1');
 

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { GridView } from './GridView';
 import type { AgentConfig, AgentTelemetry } from '../types';
 
@@ -56,16 +56,24 @@ describe('GridView maximize behavior', () => {
   it('does not size each mobile card to the full viewport height', () => {
     const originalWidth = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
 
-    const { container } = renderGrid(null);
+    try {
+      const { container } = renderGrid(null);
 
-    const root = container.firstElementChild as HTMLElement;
-    expect(root.style.gridTemplateColumns).toBe('1fr');
-    expect(root.style.gridAutoRows).not.toBe('100%');
-    expect(screen.getByTestId('terminal-agent-1')).toBeInTheDocument();
-    expect(screen.getByTestId('terminal-agent-2')).toBeInTheDocument();
-
-    Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth });
+      const root = container.firstElementChild as HTMLElement;
+      expect(root.style.gridTemplateColumns).toBe('1fr');
+      expect(root.style.gridAutoRows).not.toBe('100%');
+      expect(screen.getByTestId('terminal-agent-1')).toBeInTheDocument();
+      expect(screen.getByTestId('terminal-agent-2')).toBeInTheDocument();
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalWidth });
+      act(() => {
+        window.dispatchEvent(new Event('resize'));
+      });
+    }
   });
 
   it('maximized terminals fill the grid container', () => {

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -123,11 +123,11 @@ export const GridView: React.FC<GridViewProps> = ({
     gridTemplateColumns: (isMaximized || isMobile) 
       ? '1fr' 
       : layout.column_tracks.map(t => `${t}fr`).join(' '),
-    gridAutoRows: (isMaximized || isMobile) ? '100%' : `${layout.row_height}px`,
+    gridAutoRows: isMaximized ? '100%' : `${layout.row_height}px`,
     gap: (isMaximized || isMobile) ? '0' : '8px',
     background: 'transparent',
     padding: (isMaximized || isMobile) ? '0' : '8px',
-    height: (isMaximized || isMobile) ? '100%' : 'auto',
+    height: isMaximized ? '100%' : 'auto',
   };
 
   const bgMenuItems: ContextMenuItem[] = [


### PR DESCRIPTION
Closes #76

## Summary
- Add global agent teams to watchlist state with team-aware persistence and snake_case/camelCase normalization.
- Add team-aware context menus, bulk actions, and drag/drop membership/reordering using explicit team drop zones.
- Keep team members visible in main grid/watchlist views, including narrow layouts and persisted team entries.

## Test Plan
- [x] npm run lint
- [x] npm run test
- [x] npm run build
- [x] cd src-tauri; cargo check
- [x] cd src-tauri; cargo clippy
- [x] cd src-tauri; cargo test
- [x] npm run test:e2e

Note: the first full cargo test attempt was blocked by a stale debug Wardian.exe holding a target file lock; after stopping that debug process, the full cargo test suite passed.