### PR TITLE
chore(release): patch-bump premajor features

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "packages": {


### PR DESCRIPTION
## Summary
- Configure release-please to patch-bump `feat:` commits while Wardian is pre-1.0.
- Keeps the next release on the `0.3.x` line, so the current release train can become `0.3.1` instead of `0.4.0`.

## Release Notes
- After this merges, close/recreate or let release-please refresh the existing `0.4.0` PR (#131) so it recalculates as `0.3.1`.

## Test Plan
- [x] `Get-Content -Raw release-please-config.json | ConvertFrom-Json`
