### PR TITLE
feat(agents): add workspace folder picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "wardian",
       "version": "0.3.1",
+      "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+        "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-opener": "^2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -2013,6 +2015,15 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.0.tgz",
+      "integrity": "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
+      }
+    },
     "node_modules/@tauri-apps/plugin-opener": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
@@ -2235,7 +2246,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2895,7 +2906,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/d3-color": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
+    "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tempfile",
@@ -812,6 +813,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.3",
 ]
 
@@ -1739,7 +1742,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2767,7 +2770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3483,6 +3486,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.1",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4240,6 +4267,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation 0.3.1",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -5288,7 +5357,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ tauri-plugin-notification = "2.0.0-rc.3"
 notify = "6.1.1"
 rusqlite = { version = "0.33.0", features = ["bundled", "serde_json"] }
 once_cell = "1.20.2"
+tauri-plugin-dialog = "2"
 
 [target.'cfg(windows)'.dependencies]
 win32job = "2.0.3"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "dialog:allow-open",
     "clipboard-manager:allow-write-text",
     "clipboard-manager:allow-read-text",
     "notification:default",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,6 +76,7 @@ pub fn run() {
     }
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_notification::init())

--- a/src/features/agents/SpawnAgentPanel.test.tsx
+++ b/src/features/agents/SpawnAgentPanel.test.tsx
@@ -1,8 +1,19 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SpawnAgentPanel } from "./SpawnAgentPanel";
 
+const openMock = vi.mocked(open);
+const invokeMock = vi.mocked(invoke);
+
 describe("SpawnAgentPanel", () => {
+  beforeEach(() => {
+    openMock.mockReset();
+    invokeMock.mockReset();
+  });
+
   it("lists OpenCode as a provider option", () => {
     render(
       <SpawnAgentPanel
@@ -14,5 +25,46 @@ describe("SpawnAgentPanel", () => {
     const providerSelect = screen.getByTestId("spawn-provider");
     expect(screen.getByRole("option", { name: "OpenCode" })).toBeInTheDocument();
     expect(providerSelect).toHaveTextContent("OpenCode");
+  });
+
+  it("sets the workspace path from the native folder picker", async () => {
+    openMock.mockResolvedValue("C:\\projects\\picked-app");
+    invokeMock.mockResolvedValue(true);
+    const user = userEvent.setup();
+
+    render(
+      <SpawnAgentPanel
+        agentClasses={[{ name: "Generalist", description: "", is_default: true }]}
+        onSpawned={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Choose workspace folder" }));
+
+    expect(openMock).toHaveBeenCalledWith({
+      directory: true,
+      multiple: false,
+      title: "Choose workspace folder",
+    });
+    expect(screen.getByTestId("spawn-workspace-path")).toHaveValue("C:\\projects\\picked-app");
+  });
+
+  it("keeps the current workspace path when the folder picker is cancelled", async () => {
+    openMock.mockResolvedValue(null);
+    invokeMock.mockResolvedValue(true);
+    const user = userEvent.setup();
+
+    render(
+      <SpawnAgentPanel
+        agentClasses={[{ name: "Generalist", description: "", is_default: true }]}
+        onSpawned={() => {}}
+      />,
+    );
+
+    const workspacePath = screen.getByTestId("spawn-workspace-path");
+    await user.type(workspacePath, "C:\\projects\\typed-app");
+    await user.click(screen.getByRole("button", { name: "Choose workspace folder" }));
+
+    expect(workspacePath).toHaveValue("C:\\projects\\typed-app");
   });
 });

--- a/src/features/agents/SpawnAgentPanel.tsx
+++ b/src/features/agents/SpawnAgentPanel.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/plugin-dialog";
+import { FolderOpen } from "lucide-react";
 import { AgentConfig, AgentClassDefinition } from "../../types";
 import { AdvancedSettings } from "../../components/AdvancedSettings";
 
@@ -72,6 +74,23 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
     }
   };
 
+  const chooseWorkspaceFolder = async () => {
+    try {
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        title: "Choose workspace folder",
+      });
+
+      if (typeof selected === "string") {
+        setNewFolder(selected);
+      }
+    } catch (error) {
+      console.error("Failed to choose workspace folder:", error);
+      alert(`Failed to choose workspace folder: ${error}`);
+    }
+  };
+
   return (
     <div className="mb-8">
       <h3 className="text-xs font-bold text-muted tracking-wide mb-4">
@@ -138,22 +157,33 @@ export const SpawnAgentPanel: React.FC<Props> = ({ agentClasses, onSpawned }) =>
           <label className="block text-[10px] font-bold text-muted-neutral mb-1">
             Workspace Path
           </label>
-          <div className="relative flex items-center">
-            <input
-            data-testid="spawn-workspace-path"
-            className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors pr-10"
-              placeholder="C:/projects/my-app"
-              value={newFolder}
-              onChange={(e) => setNewFolder(e.currentTarget.value)}
-            />
-            {newFolder && (
-              <span
-                className="absolute right-3 text-[10px]"
-                title={folderIsValid ? "Valid path" : "Invalid path"}
-              >
-                {folderIsValid === true ? "✅" : folderIsValid === false ? "⚠️" : ""}
-              </span>
-            )}
+          <div className="flex items-center gap-2">
+            <div className="relative min-w-0 flex-1">
+              <input
+                data-testid="spawn-workspace-path"
+                className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-sm text-primary focus:outline-none focus:border-[var(--color-wardian-accent)] transition-colors pr-10"
+                placeholder="C:/projects/my-app"
+                value={newFolder}
+                onChange={(e) => setNewFolder(e.currentTarget.value)}
+              />
+              {newFolder && (
+                <span
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[10px]"
+                  title={folderIsValid ? "Valid path" : "Invalid path"}
+                >
+                  {folderIsValid === true ? "✅" : folderIsValid === false ? "⚠️" : ""}
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              aria-label="Choose workspace folder"
+              title="Choose workspace folder"
+              onClick={chooseWorkspaceFolder}
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-wardian-light bg-[var(--color-wardian-input-bg)] text-muted-neutral transition-colors hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)] focus:outline-none focus:border-[var(--color-wardian-accent)]"
+            >
+              <FolderOpen className="h-4 w-4" aria-hidden="true" />
+            </button>
           </div>
         </div>
         <div>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -38,6 +38,10 @@ vi.mock("@tauri-apps/api/window", () => ({
   })),
 }));
 
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+}));
+
 // Mock xterm since it requires a real DOM canvas
 vi.mock("@xterm/xterm", () => ({
   Terminal: vi.fn().mockImplementation(() => ({


### PR DESCRIPTION
## Description
Adds an OS-native folder picker to the Spawn Agent workspace path field. Users can still type a path manually, and the existing directory validation continues to run after typed or picked values.

## Related Issues
Fixes #157

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run test -- src/features/agents/SpawnAgentPanel.test.tsx` - 3 tests passed
- `npm run lint` - passed
- `npm run test` - 342 tests passed; existing watchlist React `act(...)` warnings still appear
- `npm run build` - passed; existing Vite large chunk warning still appears
- `cd src-tauri && cargo check` - passed
- `cd src-tauri && cargo test` - 257 unit tests and 4 mock provider tests passed after stopping a leftover local dev process that locked `target/debug/Wardian.exe`
- `cd src-tauri && cargo clippy` - passed
- Subagent diff review requested; no findings. Follow-up cancel-path test added for the residual test gap.

## Screenshots
Feature-specific local screenshot captured at `e2e/screenshots/workspace-picker/20260429-032346/spawn-workspace-picker.png`.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable