### PR TITLE
Fix team drag positioning in main grid

### DIFF
--- a/src/config/viteConfig.test.ts
+++ b/src/config/viteConfig.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { viteDevServerHeaders } from "./viteDevServerHeaders";
+
+describe("vite dev server config", () => {
+  it("disables browser caching for dev modules", async () => {
+    expect(viteDevServerHeaders).toMatchObject({
+      "Cache-Control": "no-store",
+    });
+  });
+});

--- a/src/config/viteDevServerHeaders.ts
+++ b/src/config/viteDevServerHeaders.ts
@@ -1,0 +1,3 @@
+export const viteDevServerHeaders = {
+  "Cache-Control": "no-store",
+};

--- a/src/layout/watchlist/AgentWatchlist.test.tsx
+++ b/src/layout/watchlist/AgentWatchlist.test.tsx
@@ -460,6 +460,29 @@ describe('AgentWatchlist', () => {
     expect(mockOnAddAgentToTeam).toHaveBeenCalledWith('team-2', 'agent-1');
   });
 
+  it('moves a dragged team member next to the target team in All Agents', async () => {
+    const agents: AgentConfig[] = [
+      ...sampleAgents,
+      { session_id: 'agent-3', session_name: 'Gamma', agent_class: 'QA', folder: 'C:/test', is_off: false },
+    ];
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={agents}
+        teams={[
+          { id: 'team-1', name: 'Core Dev Swarm', agentIds: ['agent-1', 'agent-2'] },
+          { id: 'team-2', name: 'Support Swarm', agentIds: ['agent-3'] },
+        ]}
+      />
+    );
+
+    fireEvent.mouseDown(within(screen.getByTestId('team-block-team-1')).getByText('Alpha').closest('.watchlist-row')!);
+    fireEvent.mouseUp(screen.getByTestId('team-header-team-2'));
+
+    expect(mockOnAddAgentToTeam).toHaveBeenCalledWith('team-2', 'agent-1');
+    expect(mockOnReorderAgents).toHaveBeenCalledWith(['agent-2', 'agent-3', 'agent-1']);
+  });
+
   it('reorders team members within the team', async () => {
     render(
       <AgentWatchlist

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -393,6 +393,17 @@ export default function AgentWatchlist({
     onReorderAgents(newOrder);
   };
 
+  const insertAgentInsideTeam = (draggedAgentId: string, teamId: string) => {
+    const team = teams.find((candidate) => candidate.id === teamId);
+    if (!team) return;
+    const newOrder = agents.map((agent) => agent.session_id).filter((id) => id !== draggedAgentId);
+    const indexes = team.agentIds.map((id) => newOrder.indexOf(id)).filter((index) => index !== -1);
+    if (indexes.length === 0) return;
+    newOrder.splice(Math.max(...indexes) + 1, 0, draggedAgentId);
+    if (newOrder.every((id, index) => id === agents[index]?.session_id)) return;
+    onReorderAgents(newOrder);
+  };
+
   const updateActiveEntries = async (nextEntries: ReturnType<typeof getWatchlistEntries>) => {
     if (!activeList) return;
     await persistWatchlists(watchlists.map((list) =>
@@ -473,6 +484,7 @@ export default function AgentWatchlist({
       const sourceTeam = targetTeamForAgent(draggedAgentId);
       if (target.type === "team" && target.position === "inside") {
         if (!sourceTeam || sourceTeam.id !== target.teamId) {
+          if (activeListId === "all") insertAgentInsideTeam(draggedAgentId, target.teamId);
           onAddAgentToTeam?.(target.teamId, draggedAgentId);
           wasDragging.current = true;
         }

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent, within } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import App from "./App";
 import type { AgentConfig, AgentClassDefinition } from "../types";
@@ -351,6 +351,36 @@ describe("Agent Watchlist Sidebar", () => {
       expect(screen.getAllByText("Beta").length).toBeGreaterThanOrEqual(2);
     });
   });
+
+  it("replaces the maximized grid agent when double-clicking another watchlist row", async () => {
+    setupDefaultMocks(sampleAgents, defaultClasses);
+    render(<App />);
+
+    const alphaTerminal = await screen.findByTestId("terminal-agent-1");
+    const alphaCard = alphaTerminal.closest('[data-testid="agent-card"]');
+    expect(alphaCard).not.toBeNull();
+
+    fireEvent.click(within(alphaCard as HTMLElement).getAllByRole("button")[0]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-agent-1")).toBeInTheDocument();
+      expect(screen.queryByTestId("terminal-agent-2")).not.toBeInTheDocument();
+    });
+
+    const betaWatchlistRow = screen
+      .getAllByText("Beta")
+      .map((node) => node.closest("div.watchlist-row"))
+      .find((row): row is HTMLElement => Boolean(row));
+    if (!betaWatchlistRow) throw new Error("Beta watchlist row not found");
+
+    fireEvent.click(betaWatchlistRow);
+    fireEvent.click(betaWatchlistRow);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("terminal-agent-1")).not.toBeInTheDocument();
+      expect(screen.getByTestId("terminal-agent-2")).toBeInTheDocument();
+    });
+  });
 });
 
 // ── View Mode Toggle Tests ─────────────────────────────────────────────
@@ -442,8 +472,6 @@ describe("Sidebar Navigation", () => {
 });
 
 // ── Agent Off State Tests ──────────────────────────────────────────────
-
-import { fireEvent } from "@testing-library/react";
 
 describe("Agent Off State Operations", () => {
   it("removes an agent from the main grid when paused and requires Start from context menu", async () => {

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -418,6 +418,10 @@ function AppBody() {
   }, [draggedAgentId]);
 
   const scrollToAgent = (agentId: string) => {
+    if (viewMode === "grid" && maximizedAgentId) {
+      setMaximizedAgentId(agentId);
+      return;
+    }
     const el = document.getElementById(`agent-card-${agentId}`);
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { viteDevServerHeaders } from "./src/config/viteDevServerHeaders";
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
@@ -38,6 +39,7 @@ export default defineConfig(async () => ({
     port: 1420,
     strictPort: true,
     host: host || false,
+    headers: viteDevServerHeaders,
     fs: {
       allow: [workspaceRoot, realWorkspaceRoot],
     },


### PR DESCRIPTION
## Description
Fixes watchlist/grid synchronization issues around team and maximized-agent interactions, and hardens dev startup against stale Vite/WebView module cache reuse.

- Moving an agent into another team now also moves it next to that team in the main All Agents grid order.
- Double-clicking a watchlist row while Grid view has an agent maximized now replaces the maximized card with the clicked agent.
- Vite dev responses now send `Cache-Control: no-store` so WebView does not reuse stale optimized React module graphs across dev restarts.

## Related Issues
Fixes #141

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test -- src/layout/watchlist/AgentWatchlist.test.tsx`
- `npm run test -- src/layout/watchlist/AgentWatchlist.test.tsx src/views/App.test.tsx`
- `npm run test -- src/config/viteConfig.test.ts`
- `npm run test`
- `npm run build`
- Bounded Vite request to `/src/main.tsx` returned `Cache-Control=no-store`

## Screenshots
Not applicable: this changes interaction state/order behavior and dev-server cache headers without changing visual styling.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable