### PR TITLE
fix(runtime): supervise Windows agent process trees

### DIFF
--- a/docs/developer/pty-lifecycle.md
+++ b/docs/developer/pty-lifecycle.md
@@ -13,12 +13,17 @@ Wardian utilizes the `portable-pty` crate to provide a consistent PTY interface 
 - **Slave**: The application end, where the selected runtime shell hosts the provider command.
 
 ## 🛡️ Process Integrity (Windows Job Objects)
-To prevent "zombie" processes when Wardian crashes or is force-closed, the Windows implementation uses **Job Objects** via the `win32job` crate.
+To prevent orphaned provider and console-host processes when Wardian crashes or is force-closed, the Windows implementation uses **Job Objects** via the `win32job` crate.
 
-1. On startup, Wardian creates a `win32job::Job`.
+1. On startup, Wardian creates an app-lifetime `win32job::Job`.
 2. The `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` flag is enabled.
-3. Every agent spawned is "assigned" to this job object.
-4. When the Wardian process terminates, the job object is closed by the OS, which automatically kills all processes assigned to it.
+3. Wardian assigns the backend process to that job before restoring or spawning interactive agents.
+4. Provider shells, CLIs, ConPTY console hosts, and descendants inherit the job from process creation time.
+5. When the Wardian process terminates, the job object is closed by the OS, which automatically kills all processes assigned to it.
+
+Per-agent process-tree termination is still used for normal UI actions such as kill, pause, resume, and clear. Per-agent Job Objects are only a fallback if app-level supervision cannot be installed, because post-spawn assignment is inherently less reliable than inheriting the app-level job at creation time.
+
+At startup, Wardian also sweeps stale persisted interactive sessions before restoring agents. This catches process trees from older builds or from environments where Windows refused app-level job assignment. The sweep uses Wardian session command-line markers and `WARDIAN_SESSION_ID` environment markers, and skips agents that are off or database-marked as headless.
 
 ## 🔁 Spawning Lifecycle
 Spawning an agent follows a deterministic sequence in `manager::spawn_agent`:

--- a/docs/specs/026-windows-process-supervision.md
+++ b/docs/specs/026-windows-process-supervision.md
@@ -1,0 +1,26 @@
+# 026 Windows Process Supervision
+
+## Status
+
+Accepted
+
+## Context
+
+Wardian launches long-lived interactive provider sessions through `portable-pty` on Windows. Earlier cleanup relied on explicit UI actions, `ActiveAgent::drop`, startup process scans, and per-agent Job Objects assigned after `spawn_command` returned a PID.
+
+That post-spawn assignment leaves a failure window. If Wardian crashes before the assignment completes, if assignment fails, or if the provider has already created console host descendants, Windows can leave provider or console-host processes running outside Wardian's ownership.
+
+## Decision
+
+Wardian initializes an app-lifetime Windows Job Object during startup and assigns the Wardian backend process to it before restoring or spawning agent sessions. The job uses `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, so provider processes inherit crash cleanup from process creation time. The static job handle is intentionally kept for the process lifetime and is closed by the OS when Wardian exits.
+
+Per-agent process-tree termination remains the normal cleanup path for kill, pause, resume, and clear actions. Per-agent Job Objects are now a fallback only when app-level supervision could not be installed.
+
+Startup also sweeps stale persisted interactive sessions before restore. The sweep skips off agents and database-marked headless runs, then kills process trees discovered through Wardian session command-line markers or `WARDIAN_SESSION_ID` environment markers.
+
+## Consequences
+
+- Crashes and force-closes clean up newly spawned interactive provider trees more reliably.
+- Normal UI termination remains fast and explicit.
+- If Windows refuses to assign Wardian to an app-level job, Wardian logs the failure and falls back to per-agent job assignment plus startup stale-process cleanup.
+- Native runtime E2E remains the required layer for proving real ConPTY and process-tree behavior.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,6 +70,11 @@ pub fn run() {
         eprintln!("Failed to initialize database: {}", e);
     }
 
+    #[cfg(windows)]
+    if let Err(e) = crate::utils::process::init_app_process_supervisor() {
+        eprintln!("Failed to initialize process supervisor: {}", e);
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
@@ -91,6 +96,9 @@ pub fn run() {
 
             tauri::async_runtime::spawn(async move {
                 let state = app_handle.state::<AppState>();
+                #[cfg(windows)]
+                manager::cleanup_stale_persisted_session_processes();
+
                 if let Err(e) = reconcile_headless_agents().await {
                     eprintln!("Failed to reconcile headless agents: {}", e);
                 }

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -25,7 +25,10 @@ pub use crate::utils::fs::*;
 pub use crate::utils::logging::{log_debug, log_terminal_trace_bytes, log_terminal_trace_note};
 pub use crate::utils::process::new_headless_command;
 #[cfg(windows)]
-pub use crate::utils::process::{find_wardian_session_process_roots, force_kill_process_tree};
+pub use crate::utils::process::{
+    app_process_supervisor_active, assign_pid_to_job, create_kill_on_close_job,
+    find_wardian_session_process_roots, force_kill_process_tree,
+};
 pub use crate::utils::shell::build_program_launch;
 
 use crate::models::{AgentConfig, AgentEvent};
@@ -50,6 +53,39 @@ pub(crate) fn cleanup_stale_session_processes(session_id: &str, provider: &str) 
                 session_id, pid, err
             ));
         }
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn cleanup_stale_persisted_session_processes() {
+    let Some(app_dir) = get_wardian_home() else {
+        return;
+    };
+    let state_path = app_dir.join("settings/state.json");
+    let Ok(data) = std::fs::read_to_string(state_path) else {
+        return;
+    };
+    let Ok(configs) = serde_json::from_str::<Vec<AgentConfig>>(&data) else {
+        return;
+    };
+
+    let db_status_map = crate::utils::db::get_all_agents()
+        .unwrap_or_default()
+        .into_iter()
+        .map(|agent| (agent.session_id, agent.last_status))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    for config in configs {
+        if config.is_off
+            || db_status_map
+                .get(&config.session_id)
+                .and_then(|status| status.as_deref())
+                == Some("Headless")
+        {
+            continue;
+        }
+
+        cleanup_stale_session_processes(&config.session_id, &config.provider);
     }
 }
 

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -8,18 +8,23 @@ use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::io::{BufRead, Read, Seek, Write};
 use tauri::{AppHandle, Emitter};
 
-use super::codex::{codex_provider_session_is_excluded, codex_log_lookup_session_id, codex_session_file_path, latest_codex_session_index_entry};
 use super::claude::{claude_permission_hook_matches_session, claude_project_dir_name};
+use super::codex::{
+    codex_log_lookup_session_id, codex_provider_session_is_excluded, codex_session_file_path,
+    latest_codex_session_index_entry,
+};
 use super::opencode::{opencode_interactive_env, opencode_status_from_title};
 use super::{
-    apply_agent_event, apply_agent_status_event, apply_terminal_identity_env,
-    debug_preview_bytes, extract_terminal_titles,
-    finalize_interactive_spawn_args, interactive_provider_args, interactive_provider_cwd,
-    interactive_provider_launch, set_agent_status,
+    apply_agent_event, apply_agent_status_event, apply_terminal_identity_env, debug_preview_bytes,
+    extract_terminal_titles, finalize_interactive_spawn_args, interactive_provider_args,
+    interactive_provider_cwd, interactive_provider_launch, set_agent_status,
 };
 
 #[cfg(windows)]
-use super::cleanup_stale_session_processes;
+use super::{
+    app_process_supervisor_active, assign_pid_to_job, cleanup_stale_session_processes,
+    create_kill_on_close_job,
+};
 #[cfg(windows)]
 pub async fn spawn_agent(
     app: AppHandle,
@@ -179,19 +184,15 @@ pub async fn spawn_agent(
 
     #[cfg(windows)]
     let job_object = {
-        if let Ok(job) = win32job::Job::create() {
-            let mut info = job.query_extended_limit_info().unwrap_or_default();
-            info.limit_kill_on_job_close();
-            let _ = job.set_extended_limit_info(&info);
+        if app_process_supervisor_active() {
+            None
+        } else if let Ok(job) = create_kill_on_close_job("agent fallback") {
             if let Some(pid) = process_id {
-                unsafe {
-                    use winapi::um::processthreadsapi::OpenProcess;
-                    use winapi::um::winnt::{PROCESS_SET_QUOTA, PROCESS_TERMINATE};
-                    let handle = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
-                    if !handle.is_null() {
-                        let _ = job.assign_process(handle as isize);
-                        winapi::um::handleapi::CloseHandle(handle);
-                    }
+                if let Err(err) = assign_pid_to_job(&job, pid, "agent fallback") {
+                    log_debug(&format!(
+                        "[Wardian] Failed to assign session {} PID {} to fallback job: {}",
+                        config.session_id, pid, err
+                    ));
                 }
             }
             Some(job)

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -1,3 +1,17 @@
+#[cfg(windows)]
+use std::sync::OnceLock;
+
+#[cfg(windows)]
+static APP_PROCESS_SUPERVISOR: OnceLock<AppProcessSupervisor> = OnceLock::new();
+#[cfg(windows)]
+static APP_PROCESS_SUPERVISOR_ERROR: OnceLock<String> = OnceLock::new();
+
+#[cfg(windows)]
+#[derive(Debug)]
+struct AppProcessSupervisor {
+    _job: win32job::Job,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeadlessCommandSpec {
     pub program: String,
@@ -27,8 +41,8 @@ pub fn headless_command_spec(program: &str) -> HeadlessCommandSpec {
 }
 
 pub fn new_headless_command(program: &str) -> tokio::process::Command {
-    use tokio::process::Command;
     use std::process::Stdio;
+    use tokio::process::Command;
 
     let spec = headless_command_spec(program);
     let mut cmd = Command::new(&spec.program);
@@ -69,6 +83,84 @@ pub fn new_headless_std_command(program: &str) -> std::process::Command {
     }
 
     cmd
+}
+
+#[cfg(windows)]
+pub fn init_app_process_supervisor() -> Result<(), String> {
+    if APP_PROCESS_SUPERVISOR.get().is_some() {
+        return Ok(());
+    }
+
+    if let Some(err) = APP_PROCESS_SUPERVISOR_ERROR.get() {
+        return Err(err.clone());
+    }
+
+    let supervisor = match create_app_process_supervisor() {
+        Ok(supervisor) => supervisor,
+        Err(err) => {
+            let _ = APP_PROCESS_SUPERVISOR_ERROR.set(err.clone());
+            return Err(err);
+        }
+    };
+
+    APP_PROCESS_SUPERVISOR
+        .set(supervisor)
+        .map_err(|_| "app process supervisor was initialized concurrently".to_string())
+}
+
+#[cfg(windows)]
+pub fn app_process_supervisor_active() -> bool {
+    APP_PROCESS_SUPERVISOR.get().is_some()
+}
+
+#[cfg(windows)]
+fn create_app_process_supervisor() -> Result<AppProcessSupervisor, String> {
+    let job = create_kill_on_close_job("app process supervisor")?;
+    job.assign_current_process().map_err(|err| {
+        format!(
+            "failed to assign Wardian process to supervisor job: {}",
+            err
+        )
+    })?;
+    Ok(AppProcessSupervisor { _job: job })
+}
+
+#[cfg(windows)]
+pub fn create_kill_on_close_job(context: &str) -> Result<win32job::Job, String> {
+    let job = win32job::Job::create()
+        .map_err(|err| format!("failed to create {} job object: {}", context, err))?;
+    let mut info = job
+        .query_extended_limit_info()
+        .map_err(|err| format!("failed to query {} job limits: {}", context, err))?;
+    info.limit_kill_on_job_close();
+    job.set_extended_limit_info(&info)
+        .map_err(|err| format!("failed to set {} kill-on-close limit: {}", context, err))?;
+    Ok(job)
+}
+
+#[cfg(windows)]
+pub fn assign_pid_to_job(job: &win32job::Job, pid: u32, context: &str) -> Result<(), String> {
+    unsafe {
+        use winapi::um::processthreadsapi::OpenProcess;
+        use winapi::um::winnt::{PROCESS_SET_QUOTA, PROCESS_TERMINATE};
+
+        let handle = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
+        if handle.is_null() {
+            return Err(format!(
+                "failed to open process {} for {} job assignment",
+                pid, context
+            ));
+        }
+
+        let assign_result = job.assign_process(handle as isize).map_err(|err| {
+            format!(
+                "failed to assign process {} to {} job: {}",
+                pid, context, err
+            )
+        });
+        winapi::um::handleapi::CloseHandle(handle);
+        assign_result
+    }
 }
 
 #[cfg(windows)]
@@ -118,6 +210,21 @@ pub fn is_wardian_session_process_candidate(
 }
 
 #[cfg(windows)]
+pub fn is_wardian_session_environment_candidate(environ: &[String], session_id: &str) -> bool {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return false;
+    }
+
+    environ.iter().any(|entry| {
+        entry.split_once('=').is_some_and(|(key, value)| {
+            key.eq_ignore_ascii_case("WARDIAN_SESSION_ID")
+                && value.trim().eq_ignore_ascii_case(session_id)
+        })
+    })
+}
+
+#[cfg(windows)]
 pub fn find_wardian_session_process_roots(session_id: &str, exclude_pid: Option<u32>) -> Vec<u32> {
     let mut sys = sysinfo::System::new_all();
     sys.refresh_all();
@@ -136,8 +243,15 @@ pub fn find_wardian_session_process_roots(session_id: &str, exclude_pid: Option<
             .map(|part| part.to_string_lossy())
             .collect::<Vec<_>>()
             .join(" ");
+        let environ = process
+            .environ()
+            .iter()
+            .map(|entry| entry.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
 
-        if is_wardian_session_process_candidate(&process_name, &command_line, session_id) {
+        if is_wardian_session_environment_candidate(&environ, session_id)
+            || is_wardian_session_process_candidate(&process_name, &command_line, session_id)
+        {
             matches.push(pid_u32);
         }
     }
@@ -237,6 +351,23 @@ mod tests {
         assert!(!super::is_wardian_session_process_candidate(
             "pwsh.exe",
             "pwsh.exe -NoLogo -Command \"Write-Host 019d331a-0500-7592-969f-8f437886f42b\"",
+            "019d331a-0500-7592-969f-8f437886f42b",
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn identifies_wardian_session_environment_markers() {
+        assert!(super::is_wardian_session_environment_candidate(
+            &[
+                "PATH=C:\\Windows\\System32".to_string(),
+                "WARDIAN_SESSION_ID=019d331a-0500-7592-969f-8f437886f42b".to_string(),
+            ],
+            "019d331a-0500-7592-969f-8f437886f42b",
+        ));
+
+        assert!(!super::is_wardian_session_environment_candidate(
+            &["WARDIAN_SESSION_ID=other-session".to_string()],
             "019d331a-0500-7592-969f-8f437886f42b",
         ));
     }


### PR DESCRIPTION
## Description
- Adds an app-lifetime Windows Job Object so interactive provider process trees inherit crash cleanup from Wardian at process creation time.
- Keeps per-agent process tree termination for normal kill/pause/resume/clear actions and uses per-agent Job Objects only as fallback.
- Adds startup sweeping for stale persisted interactive sessions using command-line and `WARDIAN_SESSION_ID` environment markers.
- Documents the process-supervision decision in `docs/specs/026-windows-process-supervision.md` and updates the PTY lifecycle guide.

## Related Issues
Fixes #145

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `cd src-tauri && cargo test -j 1` - 249 unit tests + 4 mock provider integration tests passed
- [x] `cd src-tauri && cargo clippy -j 1`
- [x] `npm run lint`
- [x] `npm run test` - 28 files / 336 tests passed; existing `AgentWatchlist` React `act(...)` warnings still appear
- [x] `npm run build` - production frontend build passed; existing chunk-size warning still appears
- [x] `npm run test:e2e:native` - 9 passed, 1 real OpenCode test skipped by env flag

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable