### PR TITLE
Fix OpenCode theme and status telemetry

### DIFF
--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -170,6 +170,7 @@ This is how OpenCode sees Wardian-managed class and agent context without forcin
 - OpenCode is closer to Codex than Gemini on instruction naming: it consumes `AGENTS.md` directly.
 - If OpenCode stops seeing Wardian skills or class instructions, inspect the generated `OPENCODE_CONFIG_CONTENT` first.
 - If interactive spawn works but telemetry is thin, that is expected today; OpenCode does not expose one stable per-session JSONL path the way Claude and Codex do.
+- On Windows, Wardian should prefer a native `opencode.exe` or packaged OpenCode binary over `.cmd`/script shims during PATH resolution. If only a shim exists, interactive launch must wrap it through `cmd /d /c ...` because direct PTY spawning does not get shell dispatch semantics.
 
 ## Choosing Where to Debug
 

--- a/docs/guide/watchlists.md
+++ b/docs/guide/watchlists.md
@@ -45,6 +45,7 @@ As your swarm grows, a single list becomes difficult to manage. Wardian allows y
 - **Reordering**: Drag and drop agent cards within a watchlist to prioritize your view.
 - **Filtering**: Click a watchlist tab to focus only on that group of agents.
 - **Bulk Selection**: Use `Ctrl+Click` to select multiple agents within a watchlist for broadcast commands.
+- **Bulk Context Menu**: If you right-click inside the current multi-selection, the menu applies to the whole selection. Bulk delete shows one confirmation dialog for the full selected set instead of prompting once per agent.
 
 ## 🖱️ Remote Management
 Hover over any agent in the Roster to access instant control icons:

--- a/docs/specs/025-bulk-delete-and-opencode-windows-launch.md
+++ b/docs/specs/025-bulk-delete-and-opencode-windows-launch.md
@@ -1,0 +1,43 @@
+# Spec 025: Bulk Delete Confirmation and OpenCode Windows Launch
+
+- **Status:** Implemented
+- **Date:** 2026-04-25
+- **Decider:** User
+
+## Context and Problem Statement
+
+Two small but high-friction behaviors needed tightening:
+
+1. Multi-selected agents in the watchlist could route bulk delete through repeated single-agent confirmations instead of one confirmation for the whole target set.
+2. OpenCode launches on Windows could fail when `PATH` resolved to a shell shim rather than a native executable, especially under direct PTY/process spawning where Windows does not apply shell command dispatch automatically.
+
+These both sit on boundary behavior that users already have strong expectations about: Explorer-style bulk actions in the roster, and predictable provider startup on Windows.
+
+## Proposed Decision
+
+### Bulk delete confirmation
+
+- Multi-selection context menus continue to resolve to the full current selection when the right-click target is inside that selection.
+- Delete now has a dedicated bulk callback path instead of looping through the single-agent delete callback.
+- The confirmation dialog is shown exactly once for the resolved selection.
+- The confirmation copy is selection-sized:
+  - `Delete this agent?`
+  - `Delete N selected agents?`
+- After confirmation, deletions are executed sequentially and watchlist selection/off-state cleanup is applied once for the full deleted set.
+
+### OpenCode Windows executable resolution
+
+- On Windows, OpenCode executable lookup now prefers native launch targets over shell shims:
+  - direct `opencode.exe`
+  - packaged OpenCode binary discovered behind a shim layout
+  - shim fallback only if no native executable is found anywhere in `PATH`
+- Interactive OpenCode launches still wrap non-`.exe` shim targets through `cmd /d /c ...` because Wardian launches providers directly through Windows PTY/process APIs rather than via the user's selected shell.
+- This preserves shell independence at the Wardian layer while avoiding `CreateProcessW` failures for `.cmd`/script shims.
+
+## Consequences
+
+- **Positive**: Bulk delete now matches file-explorer expectations and reduces destructive-action noise.
+- **Positive**: OpenCode startup on Windows prefers native binaries when available and remains compatible with shim-only installs.
+- **Positive**: The Windows launch rule is explicit and testable instead of depending on ambient shell behavior.
+- **Negative**: OpenCode Windows launch resolution now has slightly more branching logic in the provider adapter.
+- **Negative**: PTY launch behavior still needs a Windows shell wrapper when the resolved target is only a shim, even though the user's interactive shell choice is preserved elsewhere.

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -24,6 +24,6 @@ pub fn save_agent_session_persistence(
 }
 
 #[tauri::command]
-pub fn save_opencode_theme(theme: String) -> Result<(), String> {
-    crate::utils::save_opencode_theme(&theme)
+pub fn sync_provider_theme_settings(theme: String) -> Result<(), String> {
+    crate::utils::sync_provider_theme_settings(&theme)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -290,7 +290,7 @@ pub fn run() {
             commands::settings::list_available_shells,
             commands::settings::save_shell_settings,
             commands::settings::save_agent_session_persistence,
-            commands::settings::save_opencode_theme,
+            commands::settings::sync_provider_theme_settings,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -3,6 +3,7 @@ use crate::providers::claude::{classify_claude_user_event, ClaudeUserEventKind};
 use crate::providers::opencode::OpenCodeProvider;
 use crate::providers::ProviderFactory;
 use crate::state::{ActiveAgent, AppState};
+use chrono::TimeZone;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::collections::HashMap;
 use std::io::{BufRead, Read, Seek, Write};
@@ -1394,12 +1395,12 @@ fn opencode_env(
     if let Some(config_dir) = opencode_custom_config_dir(cwd, class_name, session_id, config)? {
         let config_path = config_dir.join("opencode.json");
 
-        // Build the runtime config (instructions + theme), and pair it with a
+        // Build the runtime config (instructions), and pair it with a
         // custom config directory so OpenCode can discover projected skills.
         let runtime_config: serde_json::Value =
             opencode_runtime_config_content(class_name, session_id, config)
                 .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_else(|| serde_json::json!({"theme": "system"}));
+                .unwrap_or_else(|| serde_json::json!({}));
 
         std::fs::write(&config_path, runtime_config.to_string()).map_err(|e| e.to_string())?;
         envs.push((
@@ -2559,12 +2560,21 @@ fn claude_status_from_log(lines: &[serde_json::Value]) -> Option<String> {
     }
 }
 
-#[cfg(test)]
 #[derive(Debug, Default, PartialEq, Eq)]
 struct OpenCodeLogMetrics {
     query_count: usize,
     init_timestamp: Option<String>,
     status: Option<String>,
+}
+
+fn opencode_log_timestamp_to_rfc3339(timestamp: &str) -> Option<String> {
+    let parsed = chrono::NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%dT%H:%M:%S").ok()?;
+    let local = chrono::Local.from_local_datetime(&parsed).earliest()?;
+    Some(
+        local
+            .with_timezone(&chrono::Utc)
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+    )
 }
 
 /// Find the newest OpenCode log file whose filesystem mtime is at or after
@@ -2676,7 +2686,6 @@ pub fn opencode_extract_created_session_id(log_path: &std::path::Path) -> Option
 ///
 /// This avoids timestamp comparisons entirely, which would be unreliable
 /// because opencode logs timestamps in local time while `now` is UTC.
-#[cfg(test)]
 fn opencode_metrics_from_log(content: &str, session_id: &str) -> OpenCodeLogMetrics {
     let mut metrics = OpenCodeLogMetrics::default();
     // true  = last session.prompt event was "exiting loop" (Idle)
@@ -2691,7 +2700,10 @@ fn opencode_metrics_from_log(content: &str, session_id: &str) -> OpenCodeLogMetr
         }
 
         if metrics.init_timestamp.is_none() {
-            metrics.init_timestamp = line.split_whitespace().nth(1).map(|ts| ts.to_string());
+            metrics.init_timestamp = line
+                .split_whitespace()
+                .nth(1)
+                .and_then(opencode_log_timestamp_to_rfc3339);
         }
 
         if line.contains("service=session.prompt") {
@@ -2728,6 +2740,25 @@ fn opencode_metrics_from_log(content: &str, session_id: &str) -> OpenCodeLogMetr
     };
 
     metrics
+}
+
+fn apply_opencode_log_metrics(
+    content: &str,
+    session_id: &str,
+    query_count: &mut usize,
+    init_timestamp: &mut Option<String>,
+    current_status: &mut String,
+) {
+    let metrics = opencode_metrics_from_log(content, session_id);
+    if metrics.query_count > 0 {
+        *query_count = metrics.query_count;
+    }
+    if init_timestamp.is_none() && metrics.init_timestamp.is_some() {
+        *init_timestamp = metrics.init_timestamp;
+    }
+    if let Some(status) = metrics.status {
+        *current_status = status;
+    }
 }
 
 pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
@@ -2843,24 +2874,24 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
             let mut q_count = *snap.query_count.lock().unwrap();
             let mut i_ts = snap.init_timestamp.lock().unwrap().clone();
             let mut log_path_lock = snap.log_path.lock().unwrap_or_else(|e| e.into_inner());
+            let opencode_session_id = snap
+                .resume_session
+                .as_deref()
+                .filter(|value| value.starts_with("ses_"))
+                .unwrap_or(&snap.session_id);
 
             // Provider-aware log discovery
             if snap.provider == "opencode" {
-                let opencode_session_id = snap
-                    .resume_session
-                    .as_deref()
-                    .filter(|value| value.starts_with("ses_"))
-                    .unwrap_or(&snap.session_id);
-                *log_path_lock = Some(opencode_session_diff_path(opencode_session_id));
-                if !log_path_lock.as_ref().is_some_and(|path| path.exists()) {
-                    let log_dirs = opencode_log_dirs();
-                    for dir in &log_dirs {
-                        if let Some(path) = opencode_log_path_in(dir, opencode_session_id) {
-                            *log_path_lock = Some(path);
-                            break;
-                        }
+                let mut discovered_log = None;
+                let log_dirs = opencode_log_dirs();
+                for dir in &log_dirs {
+                    if let Some(path) = opencode_log_path_in(dir, opencode_session_id) {
+                        discovered_log = Some(path);
+                        break;
                     }
                 }
+                *log_path_lock = discovered_log
+                    .or_else(|| Some(opencode_session_diff_path(opencode_session_id)));
             } else if snap.provider == "claude" && snap.resume_session.is_some() {
                 // For Claude, if we have a resume_session (Conversation ID), always re-verify
                 // the path so it updates immediately after a Clear rotation.
@@ -3048,8 +3079,15 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                 }
                             }
                             "opencode" => {
-                                // OpenCode status and query count come from PTY events now.
-                                // Keep the discovered storage path for diagnostics only.
+                                let mut status = snap.current_status.lock().unwrap().clone();
+                                apply_opencode_log_metrics(
+                                    &content,
+                                    opencode_session_id,
+                                    &mut q_count,
+                                    &mut i_ts,
+                                    &mut status,
+                                );
+                                *snap.current_status.lock().unwrap() = status;
                             }
                             _ => {
                                 // Gemini logs are a single JSON object with a messages array
@@ -3250,7 +3288,7 @@ pub async fn kill_all_agents(state: &AppState) {
 #[cfg(test)]
 mod tests {
     use super::{
-        claude_permission_hook_matches_session, claude_status_from_log,
+        apply_opencode_log_metrics, claude_permission_hook_matches_session, claude_status_from_log,
         codex_bootstrap_launch_context, codex_log_lookup_session_id, display_log_path,
         extract_terminal_titles, finalize_interactive_spawn_args, headless_provider_args,
         headless_provider_launch, interactive_provider_args, interactive_provider_cwd,
@@ -3690,6 +3728,66 @@ mod tests {
     }
 
     #[test]
+    fn opencode_log_metrics_update_status_and_query_count_from_current_logs() {
+        let current = concat!(
+            "INFO  2026-04-26T04:28:39 +1ms service=session.prompt session.id=ses_target step=0 loop\n",
+            "INFO  2026-04-26T04:28:42 +0ms service=session.status publishing\n",
+            "INFO  2026-04-26T04:28:42 +0ms service=session.prompt session.id=ses_target step=1 loop\n",
+            "INFO  2026-04-26T04:28:42 +1ms service=session.prompt session.id=ses_target exiting loop\n",
+            "INFO  2026-04-26T04:28:42 +1ms service=session.idle publishing\n",
+        );
+
+        let mut query_count = 0;
+        let mut init_timestamp = None;
+        let mut current_status = "Processing...".to_string();
+
+        apply_opencode_log_metrics(
+            current,
+            "ses_target",
+            &mut query_count,
+            &mut init_timestamp,
+            &mut current_status,
+        );
+
+        assert_eq!(query_count, 2);
+        let parsed_timestamp = init_timestamp
+            .as_deref()
+            .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+            .expect("OpenCode log timestamp should be normalized to RFC3339");
+        assert_eq!(
+            parsed_timestamp
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%dT%H:%M:%S")
+                .to_string(),
+            "2026-04-26T04:28:39"
+        );
+        assert_eq!(current_status, "Idle");
+    }
+
+    #[test]
+    fn opencode_log_metrics_preserve_existing_rfc3339_birth_timestamp() {
+        let current = concat!(
+            "INFO  2026-04-26T04:28:39 +1ms service=session.prompt session.id=ses_target step=0 loop\n",
+            "INFO  2026-04-26T04:28:42 +1ms service=session.prompt session.id=ses_target exiting loop\n",
+        );
+
+        let mut query_count = 0;
+        let mut init_timestamp = Some("2026-04-26T04:20:00.000Z".to_string());
+        let mut current_status = "Processing...".to_string();
+
+        apply_opencode_log_metrics(
+            current,
+            "ses_target",
+            &mut query_count,
+            &mut init_timestamp,
+            &mut current_status,
+        );
+
+        assert_eq!(init_timestamp, Some("2026-04-26T04:20:00.000Z".to_string()));
+        assert_eq!(current_status, "Idle");
+    }
+
+    #[test]
     fn opencode_interactive_args_include_dir_for_real_workspace_anchor() {
         let workspace_cwd = Path::new("D:/Development/Wardian");
 
@@ -3709,7 +3807,8 @@ mod tests {
         .expect("launch spec");
 
         assert!(
-            launch.executable.ends_with(r"\cmd.exe") || launch.executable.eq_ignore_ascii_case("cmd"),
+            launch.executable.ends_with(r"\cmd.exe")
+                || launch.executable.eq_ignore_ascii_case("cmd"),
             "expected cmd host, got {}",
             launch.executable
         );

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1525,6 +1525,24 @@ fn interactive_provider_launch(
     bin: &str,
     provider_args: &[String],
 ) -> Result<crate::utils::shell::ShellLaunchSpec, String> {
+    #[cfg(windows)]
+    if provider_name == "opencode" {
+        let bin_path = std::path::Path::new(bin);
+        let is_native_exe = bin_path
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|value| value.eq_ignore_ascii_case("exe"));
+        if !is_native_exe {
+            let cmd_host = std::env::var("ComSpec").unwrap_or_else(|_| "cmd.exe".to_string());
+            let mut fragments = vec![quote_cmd_arg(bin)];
+            fragments.extend(provider_args.iter().map(|arg| quote_cmd_arg(arg)));
+            return Ok(crate::utils::shell::ShellLaunchSpec {
+                executable: cmd_host,
+                args: vec!["/d".to_string(), "/c".to_string(), fragments.join(" ")],
+            });
+        }
+    }
+
     let _ = provider_name;
     Ok(crate::utils::shell::ShellLaunchSpec {
         executable: bin.to_string(),
@@ -3678,6 +3696,27 @@ mod tests {
         let args = interactive_provider_args("opencode", workspace_cwd, workspace_cwd, Vec::new());
 
         assert_eq!(args, vec!["D:/Development/Wardian".to_string()]);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn opencode_interactive_launch_wraps_cmd_shims_through_cmd_exe() {
+        let launch = interactive_provider_launch(
+            "opencode",
+            r"C:\nvm4w\nodejs\opencode.cmd",
+            &["--session".to_string(), "ses_test".to_string()],
+        )
+        .expect("launch spec");
+
+        assert!(
+            launch.executable.ends_with(r"\cmd.exe") || launch.executable.eq_ignore_ascii_case("cmd"),
+            "expected cmd host, got {}",
+            launch.executable
+        );
+        assert_eq!(launch.args[..2], ["/d".to_string(), "/c".to_string()]);
+        assert!(launch.args[2].contains(r"C:\nvm4w\nodejs\opencode.cmd"));
+        assert!(launch.args[2].contains("--session"));
+        assert!(launch.args[2].contains("ses_test"));
     }
     #[test]
     fn strip_flag_value_pairs_removes_all_add_dir_arguments() {

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1396,10 +1396,16 @@ fn opencode_env(
 
         // Build the runtime config (instructions + theme), and pair it with a
         // custom config directory so OpenCode can discover projected skills.
-        let runtime_config: serde_json::Value =
+        let mut runtime_config: serde_json::Value =
             opencode_runtime_config_content(class_name, session_id, config)
                 .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_else(|| serde_json::json!({"theme": "system"}));
+                .unwrap_or_else(|| serde_json::json!({}));
+        if let Some(runtime_map) = runtime_config.as_object_mut() {
+            runtime_map.insert(
+                "theme".to_string(),
+                serde_json::Value::String(crate::utils::load_saved_opencode_theme()),
+            );
+        }
 
         std::fs::write(&config_path, runtime_config.to_string()).map_err(|e| e.to_string())?;
         envs.push((
@@ -3810,6 +3816,7 @@ mod tests {
         let _guard = crate::utils::wardian_test_env_lock();
         let temp = tempfile::tempdir().expect("temp dir");
         let wardian_home = temp.path().join(".wardian");
+        let appdata_dir = temp.path().join("appdata");
         let common = wardian_home.join("common");
         let class_dir = wardian_home.join("classes").join("Builder");
         let agent_dir = wardian_home.join("agents").join("ses_123");
@@ -3827,8 +3834,14 @@ mod tests {
         std::fs::write(class_dir.join("AGENTS.md"), "class").expect("class AGENTS");
         std::fs::write(agent_dir.join("AGENTS.md"), "agent").expect("agent AGENTS");
         std::fs::write(user_dir.join("AGENTS.md"), "user").expect("user AGENTS");
-
         unsafe { std::env::set_var("WARDIAN_HOME", wardian_home.to_string_lossy().to_string()) };
+        unsafe { std::env::set_var("APPDATA", appdata_dir.to_string_lossy().to_string()) };
+        let saved_theme_path =
+            crate::utils::get_opencode_config_path().expect("resolved saved config path");
+        std::fs::create_dir_all(saved_theme_path.parent().expect("saved theme parent"))
+            .expect("appdata opencode dir");
+        std::fs::write(&saved_theme_path, r#"{"theme":"opencode"}"#)
+            .expect("write saved theme");
 
         let config = AgentConfig {
             session_id: "ses_123".into(),
@@ -3841,6 +3854,7 @@ mod tests {
             .expect("interactive envs");
 
         unsafe { std::env::remove_var("WARDIAN_HOME") };
+        unsafe { std::env::remove_var("APPDATA") };
 
         assert!(envs.contains(&("COLORTERM".to_string(), "truecolor".to_string())));
         let config_path = envs
@@ -3857,6 +3871,7 @@ mod tests {
             .expect("instructions array");
 
         assert_eq!(instructions.len(), 4);
+        assert_eq!(parsed.get("theme").and_then(|value| value.as_str()), Some("opencode"));
 
         // Config JSON must NOT contain skills.paths — OpenCode 1.4.3 does not
         // expose a skills.paths config key, so Wardian omits it entirely.

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1396,16 +1396,10 @@ fn opencode_env(
 
         // Build the runtime config (instructions + theme), and pair it with a
         // custom config directory so OpenCode can discover projected skills.
-        let mut runtime_config: serde_json::Value =
+        let runtime_config: serde_json::Value =
             opencode_runtime_config_content(class_name, session_id, config)
                 .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_else(|| serde_json::json!({}));
-        if let Some(runtime_map) = runtime_config.as_object_mut() {
-            runtime_map.insert(
-                "theme".to_string(),
-                serde_json::Value::String(crate::utils::load_saved_opencode_theme()),
-            );
-        }
+                .unwrap_or_else(|| serde_json::json!({"theme": "system"}));
 
         std::fs::write(&config_path, runtime_config.to_string()).map_err(|e| e.to_string())?;
         envs.push((
@@ -3816,7 +3810,6 @@ mod tests {
         let _guard = crate::utils::wardian_test_env_lock();
         let temp = tempfile::tempdir().expect("temp dir");
         let wardian_home = temp.path().join(".wardian");
-        let appdata_dir = temp.path().join("appdata");
         let common = wardian_home.join("common");
         let class_dir = wardian_home.join("classes").join("Builder");
         let agent_dir = wardian_home.join("agents").join("ses_123");
@@ -3834,14 +3827,8 @@ mod tests {
         std::fs::write(class_dir.join("AGENTS.md"), "class").expect("class AGENTS");
         std::fs::write(agent_dir.join("AGENTS.md"), "agent").expect("agent AGENTS");
         std::fs::write(user_dir.join("AGENTS.md"), "user").expect("user AGENTS");
+
         unsafe { std::env::set_var("WARDIAN_HOME", wardian_home.to_string_lossy().to_string()) };
-        unsafe { std::env::set_var("APPDATA", appdata_dir.to_string_lossy().to_string()) };
-        let saved_theme_path =
-            crate::utils::get_opencode_config_path().expect("resolved saved config path");
-        std::fs::create_dir_all(saved_theme_path.parent().expect("saved theme parent"))
-            .expect("appdata opencode dir");
-        std::fs::write(&saved_theme_path, r#"{"theme":"opencode"}"#)
-            .expect("write saved theme");
 
         let config = AgentConfig {
             session_id: "ses_123".into(),
@@ -3854,7 +3841,6 @@ mod tests {
             .expect("interactive envs");
 
         unsafe { std::env::remove_var("WARDIAN_HOME") };
-        unsafe { std::env::remove_var("APPDATA") };
 
         assert!(envs.contains(&("COLORTERM".to_string(), "truecolor".to_string())));
         let config_path = envs
@@ -3871,7 +3857,6 @@ mod tests {
             .expect("instructions array");
 
         assert_eq!(instructions.len(), 4);
-        assert_eq!(parsed.get("theme").and_then(|value| value.as_str()), Some("opencode"));
 
         // Config JSON must NOT contain skills.paths — OpenCode 1.4.3 does not
         // expose a skills.paths config key, so Wardian omits it entirely.

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -56,6 +56,8 @@ impl OpenCodeProvider {
     where
         I: IntoIterator<Item = std::path::PathBuf>,
     {
+        let mut shim_fallback: Option<String> = None;
+
         for path in paths {
             let direct_exe = path.join("opencode.exe");
             if direct_exe.exists() {
@@ -78,7 +80,10 @@ impl OpenCodeProvider {
                     if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
                         return Some(executable);
                     }
-                    return Some(candidate.to_string_lossy().to_string());
+                    if shim_fallback.is_none() {
+                        shim_fallback = Some(candidate.to_string_lossy().to_string());
+                    }
+                    break;
                 }
             }
 
@@ -86,18 +91,22 @@ impl OpenCodeProvider {
                 if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
                     return Some(executable);
                 }
-                return Some("opencode".to_string());
+                if shim_fallback.is_none() {
+                    shim_fallback = Some("opencode".to_string());
+                }
             }
 
             if powershell.exists() {
                 if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
                     return Some(executable);
                 }
-                return Some("opencode".to_string());
+                if shim_fallback.is_none() {
+                    shim_fallback = Some("opencode".to_string());
+                }
             }
         }
 
-        None
+        shim_fallback
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -471,6 +480,24 @@ mod tests {
         );
 
         assert_eq!(resolved, Some(cmd.to_string_lossy().to_string()));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_path_lookup_prefers_later_native_exe_over_earlier_cmd_shim() {
+        let shim_dir = tempfile::tempdir().expect("shim dir");
+        let exe_dir = tempfile::tempdir().expect("exe dir");
+        let cmd = shim_dir.path().join("opencode.cmd");
+        let exe = exe_dir.path().join("opencode.exe");
+        std::fs::write(&cmd, "@echo off\r\n").expect("cmd shim");
+        std::fs::write(&exe, "").expect("exe");
+
+        let resolved = OpenCodeProvider::find_windows_opencode_in_paths(
+            vec![shim_dir.path().to_path_buf(), exe_dir.path().to_path_buf()],
+            &[".exe".into(), ".cmd".into(), ".bat".into()],
+        );
+
+        assert_eq!(resolved, Some(exe.to_string_lossy().to_string()));
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -63,21 +63,7 @@ impl OpenCodeProvider {
             }
 
             let bare = path.join("opencode");
-            if bare.exists() {
-                if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
-                    return Some(executable);
-                }
-                return Some("opencode".to_string());
-            }
-
             let powershell = path.join("opencode.ps1");
-            if powershell.exists() {
-                if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
-                    return Some(executable);
-                }
-                return Some("opencode".to_string());
-            }
-
             for ext in path_exts {
                 let candidate = path.join(format!("opencode{ext}"));
                 if candidate.exists() {
@@ -92,8 +78,22 @@ impl OpenCodeProvider {
                     if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
                         return Some(executable);
                     }
-                    return Some("opencode".to_string());
+                    return Some(candidate.to_string_lossy().to_string());
                 }
+            }
+
+            if bare.exists() {
+                if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
+                    return Some(executable);
+                }
+                return Some("opencode".to_string());
+            }
+
+            if powershell.exists() {
+                if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
+                    return Some(executable);
+                }
+                return Some("opencode".to_string());
             }
         }
 
@@ -454,6 +454,23 @@ mod tests {
         );
 
         assert_eq!(resolved, Some(exe.to_string_lossy().to_string()));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_path_lookup_prefers_cmd_shim_when_packaged_executable_is_missing() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let bare = temp.path().join("opencode");
+        let cmd = temp.path().join("opencode.cmd");
+        std::fs::write(&bare, "#!/usr/bin/env node\n").expect("bare shim");
+        std::fs::write(&cmd, "@echo off\r\n").expect("cmd shim");
+
+        let resolved = OpenCodeProvider::find_windows_opencode_in_paths(
+            vec![temp.path().to_path_buf()],
+            &[".exe".into(), ".cmd".into(), ".bat".into()],
+        );
+
+        assert_eq!(resolved, Some(cmd.to_string_lossy().to_string()));
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -188,10 +188,6 @@ pub fn build_opencode_runtime_config(include_roots: &[std::path::PathBuf]) -> se
     }
 
     let mut config = serde_json::Map::new();
-    config.insert(
-        "theme".to_string(),
-        serde_json::Value::String("system".to_string()),
-    );
     if !instructions.is_empty() {
         config.insert(
             "instructions".to_string(),
@@ -931,7 +927,7 @@ mod tests {
             .get("instructions")
             .and_then(|v| v.as_array())
             .expect("instructions array");
-        assert_eq!(config.get("theme").and_then(|v| v.as_str()), Some("system"));
+        assert!(config.get("theme").is_none());
         assert_eq!(instructions.len(), 3);
         assert_eq!(
             instructions[0].as_str(),

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -1024,6 +1024,35 @@ fn upsert_json_theme(path: &std::path::Path, schema: &str, theme: &str) -> Resul
     Ok(())
 }
 
+fn read_json_theme(path: &std::path::Path) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+        .and_then(|value| {
+            value
+                .get("theme")
+                .and_then(|theme| theme.as_str())
+                .map(str::to_string)
+        })
+}
+
+fn load_opencode_theme_from_paths(
+    config_path: Option<&std::path::Path>,
+    tui_path: Option<&std::path::Path>,
+) -> String {
+    config_path
+        .and_then(read_json_theme)
+        .or_else(|| tui_path.and_then(read_json_theme))
+        .unwrap_or_else(|| "system".to_string())
+}
+
+pub fn load_saved_opencode_theme() -> String {
+    load_opencode_theme_from_paths(
+        get_opencode_config_path().as_deref(),
+        get_opencode_tui_path().as_deref(),
+    )
+}
+
 pub fn save_opencode_theme(theme: &str) -> Result<(), String> {
     let normalized = wardian_theme_to_opencode_theme(theme);
     let tui_path = get_opencode_tui_path().ok_or("Could not find config directory")?;
@@ -1038,7 +1067,9 @@ pub fn save_opencode_theme(theme: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod opencode_theme_tests {
-    use super::{upsert_json_theme, wardian_theme_to_opencode_theme};
+    use super::{
+        load_opencode_theme_from_paths, upsert_json_theme, wardian_theme_to_opencode_theme,
+    };
 
     #[test]
     fn wardian_theme_maps_to_opencode_system_theme() {
@@ -1076,5 +1107,26 @@ mod opencode_theme_tests {
             parsed["provider"]["lmstudio"]["name"].as_str(),
             Some("LM Studio")
         );
+    }
+
+    #[test]
+    fn load_opencode_theme_prefers_config_then_tui_then_system_default() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let config_path = temp.path().join("opencode.json");
+        let tui_path = temp.path().join("tui.json");
+
+        std::fs::write(&tui_path, r#"{"theme":"opencode"}"#).expect("write tui config");
+        assert_eq!(
+            load_opencode_theme_from_paths(None, Some(&tui_path)),
+            "opencode"
+        );
+
+        std::fs::write(&config_path, r#"{"theme":"system"}"#).expect("write runtime config");
+        assert_eq!(
+            load_opencode_theme_from_paths(Some(&config_path), Some(&tui_path)),
+            "system"
+        );
+
+        assert_eq!(load_opencode_theme_from_paths(None, None), "system");
     }
 }

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -1024,35 +1024,6 @@ fn upsert_json_theme(path: &std::path::Path, schema: &str, theme: &str) -> Resul
     Ok(())
 }
 
-fn read_json_theme(path: &std::path::Path) -> Option<String> {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
-        .and_then(|value| {
-            value
-                .get("theme")
-                .and_then(|theme| theme.as_str())
-                .map(str::to_string)
-        })
-}
-
-fn load_opencode_theme_from_paths(
-    config_path: Option<&std::path::Path>,
-    tui_path: Option<&std::path::Path>,
-) -> String {
-    config_path
-        .and_then(read_json_theme)
-        .or_else(|| tui_path.and_then(read_json_theme))
-        .unwrap_or_else(|| "system".to_string())
-}
-
-pub fn load_saved_opencode_theme() -> String {
-    load_opencode_theme_from_paths(
-        get_opencode_config_path().as_deref(),
-        get_opencode_tui_path().as_deref(),
-    )
-}
-
 pub fn save_opencode_theme(theme: &str) -> Result<(), String> {
     let normalized = wardian_theme_to_opencode_theme(theme);
     let tui_path = get_opencode_tui_path().ok_or("Could not find config directory")?;
@@ -1067,9 +1038,7 @@ pub fn save_opencode_theme(theme: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod opencode_theme_tests {
-    use super::{
-        load_opencode_theme_from_paths, upsert_json_theme, wardian_theme_to_opencode_theme,
-    };
+    use super::{upsert_json_theme, wardian_theme_to_opencode_theme};
 
     #[test]
     fn wardian_theme_maps_to_opencode_system_theme() {
@@ -1107,26 +1076,5 @@ mod opencode_theme_tests {
             parsed["provider"]["lmstudio"]["name"].as_str(),
             Some("LM Studio")
         );
-    }
-
-    #[test]
-    fn load_opencode_theme_prefers_config_then_tui_then_system_default() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let config_path = temp.path().join("opencode.json");
-        let tui_path = temp.path().join("tui.json");
-
-        std::fs::write(&tui_path, r#"{"theme":"opencode"}"#).expect("write tui config");
-        assert_eq!(
-            load_opencode_theme_from_paths(None, Some(&tui_path)),
-            "opencode"
-        );
-
-        std::fs::write(&config_path, r#"{"theme":"system"}"#).expect("write runtime config");
-        assert_eq!(
-            load_opencode_theme_from_paths(Some(&config_path), Some(&tui_path)),
-            "system"
-        );
-
-        assert_eq!(load_opencode_theme_from_paths(None, None), "system");
     }
 }

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -986,6 +986,22 @@ pub fn get_opencode_config_path() -> Option<std::path::PathBuf> {
     dirs::config_dir().map(|p| p.join("opencode").join("opencode.json"))
 }
 
+pub fn get_opencode_kv_path() -> Option<std::path::PathBuf> {
+    if let Some(state_home) = std::env::var_os("XDG_STATE_HOME")
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+    {
+        return Some(state_home.join("opencode").join("kv.json"));
+    }
+
+    dirs::home_dir().map(|p| {
+        p.join(".local")
+            .join("state")
+            .join("opencode")
+            .join("kv.json")
+    })
+}
+
 fn wardian_theme_to_opencode_theme(theme: &str) -> &str {
     match theme {
         "dark" | "light" | "system" => "system",
@@ -1024,21 +1040,94 @@ fn upsert_json_theme(path: &std::path::Path, schema: &str, theme: &str) -> Resul
     Ok(())
 }
 
-pub fn save_opencode_theme(theme: &str) -> Result<(), String> {
+fn remove_json_theme(path: &std::path::Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let mut config = std::fs::read_to_string(path)
+        .ok()
+        .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+
+    if config.remove("theme").is_none() {
+        return Ok(());
+    }
+
+    let content = serde_json::to_string_pretty(&serde_json::Value::Object(config))
+        .map_err(|e| e.to_string())?;
+    std::fs::write(path, content).map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+fn upsert_opencode_theme_mode(path: &std::path::Path, mode: &str) -> Result<(), String> {
+    let mut kv = if path.exists() {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+            .and_then(|value| value.as_object().cloned())
+            .unwrap_or_default()
+    } else {
+        serde_json::Map::new()
+    };
+
+    match mode {
+        "dark" | "light" => {
+            kv.insert(
+                "theme_mode_lock".to_string(),
+                serde_json::Value::String(mode.to_string()),
+            );
+            kv.insert(
+                "theme_mode".to_string(),
+                serde_json::Value::String(mode.to_string()),
+            );
+        }
+        "system" => {
+            kv.remove("theme_mode_lock");
+            kv.remove("theme_mode");
+        }
+        _ => return Ok(()),
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+
+    let content =
+        serde_json::to_string_pretty(&serde_json::Value::Object(kv)).map_err(|e| e.to_string())?;
+    std::fs::write(path, content).map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+fn sync_opencode_theme_settings(theme: &str) -> Result<(), String> {
     let normalized = wardian_theme_to_opencode_theme(theme);
     let tui_path = get_opencode_tui_path().ok_or("Could not find config directory")?;
     upsert_json_theme(&tui_path, "https://opencode.ai/tui.json", normalized)?;
 
     if let Some(config_path) = get_opencode_config_path() {
-        upsert_json_theme(&config_path, "https://opencode.ai/config.json", normalized)?;
+        remove_json_theme(&config_path)?;
+    }
+
+    if let Some(kv_path) = get_opencode_kv_path() {
+        upsert_opencode_theme_mode(&kv_path, theme)?;
     }
 
     Ok(())
 }
 
+pub fn sync_provider_theme_settings(theme: &str) -> Result<(), String> {
+    sync_opencode_theme_settings(theme)
+}
+
 #[cfg(test)]
 mod opencode_theme_tests {
-    use super::{upsert_json_theme, wardian_theme_to_opencode_theme};
+    use super::{
+        remove_json_theme, upsert_json_theme, upsert_opencode_theme_mode,
+        wardian_theme_to_opencode_theme,
+    };
 
     #[test]
     fn wardian_theme_maps_to_opencode_system_theme() {
@@ -1075,6 +1164,75 @@ mod opencode_theme_tests {
         assert_eq!(
             parsed["provider"]["lmstudio"]["name"].as_str(),
             Some("LM Studio")
+        );
+    }
+
+    #[test]
+    fn remove_json_theme_preserves_existing_config_keys() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("opencode.json");
+        std::fs::write(
+            &path,
+            r#"{"$schema":"https://opencode.ai/config.json","theme":"system","provider":{"lmstudio":{"name":"LM Studio"}}}"#,
+        )
+        .expect("write initial config");
+
+        remove_json_theme(&path).expect("remove theme");
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read config"))
+                .expect("parse config");
+        assert!(parsed.get("theme").is_none());
+        assert_eq!(
+            parsed["provider"]["lmstudio"]["name"].as_str(),
+            Some("LM Studio")
+        );
+    }
+
+    #[test]
+    fn opencode_theme_mode_lock_matches_manual_light_dark_choice() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("kv.json");
+        std::fs::write(&path, r#"{"theme":"system","other":true}"#).expect("write initial kv");
+
+        upsert_opencode_theme_mode(&path, "light").expect("lock light mode");
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read kv"))
+                .expect("parse kv");
+        assert_eq!(
+            parsed
+                .get("theme_mode_lock")
+                .and_then(|value| value.as_str()),
+            Some("light")
+        );
+        assert_eq!(
+            parsed.get("theme_mode").and_then(|value| value.as_str()),
+            Some("light")
+        );
+        assert_eq!(
+            parsed.get("theme").and_then(|value| value.as_str()),
+            Some("system")
+        );
+        assert_eq!(
+            parsed.get("other").and_then(|value| value.as_bool()),
+            Some(true)
+        );
+
+        upsert_opencode_theme_mode(&path, "dark").expect("lock dark mode");
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("read kv"))
+                .expect("parse kv");
+        assert_eq!(
+            parsed
+                .get("theme_mode_lock")
+                .and_then(|value| value.as_str()),
+            Some("dark")
+        );
+        assert_eq!(
+            parsed.get("theme_mode").and_then(|value| value.as_str()),
+            Some("dark")
         );
     }
 }

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect } from "react";
 import type { AgentTeam, Watchlist } from "../layout/watchlist/types";
 import { getListsContainingAgent, getListsNotContainingAgent } from "../layout/watchlist/watchlistUtils";
 
+type MaybePromise = void | Promise<void>;
+
 export interface AgentContextMenuProps {
   x: number;
   y: number;
@@ -12,19 +14,20 @@ export interface AgentContextMenuProps {
   teamId?: string;
   offAgentIds: Set<string>;
   watchlists: Watchlist[];
-  onInitiateRename: (agentId: string) => void;
-  onInitiateTeamRename?: (teamId: string) => void;
-  onQuery: (agentId: string) => void;
-  onPause: (agentId: string) => void;
-  onRestart: (agentId: string) => void;
-  onClear: (agentId: string) => void;
-  onAddToList: (listId: string, agentId: string) => void;
-  onRemoveFromList: (listId: string, agentId: string) => void;
-  onAddAgentsToList?: (listId: string, agentIds: string[]) => void;
-  onRemoveAgentsFromList?: (listId: string, agentIds: string[]) => void;
-  onDelete: (agentId: string) => void;
-  onCreateTeam?: (agentIds: string[]) => void;
-  onUngroupTeam?: (teamId: string) => void;
+  onInitiateRename: (agentId: string) => MaybePromise;
+  onInitiateTeamRename?: (teamId: string) => MaybePromise;
+  onQuery: (agentId: string) => MaybePromise;
+  onPause: (agentId: string) => MaybePromise;
+  onRestart: (agentId: string) => MaybePromise;
+  onClear: (agentId: string) => MaybePromise;
+  onAddToList: (listId: string, agentId: string) => MaybePromise;
+  onRemoveFromList: (listId: string, agentId: string) => MaybePromise;
+  onAddAgentsToList?: (listId: string, agentIds: string[]) => MaybePromise;
+  onRemoveAgentsFromList?: (listId: string, agentIds: string[]) => MaybePromise;
+  onDelete: (agentId: string) => MaybePromise;
+  onDeleteAgents?: (agentIds: string[]) => MaybePromise;
+  onCreateTeam?: (agentIds: string[]) => MaybePromise;
+  onUngroupTeam?: (teamId: string) => MaybePromise;
   onClose: () => void;
 }
 
@@ -49,6 +52,7 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   onAddAgentsToList,
   onRemoveAgentsFromList,
   onDelete,
+  onDeleteAgents,
   onCreateTeam,
   onUngroupTeam,
   onClose,
@@ -62,8 +66,10 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   const anyTargetOff = targetAgentIds.some((id) => offAgentIds.has(id));
   const anyTargetRunning = targetAgentIds.some((id) => !offAgentIds.has(id));
 
-  const forEachTarget = (handler: (id: string) => void) => {
-    for (const id of targetAgentIds) handler(id);
+  const forEachTarget = async (handler: (id: string) => MaybePromise) => {
+    for (const id of targetAgentIds) {
+      await handler(id);
+    }
   };
 
   useEffect(() => {
@@ -88,14 +94,14 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       <button
         className={`context-menu-item ${isBulk && !isTeam ? 'opacity-50 cursor-not-allowed' : ''}`}
         disabled={isBulk && !isTeam}
-        onClick={() => {
+        onClick={async () => {
           if (isTeam && teamId) {
-            onInitiateTeamRename?.(teamId);
+            await onInitiateTeamRename?.(teamId);
             onClose();
             return;
           }
           if (isBulk) return;
-          onInitiateRename(agentId);
+          await onInitiateRename(agentId);
           onClose();
         }}
       >
@@ -104,8 +110,8 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       </button>
       <button
         className="context-menu-item"
-        onClick={() => {
-          forEachTarget(onQuery);
+        onClick={async () => {
+          await forEachTarget(onQuery);
           onClose();
         }}
       >
@@ -118,8 +124,8 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       {!isTeam && onCreateTeam && (
         <button
           className="context-menu-item"
-          onClick={() => {
-            onCreateTeam(targetAgentIds);
+          onClick={async () => {
+            await onCreateTeam(targetAgentIds);
             onClose();
           }}
         >
@@ -134,9 +140,11 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
         data-testid="context-pause"
         className={`context-menu-item ${!anyTargetRunning ? 'opacity-50 cursor-not-allowed' : ''}`}
         disabled={!anyTargetRunning}
-        onClick={() => {
+        onClick={async () => {
           if (!anyTargetRunning) return;
-          forEachTarget((id) => { if (!offAgentIds.has(id)) onPause(id); });
+          await forEachTarget((id) => {
+            if (!offAgentIds.has(id)) return onPause(id);
+          });
           onClose();
         }}
       >
@@ -146,8 +154,8 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       <button
         data-testid="context-start"
         className="context-menu-item"
-        onClick={() => {
-          forEachTarget(onRestart);
+        onClick={async () => {
+          await forEachTarget(onRestart);
           onClose();
         }}
       >
@@ -169,8 +177,8 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       <button
         data-testid="context-clear"
         className="context-menu-item"
-        onClick={() => {
-          forEachTarget(onClear);
+        onClick={async () => {
+          await forEachTarget(onClear);
           onClose();
         }}
       >
@@ -198,9 +206,9 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
                 <button
                   key={l.id}
                   className="context-menu-item"
-                  onClick={() => {
-                    if (onAddAgentsToList) onAddAgentsToList(l.id, targetAgentIds);
-                    else forEachTarget((id) => onAddToList(l.id, id));
+                  onClick={async () => {
+                    if (onAddAgentsToList) await onAddAgentsToList(l.id, targetAgentIds);
+                    else await forEachTarget((id) => onAddToList(l.id, id));
                     onClose();
                   }}
                 >
@@ -230,9 +238,9 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
                 <button
                   key={l.id}
                   className="context-menu-item"
-                  onClick={() => {
-                    if (onRemoveAgentsFromList) onRemoveAgentsFromList(l.id, targetAgentIds);
-                    else forEachTarget((id) => onRemoveFromList(l.id, id));
+                  onClick={async () => {
+                    if (onRemoveAgentsFromList) await onRemoveAgentsFromList(l.id, targetAgentIds);
+                    else await forEachTarget((id) => onRemoveFromList(l.id, id));
                     onClose();
                   }}
                 >
@@ -249,8 +257,8 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
       {isTeam && teamId && onUngroupTeam && (
         <button
           className="context-menu-item"
-          onClick={() => {
-            onUngroupTeam(teamId);
+          onClick={async () => {
+            await onUngroupTeam(teamId);
             onClose();
           }}
         >
@@ -262,8 +270,9 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
 
       <button
         className="context-menu-item text-wardian-error hover:!bg-wardian-error/20"
-        onClick={() => {
-          forEachTarget(onDelete);
+        onClick={async () => {
+          if (isBulk && onDeleteAgents) await onDeleteAgents(targetAgentIds);
+          else await forEachTarget(onDelete);
           onClose();
         }}
       >

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -167,7 +167,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
           </div>
           <div className="mt-3 px-1">
             <p className="text-[10px] text-muted-neutral leading-relaxed">
-              <span className="text-[var(--color-wardian-accent)] font-bold">NOTE:</span> Gemini agents may require a manual theme change and restart.
+              <span className="text-[var(--color-wardian-accent)] font-bold">NOTE:</span> Gemini and OpenCode agents may require a manual theme change and restart.
             </p>
           </div>
         </div>

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -534,6 +534,44 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
+  it("answers OpenCode light-dark probes from the Wardian terminal theme", async () => {
+    const matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: matchMedia,
+    });
+
+    let readCount = 0;
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      switch (cmd) {
+        case "read_agent_pty":
+          readCount += 1;
+          return readCount === 1 ? "\u001b[?996n" : null;
+        case "resize_agent_terminal":
+          return null;
+        default:
+          return null;
+      }
+    });
+
+    render(<AgentTerminal sessionId="opencode-light" provider="opencode" theme="light" />);
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
+        sessionId: "opencode-light",
+        input: "\u001b[?997;2n",
+      });
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "opencode-light",
+      input: "\u001b[?997;1n",
+    });
+  });
+
   it("strips OpenCode synchronized-output toggles before writing to xterm", async () => {
     let readCount = 0;
     mockInvoke.mockImplementation(async (cmd: string) => {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -170,11 +170,8 @@ function queueOpenCodeCapabilityResponses(sessionId: string, data: string, entry
   }
   const { row, col } = terminalCursorPositionReply(entry);
   const { width, height } = terminalPixelSizeReply(entry);
-  const prefersLight =
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-color-scheme: light)").matches;
   const termTheme = entry.currentTheme ?? DARK_TERM_THEME;
+  const prefersLight = termTheme === LIGHT_TERM_THEME;
   const background = String(termTheme.background ?? DARK_TERM_THEME.background).replace("#", "");
   const foreground = String(termTheme.foreground ?? DARK_TERM_THEME.foreground).replace("#", "");
   const backgroundRgb =
@@ -781,12 +778,12 @@ export const AgentTerminal = memo(function AgentTerminal({
       const background = toRgbTriplet(termTheme.background, "02/04/02");
       const foreground = toRgbTriplet(termTheme.foreground, "ee/f2/ee");
       const prefersLight = termTheme === LIGHT_TERM_THEME;
-      // Push unsolicited OSC updates so OpenCode repaints against the new
-      // Wardian theme without needing to re-query.
+      // OpenTUI treats ?997 as a request to infer mode from subsequent OSC
+      // color replies, so send it before the current Wardian colors.
+      queueAgentInput(sessionId, `[?997;${prefersLight ? 2 : 1}n`);
       queueAgentInput(sessionId, `]11;rgb:${background}\\`);
       queueAgentInput(sessionId, `]10;rgb:${foreground}\\`);
       queueAgentInput(sessionId, `]4;0;rgb:${background}\\`);
-      queueAgentInput(sessionId, `[?997;${prefersLight ? 2 : 1}n`);
     }
   }, [sessionId, termTheme]);
 

--- a/src/features/terminal/terminalCapabilities.test.ts
+++ b/src/features/terminal/terminalCapabilities.test.ts
@@ -48,6 +48,10 @@ describe("terminal capability broker", () => {
     expect(plan.focusReported).toBe(true);
   });
 
+  it("strips OpenTUI theme notification enablement from rendered output", () => {
+    expect(normalizeOpenCodeOutput("\u001b[?2031hready\u001b[?2031l", "opencode")).toBe("ready");
+  });
+
   it("replies to palette and OSC 10/11 foreground/background queries", () => {
     const data = "\u001b]4;0;?\u0007\u001b]10;?\u0007\u001b]11;?\u001b\\";
     const plan = planTerminalCapabilityResponses("opencode", data, baseContext);

--- a/src/features/terminal/terminalCapabilities.ts
+++ b/src/features/terminal/terminalCapabilities.ts
@@ -11,6 +11,7 @@ const OSC_FOREGROUND_QUERY_ST = "\u001b]10;?\u001b\\";
 const OSC_BACKGROUND_QUERY_ST = "\u001b]11;?\u001b\\";
 const SUPPORTED_RESET_DECRQM_PARAMS = new Set([1004, 1016, 2004]);
 const UNSUPPORTED_RESET_DECRQM_PARAMS = new Set([2026, 2027, 2031]);
+const THEME_MODE_NOTIFICATION_TOGGLE = /\u001b\[\?2031[hl]/g;
 const FULLSCREEN_CLEAR_BY_NEWLINES =
   /\u001b\[\?25l(?:\u001b\[K\r?\n){8,}\u001b\[K\u001b\[H(\u001b\[\?25h)?/g;
 const HOME_CURSOR = "\u001b[H";
@@ -179,7 +180,10 @@ export function normalizeOpenCodeOutput(
     return data;
   }
 
-  return data.replace(DECRQM_QUERY, "").replace(SYNC_OUTPUT_TOGGLE, "");
+  return data
+    .replace(DECRQM_QUERY, "")
+    .replace(SYNC_OUTPUT_TOGGLE, "")
+    .replace(THEME_MODE_NOTIFICATION_TOGGLE, "");
 }
 
 export function planTerminalCapabilityResponses(

--- a/src/layout/watchlist/AgentWatchlist.test.tsx
+++ b/src/layout/watchlist/AgentWatchlist.test.tsx
@@ -29,6 +29,7 @@ describe('AgentWatchlist', () => {
   const mockOnRestart = vi.fn();
   const mockOnClear = vi.fn();
   const mockOnDelete = vi.fn();
+  const mockOnDeleteAgents = vi.fn();
   const mockOnAddAgentsToList = vi.fn();
   const mockOnRemoveAgentsFromList = vi.fn();
   const mockOnCreateTeam = vi.fn();
@@ -71,6 +72,7 @@ describe('AgentWatchlist', () => {
     onRestart: mockOnRestart,
     onClear: mockOnClear,
     onDelete: mockOnDelete,
+    onDeleteAgents: mockOnDeleteAgents,
     onCreateTeam: mockOnCreateTeam,
     onUngroupTeam: mockOnUngroupTeam,
     onAddAgentToTeam: mockOnAddAgentToTeam,
@@ -179,8 +181,67 @@ describe('AgentWatchlist', () => {
 
     fireEvent.click(within(menu).getByRole('button', { name: 'Clear Selected' }));
 
-    expect(mockOnClear).toHaveBeenCalledWith('agent-1');
-    expect(mockOnClear).toHaveBeenCalledWith('agent-2');
+    await waitFor(() => {
+      expect(mockOnClear).toHaveBeenCalledWith('agent-1');
+      expect(mockOnClear).toHaveBeenCalledWith('agent-2');
+    });
+  });
+
+  it('applies bulk query, pause, restart, and delete actions to the full selection', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        selectedAgentIds={new Set(['agent-1', 'agent-2'])}
+        offAgentIds={new Set()}
+      />
+    );
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row')!;
+
+    fireEvent.contextMenu(agentRow);
+    fireEvent.click(screen.getByRole('button', { name: 'Query Selected' }));
+    await waitFor(() => {
+      expect(mockOnQuery).toHaveBeenCalledWith('agent-1');
+      expect(mockOnQuery).toHaveBeenCalledWith('agent-2');
+    });
+
+    fireEvent.contextMenu(agentRow);
+    fireEvent.click(screen.getByTestId('context-pause'));
+    await waitFor(() => {
+      expect(mockOnPause).toHaveBeenCalledWith('agent-1');
+      expect(mockOnPause).toHaveBeenCalledWith('agent-2');
+    });
+
+    fireEvent.contextMenu(agentRow);
+    fireEvent.click(screen.getByTestId('context-start'));
+    await waitFor(() => {
+      expect(mockOnRestart).toHaveBeenCalledWith('agent-1');
+      expect(mockOnRestart).toHaveBeenCalledWith('agent-2');
+    });
+
+    fireEvent.contextMenu(agentRow);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Selected' }));
+    await waitFor(() => {
+      expect(mockOnDeleteAgents).toHaveBeenCalledWith(['agent-1', 'agent-2']);
+    });
+  });
+
+  it('uses one bulk delete action for a multi-selection', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        selectedAgentIds={new Set(['agent-1', 'agent-2'])}
+      />
+    );
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row')!;
+
+    fireEvent.contextMenu(agentRow);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Selected' }));
+
+    await waitFor(() => {
+      expect(mockOnDeleteAgents).toHaveBeenCalledWith(['agent-1', 'agent-2']);
+    });
+    expect(mockOnDeleteAgents).toHaveBeenCalledTimes(1);
+    expect(mockOnDelete).not.toHaveBeenCalled();
   });
 
   it('offers team creation for a multi-selection', async () => {
@@ -241,8 +302,10 @@ describe('AgentWatchlist', () => {
     expect(within(menu).getByRole('button', { name: 'Rename Team' })).toBeInTheDocument();
     fireEvent.click(within(menu).getByRole('button', { name: 'Query Team' }));
 
-    expect(mockOnQuery).toHaveBeenCalledWith('agent-1');
-    expect(mockOnQuery).toHaveBeenCalledWith('agent-2');
+    await waitFor(() => {
+      expect(mockOnQuery).toHaveBeenCalledWith('agent-1');
+      expect(mockOnQuery).toHaveBeenCalledWith('agent-2');
+    });
   });
 
   it('renames a team from the team context menu', async () => {

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -79,6 +79,7 @@ interface AgentWatchlistProps {
   onAddAgentsToList?: (listId: string, agentIds: string[]) => void;
   onRemoveAgentsFromList?: (listId: string, agentIds: string[]) => void;
   onDelete: (agentId: string) => void;
+  onDeleteAgents?: (agentIds: string[]) => void;
   onCreateTeam?: (agentIds: string[]) => void;
   onUngroupTeam?: (teamId: string) => void;
   onRenameTeam?: (teamId: string, newName: string) => Promise<void>;
@@ -117,6 +118,7 @@ export default function AgentWatchlist({
   onAddAgentsToList,
   onRemoveAgentsFromList,
   onDelete,
+  onDeleteAgents,
   onCreateTeam,
   onUngroupTeam,
   onRenameTeam,
@@ -1021,6 +1023,7 @@ export default function AgentWatchlist({
             setContextMenu(p => ({ ...p, visible: false }));
           } : undefined}
           onDelete={onDelete}
+          onDeleteAgents={onDeleteAgents}
           onCreateTeam={onCreateTeam}
           onClose={() => setContextMenu(p => ({ ...p, visible: false }))}
         />
@@ -1067,6 +1070,7 @@ export default function AgentWatchlist({
               setTeamContextMenu((p) => ({ ...p, visible: false }));
             } : undefined}
             onDelete={onDelete}
+            onDeleteAgents={onDeleteAgents}
             onUngroupTeam={(id) => {
               onUngroupTeam?.(id);
               setTeamContextMenu((p) => ({ ...p, visible: false }));

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -162,6 +162,16 @@ describe("Agent List Management", () => {
       expect(mockInvoke).toHaveBeenCalledWith("get_library_tree", { libraryType: "skills" });
     });
   });
+
+  it("syncs provider theme settings with the effective Wardian theme", async () => {
+    setupDefaultMocks([], defaultClasses);
+    render(<App />);
+    await screen.findByText("No Active Instances");
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("sync_provider_theme_settings", { theme: "dark" });
+    });
+  });
 });
 
 // ── Agent Class Dropdown Tests ─────────────────────────────────────────

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -301,8 +301,8 @@ function AppBody() {
       let effectiveTheme = theme;
       if (theme === "system") effectiveTheme = mediaQuery.matches ? "light" : "dark";
       document.documentElement.setAttribute("data-theme", effectiveTheme);
-      invoke("save_opencode_theme", { theme }).catch((error) => {
-        console.error("Failed to sync OpenCode theme:", error);
+      invoke("sync_provider_theme_settings", { theme: effectiveTheme }).catch((error) => {
+        console.error("Failed to sync provider theme settings:", error);
       });
     };
     applyTheme();

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -621,6 +621,41 @@ function AppBody() {
     }
   };
 
+  const onDeleteAgents = async (ids: string[]) => {
+    if (ids.length === 0) return;
+
+    const message = ids.length === 1
+      ? 'Delete this agent?'
+      : `Delete ${ids.length} selected agents?`;
+
+    if (!(await confirm(message))) return;
+
+    const deletedIds = new Set<string>();
+
+    for (const id of ids) {
+      try {
+        await invoke('kill_agent', { sessionId: id });
+        deletedIds.add(id);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+
+    if (deletedIds.size === 0) return;
+
+    setOffAgentIds(prev => {
+      const next = new Set(prev);
+      for (const id of deletedIds) next.delete(id);
+      return next;
+    });
+    setSelectedAgentIds(prev => {
+      const next = new Set(prev);
+      for (const id of deletedIds) next.delete(id);
+      return next;
+    });
+    fetchAgents();
+  };
+
   return (
     <div data-testid="app-shell" className="flex flex-col h-screen w-full bg-[var(--color-wardian-bg)] text-[var(--color-wardian-text)] overflow-hidden font-sans select-none">
       <CustomTitleBar
@@ -758,6 +793,7 @@ function AppBody() {
           onRestart={onRestart}
           onClear={onClear}
           onDelete={onDelete}
+          onDeleteAgents={onDeleteAgents}
           onAddToList={handleAddToList}
           onRemoveFromList={handleRemoveFromList}
           onAddAgentsToList={handleAddAgentsToList}


### PR DESCRIPTION
Fixes #135

## Summary
- sync OpenCode startup theme mode through provider theme settings and OpenCode KV state
- remove stale OpenCode config theme writes and document manual live theme limitations for Gemini/OpenCode
- derive OpenCode status, query count, and uptime from current provider logs so sessions do not stay stuck in Processing
- keep terminal capability handling aligned with OpenCode/OpenTUI light-dark probes without advertising unsupported live theme notification behavior

## Verification
- npm run lint
- npm run test
- npm run build
- cargo check -j 1
- cargo test -j 1
- cargo clippy -j 1 -- -D warnings

## Notes
- cargo fmt --check was not run repo-wide to completion because the existing backend tree reports formatting drift in unrelated modules. The touched Rust files were checked with rustfmt, but rustfmt follows module declarations and still reports unrelated formatting diffs.
- npm run test passes with existing React act(...) warnings in AgentWatchlist tests.
- Live OpenCode theme changes remain a manual provider-side operation for now; startup theme sync is the supported path in this change.
