### PR TITLE
fix(release): upload assets from release drafts

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -13,6 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+      - name: Dispatch asset build
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          gh workflow run release.yml \
+            --ref main \
+            -f dry_run=false \
+            -f tag="$RELEASE_TAG" \
+            -f release_tag="$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,14 @@ on:
       - "v*"
   workflow_dispatch:
     inputs:
+      tag:
+        description: "Git ref to build for manual runs (tag, branch, or SHA)"
+        required: false
+        default: ""
+      release_tag:
+        description: "Existing GitHub release tag to upload assets to when dry_run=false"
+        required: false
+        default: ""
       dry_run:
         description: "Dry run (build artifacts, do not create a release)"
         required: false
@@ -67,10 +75,30 @@ jobs:
             return res.data.id;
           result-encoding: string
 
+  resolve-release:
+    name: Resolve existing release
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.lookup.outputs.release_id }}
+    steps:
+      - name: Resolve existing release
+        id: lookup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "release_tag is required when dry_run=false" >&2
+            exit 1
+          fi
+          RELEASE_ID="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq .id)"
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.platform.os }}${{ matrix.platform.arch && format(' / {0}', matrix.platform.arch) || '' }})
-    needs: [create-release]
-    if: always() && (needs.create-release.result == 'success' || github.event_name == 'workflow_dispatch')
+    needs: [create-release, resolve-release]
+    if: always() && (needs.create-release.result == 'success' || needs.resolve-release.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true'))
     strategy:
       fail-fast: false
       matrix:
@@ -92,6 +120,8 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -127,14 +157,23 @@ jobs:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: ${{ matrix.platform.args || '' }}
 
+      - name: Build and upload (manual backfill)
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true'
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          releaseId: ${{ needs.resolve-release.outputs.release_id }}
+          args: ${{ matrix.platform.args || '' }}
+
       - name: Build (dry run)
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true'
         uses: tauri-apps/tauri-action@v0
         with:
           args: ${{ matrix.platform.args || '' }}
 
       - name: Upload dry-run artifacts
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: wardian-${{ matrix.platform.name }}
@@ -151,17 +190,17 @@ jobs:
 
   publish:
     name: Publish release
-    needs: [create-release, build]
-    if: github.event_name == 'push' && needs.build.result == 'success'
+    needs: [create-release, resolve-release, build]
+    if: needs.build.result == 'success' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true'))
     runs-on: ubuntu-latest
     steps:
-      - name: Publish the draft release
+      - name: Publish the release
         uses: actions/github-script@v7
         with:
           script: |
             await github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              release_id: ${{ needs.create-release.outputs.release_id }},
+              release_id: ${{ github.event_name == 'push' && needs.create-release.outputs.release_id || needs.resolve-release.outputs.release_id }},
               draft: false,
             });

--- a/docs/specs/027-release-artifact-ownership.md
+++ b/docs/specs/027-release-artifact-ownership.md
@@ -1,0 +1,25 @@
+# Release Artifact Ownership
+
+## Context
+
+Wardian `v0.3.1` was published by Release Please without executable release assets. The Tauri artifact workflow did not run because Release Please created the tag and GitHub release with the default `GITHUB_TOKEN`; GitHub does not trigger normal downstream workflows from most `GITHUB_TOKEN`-initiated events.
+
+## Decision
+
+Release Please owns version calculation, changelog updates, release PRs, and tag creation. The `Release` workflow owns Tauri artifact upload and final publication.
+
+To enforce that split without requiring a personal access token, `release-please-config.json` creates GitHub releases as drafts. When Release Please reports a created release, `.github/workflows/release-please.yml` dispatches `.github/workflows/release.yml` through `workflow_dispatch`, passing the tag as both the build ref and the existing release tag. The release workflow resolves that draft release, uploads platform bundles through `tauri-apps/tauri-action`, and publishes the release only after the build matrix succeeds.
+
+Manual `workflow_dispatch` runs may also backfill assets onto an existing release. In that mode, the workflow checks out the requested `tag`, resolves the existing GitHub release from `release_tag`, and uploads artifacts to that release ID. Dry runs still build and retain Actions artifacts without mutating a GitHub release.
+
+## Verification
+
+`src/config/releaseWorkflow.test.ts` guards the contract:
+
+- Release Please-created releases must remain draft until assets are uploaded.
+- Release Please must dispatch the artifact workflow when it creates a release.
+- The release workflow must remain tag-triggered for manually pushed tags.
+- The release workflow must still upload Tauri artifacts to a release ID before publishing.
+- Manual backfills must resolve an existing release and upload to that release ID.
+
+This prevents a future release from silently returning to the broken flow that produced an assetless public release.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
   "bump-patch-for-minor-pre-major": true,
   "include-v-in-tag": true,
   "include-component-in-tag": false,
+  "draft": true,
   "packages": {
     ".": {
       "package-name": "wardian",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Wardian"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/src-tauri/src/manager/headless.rs
+++ b/src-tauri/src/manager/headless.rs
@@ -17,6 +17,9 @@ use crate::utils::logging::log_debug;
 
 #[cfg(windows)]
 use super::quote_cmd_arg;
+#[cfg(target_os = "macos")]
+use super::macos_extended_path;
+
 pub(crate) fn headless_provider_launch(
     provider_name: &str,
     bin: &str,

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import releasePleaseConfig from "../../release-please-config.json";
+import releaseWorkflow from "../../.github/workflows/release.yml?raw";
+import releasePleaseWorkflow from "../../.github/workflows/release-please.yml?raw";
+
+describe("release workflow contract", () => {
+  it("keeps Release Please releases draft until assets are uploaded", () => {
+    expect(releasePleaseConfig).toMatchObject({ draft: true });
+    expect(releasePleaseWorkflow).toContain("actions: write");
+    expect(releasePleaseWorkflow).toContain("Dispatch asset build");
+    expect(releasePleaseWorkflow).toContain("gh workflow run release.yml");
+    expect(releasePleaseWorkflow).toContain("steps.release.outputs.tag_name");
+  });
+
+  it("keeps the artifact release workflow responsible for tag releases", () => {
+    expect(releaseWorkflow).toContain("tags:");
+    expect(releaseWorkflow).toContain('- "v*"');
+    expect(releaseWorkflow).toContain("tauri-apps/tauri-action@v0");
+    expect(releaseWorkflow).toContain("releaseId:");
+    expect(releaseWorkflow).toContain("Publish release");
+  });
+
+  it("can manually backfill assets onto an existing release", () => {
+    expect(releaseWorkflow).toContain("tag:");
+    expect(releaseWorkflow).toContain("release_tag:");
+    expect(releaseWorkflow).toContain("Resolve existing release");
+    expect(releaseWorkflow).toContain("/releases/tags/");
+    expect(releaseWorkflow).toContain("needs.resolve-release.outputs.release_id");
+    expect(releaseWorkflow).toContain("Publish the release");
+  });
+});


### PR DESCRIPTION
## Description
Fixes the release pipeline so Release Please-created releases do not go public before Tauri executable assets are uploaded. Release Please now creates draft releases, dispatches the Release workflow with the created tag, and the Release workflow uploads assets to the existing release before publishing it. Also adds a manual backfill path for existing releases such as v0.3.1.

This PR also fixes a macOS-only compile error in the headless runtime path discovered while attempting the v0.3.1 backfill: `headless.rs` now imports the macOS PATH helper it already uses behind `#[cfg(target_os = "macos")]`.

## Related Issues
Fixes #153

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run test -- src/config/releaseWorkflow.test.ts` first failed before the manual backfill path existed, then passed after implementation.
- `npm run lint`
- `npm run test` (340 tests passed; existing AgentWatchlist React `act(...)` warnings still print)
- `npm run build` (passes; existing large chunk warning still prints)
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test` (257 unit tests plus mock provider tests passed)
- `cd src-tauri && cargo clippy -- -D warnings`
- `cd src-tauri && rustup target add aarch64-apple-darwin; cargo check --target aarch64-apple-darwin` was attempted, but this Windows host lacks the `cc` toolchain required by Objective-C dependency build scripts. The prior GitHub macOS release dry run exposed the missing import directly.

## Backfill Status
- Uploaded available v0.3.1 Windows and Linux assets from Release workflow dry-run `25011914666`.
- macOS v0.3.1 assets could not be produced from the current v0.3.1 source because the tag has the macOS compile error fixed by this PR.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable