### PR TITLE
fix: normalize agent telemetry metrics

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,7 +90,9 @@ pub fn run() {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     let state = metrics_handle.state::<AppState>();
                     let metrics = manager::get_all_metrics(&state).await;
+                    let app_metrics = manager::get_app_metrics(&state).await;
                     let _ = metrics_handle.emit("agent-metrics", &metrics);
+                    let _ = metrics_handle.emit("app-metrics", &app_metrics);
                 }
             });
 

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -19,7 +19,7 @@ pub use headless::{
 pub use opencode::opencode_extract_created_session_id;
 pub use codex::latest_codex_session_index_entry;
 pub use spawn::{resize_pty, spawn_agent};
-pub use telemetry::get_all_metrics;
+pub use telemetry::{get_all_metrics, get_app_metrics};
 
 pub use crate::utils::fs::*;
 pub use crate::utils::logging::{log_debug, log_terminal_trace_bytes, log_terminal_trace_note};

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -1,17 +1,59 @@
-use crate::models::AgentTelemetry;
+use crate::models::{AgentTelemetry, AppTelemetry};
 use crate::state::AppState;
 use crate::utils::fs::get_wardian_home;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use super::claude::{claude_is_real_user_query, claude_project_dir_name, claude_status_from_log};
-use super::codex::{
-    codex_log_lookup_session_id, codex_session_file_path, codex_status_from_log,
-};
+use super::codex::{codex_log_lookup_session_id, codex_session_file_path, codex_status_from_log};
+use super::display_log_path;
 use super::opencode::{
     apply_opencode_log_metrics, opencode_log_dirs, opencode_log_path_in,
     opencode_session_diff_path, opencode_should_fallback_to_idle,
 };
-use super::display_log_path;
+
+fn normalize_cpu_usage(raw_cpu_usage: f32, logical_cpu_count: usize) -> f32 {
+    let divisor = logical_cpu_count.max(1) as f32;
+    (raw_cpu_usage / divisor).clamp(0.0, 100.0)
+}
+
+fn bytes_to_mib(bytes: u64) -> f64 {
+    bytes as f64 / 1_048_576.0
+}
+
+fn collect_descendant_pids(
+    pid: u32,
+    children_map: &HashMap<u32, Vec<u32>>,
+    related_pids: &mut BTreeSet<u32>,
+) {
+    if !related_pids.insert(pid) {
+        return;
+    }
+
+    if let Some(children) = children_map.get(&pid) {
+        for &child_pid in children {
+            collect_descendant_pids(child_pid, children_map, related_pids);
+        }
+    }
+}
+
+fn collect_related_pids(
+    primary_pid: Option<u32>,
+    discovered_roots: &[u32],
+    children_map: &HashMap<u32, Vec<u32>>,
+) -> BTreeSet<u32> {
+    let mut related_pids = BTreeSet::new();
+
+    if let Some(pid) = primary_pid {
+        collect_descendant_pids(pid, children_map, &mut related_pids);
+    }
+
+    for &pid in discovered_roots {
+        collect_descendant_pids(pid, children_map, &mut related_pids);
+    }
+
+    related_pids
+}
+
 pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
     struct AgentSnapshot {
         session_id: String,
@@ -55,11 +97,15 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
         let mut results = Vec::new();
         let mut sys = sys_metrics.blocking_lock();
         sys.refresh_all();
+        let logical_cpu_count = sys.cpus().len();
 
-        let mut children_map: HashMap<sysinfo::Pid, Vec<sysinfo::Pid>> = HashMap::new();
+        let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
         for (pid, process) in sys.processes() {
             if let Some(parent) = process.parent() {
-                children_map.entry(parent).or_default().push(*pid);
+                children_map
+                    .entry(parent.as_u32())
+                    .or_default()
+                    .push(pid.as_u32());
             }
         }
 
@@ -67,36 +113,30 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
             let mut cpu = 0.0;
             let mut mem = 0.0;
             let mut uptime = 0;
+            let mut related_process_ids = BTreeSet::new();
 
             if let Some(pid) = snap.process_id {
-                let root_pid = sysinfo::Pid::from_u32(pid);
-                fn sum_tree(
-                    pid: sysinfo::Pid,
-                    sys: &sysinfo::System,
-                    cmap: &HashMap<sysinfo::Pid, Vec<sysinfo::Pid>>,
-                    cpu: &mut f32,
-                    mem: &mut f64,
-                    uptime: &mut u64,
-                ) {
-                    if let Some(p) = sys.process(pid) {
-                        *cpu += p.cpu_usage();
-                        *mem += p.memory() as f64 / 1_048_576.0;
-                        *uptime = std::cmp::max(*uptime, p.run_time());
-                    }
-                    if let Some(children) = cmap.get(&pid) {
-                        for &cpid in children {
-                            sum_tree(cpid, sys, cmap, cpu, mem, uptime);
-                        }
+                #[cfg(windows)]
+                let discovered_roots = crate::utils::process::find_wardian_session_process_roots(
+                    &snap.session_id,
+                    Some(pid),
+                );
+                #[cfg(not(windows))]
+                let discovered_roots = Vec::new();
+
+                related_process_ids =
+                    collect_related_pids(Some(pid), &discovered_roots, &children_map);
+                let mut raw_cpu = 0.0;
+                let mut memory_bytes = 0_u64;
+                for pid in &related_process_ids {
+                    if let Some(process) = sys.process(sysinfo::Pid::from_u32(*pid)) {
+                        raw_cpu += process.cpu_usage();
+                        memory_bytes = memory_bytes.saturating_add(process.memory());
+                        uptime = std::cmp::max(uptime, process.run_time());
                     }
                 }
-                sum_tree(
-                    root_pid,
-                    &sys,
-                    &children_map,
-                    &mut cpu,
-                    &mut mem,
-                    &mut uptime,
-                );
+                cpu = normalize_cpu_usage(raw_cpu, logical_cpu_count);
+                mem = bytes_to_mib(memory_bytes);
 
                 // Phase 3: Uptime Alignment
                 // If we have a 'Born' date, calculate total lifetime uptime while active.
@@ -117,10 +157,9 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
             }
 
             // Detect whether the agent process is still alive
-            let process_alive = snap
-                .process_id
-                .map(|pid| sys.process(sysinfo::Pid::from_u32(pid)).is_some())
-                .unwrap_or(false);
+            let process_alive = related_process_ids
+                .iter()
+                .any(|pid| sys.process(sysinfo::Pid::from_u32(*pid)).is_some());
 
             let mut q_count = *snap.query_count.lock().unwrap();
             let mut i_ts = snap.init_timestamp.lock().unwrap().clone();
@@ -423,4 +462,78 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
     })
     .await
     .unwrap_or_default()
+}
+
+pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
+    let sys_metrics = state.system_metrics.clone();
+    tokio::task::spawn_blocking(move || {
+        // Reuse the snapshot refreshed by get_all_metrics in the telemetry loop.
+        // Refreshing again immediately would reset sysinfo's CPU deltas.
+        let sys = sys_metrics.blocking_lock();
+        let logical_cpu_count = sys.cpus().len();
+
+        let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
+        for (pid, process) in sys.processes() {
+            if let Some(parent) = process.parent() {
+                children_map
+                    .entry(parent.as_u32())
+                    .or_default()
+                    .push(pid.as_u32());
+            }
+        }
+
+        let related_process_ids =
+            collect_related_pids(Some(std::process::id()), &[], &children_map);
+        let mut raw_cpu = 0.0;
+        let mut memory_bytes = 0_u64;
+        for pid in &related_process_ids {
+            if let Some(process) = sys.process(sysinfo::Pid::from_u32(*pid)) {
+                raw_cpu += process.cpu_usage();
+                memory_bytes = memory_bytes.saturating_add(process.memory());
+            }
+        }
+
+        AppTelemetry {
+            cpu_usage: normalize_cpu_usage(raw_cpu, logical_cpu_count),
+            memory_mb: bytes_to_mib(memory_bytes),
+        }
+    })
+    .await
+    .unwrap_or(AppTelemetry {
+        cpu_usage: 0.0,
+        memory_mb: 0.0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeSet, HashMap};
+
+    #[test]
+    fn normalizes_process_tree_cpu_to_whole_machine_capacity() {
+        assert_eq!(super::normalize_cpu_usage(260.0, 4), 65.0);
+        assert_eq!(super::normalize_cpu_usage(800.0, 4), 100.0);
+        assert_eq!(super::normalize_cpu_usage(-5.0, 4), 0.0);
+    }
+
+    #[test]
+    fn treats_missing_cpu_count_as_single_cpu() {
+        assert_eq!(super::normalize_cpu_usage(260.0, 0), 100.0);
+    }
+
+    #[test]
+    fn converts_resident_bytes_to_mib() {
+        assert_eq!(super::bytes_to_mib(1_048_576), 1.0);
+        assert_eq!(super::bytes_to_mib(2_621_440), 2.5);
+    }
+
+    #[test]
+    fn collects_root_descendants_and_discovered_session_roots_without_duplicates() {
+        let children_map =
+            HashMap::from([(1, vec![2, 4]), (2, vec![3]), (4, vec![5]), (9, vec![10])]);
+
+        let related = super::collect_related_pids(Some(1), &[2, 9], &children_map);
+
+        assert_eq!(related, BTreeSet::from([1_u32, 2, 3, 4, 5, 9, 10]));
+    }
 }

--- a/src-tauri/src/models/app_telemetry.rs
+++ b/src-tauri/src/models/app_telemetry.rs
@@ -1,0 +1,23 @@
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct AppTelemetry {
+    pub cpu_usage: f32,
+    pub memory_mb: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_telemetry_serializes() {
+        let telemetry = AppTelemetry {
+            cpu_usage: 2.5,
+            memory_mb: 128.4,
+        };
+
+        let json = serde_json::to_string(&telemetry).unwrap();
+
+        assert!(json.contains("\"cpu_usage\":2.5"));
+        assert!(json.contains("\"memory_mb\":128.4"));
+    }
+}

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_config;
 pub mod agent_telemetry;
+pub mod app_telemetry;
 pub mod fs;
 pub mod git;
 pub mod library;
@@ -9,6 +10,7 @@ pub mod workflow;
 
 pub use agent_config::{AgentClassDefinition, AgentConfig};
 pub use agent_telemetry::AgentTelemetry;
+pub use app_telemetry::AppTelemetry;
 pub use fs::*;
 pub use library::*;
 pub use provider::{AgentEvent, AgentProvider};

--- a/src/layout/titlebar/CustomTitleBar.tsx
+++ b/src/layout/titlebar/CustomTitleBar.tsx
@@ -4,7 +4,7 @@ import { LeftSidebarControls } from "./LeftSidebarControls";
 import { WorkspaceTabs } from "./WorkspaceTabs";
 import type { ViewMode } from "./WorkspaceTabs";
 import { RightWindowControls } from "./RightWindowControls";
-import type { AgentTelemetry, AgentConfig } from "../../types";
+import type { AgentTelemetry, AgentConfig, AppTelemetry } from "../../types";
 
 export type { ViewMode };
 
@@ -19,6 +19,7 @@ interface CustomTitleBarProps {
   rightCollapsed: boolean;
   setRightCollapsed: (collapsed: boolean) => void;
   telemetry: Record<string, AgentTelemetry>;
+  appTelemetry: AppTelemetry;
   agents: AgentConfig[];
   offAgentIds: Set<string>;
 }
@@ -47,6 +48,7 @@ export const CustomTitleBar: React.FC<CustomTitleBarProps> = (props) => {
         leftCollapsed={props.leftCollapsed}
         setLeftCollapsed={props.setLeftCollapsed}
         telemetry={props.telemetry}
+        appTelemetry={props.appTelemetry}
         agents={props.agents}
         offAgentIds={props.offAgentIds}
       />

--- a/src/layout/titlebar/LeftSidebarControls.test.tsx
+++ b/src/layout/titlebar/LeftSidebarControls.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LeftSidebarControls } from "./LeftSidebarControls";
+import type { AppTelemetry } from "../../types";
+
+describe("LeftSidebarControls telemetry", () => {
+  it("includes Wardian app telemetry when no agents are present", () => {
+    const appTelemetry: AppTelemetry = {
+      cpu_usage: 2.5,
+      memory_mb: 128.4,
+    };
+
+    render(
+      <LeftSidebarControls
+        leftCollapsed={false}
+        setLeftCollapsed={vi.fn()}
+        telemetry={{}}
+        appTelemetry={appTelemetry}
+        agents={[]}
+        offAgentIds={new Set()}
+      />,
+    );
+
+    expect(screen.getByText("CPU 2.5%")).toBeInTheDocument();
+    expect(screen.getByText("MEM 128MB")).toBeInTheDocument();
+  });
+});

--- a/src/layout/titlebar/LeftSidebarControls.tsx
+++ b/src/layout/titlebar/LeftSidebarControls.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { AgentTelemetry, AgentConfig } from "../../types";
+import type { AgentTelemetry, AgentConfig, AppTelemetry } from "../../types";
 
 const isMac = typeof navigator !== "undefined" && navigator.userAgent.includes("Macintosh");
 
@@ -7,6 +7,7 @@ interface LeftSidebarControlsProps {
   leftCollapsed: boolean;
   setLeftCollapsed: (collapsed: boolean) => void;
   telemetry: Record<string, AgentTelemetry>;
+  appTelemetry: AppTelemetry;
   agents: AgentConfig[];
   offAgentIds: Set<string>;
 }
@@ -15,29 +16,37 @@ export const LeftSidebarControls: React.FC<LeftSidebarControlsProps> = ({
   leftCollapsed,
   setLeftCollapsed,
   telemetry,
+  appTelemetry,
   agents,
   offAgentIds,
-}) => (
-  <div className="titlebar-zone titlebar-left" style={isMac ? { paddingLeft: "72px" } : undefined}>
-    <button
-      onClick={() => setLeftCollapsed(!leftCollapsed)}
-      className={`titlebar-toggle ${!leftCollapsed ? "active" : ""}`}
-      title={leftCollapsed ? "Show Left Sidebar" : "Hide Left Sidebar"}
-    >
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="1" y="2" width="14" height="12" rx="1.5" />
-        <line x1="5.5" y1="2" x2="5.5" y2="14" />
-      </svg>
-    </button>
-    
-    {!leftCollapsed && (
-      <div className="titlebar-telemetry label-small !tracking-normal">
-        <span>CPU {Object.values(telemetry).reduce((acc, t) => acc + t.cpu_usage, 0).toFixed(1)}%</span>
-        <span>MEM {Object.values(telemetry).reduce((acc, t) => acc + t.memory_mb, 0).toFixed(0)}MB</span>
-        <span className="titlebar-telemetry-accent">
-          {agents.filter(a => !offAgentIds.has(a.session_id)).length} Active
-        </span>
-      </div>
-    )}
-  </div>
-);
+}) => {
+  const agentCpu = Object.values(telemetry).reduce((acc, t) => acc + t.cpu_usage, 0);
+  const agentMemory = Object.values(telemetry).reduce((acc, t) => acc + t.memory_mb, 0);
+  const totalCpu = appTelemetry.cpu_usage + agentCpu;
+  const totalMemory = appTelemetry.memory_mb + agentMemory;
+
+  return (
+    <div className="titlebar-zone titlebar-left" style={isMac ? { paddingLeft: "72px" } : undefined}>
+      <button
+        onClick={() => setLeftCollapsed(!leftCollapsed)}
+        className={`titlebar-toggle ${!leftCollapsed ? "active" : ""}`}
+        title={leftCollapsed ? "Show Left Sidebar" : "Hide Left Sidebar"}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="1" y="2" width="14" height="12" rx="1.5" />
+          <line x1="5.5" y1="2" x2="5.5" y2="14" />
+        </svg>
+      </button>
+
+      {!leftCollapsed && (
+        <div className="titlebar-telemetry label-small !tracking-normal">
+          <span>CPU {totalCpu.toFixed(1)}%</span>
+          <span>MEM {totalMemory.toFixed(0)}MB</span>
+          <span className="titlebar-telemetry-accent">
+            {agents.filter(a => !offAgentIds.has(a.session_id)).length} Active
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,6 +103,11 @@ export interface AgentTelemetry {
     log_path: string | null;
 }
 
+export interface AppTelemetry {
+    cpu_usage: number;
+    memory_mb: number;
+}
+
 export interface AgentClassDefinition {
     name: string;
     description: string;

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { AgentConfig, AgentJsonEvent, AgentTelemetry, AgentClassDefinition, AgentStatusUpdate } from "../types";
+import { AgentConfig, AgentJsonEvent, AgentTelemetry, AgentClassDefinition, AgentStatusUpdate, AppTelemetry } from "../types";
 import "../styles/App.css";
 
 import AgentWatchlist from "../layout/watchlist/AgentWatchlist";
@@ -114,6 +114,7 @@ function AppBody() {
   }, []);
 
   const [telemetry, setTelemetry] = useState<Record<string, AgentTelemetry>>({});
+  const [appTelemetry, setAppTelemetry] = useState<AppTelemetry>({ cpu_usage: 0, memory_mb: 0 });
   const [terminalTitles, setTerminalTitles] = useState<Record<string, string>>({});
   const handleTitleChange = useCallback((agentId: string, title: string) => {
     setTerminalTitles(prev => ({ ...prev, [agentId]: title }));
@@ -489,6 +490,9 @@ function AppBody() {
         return next;
       });
     });
+    const unlistenAppMetrics = listen<AppTelemetry>('app-metrics', (event) => {
+      setAppTelemetry(event.payload);
+    });
     const unlistenStatus = listen<AgentStatusUpdate>("agent-status-updated", (event) => {
       const { session_id, current_status } = event.payload;
       if (current_status === "Idle" || current_status === "Off" || current_status === "Action Needed") {
@@ -510,6 +514,7 @@ function AppBody() {
     });
     return () => {
       unlistenMetrics.then(fn => fn());
+      unlistenAppMetrics.then(fn => fn());
       unlistenStatus.then(fn => fn());
     };
   }, []);
@@ -670,6 +675,7 @@ function AppBody() {
         rightCollapsed={rightCollapsed}
         setRightCollapsed={setRightCollapsed}
         telemetry={telemetry}
+        appTelemetry={appTelemetry}
         agents={agents}
         offAgentIds={offAgentIds}
       />


### PR DESCRIPTION
## Description
Normalizes agent CPU telemetry to represent share of whole machine capacity instead of raw summed per-core process percentages. Agent memory telemetry now sums the resident footprint for a deduped related-process set, including the primary process tree and Windows-discovered Wardian session roots for detached provider children.

Also adds separate Wardian app telemetry for the titlebar, so CPU/MEM no longer drop to `0` when there are no agents. The titlebar now displays Wardian app process-tree usage plus agent usage, while the watchlist/dashboard still receive only per-agent telemetry.

## Related Issues
Fixes #77

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test`
- `npm run build`
- `cargo test --lib -- --test-threads=1`
- `cargo check --lib`
- `cargo clippy --lib`
- `git diff --check`

Note: a full `cargo test -- --test-threads=1` run was attempted, but Windows could not replace `src-tauri/target/debug/Wardian.exe` because the dev Wardian app was running and holding the executable lock.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable