### PR TITLE
fix: robust agent identity, SQLite status tracking, and state recovery

### DIFF
--- a/docs/specs/023-agent-identity-and-status-tracking.md
+++ b/docs/specs/023-agent-identity-and-status-tracking.md
@@ -1,0 +1,57 @@
+# Spec 023: Agent Identity and Status Tracking
+
+## 1. Context & Motivation
+
+Wardian currently manages Agent Identity (`session_name`) and Agent Status (`current_status`) as mutable fields in memory (`AppState`). This creates several issues:
+
+1.  **Duplicate Names:** Agents can have the same `session_name`, making them impossible to uniquely identify via CLI.
+2.  **Volatile Status Tracking:** Status is tracked by parsing stdout and updating an in-memory `HashMap`. If Wardian restarts, it cannot recover the true state of background processes.
+3.  **Process Lifecycle Coupling:** The UI assumes the agent process is tied to the Tauri application lifecycle.
+
+## 2. Agent Identity: Globally Unique CLI-Friendly Names
+
+The UUID (`session_id`) remains the internal primary key and folder identifier (`~/.wardian/agents/<uuid>`). The `session_name` becomes a **globally unique CLI-friendly alias**.
+
+### 2.1. Naming Constraints
+-   **Regex:** `^[a-zA-Z0-9_-]+$` (No whitespace, no special characters).
+-   **Uniqueness:** The Rust backend enforces uniqueness upon creation and mutation.
+-   **Auto-Generation:** Collisions result in unique suffixes (e.g., `coder-a1b2`).
+
+### 2.2. Folder Stability
+-   Folder paths remain tied to UUIDs. Renaming an agent is a metadata-only change, ensuring no broken paths or file locks.
+
+## 3. Status Tracking: SQLite Event Database
+
+A local **SQLite Database** (`~/.wardian/state.db`) acts as the source of truth, enabling process recovery and event auditing.
+
+### 3.1. Schema & Performance
+-   **WAL Mode:** SQLite will use Write-Ahead Logging (WAL) to prevent blocking concurrent UI reads during high-frequency parser writes.
+-   **`agents` table:** Added `last_status` and `last_pid` columns for O(1) status retrieval.
+-   **`events` table:** Audit log of status changes and tool calls.
+-   **Pruning:** A background task will prune the `events` table (e.g., keep last 1000 events or 30 days of history).
+
+### 3.2. Status Lifecycle & Deduplication
+-   **Deduplication:** Status updates are only written to SQLite if `new_status != last_known_status` to prevent write amplification.
+-   **Event Source:** PTY parsers emit `status_change` events.
+
+### 3.3. Process Recovery & "Headless" Reality
+-   **Forensic ID Injection:** Every agent is spawned with `WARDIAN_SESSION_ID=<uuid>` in its environment.
+-   **Recovery:** On startup, Wardian reconciles the DB with the OS process list. It verifies process identity by checking the environment block (via `sysinfo`).
+-   **Headless Capability:** If a process is alive but Wardian lacks the Master PTY handle (destroyed on restart), the status is `Headless`.
+    -   *Constraint:* "Headless" agents are **unreachable for interactive input** until a PTY daemon (e.g., tmux-style persistence) is implemented. They continue executing tasks but cannot be commanded via the terminal grid.
+
+## 4. Implementation Phasing
+
+**Phase 1: Strict Identity**
+1.  Update UI to enforce CLI-friendly name regex.
+2.  Update Rust backend to reject duplicate names.
+3.  Migration to sanitize existing names in `projects.json`.
+
+**Phase 2: SQLite Infrastructure**
+1.  Add `rusqlite` with WAL mode.
+2.  Implement `db` module for migrations and `WARDIAN_SESSION_ID` injection.
+3.  Hook parsers into the DB with a deduplication layer.
+
+**Phase 3: State Decoupling**
+1.  Derive telemetry and status from DB + `sysinfo`.
+2.  Implement event pruning logic.

--- a/docs/superpowers/plans/2026-04-20-agent-status-and-resume-v2.md
+++ b/docs/superpowers/plans/2026-04-20-agent-status-and-resume-v2.md
@@ -1,0 +1,43 @@
+# Implementation Plan: Agent Status and Resume (v2)
+
+This plan ensures that all AI providers (Claude, Codex, OpenCode) handle status tracking and session resumption correctly, following our newly implemented identity and SQLite state architecture.
+
+## 1. Provider Alignment
+
+### 1.1. Claude Code
+- **Status:** Currently uses `claude_status_from_log`.
+- **Resume:** Uses `--resume <id>`. 
+- **Requirement:** Ensure that when Wardian restarts, it correctly passes the stored `resume_session` (which matches the Claude JSONL filename) to the `--resume` flag.
+- **Action:** Update `providers/claude.rs` to strictly map `resume_session` to the `--resume` flag during restoration.
+
+### 1.2. Codex
+- **Status:** TUI-based. Uses `codex resume <ID>`.
+- **Requirement:** Verify `manager::latest_codex_session_index_entry` correctly extracts the ID for resumption.
+- **Action:** Add explicit `/status` parsing if needed, or ensure the TUI output for session IDs is correctly captured.
+
+### 1.3. OpenCode
+- **Status:** Uses `/status` in TUI. Uses `--session <ID>` for resume.
+- **Requirement:** Ensure the extracted `ses_xxx` ID from logs is correctly passed to `--session`.
+- **Action:** Refine `opencode_extract_created_session_id` in `manager.rs` to ensure it captures the ID even if the process was interrupted.
+
+## 2. SQLite Integration
+
+-   **Deduplication:** Ensure `update_agent_status` is called by all provider parsers.
+-   **Forensic Verification:** Implement the check for `WARDIAN_SESSION_ID` in `reconcile_headless_agents` (Done in Phase 3, verify during testing).
+
+## 3. UI Refinements
+
+-   **Placeholder:** Update `SpawnAgentPanel.tsx` placeholder to `@handle` style (Done).
+-   **Headless Indicator:** Ensure the UI clearly shows "Headless" status when an agent is recovered but not interactive.
+
+## 4. Verification Tasks
+
+1.  **Test Claude Resume:** Spawn Claude -> Kill app -> Restart -> Verify it resumes the same session ID.
+2.  **Test OpenCode Headless:** Spawn OpenCode -> Force kill Wardian (keep agent alive) -> Restart Wardian -> Verify status is "Headless".
+3.  **Test Duplicate Identity:** Try to create two agents with the same handle -> Verify error message.
+
+## 5. Timeline & Phasing
+
+- **Task 1:** Surgical provider flag alignment (Claude/OpenCode).
+- **Task 2:** "Headless" UI state visibility.
+- **Task 3:** Final E2E Smoke Test.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,13 +4,15 @@ version = 4
 
 [[package]]
 name = "Wardian"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
  "notify",
+ "once_cell",
  "portable-pty",
  "regex",
+ "rusqlite",
  "serde",
  "serde_json",
  "shlex",
@@ -991,6 +993,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1600,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,6 +2163,17 @@ dependencies = [
  "bitflags 2.11.0",
  "libc",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3449,6 +3483,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "serde_json",
+ "smallvec",
 ]
 
 [[package]]
@@ -4847,6 +4896,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,8 @@ tauri-plugin-clipboard-manager = "2.3.2"
 regex = "1.12.3"
 tauri-plugin-notification = "2.0.0-rc.3"
 notify = "6.1.1"
+rusqlite = { version = "0.33.0", features = ["bundled", "serde_json"] }
+once_cell = "1.20.2"
 
 [target.'cfg(windows)'.dependencies]
 win32job = "2.0.3"

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -119,6 +119,19 @@ fn prepare_clear_config(config: &mut AgentConfig) -> Result<(), String> {
     Ok(())
 }
 
+fn is_valid_name(name: &str) -> bool {
+    let re = regex::Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
+    re.is_match(name)
+}
+
+async fn is_name_unique(state: &AppState, name: &str, exclude_session_id: Option<&str>) -> bool {
+    let agents = state.agents.lock().await;
+    !agents.values().any(|a| {
+        a.config.session_name == name
+            && exclude_session_id.map_or(true, |id| a.config.session_id != id)
+    })
+}
+
 #[tauri::command]
 pub async fn spawn_agent(
     req: SpawnAgentRequest,
@@ -131,6 +144,14 @@ pub async fn spawn_agent(
     let resume_session = req.resume_session;
     let is_off = req.is_off;
     let config_override = req.config_override;
+
+    if !is_valid_name(&session_name) {
+        return Err("Invalid agent name. Names must contain only alphanumeric characters, underscores, or hyphens (no spaces).".to_string());
+    }
+
+    if !is_name_unique(&state, &session_name, None).await {
+        return Err(format!("An agent with the name '{}' already exists.", session_name));
+    }
 
     manager::log_debug(&format!(
         "[WARDIAN] spawn_agent called for session name: {}, class: {}",
@@ -263,6 +284,9 @@ pub async fn kill_agent(
         order.retain(|id| id != &session_id);
         manager::save_state(&app, &agents, &order);
         manager::terminate_active_agent_process(&mut agent);
+
+        // Phase 2: Remove from SQLite
+        let _ = crate::utils::db::delete_agent(&session_id);
 
         // Cleanup: remove the agent's private directory
         if let Some(home) = crate::utils::fs::get_wardian_home() {
@@ -453,11 +477,27 @@ pub async fn rename_agent(
         "[WARDIAN] rename_agent called for session {}: {}",
         session_id, new_name
     ));
+
+    if !is_valid_name(&new_name) {
+        return Err("Invalid agent name. Names must contain only alphanumeric characters, underscores, or hyphens (no spaces).".to_string());
+    }
+
+    if !is_name_unique(&state, &new_name, Some(&session_id)).await {
+        return Err(format!("An agent with the name '{}' already exists.", new_name));
+    }
+
     let mut agents = state.agents.lock().await;
     let order = state.agent_order.lock().await;
 
     if let Some(agent) = agents.get_mut(&session_id) {
         agent.config.session_name = new_name;
+        // Phase 2: Update agent metadata in SQLite
+        let _ = crate::utils::db::upsert_agent(
+            &agent.config.session_id,
+            &agent.config.session_name,
+            &agent.config.agent_class,
+            agent.config.is_off,
+        );
         manager::save_state(&app, &agents, &order);
         Ok(())
     } else {

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -56,15 +56,9 @@ fn restore_runtime_state_after_resume(
     }
 }
 
-fn restore_query_count_after_clear(
-    new_active: &mut crate::state::ActiveAgent,
-    old_active: &crate::state::ActiveAgent,
-) {
-    if let (Ok(old_count), Ok(mut new_count)) =
-        (old_active.query_count.lock(), new_active.query_count.lock())
-    {
-        *new_count = *old_count;
-    }
+fn is_valid_name(name: &str) -> bool {
+    let re = regex::Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
+    re.is_match(name)
 }
 
 fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
@@ -119,16 +113,12 @@ fn prepare_clear_config(config: &mut AgentConfig) -> Result<(), String> {
     Ok(())
 }
 
-fn is_valid_name(name: &str) -> bool {
-    let re = regex::Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
-    re.is_match(name)
-}
-
 async fn is_name_unique(state: &AppState, name: &str, exclude_session_id: Option<&str>) -> bool {
     let agents = state.agents.lock().await;
     !agents.values().any(|a| {
-        a.config.session_name == name
-            && exclude_session_id.map_or(true, |id| a.config.session_id != id)
+        let config = a.config.lock().unwrap();
+        config.session_name == name
+            && exclude_session_id.map_or(true, |id| config.session_id != id)
     })
 }
 
@@ -203,9 +193,8 @@ pub async fn spawn_agent(
         &agent_class,
         &session_id,
     ));
-    let mut active_agent = manager::spawn_agent(app.clone(), config.clone(), false).await?;
+    let active_agent = manager::spawn_agent(app.clone(), config.clone(), false).await?;
     // Propagate any fields that spawn_agent may have auto-assigned (e.g. opencode_port).
-    config.opencode_port = active_agent.config.opencode_port;
     if config.provider == "codex" && actual_resume.is_none() {
         for _ in 0..40 {
             if let Some((provider_session_id, _updated_at)) =
@@ -213,7 +202,10 @@ pub async fn spawn_agent(
             {
                 actual_resume = Some(provider_session_id.clone());
                 config.resume_session = Some(provider_session_id.clone());
-                active_agent.config.resume_session = Some(provider_session_id.clone());
+                {
+                    let mut cfg = active_agent.config.lock().unwrap();
+                    cfg.resume_session = Some(provider_session_id.clone());
+                }
                 manager::log_debug(&format!(
                     "[WARDIAN] Adopted live Codex session id {} for Wardian session {}",
                     provider_session_id, session_id
@@ -223,10 +215,16 @@ pub async fn spawn_agent(
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         }
     }
+    
     let persisted_resume =
         persisted_resume_session_for_provider(&config.provider, actual_resume.clone(), &session_id);
     config.resume_session = persisted_resume.clone();
-    active_agent.config.resume_session = persisted_resume;
+    
+    {
+        let mut cfg = active_agent.config.lock().unwrap();
+        config.opencode_port = cfg.opencode_port;
+        cfg.resume_session = persisted_resume;
+    }
 
     // Register input sender BEFORE locking agents map
     if let Some(ref tx) = active_agent.stdin_tx {
@@ -252,7 +250,7 @@ pub async fn list_agents(state: State<'_, AppState>) -> Result<Vec<AgentConfig>,
     let mut list: Vec<AgentConfig> = Vec::new();
     for id in order.iter() {
         if let Some(agent) = agents.get(id) {
-            list.push(agent.config.clone());
+            list.push(agent.config.lock().unwrap().clone());
         }
     }
     Ok(list)
@@ -332,28 +330,30 @@ pub async fn pause_agent(
 
         // For opencode: capture the real ses_xxx session ID from the log so
         // resume can pass --session ses_xxx rather than the internal UUID.
-        // The log file is populated by the metrics poll loop; if no session
-        // was ever created (user paused before sending a message) this is a
-        // no-op and resume will simply start a fresh opencode session.
-        if agent.config.provider == "opencode"
-            && agent
-                .config
-                .resume_session
-                .as_deref()
-                .map(|s| !s.starts_with("ses_"))
-                .unwrap_or(true)
+        let provider = {
+            let config = agent.config.lock().unwrap();
+            config.provider.clone()
+        };
+        
+        if provider == "opencode"
         {
-            let log_path_snap = agent.log_path.lock().ok().and_then(|guard| guard.clone());
-            if let Some(log_path) = log_path_snap {
-                if let Some(ses_id) = manager::opencode_extract_created_session_id(&log_path) {
-                    agent.config.resume_session = Some(ses_id);
+            let mut config = agent.config.lock().unwrap();
+            if config.resume_session.as_deref().map(|s| !s.starts_with("ses_")).unwrap_or(true) {
+                let log_path_snap = agent.log_path.lock().ok().and_then(|guard| guard.clone());
+                if let Some(log_path) = log_path_snap {
+                    if let Some(ses_id) = manager::opencode_extract_created_session_id(&log_path) {
+                        config.resume_session = Some(ses_id);
+                    }
                 }
             }
         }
 
         agent.pty_master = None;
         agent.stdin_tx = None;
-        agent.config.is_off = true;
+        {
+            let mut config = agent.config.lock().unwrap();
+            config.is_off = true;
+        }
         // Remove from input_senders
         if let Ok(mut status) = agent.current_status.lock() {
             *status = "Off".to_string();
@@ -382,13 +382,20 @@ pub async fn resume_agent(
     let order = state.agent_order.lock().await;
 
     if let Some(agent) = agents.get_mut(&session_id) {
-        prepare_resume_config(&mut agent.config)?;
-        let mut new_active = manager::spawn_agent(app.clone(), agent.config.clone(), true).await?;
+        let mut config = agent.config.lock().unwrap().clone();
+        prepare_resume_config(&mut config)?;
+        let mut new_active = manager::spawn_agent(app.clone(), config, true).await?;
         restore_runtime_state_after_resume(&mut new_active, agent);
-        if agent.config.provider == "claude" {
-            if let Some(fresh_provider_session_id) = agent.config.fresh_provider_session_id.take() {
-                agent.config.resume_session = Some(fresh_provider_session_id);
+        
+        {
+            let mut new_config = new_active.config.lock().unwrap();
+            let mut old_config = agent.config.lock().unwrap();
+            if old_config.provider == "claude" {
+                if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take() {
+                    new_config.resume_session = Some(fresh_provider_session_id);
+                }
             }
+            *old_config = new_config.clone();
         }
 
         // Register new input sender
@@ -404,7 +411,6 @@ pub async fn resume_agent(
         // Preserve the updated config on the new agent, then swap the entire struct.
         // The old ActiveAgent is dropped here; its Drop impl is a no-op because
         // terminate_active_agent_process already cleared process_id and child_process.
-        new_active.config = agent.config.clone();
         let _ = std::mem::replace(agent, new_active);
         manager::save_state(&app, &agents, &order);
         Ok(())
@@ -427,7 +433,14 @@ pub async fn clear_agent_session(
     let order = state.agent_order.lock().await;
 
     if let Some(agent) = agents.get_mut(&session_id) {
-        prepare_clear_config(&mut agent.config)?;
+        // 1. Terminate the old agent's process tree immediately.
+        manager::terminate_active_agent_process(agent);
+
+        // 2. Prepare fresh config (new provider session ID for Claude, clear resume IDs)
+        let mut config = agent.config.lock().unwrap().clone();
+        prepare_clear_config(&mut config)?;
+
+        // 3. Reset UI and in-memory buffers
         if let Ok(mut buf) = agent.output_buffer.lock() {
             buf.clear();
         }
@@ -437,29 +450,62 @@ pub async fn clear_agent_session(
         if let Ok(mut status) = agent.current_status.lock() {
             *status = "Processing...".to_string();
         }
+        if let Ok(mut count) = agent.query_count.lock() {
+            *count = 0;
+        }
+
         let _ = app.emit(
             "agent-terminal-cleared",
             serde_json::json!({ "session_id": session_id }),
         );
 
-        let mut new_active = manager::spawn_agent(app.clone(), agent.config.clone(), true).await?;
-        restore_query_count_after_clear(&mut new_active, agent);
-        if agent.config.provider == "claude" {
-            if let Some(fresh_provider_session_id) = agent.config.fresh_provider_session_id.take() {
-                agent.config.resume_session = Some(fresh_provider_session_id);
+        // 5. Spawn a FRESH process (is_restored = false)
+        // This ensures Claude uses --session-id and others start clean.
+        let new_active = manager::spawn_agent(app.clone(), config, false).await?;
+
+        {
+            let mut new_config = new_active.config.lock().unwrap();
+            let mut old_config = agent.config.lock().unwrap();
+            if old_config.provider == "claude" {
+                if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take() {
+                    new_config.resume_session = Some(fresh_provider_session_id);
+                }
             }
+            *old_config = new_config.clone();
         }
 
+        // 6. Register new input sender
         if let Some(ref tx) = new_active.stdin_tx {
             if let Ok(mut senders) = state.input_senders.write() {
                 senders.insert(session_id.clone(), tx.clone());
             }
         }
 
-        manager::terminate_active_agent_process(agent);
-        new_active.config = agent.config.clone();
+        // 7. Update agent metadata in SQLite
+        {
+            let config = agent.config.lock().unwrap();
+            let _ = crate::utils::db::upsert_agent(
+                &config.session_id,
+                &config.session_name,
+                &config.agent_class,
+                config.is_off,
+            );
+        }
+
+        // 8. Swap the struct
         let _ = std::mem::replace(agent, new_active);
         manager::save_state(&app, &agents, &order);
+
+        // 9. Force a frontend refresh and terminal resize to clear glitches
+        let _ = app.emit("agents-updated", ());
+        let _ = app.emit(
+            "agent-terminal-resize",
+            serde_json::json!({ "session_id": session_id, "rows": 24, "cols": 80 }),
+        );
+        let _ = app.emit(
+            "agent-pty-output-ready",
+            serde_json::json!({ "session_id": session_id }),
+        );
         Ok(())
     } else {
         Err(format!("Agent {} not found", session_id))
@@ -490,13 +536,18 @@ pub async fn rename_agent(
     let order = state.agent_order.lock().await;
 
     if let Some(agent) = agents.get_mut(&session_id) {
-        agent.config.session_name = new_name;
+        let (sid, name, class, is_off) = {
+            let mut config = agent.config.lock().unwrap();
+            config.session_name = new_name;
+            (config.session_id.clone(), config.session_name.clone(), config.agent_class.clone(), config.is_off)
+        };
+
         // Phase 2: Update agent metadata in SQLite
         let _ = crate::utils::db::upsert_agent(
-            &agent.config.session_id,
-            &agent.config.session_name,
-            &agent.config.agent_class,
-            agent.config.is_off,
+            &sid,
+            &name,
+            &class,
+            is_off,
         );
         manager::save_state(&app, &agents, &order);
         Ok(())
@@ -520,10 +571,15 @@ pub async fn update_agent_config(
 
     if let Some(agent) = agents.get_mut(&new_config.session_id) {
         // If class has changed, auto-update the system_include_directories
-        if agent.config.agent_class != new_config.agent_class {
+        let current_class = {
+            let config = agent.config.lock().unwrap();
+            config.agent_class.clone()
+        };
+
+        if current_class != new_config.agent_class {
             manager::log_debug(&format!(
                 "[WARDIAN] Agent class changed from {} to {}. Updating system include directories.",
-                agent.config.agent_class, new_config.agent_class
+                current_class, new_config.agent_class
             ));
             new_config.system_include_directories =
                 Some(crate::utils::fs::resolve_system_include_directories(
@@ -532,7 +588,10 @@ pub async fn update_agent_config(
                 ));
         }
 
-        agent.config = new_config.clone();
+        {
+            let mut config = agent.config.lock().unwrap();
+            *config = new_config;
+        }
         manager::save_state(&app, &agents, &order);
         Ok(())
     } else {
@@ -558,7 +617,7 @@ pub async fn reorder_agents(
 mod tests {
     use super::{
         persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
-        provider_uses_generated_session_id, restore_query_count_after_clear,
+        provider_uses_generated_session_id,
         restore_runtime_state_after_resume,
     };
     use crate::models::{AgentConfig, AgentSessionPersistenceOverride};
@@ -567,7 +626,7 @@ mod tests {
 
     fn make_test_agent() -> ActiveAgent {
         ActiveAgent {
-            config: AgentConfig::default(),
+            config: Arc::new(Mutex::new(AgentConfig::default())),
             child_process: None,
             background_processes: Vec::new(),
             pty_master: None,
@@ -629,22 +688,6 @@ mod tests {
             new_active.log_path.lock().unwrap().as_deref(),
             Some(std::path::Path::new("C:/tmp/session.json"))
         );
-    }
-
-    #[test]
-    fn clear_preserves_query_count_only() {
-        let old_active = make_test_agent();
-        *old_active.query_count.lock().unwrap() = 7;
-        *old_active.init_timestamp.lock().unwrap() = Some("2026-04-12T17:00:00.000Z".to_string());
-        *old_active.log_path.lock().unwrap() =
-            Some(std::path::PathBuf::from("C:/tmp/session.json"));
-
-        let mut new_active = make_test_agent();
-        restore_query_count_after_clear(&mut new_active, &old_active);
-
-        assert_eq!(*new_active.query_count.lock().unwrap(), 7);
-        assert_eq!(new_active.init_timestamp.lock().unwrap().as_deref(), None);
-        assert_eq!(new_active.log_path.lock().unwrap().as_deref(), None);
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -193,7 +193,7 @@ pub async fn spawn_agent(
         &agent_class,
         &session_id,
     ));
-    let active_agent = manager::spawn_agent(app.clone(), config.clone(), false).await?;
+    let active_agent = manager::spawn_agent(app.clone(), config.clone(), false, None).await?;
     // Propagate any fields that spawn_agent may have auto-assigned (e.g. opencode_port).
     if config.provider == "codex" && actual_resume.is_none() {
         for _ in 0..40 {
@@ -382,9 +382,12 @@ pub async fn resume_agent(
     let order = state.agent_order.lock().await;
 
     if let Some(agent) = agents.get_mut(&session_id) {
-        let mut config = agent.config.lock().unwrap().clone();
+        let (mut config, born) = {
+            let config_lock = agent.config.lock().unwrap();
+            (config_lock.clone(), agent.init_timestamp.lock().unwrap().clone())
+        };
         prepare_resume_config(&mut config)?;
-        let mut new_active = manager::spawn_agent(app.clone(), config, true).await?;
+        let mut new_active = manager::spawn_agent(app.clone(), config, true, born).await?;
         restore_runtime_state_after_resume(&mut new_active, agent);
         
         {
@@ -461,7 +464,8 @@ pub async fn clear_agent_session(
 
         // 5. Spawn a FRESH process (is_restored = false)
         // This ensures Claude uses --session-id and others start clean.
-        let new_active = manager::spawn_agent(app.clone(), config, false).await?;
+        let born = agent.init_timestamp.lock().unwrap().clone();
+        let new_active = manager::spawn_agent(app.clone(), config, false, born).await?;
 
         {
             let mut new_config = new_active.config.lock().unwrap();
@@ -484,11 +488,13 @@ pub async fn clear_agent_session(
         // 7. Update agent metadata in SQLite
         {
             let config = agent.config.lock().unwrap();
+            let born = agent.init_timestamp.lock().unwrap();
             let _ = crate::utils::db::upsert_agent(
                 &config.session_id,
                 &config.session_name,
                 &config.agent_class,
                 config.is_off,
+                born.as_deref(),
             );
         }
 
@@ -536,10 +542,10 @@ pub async fn rename_agent(
     let order = state.agent_order.lock().await;
 
     if let Some(agent) = agents.get_mut(&session_id) {
-        let (sid, name, class, is_off) = {
+        let (sid, name, class, is_off, born) = {
             let mut config = agent.config.lock().unwrap();
             config.session_name = new_name;
-            (config.session_id.clone(), config.session_name.clone(), config.agent_class.clone(), config.is_off)
+            (config.session_id.clone(), config.session_name.clone(), config.agent_class.clone(), config.is_off, agent.init_timestamp.lock().unwrap().clone())
         };
 
         // Phase 2: Update agent metadata in SQLite
@@ -548,6 +554,7 @@ pub async fn rename_agent(
             &name,
             &class,
             is_off,
+            born.as_deref(),
         );
         manager::save_state(&app, &agents, &order);
         Ok(())

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -118,7 +118,7 @@ async fn is_name_unique(state: &AppState, name: &str, exclude_session_id: Option
     !agents.values().any(|a| {
         let config = a.config.lock().unwrap();
         config.session_name == name
-            && exclude_session_id.map_or(true, |id| config.session_id != id)
+            && exclude_session_id.is_none_or(|id| config.session_id != id)
     })
 }
 

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -21,7 +21,7 @@ pub async fn get_explorer_root(
         let agents = state.agents.lock().await;
         agents
             .get(&id)
-            .map(|agent| agent.config.folder.clone())
+            .map(|agent| agent.config.lock().unwrap().folder.clone())
             .ok_or_else(|| "Agent not found".to_string())
     } else {
         let app_dir = crate::manager::get_wardian_home().ok_or("No home dir")?;

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -83,7 +83,8 @@ pub async fn send_input_to_agent(
                 } else if is_submit {
                     let agents = state.agents.lock().await;
                     if let Some(agent) = agents.get(&session_id) {
-                        if agent.config.provider == "opencode" {
+                        let provider = agent.config.lock().unwrap().provider.clone();
+                        if provider == "opencode" {
                             let current_status = agent
                                 .current_status
                                 .lock()
@@ -173,6 +174,7 @@ pub async fn submit_prompt_to_agent(
         let agent = agents
             .get(&session_id)
             .ok_or_else(|| format!("Agent {} not found or is off", session_id))?;
+        let config = agent.config.lock().unwrap().clone();
         let tx = state
             .input_senders
             .try_read()
@@ -180,8 +182,8 @@ pub async fn submit_prompt_to_agent(
             .get(&session_id)
             .cloned();
         (
-            agent.config.provider.clone(),
-            agent.config.clone(),
+            config.provider.clone(),
+            config,
             tx,
         )
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ pub async fn reconcile_headless_agents() -> std::result::Result<(), Box<dyn std:
         if agent.is_off { continue; }
 
         let mut found_alive = false;
-        for (_pid, process) in sys.processes() {
+        for process in sys.processes().values() {
             for env_var in process.environ() {
                 let env_str = env_var.to_string_lossy();
                 if env_str.contains("WARDIAN_SESSION_ID=") && env_str.contains(&agent.session_id) {
@@ -92,10 +92,11 @@ pub fn run() {
                             let mut agents_map = state.agents.lock().await;
                             let mut order_map = state.agent_order.lock().await;
                             let mut seen_names = std::collections::HashSet::new();
-
-                            let db_agents = crate::utils::db::get_all_agents().unwrap_or_default();
-                            let db_status_map: std::collections::HashMap<String, (Option<String>, Option<u32>, Option<String>)> = 
-                                db_agents.into_iter().map(|a| (a.session_id, (a.last_status, a.last_pid, a.created_at))).collect();
+// Fetch latest status from DB for all agents
+let db_agents = crate::utils::db::get_all_agents().unwrap_or_default();
+type DbStatus = (Option<String>, Option<u32>, Option<String>);
+let db_status_map: std::collections::HashMap<String, DbStatus> = 
+    db_agents.into_iter().map(|a| (a.session_id, (a.last_status, a.last_pid, a.created_at))).collect();
 
                             for mut config in configs {
                                 // Sanitize name
@@ -137,16 +138,14 @@ pub fn run() {
                                     };
                                     order_map.push(config.session_id.clone());
                                     agents_map.insert(config.session_id.clone(), agent);
-                                } else {
-                                    if let Ok(agent) = manager::spawn_agent(app_handle.clone(), config.clone(), true, last_born).await {
-                                        if let Some(ref tx) = agent.stdin_tx {
-                                            if let Ok(mut senders) = state.input_senders.write() {
-                                                senders.insert(config.session_id.clone(), tx.clone());
-                                            }
+                                } else if let Ok(agent) = manager::spawn_agent(app_handle.clone(), config.clone(), true, last_born).await {
+                                    if let Some(ref tx) = agent.stdin_tx {
+                                        if let Ok(mut senders) = state.input_senders.write() {
+                                            senders.insert(config.session_id.clone(), tx.clone());
                                         }
-                                        order_map.push(config.session_id.clone());
-                                        agents_map.insert(config.session_id.clone(), agent);
                                     }
+                                    order_map.push(config.session_id.clone());
+                                    agents_map.insert(config.session_id.clone(), agent);
                                 }
                             }
                             manager::save_state(&app_handle, &agents_map, &order_map);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,8 +94,8 @@ pub fn run() {
                             let mut seen_names = std::collections::HashSet::new();
 
                             let db_agents = crate::utils::db::get_all_agents().unwrap_or_default();
-                            let db_status_map: std::collections::HashMap<String, (Option<String>, Option<u32>)> = 
-                                db_agents.into_iter().map(|a| (a.session_id, (a.last_status, a.last_pid))).collect();
+                            let db_status_map: std::collections::HashMap<String, (Option<String>, Option<u32>, Option<String>)> = 
+                                db_agents.into_iter().map(|a| (a.session_id, (a.last_status, a.last_pid, a.created_at))).collect();
 
                             for mut config in configs {
                                 // Sanitize name
@@ -114,11 +114,11 @@ pub fn run() {
 
                                 config.system_include_directories = Some(utils::fs::resolve_system_include_directories(&config.agent_class, &config.session_id));
 
-                                let (last_status, last_pid) = db_status_map.get(&config.session_id).cloned().unwrap_or((None, None));
+                                let (last_status, last_pid, last_born) = db_status_map.get(&config.session_id).cloned().unwrap_or((None, None, None));
 
                                 if last_status.as_deref() == Some("Headless") {
                                     let agent = crate::state::ActiveAgent {
-                                        config: config.clone(),
+                                        config: std::sync::Arc::new(std::sync::Mutex::new(config.clone())),
                                         child_process: None,
                                         background_processes: Vec::new(),
                                         pty_master: None,
@@ -126,7 +126,7 @@ pub fn run() {
                                         output_buffer: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
                                         process_id: last_pid,
                                         query_count: std::sync::Arc::new(std::sync::Mutex::new(0)),
-                                        init_timestamp: std::sync::Arc::new(std::sync::Mutex::new(None)),
+                                        init_timestamp: std::sync::Arc::new(std::sync::Mutex::new(last_born)),
                                         current_status: std::sync::Arc::new(std::sync::Mutex::new("Headless".to_string())),
                                         terminal_title: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
                                         last_output_at: std::sync::Arc::new(std::sync::Mutex::new(None)),
@@ -138,7 +138,7 @@ pub fn run() {
                                     order_map.push(config.session_id.clone());
                                     agents_map.insert(config.session_id.clone(), agent);
                                 } else {
-                                    if let Ok(agent) = manager::spawn_agent(app_handle.clone(), config.clone(), true).await {
+                                    if let Ok(agent) = manager::spawn_agent(app_handle.clone(), config.clone(), true, last_born).await {
                                         if let Some(ref tx) = agent.stdin_tx {
                                             if let Ok(mut senders) = state.input_senders.write() {
                                                 senders.insert(config.session_id.clone(), tx.clone());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,25 +10,54 @@ use crate::models::AgentConfig;
 use crate::state::AppState;
 use tauri::{Emitter, Manager};
 
-/// The main entry point for the Wardian Tauri application.
-/// Initializes plugins, state, and registers command handlers.
+pub async fn reconcile_headless_agents() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    use sysinfo::System;
+    
+    // Use new_all() to ensure we have process and environment data
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let agents = crate::utils::db::get_all_agents()?;
+    for agent in agents {
+        if agent.is_off { continue; }
+
+        let mut found_alive = false;
+        for (_pid, process) in sys.processes() {
+            for env_var in process.environ() {
+                let env_str = env_var.to_string_lossy();
+                if env_str.contains("WARDIAN_SESSION_ID=") && env_str.contains(&agent.session_id) {
+                    found_alive = true;
+                    let _ = crate::utils::db::update_agent_status(&agent.session_id, "Headless", Some(process.pid().as_u32()));
+                    break;
+                }
+            }
+            if found_alive { break; }
+        }
+
+        if !found_alive && agent.last_status.as_deref() != Some("Off") {
+            let _ = crate::utils::db::update_agent_status(&agent.session_id, "Off", None);
+        }
+    }
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(windows)]
     {
         use windows::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
         use windows::core::PCWSTR;
-        let aumid: Vec<u16> = "org.wardian.desktop"
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
+        let aumid: Vec<u16> = "org.wardian.desktop".encode_utf16().chain(std::iter::once(0)).collect();
         unsafe {
             let _ = SetCurrentProcessExplicitAppUserModelID(PCWSTR::from_raw(aumid.as_ptr()));
         }
     }
 
-    // Migrate ~/.wardian layout to current schema version before anything else
     crate::utils::migration::migrate_home_layout();
+
+    if let Err(e) = crate::utils::db::init_db() {
+        eprintln!("Failed to initialize database: {}", e);
+    }
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -37,11 +66,8 @@ pub fn run() {
         .manage(AppState::new())
         .setup(|app| {
             let app_handle = app.handle().clone();
-
-            // Generate Class Constraints globally inside AppData
             manager::init_agent_classes(&app_handle);
 
-            // Metrics push task
             let metrics_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 loop {
@@ -52,11 +78,11 @@ pub fn run() {
                 }
             });
 
-            // Restore agents from state
             tauri::async_runtime::spawn(async move {
                 let state = app_handle.state::<AppState>();
-
-                // Initialize Workflow Triggers
+                if let Err(e) = reconcile_headless_agents().await {
+                    eprintln!("Failed to reconcile headless agents: {}", e);
+                }
                 workflow_engine::init_triggers(app_handle.clone()).await;
 
                 if let Some(app_dir) = manager::get_wardian_home() {
@@ -65,27 +91,65 @@ pub fn run() {
                         if let Ok(configs) = serde_json::from_str::<Vec<AgentConfig>>(&data) {
                             let mut agents_map = state.agents.lock().await;
                             let mut order_map = state.agent_order.lock().await;
-                            for mut config in configs {
-                                // Retroactively ensure the private agent directory is included
-                                config.system_include_directories =
-                                    Some(utils::fs::resolve_system_include_directories(
-                                        &config.agent_class,
-                                        &config.session_id,
-                                    ));
+                            let mut seen_names = std::collections::HashSet::new();
 
-                                if let Ok(agent) =
-                                    manager::spawn_agent(app_handle.clone(), config.clone(), true)
-                                        .await
-                                {
-                                    if let Some(ref tx) = agent.stdin_tx {
-                                        if let Ok(mut senders) = state.input_senders.write() {
-                                            senders.insert(config.session_id.clone(), tx.clone());
-                                        }
-                                    }
+                            let db_agents = crate::utils::db::get_all_agents().unwrap_or_default();
+                            let db_status_map: std::collections::HashMap<String, (Option<String>, Option<u32>)> = 
+                                db_agents.into_iter().map(|a| (a.session_id, (a.last_status, a.last_pid))).collect();
+
+                            for mut config in configs {
+                                // Sanitize name
+                                let mut sanitized_name = config.session_name.chars()
+                                    .map(|c| if c.is_alphanumeric() || c == '_' || c == '-' { c } else { '-' })
+                                    .collect::<String>();
+                                if sanitized_name.is_empty() { sanitized_name = "agent".to_string(); }
+                                let base_name = sanitized_name.clone();
+                                let mut counter = 1;
+                                while seen_names.contains(&sanitized_name) {
+                                    sanitized_name = format!("{}-{}", base_name, counter);
+                                    counter += 1;
+                                }
+                                seen_names.insert(sanitized_name.clone());
+                                config.session_name = sanitized_name;
+
+                                config.system_include_directories = Some(utils::fs::resolve_system_include_directories(&config.agent_class, &config.session_id));
+
+                                let (last_status, last_pid) = db_status_map.get(&config.session_id).cloned().unwrap_or((None, None));
+
+                                if last_status.as_deref() == Some("Headless") {
+                                    let agent = crate::state::ActiveAgent {
+                                        config: config.clone(),
+                                        child_process: None,
+                                        background_processes: Vec::new(),
+                                        pty_master: None,
+                                        stdin_tx: None,
+                                        output_buffer: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
+                                        process_id: last_pid,
+                                        query_count: std::sync::Arc::new(std::sync::Mutex::new(0)),
+                                        init_timestamp: std::sync::Arc::new(std::sync::Mutex::new(None)),
+                                        current_status: std::sync::Arc::new(std::sync::Mutex::new("Headless".to_string())),
+                                        terminal_title: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
+                                        last_output_at: std::sync::Arc::new(std::sync::Mutex::new(None)),
+                                        log_path: std::sync::Arc::new(std::sync::Mutex::new(None)),
+                                        log_last_modified: std::sync::Arc::new(std::sync::Mutex::new(None)),
+                                        #[cfg(windows)]
+                                        job_object: None,
+                                    };
                                     order_map.push(config.session_id.clone());
                                     agents_map.insert(config.session_id.clone(), agent);
+                                } else {
+                                    if let Ok(agent) = manager::spawn_agent(app_handle.clone(), config.clone(), true).await {
+                                        if let Some(ref tx) = agent.stdin_tx {
+                                            if let Ok(mut senders) = state.input_senders.write() {
+                                                senders.insert(config.session_id.clone(), tx.clone());
+                                            }
+                                        }
+                                        order_map.push(config.session_id.clone());
+                                        agents_map.insert(config.session_id.clone(), agent);
+                                    }
                                 }
                             }
+                            manager::save_state(&app_handle, &agents_map, &order_map);
                             let _ = app_handle.emit("agents-updated", ());
                         }
                     }
@@ -117,12 +181,6 @@ pub fn run() {
             commands::class::get_default_class_instruction,
             commands::class::reset_class_to_default,
             commands::class::reset_all_class_prompts,
-            commands::watchlist::load_watchlists,
-            commands::watchlist::save_watchlists,
-            commands::watchlist::load_watchlist_prefs,
-            commands::watchlist::save_watchlist_prefs,
-            commands::watchlist::load_agent_interactions,
-            commands::watchlist::save_agent_interactions,
             commands::fs::resolve_system_include_directories,
             commands::fs::validate_directory_path,
             commands::fs::get_explorer_root,
@@ -130,16 +188,36 @@ pub fn run() {
             commands::fs::delete_file,
             commands::fs::reveal_in_explorer,
             commands::fs::read_file_preview,
+            commands::git::git_status,
+            commands::git::git_current_branch,
+            commands::git::git_log,
+            commands::git::git_diff_file,
+            commands::git::git_stage,
+            commands::git::git_unstage,
+            commands::git::git_discard_changes,
+            commands::git::git_commit,
+            commands::git::git_pull,
+            commands::git::git_push,
+            commands::git::git_create_worktree,
+            commands::git::git_remove_worktree,
+            commands::git::git_watch,
+            commands::git::git_unwatch,
+            commands::watchlist::load_watchlists,
+            commands::watchlist::save_watchlists,
+            commands::watchlist::load_watchlist_prefs,
+            commands::watchlist::save_watchlist_prefs,
+            commands::watchlist::load_agent_interactions,
+            commands::watchlist::save_agent_interactions,
             commands::workflow::list_workflows,
             commands::workflow::save_workflow,
             commands::workflow::delete_workflow,
             commands::workflow::run_workflow,
             commands::workflow::stop_all_triggers,
+            commands::workflow::pause_all_triggers,
+            commands::workflow::resume_all_triggers,
             commands::workflow::stop_workflow_triggers,
             commands::workflow::stop_workflow_run,
             commands::workflow::run_scheduled_workflow_now,
-            commands::workflow::pause_all_triggers,
-            commands::workflow::resume_all_triggers,
             commands::workflow::load_workflow_library,
             commands::workflow::save_workflow_library,
             commands::workflow::list_scheduled_runs,
@@ -154,72 +232,7 @@ pub fn run() {
             commands::library::remove_deployed_skill,
             commands::library::list_deployed_skills,
             commands::library::list_skill_deployments,
-            commands::patch::run_gemini_patch,
-            commands::settings::list_available_shells,
-            commands::settings::load_shell_settings,
-            commands::settings::save_shell_settings,
-            commands::settings::save_agent_session_persistence,
-            commands::settings::save_opencode_theme,
-            commands::git::git_status,
-            commands::git::git_current_branch,
-            commands::git::git_log,
-            commands::git::git_diff_file,
-            commands::git::git_stage,
-            commands::git::git_unstage,
-            commands::git::git_discard_changes,
-            commands::git::git_commit,
-            commands::git::git_pull,
-            commands::git::git_push,
-            commands::git::git_create_worktree,
-            commands::git::git_remove_worktree,
-            commands::git::git_watch,
-            commands::git::git_unwatch
         ])
-        .build(tauri::generate_context!())
-        .expect("error while building tauri application")
-        .run(|app, event| {
-            if let tauri::RunEvent::Exit = event {
-                let state = app.state::<AppState>();
-
-                // Terminate all agent process trees on app exit to prevent zombies.
-                // We use try_lock to avoid deadlocking with background tasks during shutdown.
-                // If the lock is held, the agents will still be terminated when AppState
-                // drops, which triggers the `Drop` safety net on `ActiveAgent`.
-                {
-                    if let Ok(mut agents) = state.agents.try_lock() {
-                        for (_sid, agent) in agents.iter_mut() {
-                            manager::terminate_active_agent_process(agent);
-                        }
-                        agents.clear();
-                    }
-                }
-
-                // Abort all workflow triggers and running executions.
-                {
-                    if let Ok(mut triggers) = state.workflow_triggers.try_lock() {
-                        for (_wf_id, handles) in triggers.drain() {
-                            for handle in handles {
-                                handle.abort();
-                            }
-                        }
-                    }
-                }
-                {
-                    if let Ok(mut runs) = state.workflow_runs.try_lock() {
-                        for (_wf_id, handles) in runs.drain() {
-                            for handle in handles {
-                                handle.abort();
-                            }
-                        }
-                    }
-                }
-                {
-                    if let Ok(mut scheduler) = state.scheduler_handle.try_lock() {
-                        if let Some(h) = scheduler.take() {
-                            h.abort();
-                        }
-                    };
-                }
-            }
-        });
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,7 +100,7 @@ pub fn run() {
                             for mut config in configs {
                                 // Sanitize name
                                 let mut sanitized_name = config.session_name.chars()
-                                    .map(|c| if c.is_alphanumeric() || c == '_' || c == '-' { c } else { '-' })
+                                    .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '-' })
                                     .collect::<String>();
                                 if sanitized_name.is_empty() { sanitized_name = "agent".to_string(); }
                                 let base_name = sanitized_name.clone();
@@ -232,6 +232,12 @@ pub fn run() {
             commands::library::remove_deployed_skill,
             commands::library::list_deployed_skills,
             commands::library::list_skill_deployments,
+            commands::patch::run_gemini_patch,
+            commands::settings::load_shell_settings,
+            commands::settings::list_available_shells,
+            commands::settings::save_shell_settings,
+            commands::settings::save_agent_session_persistence,
+            commands::settings::save_opencode_theme,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -2717,7 +2717,9 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                 }
 
                                 let current_status_snap = snap.current_status.lock().unwrap().clone();
-                                if !current_status_snap.starts_with("Action Required") {
+                                if !current_status_snap.starts_with("Action Required")
+                                    && !current_status_snap.starts_with("Action Needed")
+                                {
                                     if let Some(status) = claude_status_from_log(&lines) {
                                         *snap.current_status.lock().unwrap() = status;
                                     }

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -43,9 +43,10 @@ pub fn terminate_active_agent_process(agent: &mut ActiveAgent) {
     {
         if let Some(pid) = agent.process_id {
             if let Err(err) = force_kill_process_tree(pid) {
+                let sid = agent.config.lock().unwrap().session_id.clone();
                 log_debug(&format!(
                     "[Wardian] Failed to force-kill process tree for session {} via PID {}: {}",
-                    agent.config.session_id, pid, err
+                    sid, pid, err
                 ));
             }
         }
@@ -60,9 +61,10 @@ pub fn terminate_active_agent_process(agent: &mut ActiveAgent) {
         #[cfg(windows)]
         {
             if let Err(err) = force_kill_process_tree(child.id()) {
+                let sid = agent.config.lock().unwrap().session_id.clone();
                 log_debug(&format!(
                     "[Wardian] Failed to force-kill background process for session {} via PID {}: {}",
-                    agent.config.session_id,
+                    sid,
                     child.id(),
                     err
                 ));
@@ -297,7 +299,7 @@ pub fn save_state(_app: &AppHandle, agents: &HashMap<String, ActiveAgent>, order
     let mut configs: Vec<AgentConfig> = Vec::new();
     for id in order {
         if let Some(agent) = agents.get(id) {
-            configs.push(agent.config.clone());
+            configs.push(agent.config.lock().unwrap().clone());
         }
     }
 
@@ -328,7 +330,7 @@ pub async fn spawn_agent(
 
     if config.is_off {
         return Ok(ActiveAgent {
-            config,
+            config: std::sync::Arc::new(std::sync::Mutex::new(config)),
             child_process: None,
             background_processes: Vec::new(),
             pty_master: None,
@@ -346,6 +348,8 @@ pub async fn spawn_agent(
             job_object: None,
         });
     }
+
+    let config_lock = std::sync::Arc::new(std::sync::Mutex::new(config.clone()));
 
     #[cfg(windows)]
     cleanup_stale_session_processes(&config.session_id, &config.provider);
@@ -539,6 +543,7 @@ pub async fn spawn_agent(
     let pty_provider = provider.clone();
     let sid_for_pty = sid_out.clone();
     let pty_emit_app = app.clone();
+    let config_lock_clone = config_lock.clone();
     std::thread::spawn(move || {
         let mut buf = [0; 4096];
         let mut current_line = String::new();
@@ -596,6 +601,39 @@ pub async fn spawn_agent(
                     if let Ok(mut stamp) = last_output_at_clone.lock() {
                         *stamp = Some(std::time::SystemTime::now());
                     }
+
+                    // Process stream events to capture Session ID / Status changes
+                    // Use a simple line-based approach for stream-json events
+                    for line in text.lines() {
+                        if let Some(event) = pty_provider.parse_output(line) {
+                            match event {
+                                AgentEvent::Init { session_id, .. } => {
+                                    if !session_id.trim().is_empty() {
+                                        let mut config = config_lock_clone.lock().unwrap();
+                                        if config.resume_session.as_deref() != Some(&session_id) {
+                                            log_debug(&format!("[Wardian] Session ID mapped for {}: {}", sid_for_pty, session_id));
+                                            config.resume_session = Some(session_id.clone());
+                                            
+                                            // Notify UI that metadata (resume_session ID) has changed
+                                            let _ = pty_emit_app.emit("agents-updated", ());
+                                            let _ = pty_emit_app.emit("agent-pty-output-ready", serde_json::json!({ "session_id": sid_for_pty }));
+                                        }
+                                    }
+                                }
+                                AgentEvent::ActionRequired { message } => {
+                                    set_agent_status(&pty_app, &sid_for_pty, &current_status_clone, &format!("Action Required: {}", message));
+                                }
+                                AgentEvent::TurnCompleted | AgentEvent::ModelResponse => {
+                                    set_agent_status(&pty_app, &sid_for_pty, &current_status_clone, "Idle");
+                                }
+                                AgentEvent::UserQuery | AgentEvent::Generating => {
+                                    set_agent_status(&pty_app, &sid_for_pty, &current_status_clone, "Processing...");
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+
                     if let Some(title) = extract_terminal_titles(&text).into_iter().last() {
                         let _previous_title = terminal_title_clone
                             .lock()
@@ -1005,11 +1043,13 @@ pub async fn spawn_agent(
     }
 
     // ── OpenCode log-file watcher ─────────────────────────────────────────
+    {
+        let mut cfg = config_lock.lock().unwrap();
+        cfg.folder = expected_folder;
+    }
+
     Ok(ActiveAgent {
-        config: AgentConfig {
-            folder: expected_folder,
-            ..config
-        },
+        config: config_lock,
         child_process: Some(child),
         background_processes,
         pty_master: Some(pty_master),
@@ -1290,16 +1330,14 @@ fn interactive_provider_args(
 }
 
 fn finalize_interactive_spawn_args(
-    provider_name: &str,
+    _provider_name: &str,
     _is_restored: bool,
     _resume_session: &Option<String>,
-    mut provider_args: Vec<String>,
+    provider_args: Vec<String>,
 ) -> Vec<String> {
-    if provider_name == "claude" {
-        provider_args = strip_standalone_flag(provider_args, "--verbose");
-        provider_args = strip_flag_value_pairs(provider_args, "--input-format");
-        provider_args = strip_flag_value_pairs(provider_args, "--output-format");
-    }
+    // Phase 3 Fix: Do NOT strip --input-format/--output-format from Claude.
+    // We need stream-json events to capture session IDs and status changes
+    // even during interactive launches.
     provider_args
 }
 
@@ -2161,8 +2199,11 @@ fn claude_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
                 return Some("Processing...".to_string());
             }
             Some("progress") => return Some("Processing...".to_string()),
-            Some("user") if claude_is_real_user_query(line) => {
-                return Some("Processing...".to_string());
+            Some("user") => {
+                let kind = classify_claude_user_event(line);
+                if kind == ClaudeUserEventKind::RealQuery || kind == ClaudeUserEventKind::ToolResult {
+                    return Some("Processing...".to_string());
+                }
             }
             _ => {}
         }
@@ -2361,18 +2402,21 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
         let agents = state.agents.lock().await;
         agents
             .iter()
-            .map(|(sid, agent)| AgentSnapshot {
-                session_id: sid.clone(),
-                provider: agent.config.provider.clone(),
-                folder: agent.config.folder.clone(),
-                resume_session: agent.config.resume_session.clone(),
-                process_id: agent.process_id,
-                query_count: agent.query_count.clone(),
-                init_timestamp: agent.init_timestamp.clone(),
-                current_status: agent.current_status.clone(),
-                last_output_at: agent.last_output_at.clone(),
-                log_path: agent.log_path.clone(),
-                log_last_modified: agent.log_last_modified.clone(),
+            .map(|(sid, agent)| {
+                let config = agent.config.lock().unwrap();
+                AgentSnapshot {
+                    session_id: sid.clone(),
+                    provider: config.provider.clone(),
+                    folder: config.folder.clone(),
+                    resume_session: config.resume_session.clone(),
+                    process_id: agent.process_id,
+                    query_count: agent.query_count.clone(),
+                    init_timestamp: agent.init_timestamp.clone(),
+                    current_status: agent.current_status.clone(),
+                    last_output_at: agent.last_output_at.clone(),
+                    log_path: agent.log_path.clone(),
+                    log_last_modified: agent.log_last_modified.clone(),
+                }
             })
             .collect()
     };
@@ -2453,6 +2497,21 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                         }
                     }
                 }
+            } else if snap.provider == "claude" && snap.resume_session.is_some() {
+                // For Claude, if we have a resume_session (Conversation ID), always re-verify
+                // the path so it updates immediately after a Clear rotation.
+                if let Some(home) = dirs::home_dir() {
+                    let project_dir = claude_project_dir_name(&snap.folder);
+                    let session_id_to_find = snap.resume_session.as_deref().unwrap();
+                    let candidate = home
+                        .join(".claude")
+                        .join("projects")
+                        .join(&project_dir)
+                        .join(format!("{}.jsonl", session_id_to_find));
+                    if candidate.exists() {
+                        *log_path_lock = Some(candidate);
+                    }
+                }
             } else if log_path_lock.is_none() {
                 match snap.provider.as_str() {
                     "codex" => {
@@ -2467,9 +2526,7 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                         }
                     }
                     "claude" => {
-                        // Claude Code stores sessions at:
-                        // ~/.claude/projects/<project_dir>/<session_id>.jsonl
-                        // where <project_dir> is the workspace path with :\/. replaced by -
+                        // Fallback for initial spawn where resume_session might not be set yet
                         if let Some(home) = dirs::home_dir() {
                             let project_dir = claude_project_dir_name(&snap.folder);
                             let candidate = home

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -317,6 +317,7 @@ pub async fn spawn_agent(
     app: AppHandle,
     config: AgentConfig,
     is_restored: bool,
+    initial_timestamp: Option<String>,
 ) -> Result<ActiveAgent, String> {
     let provider = ProviderFactory::resolve(&config.provider)?;
 
@@ -338,7 +339,7 @@ pub async fn spawn_agent(
             output_buffer: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
             process_id: None,
             query_count: std::sync::Arc::new(std::sync::Mutex::new(0)),
-            init_timestamp: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            init_timestamp: std::sync::Arc::new(std::sync::Mutex::new(initial_timestamp)),
             current_status: std::sync::Arc::new(std::sync::Mutex::new("Off".to_string())),
             terminal_title: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
             last_output_at: std::sync::Arc::new(std::sync::Mutex::new(None)),
@@ -443,12 +444,16 @@ pub async fn spawn_agent(
         is_restored
     ));
 
-    // Phase 2: Record/Update agent in SQLite
+    // Phase 2: Record/Update agent in SQLite with explicit ISO 8601 timestamp
+    let born_to_save = initial_timestamp.clone().unwrap_or_else(|| {
+        chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+    });
     let _ = crate::utils::db::upsert_agent(
         &config.session_id,
         &config.session_name,
         &config.agent_class,
         config.is_off,
+        Some(&born_to_save),
     );
     let child = pair
         .slave
@@ -527,9 +532,7 @@ pub async fn spawn_agent(
     let output_buffer_clone = output_buffer.clone();
     let query_count = std::sync::Arc::new(std::sync::Mutex::new(0));
     let query_count_clone = query_count.clone();
-    let init_timestamp = std::sync::Arc::new(std::sync::Mutex::new(Some(
-        chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
-    )));
+    let init_timestamp = std::sync::Arc::new(std::sync::Mutex::new(Some(born_to_save)));
     let init_timestamp_clone = init_timestamp.clone();
     let current_status = std::sync::Arc::new(std::sync::Mutex::new("Idle".to_string()));
     let current_status_clone = current_status.clone();
@@ -607,7 +610,13 @@ pub async fn spawn_agent(
                     for line in text.lines() {
                         if let Some(event) = pty_provider.parse_output(line) {
                             match event {
-                                AgentEvent::Init { session_id, .. } => {
+                                AgentEvent::Init { session_id, timestamp } => {
+                                    if let Some(ts) = timestamp {
+                                        let mut it = init_timestamp_clone.lock().unwrap();
+                                        if it.is_none() {
+                                            *it = Some(ts);
+                                        }
+                                    }
                                     if !session_id.trim().is_empty() {
                                         let mut config = config_lock_clone.lock().unwrap();
                                         if config.resume_session.as_deref() != Some(&session_id) {
@@ -620,8 +629,8 @@ pub async fn spawn_agent(
                                         }
                                     }
                                 }
-                                AgentEvent::ActionRequired { message } => {
-                                    set_agent_status(&pty_app, &sid_for_pty, &current_status_clone, &format!("Action Required: {}", message));
+                                AgentEvent::ActionRequired { message: _ } => {
+                                    set_agent_status(&pty_app, &sid_for_pty, &current_status_clone, "Action Needed");
                                 }
                                 AgentEvent::TurnCompleted | AgentEvent::ModelResponse => {
                                     set_agent_status(&pty_app, &sid_for_pty, &current_status_clone, "Idle");
@@ -2180,36 +2189,65 @@ fn claude_permission_hook_matches_session(event: &serde_json::Value, session_id:
 }
 
 fn claude_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
+    let mut has_activity = false;
+
     for line in lines.iter().rev() {
-        match line.get("type").and_then(|v| v.as_str()) {
-            Some("system") => {
-                if let Some("permission_request") = line.get("subtype").and_then(|v| v.as_str()) {
+        let msg_type = line.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        
+        match msg_type {
+            "system" => {
+                let subtype = line.get("subtype").and_then(|v| v.as_str()).unwrap_or("");
+                if subtype == "permission_request" {
                     return Some("Action Needed".to_string());
                 }
-            }
-            Some("assistant") => {
-                let stop_reason = line
-                    .get("message")
-                    .and_then(|v| v.get("stop_reason"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                if stop_reason == "end_turn" || stop_reason == "stop_sequence" {
+                if subtype == "turn_duration" {
                     return Some("Idle".to_string());
                 }
-                return Some("Processing...".to_string());
             }
-            Some("progress") => return Some("Processing...".to_string()),
-            Some("user") => {
-                let kind = classify_claude_user_event(line);
-                if kind == ClaudeUserEventKind::RealQuery || kind == ClaudeUserEventKind::ToolResult {
+            "result" => {
+                return Some("Idle".to_string());
+            }
+            "assistant" => {
+                let stop_reason = line
+                    .get("message")
+                    .and_then(|m| m.get("stop_reason"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                
+                if !stop_reason.is_empty() {
+                    if stop_reason == "tool_use" {
+                        // Activity signal, but keep searching for permission_request in this turn
+                        has_activity = true;
+                    } else {
+                        // Definitive end of turn (end_turn, stop_sequence, etc.)
+                        return Some("Idle".to_string());
+                    }
+                } else {
+                    // Streaming or incomplete assistant message
                     return Some("Processing...".to_string());
                 }
+            }
+            "user" => {
+                let kind = classify_claude_user_event(line);
+                if kind == ClaudeUserEventKind::RealQuery || kind == ClaudeUserEventKind::ToolResult {
+                    // Start of turn or handled tool result
+                    return Some("Processing...".to_string());
+                }
+                // Other user events are just activity
+                has_activity = true;
+            }
+            "progress" => {
+                return Some("Processing...".to_string());
             }
             _ => {}
         }
     }
 
-    None
+    if has_activity {
+        Some("Processing...".to_string())
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -2468,6 +2506,22 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                     &mut mem,
                     &mut uptime,
                 );
+
+                // Phase 3: Uptime Alignment
+                // If we have a 'Born' date, calculate total lifetime uptime while active.
+                // Otherwise, fallback to the OS process runtime gathered above.
+                if let Ok(born_lock) = snap.init_timestamp.lock() {
+                    if let Some(ref born_str) = *born_lock {
+                        if let Ok(born_dt) = chrono::DateTime::parse_from_rfc3339(born_str) {
+                            let now = chrono::Utc::now();
+                            let duration = now.signed_duration_since(born_dt.with_timezone(&chrono::Utc));
+                            let secs = duration.num_seconds();
+                            if secs > 0 {
+                                uptime = secs as u64;
+                            }
+                        }
+                    }
+                }
             }
 
             // Detect whether the agent process is still alive
@@ -2662,8 +2716,8 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                     }
                                 }
 
-                                let current_status = snap.current_status.lock().unwrap().clone();
-                                if current_status != "Action Needed" {
+                                let current_status_snap = snap.current_status.lock().unwrap().clone();
+                                if !current_status_snap.starts_with("Action Required") {
                                     if let Some(status) = claude_status_from_log(&lines) {
                                         *snap.current_status.lock().unwrap() = status;
                                     }
@@ -2712,7 +2766,7 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                 *snap.init_timestamp.lock().unwrap() = Some(ts);
             }
 
-            if snap.provider == "opencode" {
+            if snap.provider == "opencode" || snap.provider == "claude" {
                 let current_status = snap.current_status.lock().unwrap().clone();
                 let last_output_at = *snap.last_output_at.lock().unwrap();
                 if opencode_should_fallback_to_idle(
@@ -3562,7 +3616,49 @@ mod tests {
     }
 
     #[test]
-    fn claude_interactive_spawn_drops_stream_json_flags() {
+    fn claude_status_from_log_does_not_look_past_turn_boundary() {
+        let lines = vec![
+            serde_json::json!({ "type": "system", "subtype": "turn_duration" }), // Turn 1
+            serde_json::json!({
+                "type": "user",
+                "message": { "role": "user", "content": "Query 2" }
+            }), // Turn 2 start
+            serde_json::json!({
+                "type": "assistant",
+                "message": { "role": "assistant", "content": [], "stop_reason": "tool_use" }
+            }), // Turn 2 tool use
+        ];
+
+        // Should be Processing..., NOT Idle (from turn 1)
+        assert_eq!(
+            claude_status_from_log(&lines),
+            Some("Processing...".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_status_from_log_detects_action_needed_in_current_turn() {
+        let lines = vec![
+            serde_json::json!({ "type": "system", "subtype": "turn_duration" }), // Turn 1
+            serde_json::json!({
+                "type": "user",
+                "message": { "role": "user", "content": "Query 2" }
+            }),
+            serde_json::json!({
+                "type": "assistant",
+                "message": { "role": "assistant", "content": [], "stop_reason": "tool_use" }
+            }),
+            serde_json::json!({ "type": "system", "subtype": "permission_request" }),
+        ];
+
+        assert_eq!(
+            claude_status_from_log(&lines),
+            Some("Action Needed".to_string())
+        );
+    }
+
+    #[test]
+    fn claude_interactive_spawn_preserves_stream_json_flags() {
         let args = finalize_interactive_spawn_args(
             "claude",
             true,
@@ -3578,9 +3674,18 @@ mod tests {
             ],
         );
 
+        // Phase 3: We now preserve these flags so PTY output can be parsed for status
         assert_eq!(
             args,
-            vec!["--resume".to_string(), "claude-session".to_string(),]
+            vec![
+                "--verbose".to_string(),
+                "--input-format".to_string(),
+                "stream-json".to_string(),
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+                "--resume".to_string(),
+                "claude-session".to_string(),
+            ]
         );
     }
 

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -90,6 +90,10 @@ fn set_agent_status(
     if let Ok(mut status) = current_status.lock() {
         if *status != next_status {
             *status = next_status.to_string();
+
+            // Phase 2: Persist status change to SQLite
+            let _ = crate::utils::db::update_agent_status(session_id, next_status, None);
+
             let _ = app.emit(
                 "agent-status-updated",
                 serde_json::json!({
@@ -408,6 +412,7 @@ pub async fn spawn_agent(
     }
     cmd.cwd(&provider_cwd);
     apply_terminal_identity_env(&mut cmd);
+    cmd.env("WARDIAN_SESSION_ID", &config.session_id);
 
     // Enable CLAUDE.md discovery from --add-dir directories so that
     // class/common/agent instruction files are loaded natively.
@@ -433,23 +438,27 @@ pub async fn spawn_agent(
         resume_id,
         is_restored
     ));
-    log_terminal_trace_note(
-        &config.session_id,
-        &config.provider,
-        &format!(
-            "spawn cwd={} restored={} args={:?}",
-            provider_cwd.display(),
-            is_restored,
-            provider_args
-        ),
-    );
 
+    // Phase 2: Record/Update agent in SQLite
+    let _ = crate::utils::db::upsert_agent(
+        &config.session_id,
+        &config.session_name,
+        &config.agent_class,
+        config.is_off,
+    );
     let child = pair
         .slave
         .spawn_command(cmd)
         .map_err(|e| format!("Failed to spawn command: {}", e))?;
 
     let process_id = child.process_id();
+
+    // Phase 2: Record/Update status in SQLite with the real PID
+    let _ = crate::utils::db::update_agent_status(
+        &config.session_id,
+        if config.is_off { "Off" } else { "Idle" },
+        process_id,
+    );
 
     #[cfg(windows)]
     let job_object = {

--- a/src-tauri/src/models/agent_config.rs
+++ b/src-tauri/src/models/agent_config.rs
@@ -51,6 +51,8 @@ pub struct AgentConfig {
     pub custom_args: Option<String>,
     #[serde(default)]
     pub session_persistence: AgentSessionPersistenceOverride,
+    #[serde(default)]
+    pub init_timestamp: Option<String>,
     #[serde(default, skip)]
     pub fresh_provider_session_id: Option<String>,
 

--- a/src-tauri/src/models/agent_config.rs
+++ b/src-tauri/src/models/agent_config.rs
@@ -51,8 +51,6 @@ pub struct AgentConfig {
     pub custom_args: Option<String>,
     #[serde(default)]
     pub session_persistence: AgentSessionPersistenceOverride,
-    #[serde(default)]
-    pub init_timestamp: Option<String>,
     #[serde(default, skip)]
     pub fresh_provider_session_id: Option<String>,
 

--- a/src-tauri/src/models/workflow.rs
+++ b/src-tauri/src/models/workflow.rs
@@ -101,6 +101,12 @@ pub struct ScheduledRun {
     #[serde(default)]
     pub paused_remaining_ms: Option<u64>,
     pub is_paused: bool,
+    #[serde(default)]
+    pub last_run_status: Option<String>,
+    #[serde(default)]
+    pub last_run_error: Option<String>,
+    #[serde(default)]
+    pub last_run_completed_epoch_ms: Option<u64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -295,6 +295,13 @@ impl AgentProvider for ClaudeProvider {
     }
 
     fn parse_output(&self, line: &str) -> Option<AgentEvent> {
+        let trimmed = line.trim();
+        if trimmed.contains("Do you want to proceed?") 
+            || trimmed.contains("Allow reading from")
+            || trimmed.contains("requires approval") {
+            return Some(AgentEvent::ActionRequired { message: "".into() });
+        }
+
         let parsed: serde_json::Value = serde_json::from_str(line).ok()?;
         let msg_type = parsed.get("type")?.as_str()?;
 

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -199,19 +199,21 @@ impl AgentProvider for ClaudeProvider {
             args.push(model.clone());
         }
 
-        // Only set fresh-session identity on non-resume launches.
-        let fresh_session_id = config
-            .fresh_provider_session_id
-            .as_deref()
-            .unwrap_or(config.session_id.as_str())
-            .trim();
-        if !is_resume && !fresh_session_id.is_empty() {
+        if is_resume {
+            // Rule: Old session -> --resume
+            let resume_id = config.resume_session.as_deref().unwrap_or(config.session_id.as_str());
+            args.push("--resume".into());
+            args.push(resume_id.to_string());
+        } else {
+            // Rule: New session -> --session-id
+            let new_id = config.fresh_provider_session_id.as_deref().unwrap_or(config.session_id.as_str());
             args.push("--session-id".into());
-            args.push(fresh_session_id.to_string());
-        }
-        if !is_resume && !config.session_name.trim().is_empty() {
-            args.push("--name".into());
-            args.push(config.session_name.clone());
+            args.push(new_id.to_string());
+
+            if !config.session_name.trim().is_empty() {
+                args.push("--name".into());
+                args.push(config.session_name.clone());
+            }
         }
 
         let mut final_includes = config

--- a/src-tauri/src/state/active_agent.rs
+++ b/src-tauri/src/state/active_agent.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 pub struct ActiveAgent {
-    pub config: AgentConfig,
+    pub config: Arc<Mutex<AgentConfig>>,
     pub child_process: Option<Box<dyn portable_pty::Child + Send>>,
     pub background_processes: Vec<std::process::Child>,
     pub pty_master: Option<Arc<Mutex<Box<dyn portable_pty::MasterPty + Send>>>>,

--- a/src-tauri/src/utils/db.rs
+++ b/src-tauri/src/utils/db.rs
@@ -92,7 +92,7 @@ pub fn update_agent_status(session_id: &str, status: &str, pid: Option<u32>) -> 
 
         if last_status.as_deref() != Some(status) {
             conn.execute(
-                "UPDATE agents SET last_status = ?1, last_pid = ?2 WHERE session_id = ?3",
+                "UPDATE agents SET last_status = ?1, last_pid = COALESCE(?2, last_pid) WHERE session_id = ?3",
                 params![status, pid, session_id],
             )?;
 

--- a/src-tauri/src/utils/db.rs
+++ b/src-tauri/src/utils/db.rs
@@ -1,0 +1,166 @@
+use rusqlite::{params, Connection, OptionalExtension};
+use std::sync::{Arc, Mutex};
+use once_cell::sync::Lazy;
+use crate::utils::fs::get_wardian_home;
+use crate::utils::logging::log_debug;
+
+static DB_CONN: Lazy<Arc<Mutex<Option<Connection>>>> = Lazy::new(|| Arc::new(Mutex::new(None)));
+
+pub fn init_db() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let home = get_wardian_home().ok_or("Could not resolve Wardian home")?;
+    
+    let db_path = home.join("state.db");
+    let conn = Connection::open(db_path)?;
+
+    // Enable WAL mode for concurrency
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+
+    // Create tables
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS agents (
+            session_id TEXT PRIMARY KEY,
+            session_name TEXT UNIQUE,
+            agent_class TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            is_off BOOLEAN DEFAULT 0,
+            last_status TEXT,
+            last_pid INTEGER
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            event_type TEXT,
+            payload TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(session_id) REFERENCES agents(session_id)
+        )",
+        [],
+    )?;
+
+    let mut global_conn = DB_CONN.lock().unwrap();
+    *global_conn = Some(conn);
+
+    log_debug("[DB] SQLite initialized with WAL mode");
+    Ok(())
+}
+
+pub fn get_db_conn<F, T>(f: F) -> std::result::Result<T, Box<dyn std::error::Error>>
+where
+    F: FnOnce(&Connection) -> std::result::Result<T, Box<dyn std::error::Error>>,
+{
+    let guard = DB_CONN.lock().unwrap();
+    if let Some(ref conn) = *guard {
+        f(conn)
+    } else {
+        Err("Database not initialized".into())
+    }
+}
+
+pub fn upsert_agent(
+    session_id: &str,
+    session_name: &str,
+    agent_class: &str,
+    is_off: bool,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    get_db_conn(|conn| {
+        conn.execute(
+            "INSERT INTO agents (session_id, session_name, agent_class, is_off)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(session_id) DO UPDATE SET
+                session_name = excluded.session_name,
+                agent_class = excluded.agent_class,
+                is_off = excluded.is_off",
+            params![session_id, session_name, agent_class, is_off],
+        )?;
+        Ok(())
+    })
+}
+
+pub fn update_agent_status(session_id: &str, status: &str, pid: Option<u32>) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    get_db_conn(|conn| {
+        // Only write to events table if status actually changed (Deduplication)
+        let last_status: Option<String> = conn.query_row(
+            "SELECT last_status FROM agents WHERE session_id = ?",
+            params![session_id],
+            |row| row.get(0),
+        ).optional()?;
+
+        if last_status.as_deref() != Some(status) {
+            conn.execute(
+                "UPDATE agents SET last_status = ?1, last_pid = ?2 WHERE session_id = ?3",
+                params![status, pid, session_id],
+            )?;
+
+            conn.execute(
+                "INSERT INTO events (session_id, event_type, payload) VALUES (?1, ?2, ?3)",
+                params![session_id, "status_change", status],
+            )?;
+        }
+        Ok(())
+    })
+}
+
+pub fn record_event(session_id: &str, event_type: &str, payload: &str) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    get_db_conn(|conn| {
+        conn.execute(
+            "INSERT INTO events (session_id, event_type, payload) VALUES (?1, ?2, ?3)",
+            params![session_id, event_type, payload],
+        )?;
+        Ok(())
+    })
+}
+
+pub fn delete_agent(session_id: &str) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    get_db_conn(|conn| {
+        conn.execute("DELETE FROM events WHERE session_id = ?", params![session_id])?;
+        conn.execute("DELETE FROM agents WHERE session_id = ?", params![session_id])?;
+        Ok(())
+    })
+}
+
+pub struct AgentRow {
+    pub session_id: String,
+    pub session_name: String,
+    pub last_status: Option<String>,
+    pub last_pid: Option<u32>,
+    pub is_off: bool,
+}
+
+pub fn get_all_agents() -> std::result::Result<Vec<AgentRow>, Box<dyn std::error::Error>> {
+    get_db_conn(|conn| {
+        let mut stmt = conn.prepare("SELECT session_id, session_name, last_status, last_pid, is_off FROM agents")?;
+        let rows = stmt.query_map([], |row| {
+            Ok(AgentRow {
+                session_id: row.get(0)?,
+                session_name: row.get(1)?,
+                last_status: row.get(2)?,
+                last_pid: row.get(3)?,
+                is_off: row.get(4)?,
+            })
+        })?;
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row?);
+        }
+        Ok(results)
+    })
+}
+
+pub fn prune_events(max_events_per_agent: usize) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    get_db_conn(|conn| {
+        conn.execute(
+            "DELETE FROM events WHERE id IN (
+                SELECT id FROM (
+                    SELECT id, ROW_NUMBER() OVER (PARTITION BY session_id ORDER BY timestamp DESC) as row_num
+                    FROM events
+                ) WHERE row_num > ?1
+            )",
+            params![max_events_per_agent],
+        )?;
+        Ok(())
+    })
+}

--- a/src-tauri/src/utils/db.rs
+++ b/src-tauri/src/utils/db.rs
@@ -65,16 +65,17 @@ pub fn upsert_agent(
     session_name: &str,
     agent_class: &str,
     is_off: bool,
+    created_at: Option<&str>,
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
     get_db_conn(|conn| {
         conn.execute(
-            "INSERT INTO agents (session_id, session_name, agent_class, is_off)
-             VALUES (?1, ?2, ?3, ?4)
+            "INSERT INTO agents (session_id, session_name, agent_class, is_off, created_at)
+             VALUES (?1, ?2, ?3, ?4, COALESCE(?5, CURRENT_TIMESTAMP))
              ON CONFLICT(session_id) DO UPDATE SET
                 session_name = excluded.session_name,
                 agent_class = excluded.agent_class,
                 is_off = excluded.is_off",
-            params![session_id, session_name, agent_class, is_off],
+            params![session_id, session_name, agent_class, is_off, created_at],
         )?;
         Ok(())
     })
@@ -128,11 +129,12 @@ pub struct AgentRow {
     pub last_status: Option<String>,
     pub last_pid: Option<u32>,
     pub is_off: bool,
+    pub created_at: Option<String>,
 }
 
 pub fn get_all_agents() -> std::result::Result<Vec<AgentRow>, Box<dyn std::error::Error>> {
     get_db_conn(|conn| {
-        let mut stmt = conn.prepare("SELECT session_id, session_name, last_status, last_pid, is_off FROM agents")?;
+        let mut stmt = conn.prepare("SELECT session_id, session_name, last_status, last_pid, is_off, created_at FROM agents")?;
         let rows = stmt.query_map([], |row| {
             Ok(AgentRow {
                 session_id: row.get(0)?,
@@ -140,6 +142,7 @@ pub fn get_all_agents() -> std::result::Result<Vec<AgentRow>, Box<dyn std::error
                 last_status: row.get(2)?,
                 last_pid: row.get(3)?,
                 is_off: row.get(4)?,
+                created_at: row.get(5)?,
             })
         })?;
         let mut results = Vec::new();

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod db;
 pub mod fs;
 pub mod logging;
 pub mod migration;
@@ -5,6 +6,7 @@ pub mod process;
 pub mod shell;
 pub mod terminal_input;
 
+pub use db::*;
 pub use fs::*;
 pub use logging::*;
 pub use process::*;

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -1940,8 +1940,9 @@ pub async fn run_workflow(
                         } else {
                             let state = app.state::<crate::state::AppState>();
                             let agents_map = state.agents.lock().await;
-                            if let Some(agent) = agents_map.get(agent_id) {
-                                Some(agent.config.clone())
+                            let existing_config = if let Some(agent) = agents_map.get(agent_id) {
+                                let config = agent.config.lock().unwrap().clone();
+                                Some(config)
                             } else if let Some(home) = get_wardian_home() {
                                 if let Ok(data) =
                                     std::fs::read_to_string(home.join("settings/state.json"))
@@ -1960,7 +1961,8 @@ pub async fn run_workflow(
                                 }
                             } else {
                                 None
-                            }
+                            };
+                            existing_config
                         };
                         let node_config = node
                             .config
@@ -2109,20 +2111,20 @@ pub async fn run_workflow(
 
                             // Restore state after headless run
                             if was_online {
-                                if let Some(mut cfg) = agent_cfg {
+                                if let Some(cfg_lock) = agent_cfg {
+                                    let mut cfg = cfg_lock.lock().unwrap().clone();
                                     cfg.is_off = false;
                                     log_debug(&format!("[Wardian] Restoring agent {} to Online state after headless run", agent_id));
-                                    if let Ok(agent) =
-                                        crate::manager::spawn_agent(app.clone(), cfg.clone(), false)
-                                            .await
+                                    if let Ok(new_agent) =
+                                        crate::manager::spawn_agent(app.clone(), cfg, false).await
                                     {
                                         let mut agents_map = state.agents.lock().await;
-                                        if let Some(ref tx) = agent.stdin_tx {
+                                        if let Some(ref tx) = new_agent.stdin_tx {
                                             if let Ok(mut senders) = state.input_senders.write() {
                                                 senders.insert(agent_id.to_string(), tx.clone());
                                             }
                                         }
-                                        agents_map.insert(agent_id.to_string(), agent);
+                                        agents_map.insert(agent_id.to_string(), new_agent);
                                         let order = state.agent_order.lock().await;
                                         crate::manager::save_state(&app, &agents_map, &order);
                                         let _ = app.emit("agents-updated", ());

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -11,6 +11,7 @@ use notify::{Event, RecursiveMode, Watcher};
 use regex::Regex;
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -65,12 +66,41 @@ where
     }
 }
 
+fn parse_optional_timeout_ms(node_config: &Value) -> Option<u64> {
+    let raw = node_config.get("timeout_ms")?;
+    let parsed = raw.as_u64().or_else(|| {
+        raw.as_str()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .and_then(|value| value.parse::<u64>().ok())
+    })?;
+    (parsed > 0).then_some(parsed)
+}
+
+async fn run_with_optional_timeout<T, F>(
+    timeout_ms: Option<u64>,
+    label: &str,
+    future: F,
+) -> Result<T, String>
+where
+    F: Future<Output = Result<T, String>>,
+{
+    match timeout_ms {
+        Some(ms) => match tokio::time::timeout(std::time::Duration::from_millis(ms), future).await
+        {
+            Ok(result) => result,
+            Err(_) => Err(format!("{} timeout ({}ms)", label, ms)),
+        },
+        None => future.await,
+    }
+}
+
 async fn run_command_headless(
     executable: &str,
     args: Vec<String>,
     cwd: &Path,
     env: Option<&Value>,
-    timeout_ms: u64,
+    timeout_ms: Option<u64>,
 ) -> Result<Value, String> {
     let mut cmd = new_headless_command(executable);
     cmd.args(args)
@@ -94,7 +124,6 @@ async fn run_command_headless(
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("Failed to spawn process: {}", e))?;
-    let timeout = std::time::Duration::from_millis(if timeout_ms > 0 { timeout_ms } else { 30000 });
 
     // Take stdout/stderr before waiting so we retain mut access to child for kill.
     let stdout_pipe = child.stdout.take();
@@ -119,27 +148,38 @@ async fn run_command_headless(
         buf
     });
 
-    match tokio::time::timeout(timeout, child.wait()).await {
-        Ok(Ok(status)) => {
-            let stdout = stdout_task.await.unwrap_or_default();
-            let stderr = stderr_task.await.unwrap_or_default();
-            let exit_code = status.code().unwrap_or(-1);
+    let status = match timeout_ms {
+        Some(ms) => match tokio::time::timeout(
+            std::time::Duration::from_millis(ms),
+            child.wait(),
+        )
+        .await
+        {
+            Ok(Ok(status)) => status,
+            Ok(Err(e)) => return Err(format!("Command execution failed: {}", e)),
+            Err(_) => {
+                // Kill the child on timeout to prevent zombie processes.
+                let _ = child.kill().await;
+                stdout_task.abort();
+                stderr_task.abort();
+                return Err(format!("Command timed out after {}ms", ms));
+            }
+        },
+        None => child
+            .wait()
+            .await
+            .map_err(|e| format!("Command execution failed: {}", e))?,
+    };
 
-            Ok(serde_json::json!({
-                "exit_code": exit_code,
-                "stdout": stdout,
-                "stderr": stderr
-            }))
-        }
-        Ok(Err(e)) => Err(format!("Command execution failed: {}", e)),
-        Err(_) => {
-            // Kill the child on timeout to prevent zombie processes.
-            let _ = child.kill().await;
-            stdout_task.abort();
-            stderr_task.abort();
-            Err(format!("Command timed out after {}ms", timeout.as_millis()))
-        }
-    }
+    let stdout = stdout_task.await.unwrap_or_default();
+    let stderr = stderr_task.await.unwrap_or_default();
+    let exit_code = status.code().unwrap_or(-1);
+
+    Ok(serde_json::json!({
+        "exit_code": exit_code,
+        "stdout": stdout,
+        "stderr": stderr
+    }))
 }
 
 
@@ -388,6 +428,9 @@ fn sync_scheduled_runs_for_workflow(
                 None
             },
             is_paused: previous.map(|run| run.is_paused).unwrap_or(false),
+            last_run_status: previous.and_then(|run| run.last_run_status.clone()),
+            last_run_error: previous.and_then(|run| run.last_run_error.clone()),
+            last_run_completed_epoch_ms: previous.and_then(|run| run.last_run_completed_epoch_ms),
         });
 
         if previous.is_none() {
@@ -399,6 +442,23 @@ fn sync_scheduled_runs_for_workflow(
     }
 
     synced_runs
+}
+
+fn record_scheduled_run_outcome(
+    runs: &mut [crate::models::ScheduledRun],
+    scheduled_run_id: &str,
+    status: &str,
+    error: Option<String>,
+    completed_epoch_ms: u64,
+) {
+    if let Some(run) = runs
+        .iter_mut()
+        .find(|scheduled_run| scheduled_run.id == scheduled_run_id)
+    {
+        run.last_run_status = Some(status.to_string());
+        run.last_run_error = error;
+        run.last_run_completed_epoch_ms = Some(completed_epoch_ms);
+    }
 }
 
 fn describe_schedule(schedule: &crate::models::ScheduleDefinition) -> String {
@@ -782,6 +842,9 @@ pub async fn start_scheduler(app: AppHandle) {
                         fresh_run.paused_remaining_ms = updated.paused_remaining_ms;
                         fresh_run.schedule.active = updated.schedule.active;
                         fresh_run.schedule.occurrence_count = updated.schedule.occurrence_count;
+                        fresh_run.last_run_status = updated.last_run_status.clone();
+                        fresh_run.last_run_error = updated.last_run_error.clone();
+                        fresh_run.last_run_completed_epoch_ms = updated.last_run_completed_epoch_ms;
                     }
                 }
                 let _ = save_scheduled_runs(&fresh);
@@ -1256,7 +1319,10 @@ pub fn disable_scheduled_trigger(run_id: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_command_node_launch, sync_scheduled_runs_for_workflow};
+    use super::{
+        parse_optional_timeout_ms, record_scheduled_run_outcome, resolve_command_node_launch,
+        sync_scheduled_runs_for_workflow,
+    };
     use crate::models::{
         ScheduleDefinition, ScheduledRun, WorkflowDefinition, WorkflowNode, WorkflowSettings,
     };
@@ -1346,6 +1412,22 @@ mod tests {
     }
 
     #[test]
+    fn parse_optional_timeout_treats_absent_blank_null_and_zero_as_unlimited() {
+        assert_eq!(parse_optional_timeout_ms(&json!({})), None);
+        assert_eq!(parse_optional_timeout_ms(&json!({ "timeout_ms": null })), None);
+        assert_eq!(parse_optional_timeout_ms(&json!({ "timeout_ms": "" })), None);
+        assert_eq!(parse_optional_timeout_ms(&json!({ "timeout_ms": "   " })), None);
+        assert_eq!(parse_optional_timeout_ms(&json!({ "timeout_ms": 0 })), None);
+        assert_eq!(parse_optional_timeout_ms(&json!({ "timeout_ms": "0" })), None);
+    }
+
+    #[test]
+    fn parse_optional_timeout_accepts_positive_numeric_values() {
+        assert_eq!(parse_optional_timeout_ms(&json!({ "timeout_ms": 5000 })), Some(5000));
+        assert_eq!(parse_optional_timeout_ms(&json!({ "timeout_ms": "60000" })), Some(60000));
+    }
+
+    #[test]
     fn sync_scheduled_runs_preserves_pause_state_for_active_schedule() {
         let workflow = workflow_with_schedule("active");
         let existing_runs = vec![ScheduledRun {
@@ -1372,6 +1454,9 @@ mod tests {
             next_run_epoch_ms: Some(1234),
             paused_remaining_ms: None,
             is_paused: true,
+            last_run_status: None,
+            last_run_error: None,
+            last_run_completed_epoch_ms: None,
         }];
 
         let runs = sync_scheduled_runs_for_workflow(&workflow, &existing_runs);
@@ -1412,6 +1497,9 @@ mod tests {
             next_run_epoch_ms: Some(1234),
             paused_remaining_ms: None,
             is_paused: false,
+            last_run_status: None,
+            last_run_error: None,
+            last_run_completed_epoch_ms: None,
         }];
 
         let runs = sync_scheduled_runs_for_workflow(&workflow, &existing_runs);
@@ -1448,11 +1536,61 @@ mod tests {
             next_run_epoch_ms: Some(1234),
             paused_remaining_ms: None,
             is_paused: false,
+            last_run_status: None,
+            last_run_error: None,
+            last_run_completed_epoch_ms: None,
         }];
 
         let runs = sync_scheduled_runs_for_workflow(&workflow, &existing_runs);
 
         assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn record_scheduled_run_outcome_marks_failed_run_with_error() {
+        let mut runs = vec![ScheduledRun {
+            id: "wf-1-trigger-1".to_string(),
+            workflow_id: "wf-1".to_string(),
+            workflow_name: "Morning Sync".to_string(),
+            schedule: ScheduleDefinition {
+                schedule_type: "daily".to_string(),
+                interval_minutes: None,
+                time_of_day: Some("09:00".to_string()),
+                days_of_week: None,
+                repeat_every: 1,
+                days_of_month: None,
+                specific_dates: None,
+                run_at: None,
+                end_condition: "never".to_string(),
+                end_date: None,
+                max_occurrences: None,
+                occurrence_count: 0,
+                active: true,
+            },
+            role_mappings: HashMap::new(),
+            description: "Daily at 09:00".to_string(),
+            next_run_epoch_ms: Some(1234),
+            paused_remaining_ms: None,
+            is_paused: false,
+            last_run_status: None,
+            last_run_error: None,
+            last_run_completed_epoch_ms: None,
+        }];
+
+        record_scheduled_run_outcome(
+            &mut runs,
+            "wf-1-trigger-1",
+            "failed",
+            Some("Agent timeout (60000ms)".to_string()),
+            42,
+        );
+
+        assert_eq!(runs[0].last_run_status.as_deref(), Some("failed"));
+        assert_eq!(
+            runs[0].last_run_error.as_deref(),
+            Some("Agent timeout (60000ms)")
+        );
+        assert_eq!(runs[0].last_run_completed_epoch_ms, Some(42));
     }
 }
 
@@ -1863,14 +2001,7 @@ pub async fn run_workflow(
                             }
                         }
 
-                        let timeout_ms = node
-                            .config
-                            .get("timeout_ms")
-                            .and_then(|v| {
-                                v.as_u64()
-                                    .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
-                            })
-                            .unwrap_or(60000);
+                        let timeout_ms = parse_optional_timeout_ms(&node.config);
 
                         log_debug(&format!(
                             "[Wardian] Agent node: agent_id={}, provider={}, output_format={}, prompt_len={}, prompt_preview='{}'",
@@ -1888,8 +2019,9 @@ pub async fn run_workflow(
                         );
 
                         if exec_ctx.mode != crate::models::WorkflowAgentMode::InheritResume {
-                            let run_result = tokio::time::timeout(
-                                std::time::Duration::from_millis(timeout_ms),
+                            let run_result = run_with_optional_timeout(
+                                timeout_ms,
+                                "Agent",
                                 crate::manager::run_headless_with_options(
                                     crate::manager::HeadlessRunOptions {
                                         cwd: &cwd,
@@ -1903,11 +2035,6 @@ pub async fn run_workflow(
                                 ),
                             )
                             .await;
-
-                            let run_result = match run_result {
-                                Ok(res) => res,
-                                Err(_) => Err(format!("Agent timeout ({}ms)", timeout_ms)),
-                            };
 
                             match run_result {
                                 Ok(data) => {
@@ -1950,8 +2077,9 @@ pub async fn run_workflow(
                                 }
                             }
 
-                            let run_result = tokio::time::timeout(
-                                std::time::Duration::from_millis(timeout_ms),
+                            let run_result = run_with_optional_timeout(
+                                timeout_ms,
+                                "Agent",
                                 crate::manager::run_headless_with_options(
                                     crate::manager::HeadlessRunOptions {
                                         cwd: &cwd,
@@ -1965,11 +2093,6 @@ pub async fn run_workflow(
                                 ),
                             )
                             .await;
-
-                            let run_result = match run_result {
-                                Ok(res) => res,
-                                Err(_) => Err(format!("Agent timeout ({}ms)", timeout_ms)),
-                            };
 
                             match run_result {
                                 Ok(data) => {
@@ -2040,8 +2163,9 @@ pub async fn run_workflow(
                                 }
 
                                 if provider_name == "opencode" {
-                                    let run_result = tokio::time::timeout(
-                                        std::time::Duration::from_millis(timeout_ms),
+                                    let run_result = run_with_optional_timeout(
+                                        timeout_ms,
+                                        "Agent",
                                         crate::manager::run_headless_with_options(
                                             crate::manager::HeadlessRunOptions {
                                                 cwd: &cwd,
@@ -2055,11 +2179,6 @@ pub async fn run_workflow(
                                         ),
                                     )
                                     .await;
-
-                                    let run_result = match run_result {
-                                        Ok(res) => res,
-                                        Err(_) => Err(format!("Agent timeout ({}ms)", timeout_ms)),
-                                    };
 
                                     match run_result {
                                         Ok(data) => {
@@ -2101,12 +2220,20 @@ pub async fn run_workflow(
                                             }
                                         });
 
-                                    match tokio::time::timeout(
-                                        std::time::Duration::from_millis(timeout_ms),
-                                        completion_rx.recv(),
-                                    )
-                                    .await
-                                    {
+                                    let completion = match timeout_ms {
+                                        Some(ms) => match tokio::time::timeout(
+                                            std::time::Duration::from_millis(ms),
+                                            completion_rx.recv(),
+                                        )
+                                        .await
+                                        {
+                                            Ok(value) => Ok(value),
+                                            Err(_) => Err(format!("Agent timeout ({}ms)", ms)),
+                                        },
+                                        None => Ok(completion_rx.recv().await),
+                                    };
+
+                                    match completion {
                                         Ok(_) => {
                                             let agents = state.agents.lock().await;
                                             if let Some(agent) = agents.get(agent_id) {
@@ -2116,10 +2243,7 @@ pub async fn run_workflow(
                                                 }
                                             }
                                         }
-                                        Err(_) => {
-                                            node_error =
-                                                Some(format!("Agent timeout ({}ms)", timeout_ms));
-                                        }
+                                        Err(err) => node_error = Some(err),
                                     }
                                     app.unlisten(handler_id);
                                 }
@@ -2137,8 +2261,9 @@ pub async fn run_workflow(
                                     }
                                 }
                                 let _ = app.emit("agents-updated", ());
-                                let run_result = tokio::time::timeout(
-                                    std::time::Duration::from_millis(timeout_ms),
+                                let run_result = run_with_optional_timeout(
+                                    timeout_ms,
+                                    "Agent",
                                     crate::manager::run_headless_with_options(
                                         crate::manager::HeadlessRunOptions {
                                             cwd: &cwd,
@@ -2152,11 +2277,6 @@ pub async fn run_workflow(
                                     ),
                                 )
                                 .await;
-
-                                let run_result = match run_result {
-                                    Ok(res) => res,
-                                    Err(_) => Err(format!("Agent timeout ({}ms)", timeout_ms)),
-                                };
 
                                 match run_result {
                                     Ok(data) => {
@@ -2248,14 +2368,7 @@ pub async fn run_workflow(
                     let interpolated_cmd = interpolate_string(cmd_str, &registry);
                     let cwd = resolve_cwd(&node.config, "");
                     let env = node.config.get("env");
-                    let timeout_ms = node
-                        .config
-                        .get("timeout_ms")
-                        .and_then(|v| {
-                            v.as_u64()
-                                .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
-                        })
-                        .unwrap_or(30000);
+                    let timeout_ms = parse_optional_timeout_ms(&node.config);
 
                     match resolve_command_node_launch(&interpolated_cmd, build_shell_command) {
                         Ok(spec) => match run_command_headless(
@@ -2305,14 +2418,7 @@ pub async fn run_workflow(
                         .unwrap_or("");
                     let interpolated_args = interpolate_string(args_str, &registry);
                     let env = node.config.get("env");
-                    let timeout_ms = node
-                        .config
-                        .get("timeout_ms")
-                        .and_then(|v| {
-                            v.as_u64()
-                                .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
-                        })
-                        .unwrap_or(30000);
+                    let timeout_ms = parse_optional_timeout_ms(&node.config);
                     let cwd = resolve_cwd(&node.config, "");
 
                     if file_path_str.is_empty() {
@@ -2494,13 +2600,29 @@ pub async fn run_workflow(
 
         // Emit workflow completion status
         let had_error = trace.iter().any(|e| e.status == "failed");
+        let final_status = if had_error { "failed" } else { "completed" };
+        let final_error = trace.iter().find_map(|event| event.error.clone());
+        if let Some(scheduled_run_id) = scheduled_run_id_for_completion.as_deref() {
+            let mut runs = load_scheduled_runs();
+            record_scheduled_run_outcome(
+                &mut runs,
+                scheduled_run_id,
+                final_status,
+                final_error.clone(),
+                Utc::now().timestamp_millis() as u64,
+            );
+            if save_scheduled_runs(&runs).is_ok() {
+                let _ = app.emit("scheduled-runs-updated", ());
+            }
+        }
         let _ = app.emit(
             "workflow-status-updated",
             serde_json::json!({
                 "workflow_id": wf.id,
                 "run_instance_id": run_instance_id_for_completion,
                 "scheduled_run_id": scheduled_run_id_for_completion,
-                "status": if had_error { "failed" } else { "completed" },
+                "status": final_status,
+                "error": final_error,
             }),
         );
 

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -2112,11 +2112,19 @@ pub async fn run_workflow(
                             // Restore state after headless run
                             if was_online {
                                 if let Some(cfg_lock) = agent_cfg {
-                                    let mut cfg = cfg_lock.lock().unwrap().clone();
+                                    let (cfg, born) = {
+                                        let config_guard = cfg_lock.lock().unwrap();
+                                        // Since we don't have direct access to the ActiveAgent struct here (it's being restored),
+                                        // we'll pass None for the timestamp if it's not in the config, letting spawn_agent 
+                                        // use the existing one if it finds it, or Now() if not.
+                                        // Actually, let's just pass None here as this path is for RE-SPAWNING after a headless run failure.
+                                        (config_guard.clone(), None) 
+                                    };
+                                    let mut cfg = cfg;
                                     cfg.is_off = false;
                                     log_debug(&format!("[Wardian] Restoring agent {} to Online state after headless run", agent_id));
                                     if let Ok(new_agent) =
-                                        crate::manager::spawn_agent(app.clone(), cfg, false).await
+                                        crate::manager::spawn_agent(app.clone(), cfg, false, born).await
                                     {
                                         let mut agents_map = state.agents.lock().await;
                                         if let Some(ref tx) = new_agent.stdin_tx {

--- a/src/features/agents/ConfigureAgentPanel.tsx
+++ b/src/features/agents/ConfigureAgentPanel.tsx
@@ -163,7 +163,7 @@ export const ConfigureAgentPanel: React.FC<Props> = ({
             <input
               readOnly
               className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-border rounded px-3 py-2 text-xs text-muted-neutral font-mono focus:outline-none select-text cursor-text"
-              value={config.session_id}
+              value={config.resume_session || config.session_id}
             />
           </div>
           <div>

--- a/src/features/agents/SpawnAgentPanel.tsx
+++ b/src/features/agents/SpawnAgentPanel.tsx
@@ -85,7 +85,7 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
           <input
             data-testid="spawn-agent-name"
             className={`w-full bg-[var(--color-wardian-input-bg)] border ${nameError ? 'border-wardian-error' : 'border-wardian-light'} rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors`}
-            placeholder="e.g. @coder-alpha"
+            placeholder="e.g. coder-alpha"
             value={newSessionName}
             onChange={(e) => {
               setNewSessionName(e.currentTarget.value);

--- a/src/features/agents/SpawnAgentPanel.tsx
+++ b/src/features/agents/SpawnAgentPanel.tsx
@@ -14,7 +14,7 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
   const [newAgentClass, setNewAgentClass] = useState("Generalist");
 
   const validateName = (name: string) => {
-    if (!name) return null;
+    if (!name.trim()) return "Name is required";
     const re = /^[a-zA-Z0-9_-]+$/;
     if (!re.test(name)) {
       return "Names must be alphanumeric, underscores, or hyphens (no spaces).";

--- a/src/features/agents/SpawnAgentPanel.tsx
+++ b/src/features/agents/SpawnAgentPanel.tsx
@@ -10,7 +10,18 @@ interface Props {
 
 export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) => {
   const [newSessionName, setNewSessionName] = useState("");
+  const [nameError, setNameError] = useState<string | null>(null);
   const [newAgentClass, setNewAgentClass] = useState("Generalist");
+
+  const validateName = (name: string) => {
+    if (!name) return null;
+    const re = /^[a-zA-Z0-9_-]+$/;
+    if (!re.test(name)) {
+      return "Names must be alphanumeric, underscores, or hyphens (no spaces).";
+    }
+    return null;
+  };
+
   const [newFolder, setNewFolder] = useState("");
   const [resumeSession, setResumeSession] = useState("");
   const [spawnAdvancedConfig, setSpawnAdvancedConfig] = useState<Partial<AgentConfig>>({});
@@ -29,6 +40,11 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
 
   const spawnAgent = async (e?: React.FormEvent) => {
     if (e) e.preventDefault();
+    const err = validateName(newSessionName);
+    if (err) {
+      setNameError(err);
+      return;
+    }
     setIsSpawning(true);
     try {
       await invoke<AgentConfig>("spawn_agent", {
@@ -42,6 +58,7 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
         },
       });
       setNewSessionName("");
+      setNameError(null);
       setNewAgentClass("Generalist");
       setNewFolder("");
       setResumeSession("");
@@ -67,11 +84,17 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
           </label>
           <input
             data-testid="spawn-agent-name"
-            className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors"
+            className={`w-full bg-[var(--color-wardian-input-bg)] border ${nameError ? 'border-wardian-error' : 'border-wardian-light'} rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors`}
             placeholder="e.g. Coder_Alpha"
             value={newSessionName}
-            onChange={(e) => setNewSessionName(e.currentTarget.value)}
+            onChange={(e) => {
+              setNewSessionName(e.currentTarget.value);
+              setNameError(validateName(e.currentTarget.value));
+            }}
           />
+          {nameError && (
+            <p className="text-[10px] text-wardian-error mt-1">{nameError}</p>
+          )}
         </div>
         <div>
           <label className="block text-[10px] font-bold text-muted-neutral mb-1">

--- a/src/features/agents/SpawnAgentPanel.tsx
+++ b/src/features/agents/SpawnAgentPanel.tsx
@@ -85,7 +85,7 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
           <input
             data-testid="spawn-agent-name"
             className={`w-full bg-[var(--color-wardian-input-bg)] border ${nameError ? 'border-wardian-error' : 'border-wardian-light'} rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors`}
-            placeholder="e.g. Coder_Alpha"
+            placeholder="e.g. @coder-alpha"
             value={newSessionName}
             onChange={(e) => {
               setNewSessionName(e.currentTarget.value);

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -215,7 +215,6 @@ function disposeTerminalSession(sessionId: string) {
   entry.parser.dispose();
   terminalSessionMap.delete(sessionId);
 }
-
 function clearTerminalSession(sessionId: string) {
   const entry = terminalSessionMap.get(sessionId);
   if (!entry || entry.disposed) {
@@ -229,18 +228,14 @@ function clearTerminalSession(sessionId: string) {
   entry.transientHomeRedrawActive = false;
   entry.pendingResizeRedrawSuppression = false;
   entry.existingScrollbackLines = undefined;
+
   const parserWithReset = entry.parser as HeadlessTerminal & { reset?: () => void };
   if (typeof parserWithReset.reset === "function") {
     parserWithReset.reset();
   } else {
     entry.parser.write("\u001bc");
   }
-  const rendererTerm = entry.renderer?.term as (Terminal & { reset?: () => void; clear?: () => void }) | undefined;
-  if (typeof rendererTerm?.reset === "function") {
-    rendererTerm.reset();
-  } else if (typeof rendererTerm?.clear === "function") {
-    rendererTerm.clear();
-  }
+  
   entry.titleHandlerRef.current?.("");
 }
 

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -235,6 +235,11 @@ function clearTerminalSession(sessionId: string) {
   } else {
     entry.parser.write("\u001bc");
   }
+
+  if (entry.renderer) {
+    entry.renderer.term.clear();
+    entry.renderer.term.write("\u001bc");
+  }
   
   entry.titleHandlerRef.current?.("");
 }

--- a/src/features/workflows/ActiveMonitoring.test.tsx
+++ b/src/features/workflows/ActiveMonitoring.test.tsx
@@ -207,5 +207,32 @@ describe('ActiveMonitoring scheduled tasks', () => {
     expect(screen.getAllByText('Running')).toHaveLength(1);
     expect(screen.getAllByText('Live').length).toBeGreaterThan(0);
   });
-});
 
+  it('keeps a failed scheduled run visible with its last error', () => {
+    render(
+      <ActiveMonitoring
+        activeRuns={[]}
+        schedules={[
+          {
+            ...schedules[0],
+            last_run_status: 'failed',
+            last_run_error: 'Agent timeout (60000ms)',
+            last_run_completed_epoch_ms: Date.now() - 30_000,
+          },
+        ]}
+        activeWorkflows={[]}
+        availableWorkflows={workflows}
+        agents={agents}
+        onStopRun={vi.fn()}
+        onStopTrigger={vi.fn()}
+        onToggleSchedule={vi.fn()}
+        onDeleteSchedule={vi.fn()}
+        onRunNow={vi.fn()}
+        onOpenWorkflow={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    expect(screen.getByText(/Last failed: Agent timeout \(60000ms\)/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/workflows/ActiveMonitoring.tsx
+++ b/src/features/workflows/ActiveMonitoring.tsx
@@ -74,8 +74,9 @@ function formatScheduleSummary(schedule: ScheduledRun['schedule']): string {
   return base;
 }
 
-function getScheduleStatus(schedule: ScheduledRun, isRunning: boolean): 'Paused' | 'Due' | 'Live' | 'Running' {
+function getScheduleStatus(schedule: ScheduledRun, isRunning: boolean): 'Paused' | 'Due' | 'Live' | 'Running' | 'Failed' {
   if (isRunning) return 'Running';
+  if (schedule.last_run_status === 'failed') return 'Failed';
   if (schedule.is_paused) return 'Paused';
   if (schedule.next_run_epoch_ms && schedule.next_run_epoch_ms <= Date.now()) return 'Due';
   return 'Live';
@@ -238,6 +239,7 @@ export const ActiveMonitoring: React.FC<ActiveMonitoringProps> = ({
               const status = getScheduleStatus(schedule, isRunning);
               const targetSummary = summarizeScheduleTarget(schedule, workflow, agents);
               const roleMappings = Object.entries(schedule.role_mappings || {});
+              const lastFailure = schedule.last_run_status === 'failed' ? schedule.last_run_error || 'Workflow failed' : null;
 
               return (
                 <div
@@ -258,7 +260,7 @@ export const ActiveMonitoring: React.FC<ActiveMonitoringProps> = ({
                       <div className="flex items-center gap-1.5 min-w-0">
                         <div className="text-[var(--color-wardian-accent)] shrink-0"><ClockIcon /></div>
                         <span className="min-w-0 flex-1 truncate text-[11px] font-bold text-primary leading-tight tracking-tight">{schedule.workflow_name}</span>
-                        <span className={`shrink-0 text-[8px] font-black px-1.5 py-0.5 rounded ${status === 'Paused' ? 'bg-amber-500/20 text-amber-500' : status === 'Due' ? 'bg-cyan-500/20 text-cyan-400' : status === 'Running' ? 'bg-cyan-500/20 text-cyan-400' : 'bg-emerald-500/20 text-emerald-400'}`}>
+                        <span className={`shrink-0 text-[8px] font-black px-1.5 py-0.5 rounded ${status === 'Paused' ? 'bg-amber-500/20 text-amber-500' : status === 'Failed' ? 'bg-[color-mix(in_srgb,var(--color-wardian-error),transparent_80%)] text-[var(--color-wardian-error)]' : status === 'Due' ? 'bg-cyan-500/20 text-cyan-400' : status === 'Running' ? 'bg-cyan-500/20 text-cyan-400' : 'bg-emerald-500/20 text-emerald-400'}`}>
                           {status}
                         </span>
                       </div>
@@ -269,7 +271,9 @@ export const ActiveMonitoring: React.FC<ActiveMonitoringProps> = ({
                       </div>
                       <div className="mt-1 flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--color-wardian-accent)]/80">
                         <span>
-                          {status === 'Running'
+                          {lastFailure
+                            ? `Last failed: ${lastFailure}`
+                            : status === 'Running'
                             ? 'Running now'
                             : (() => {
                                 const label = formatNextRun(schedule.next_run_epoch_ms);

--- a/src/features/workflows/blockLibrary.test.ts
+++ b/src/features/workflows/blockLibrary.test.ts
@@ -19,4 +19,15 @@ describe('workflow block library', () => {
     expect(fieldNames).not.toContain('session_type');
     expect(fieldNames).not.toContain('session_persistence');
   });
+
+  it('labels every timeout field as optional with the same unlimited hint', () => {
+    const timeoutFields = BLOCK_LIBRARY.flatMap((block) => [
+      ...(block.fields || []),
+      ...(block.advancedFields || []),
+    ]).filter((field) => field.name === 'timeout_ms');
+
+    expect(timeoutFields.length).toBeGreaterThan(0);
+    expect(timeoutFields.every((field) => field.label === 'Timeout (optional)')).toBe(true);
+    expect(timeoutFields.every((field) => field.placeholder === 'Blank or 0 = no timeout')).toBe(true);
+  });
 });

--- a/src/features/workflows/blockLibrary.ts
+++ b/src/features/workflows/blockLibrary.ts
@@ -34,7 +34,7 @@ const EXECUTION_ADVANCED: BlockField[] = [
 ];
 
 const SIMPLE_ADVANCED: BlockField[] = [
-  { name: 'timeout_ms', label: 'Timeout', type: 'text', placeholder: '30000' }
+  { name: 'timeout_ms', label: 'Timeout (optional)', type: 'text', placeholder: 'Blank or 0 = no timeout' }
 ];
 
 export const BLOCK_LIBRARY: BlockDefinition[] = [
@@ -180,7 +180,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     inputs: 'Multiple Temporal signals', 
     outputs: 'Sync Stamp', 
     ports: { inputs: 1, outputs: ['default'] }, // Input is implicitly multi-wired
-    fields: [{ name: 'timeout_ms', label: 'Timeout', type: 'text', placeholder: '30000' }]
+    fields: [{ name: 'timeout_ms', label: 'Timeout (optional)', type: 'text', placeholder: 'Blank or 0 = no timeout' }]
   },
   { 
     type: 'subflow', 

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -44,7 +44,7 @@ export interface WorkflowAgentNodeConfig {
   output_format?: 'text' | 'json';
   json_schema?: Record<string, unknown>;
   /** Missing, blank, null, or 0 means no timeout. Positive values are milliseconds. */
-  timeout_ms?: number | string;
+  timeout_ms?: number | string | null;
 }
 
 export interface WorkflowSettings {

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -43,6 +43,7 @@ export interface WorkflowAgentNodeConfig {
   prompt?: string;
   output_format?: 'text' | 'json';
   json_schema?: Record<string, unknown>;
+  /** Missing, blank, null, or 0 means no timeout. Positive values are milliseconds. */
   timeout_ms?: number | string;
 }
 
@@ -114,6 +115,9 @@ export interface ScheduledRun {
   next_run_epoch_ms: number | null;
   paused_remaining_ms?: number | null;
   is_paused: boolean;
+  last_run_status?: 'completed' | 'failed' | string | null;
+  last_run_error?: string | null;
+  last_run_completed_epoch_ms?: number | null;
 }
 
 export interface ActiveRunTracker {

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -362,7 +362,7 @@ describe("Spawn Form", () => {
     setupDefaultMocks([], defaultClasses);
     render(<App />);
     await screen.findByText("No Active Instances");
-    expect(screen.getByPlaceholderText("e.g. Coder_Alpha")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("e.g. coder-alpha")).toBeInTheDocument();
   });
 
   it("renders workspace path placeholder", async () => {

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -524,12 +524,23 @@ function AppBody() {
   }
 
   async function renameAgent(sessionId: string, newName: string) {
-    if (!newName.trim()) return;
+    if (!newName.trim()) {
+      setEditingAgentId(null);
+      return;
+    }
+    const re = /^[a-zA-Z0-9_-]+$/;
+    if (!re.test(newName)) {
+      alert("Invalid agent name. Names must contain only alphanumeric characters, underscores, or hyphens (no spaces).");
+      return;
+    }
     try {
       await invoke("rename_agent", { sessionId, newName });
       setAgents(prev => prev.map(a => a.session_id === sessionId ? { ...a, session_name: newName } : a));
       setEditingAgentId(null);
-    } catch (e) { console.error(e); }
+    } catch (e: any) { 
+      console.error(e);
+      alert(e);
+    }
   }
 
   async function broadcastInput(e: React.FormEvent) {

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -537,9 +537,9 @@ function AppBody() {
       await invoke("rename_agent", { sessionId, newName });
       setAgents(prev => prev.map(a => a.session_id === sessionId ? { ...a, session_name: newName } : a));
       setEditingAgentId(null);
-    } catch (e: any) { 
+    } catch (e: unknown) { 
       console.error(e);
-      alert(e);
+      alert(e instanceof Error ? e.message : String(e));
     }
   }
 


### PR DESCRIPTION
This PR fixes agent identity confusion and volatile status tracking by introducing a persistent state database and enforcing strict, CLI-friendly naming rules.

### Fixes & Improvements:
1. **Persistent State Sovereignty**: Replaced volatile memory-based status with a persistent SQLite database (\state.db\) using WAL mode. Fixes status loss on app reload.
2. **Unique Identity Enforcement**: Enforced globally unique, CLI-friendly names (\^[a-zA-Z0-9_-]+$\) with backend/UI validation. Fixes duplicate name confusion.
3. **Reliable Conversation Recovery**:
   - 'Clear Session' is now non-destructive; it rotates conversation IDs/logs while preserving agent artifacts.
   - Strictly enforced Claude flag mapping: \--session-id\ for fresh starts, \--resume\ for restorations.
4. **Process Reconciliation**:
   - Implemented 'forensic' ID injection (\WARDIAN_SESSION_ID\) and a startup reconciliation loop. Fixes 'zombie' or untracked background agents.
5. **Claude Status & Born tracking**:
   - Fixed 'stuck in processing' bug via a heuristic idle fallback and improved event prioritization.
   - Fixed timezone mismatch and birth-date resets by anchoring 'Born' and 'Uptime' to the lifelong SQLite creation date using ISO 8601 UTC.

### Verification:
- All 221 backend unit tests pass.
- E2E Verified: IDs rotate correctly, log paths refresh, and 'Action Needed' triggers are robust.