### PR TITLE
fix(release): force tags for draft releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "draft": true,
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "package-name": "wardian",

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -5,7 +5,10 @@ import releasePleaseWorkflow from "../../.github/workflows/release-please.yml?ra
 
 describe("release workflow contract", () => {
   it("keeps Release Please releases draft until assets are uploaded", () => {
-    expect(releasePleaseConfig).toMatchObject({ draft: true });
+    expect(releasePleaseConfig).toMatchObject({
+      draft: true,
+      "force-tag-creation": true,
+    });
     expect(releasePleaseWorkflow).toContain("actions: write");
     expect(releasePleaseWorkflow).toContain("Dispatch asset build");
     expect(releasePleaseWorkflow).toContain("gh workflow run release.yml");


### PR DESCRIPTION
## Description
Adds `force-tag-creation: true` to the Release Please manifest config. This is required now that Release Please creates draft GitHub releases: without it, GitHub may defer creating the tag until the draft is published, while the release asset workflow needs to check out that tag before publishing.

This does not fix the current GitHub GraphQL internal error in the Release Please run. I reproduced that error independently with `gh api graphql` against the `associatedPullRequests` field Release Please uses. The failed request has normal rate-limit headroom and returns GitHub request ids such as `C4D5:31E724:11F0A30:481946A:69EFAE1C`.

## Related Issues
Refs #153

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run test -- src/config/releaseWorkflow.test.ts`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable