### PR TITLE
ci: move backend coverage from Windows to Linux to unblock PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   backend-windows:
-    name: Backend (Windows - Full Test)
+    name: Backend (Windows - Lint & Test)
     runs-on: windows-latest
     if: github.event_name == 'pull_request'
     steps:
@@ -67,25 +67,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
       - name: Clippy
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
-      - name: Test with Coverage
+      - name: Test
         working-directory: src-tauri
-        run: |
-          mkdir -p ../coverage
-          cargo llvm-cov --lcov --output-path ../coverage/rust-lcov.info
-      - name: Upload Backend Coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage/rust-lcov.info
-          flags: backend
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+        run: cargo test
 
   e2e-smoke:
     name: E2E Smoke Tests (Windows)
@@ -119,8 +106,8 @@ jobs:
           name: e2e-results
           path: e2e/test-results/
 
-  backend-linux-check:
-    name: Backend (Linux - Compile Check)
+  backend-linux-coverage:
+    name: Backend (Linux - Test & Coverage)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
@@ -137,10 +124,25 @@ jobs:
           echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-      - name: Check Compilation
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Test with Coverage
         working-directory: src-tauri
-        run: cargo check
+        run: |
+          mkdir -p ../coverage
+          cargo llvm-cov --lcov --output-path ../coverage/rust-lcov.info
+      - name: Upload Backend Coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/rust-lcov.info
+          flags: backend
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

The Windows backend job currently runs **both** \`cargo clippy\` and \`cargo llvm-cov\`. Because clippy and llvm-cov use different rustflags, the tree gets fully recompiled twice in the same job — once for lints, once with profiling instrumentation. On \`windows-latest\` that's ~10-12 min just on the second compile (see e.g. PR #146 sitting at 13 min). The rust-cache action can't help between steps, only between runs.

This PR splits the work across runners:

| Job | Now | After |
|---|---|---|
| Backend (Windows) | clippy + \`cargo llvm-cov\` (~12 min) | clippy + \`cargo test\` (~3-4 min) |
| Backend (Linux)   | \`cargo check\` only           | \`cargo llvm-cov\` + Codecov upload (~4-5 min) |

Both jobs gate the PR; the Codecov flag name stays \`backend\`, so dashboards and the README badge keep working.

## Tradeoff

\`#[cfg(windows)]\` code paths still get **correctness-tested** by the Windows \`cargo test\` step, but they are no longer **instrumented for coverage**. Net effect: the Codecov backend metric will undercount Windows-only logic (job supervisor, junctions, shell escaping, some provider quirks — about 82 cfg sites across 16 files).

Accepted as a known gap. If the metric quality starts mattering, the path forward is a nightly Windows coverage cron uploading under a separate Codecov flag, leaving PR feedback fast.

## Test plan

- [ ] CI on this PR completes green
- [ ] Backend (Windows) finishes faster than the historical baseline
- [ ] Backend (Linux - Test & Coverage) appears as a new check
- [ ] Codecov receives a backend-flagged report from the Linux job