### PR TITLE
feat(agent): add single-agent clone actions

### DIFF
--- a/docs/specs/028-agent-cloning.md
+++ b/docs/specs/028-agent-cloning.md
@@ -1,0 +1,168 @@
+# Agent Cloning
+
+## Status
+
+Proposed
+
+## Context
+
+Wardian users can already spawn, pause, resume, clear, rename, group, and delete agents from the roster context menu. They also manage reusable identity through common, class, and instance-level `AGENTS.md` files plus deployed skills. Creating another agent with the same setup is currently manual: users must reopen the spawn panel, copy provider settings, choose the same workspace, and optionally recreate instance-level files or skills.
+
+Cloning should preserve Wardian's physical-first model without accidentally carrying opaque provider conversation state. Provider sessions, logs, generated habitats, and telemetry are runtime artifacts. Agent classes, settings, workspace paths, instance instructions, and instance skills are user-authored profile data.
+
+## Goals
+
+- Add a single-agent clone action to the agent right-click menu.
+- Keep the top-level context menu compact.
+- Make the default clone behavior fast and safe.
+- Distinguish visible setup/profile cloning from provider conversation memory.
+- Keep clone creation backend-owned so session IDs, provider bootstrap, saved state, and habitat projection remain authoritative in Rust.
+
+## Non-Goals
+
+- Bulk clone for multi-selected agents or teams.
+- Provider conversation/session memory cloning.
+- Cross-provider conversion rules beyond copying supported config fields.
+- A settings preference for the default clone action in the first iteration.
+
+## User Experience
+
+The shared `AgentContextMenu` gets one top-level item:
+
+- `Clone`
+
+The item is both clickable and expandable:
+
+- Clicking `Clone` directly runs `Fresh Clone`.
+- Hovering opens:
+  - `Fresh Clone`
+  - `Profile Clone`
+  - `Custom...`
+
+For the first implementation, clone is available only when exactly one agent is targeted. Bulk selections and team context menus should hide or disable cloning.
+
+If `Custom...` is not implemented in the same change, omit it rather than shipping a dead-end menu item.
+
+## Clone Modes
+
+### Fresh Clone
+
+Fresh clone creates another agent with the same visible setup and a clean provider conversation.
+
+It carries:
+
+- `agent_class`
+- `folder`
+- provider
+- model and provider settings
+- sandbox, approval, permission, output, and custom argument settings
+- include directories
+- session persistence preference
+- git worktree setting
+- global and class skills, by virtue of using the same class and normal include resolution
+
+It resets or regenerates:
+
+- `session_id`
+- `session_name`, using a unique copy name such as `<source>-copy` or `<source>-copy-2`
+- `resume_session`
+- `fresh_provider_session_id`
+- `is_off`
+- provider session exclusion lists and other runtime-only resume helpers
+- telemetry, terminal title, query count, log path, and status
+
+It does not copy:
+
+- provider conversation memory
+- generated `habitat/`
+- provider history/session files
+- logs
+- permission request logs
+- instance-local `AGENTS.md`
+- instance-local `.agents/skills`
+
+### Profile Clone
+
+Profile clone does everything Fresh Clone does and also copies whitelisted agent-local profile files from `WARDIAN_HOME/agents/<source_session_id>/` into the new agent directory.
+
+Initial whitelist:
+
+- `AGENTS.md`
+- `.agents/skills`
+
+The copy must exclude runtime and generated data, including:
+
+- `habitat/`
+- provider session/history directories and files
+- `claude/permission-requests.jsonl`
+- logs
+- telemetry or database-derived state
+
+Profile clone still starts a fresh provider conversation.
+
+### Custom Clone
+
+Custom clone opens a compact wizard for users who want to change name, provider, class, workspace, or clone mode before creation. This can be implemented after Fresh/Profile clone unless the UI work is included in the same change.
+
+## Backend Design
+
+Add a Tauri command named `clone_agent`.
+
+Suggested request shape:
+
+```ts
+{
+  source_session_id: string;
+  mode: "fresh" | "profile";
+  session_name?: string;
+  provider?: string;
+  folder?: string;
+  agent_class?: string;
+  start?: boolean;
+}
+```
+
+The command should:
+
+1. Load the source `AgentConfig` from active state.
+2. Build a sanitized clone config.
+3. Generate a unique clone name when none is provided.
+4. Call the same backend spawn path used by normal agent creation.
+5. For profile clone, copy whitelisted profile files after the new agent directory exists and before provider habitat projection needs them.
+6. Save state and emit the normal agent update events.
+
+Sanitization must be centralized and unit tested. It should never reuse source `session_id` or provider conversation identifiers.
+
+## Frontend Design
+
+`AgentContextMenu` should accept an optional clone handler:
+
+```ts
+onClone?: (agentId: string, mode: "fresh" | "profile") => MaybePromise;
+```
+
+The menu should render clone only for a single agent context. The parent click calls `onClone(agentId, "fresh")`; submenu items call `fresh` or `profile`.
+
+`App.tsx` owns the handler and invokes `clone_agent`, then refreshes agents.
+
+## Testing
+
+Backend:
+
+- Unit test clone config sanitization.
+- Unit test unique clone name generation.
+- Unit test profile copy whitelist and runtime exclusions.
+- Command-level test if practical with isolated `WARDIAN_HOME`.
+
+Frontend:
+
+- Context menu shows `Clone` for a single agent.
+- Parent click invokes fresh mode.
+- Submenu invokes fresh/profile modes.
+- Bulk and team context menus do not expose an active clone action.
+
+E2E:
+
+- Browser E2E with mock provider for roster right-click fresh clone if the mock layer can prove the behavior.
+- Native E2E only if validating real provider spawn, filesystem projections, or PTY behavior.
+

--- a/docs/specs/028-agent-cloning.md
+++ b/docs/specs/028-agent-cloning.md
@@ -69,6 +69,7 @@ It resets or regenerates:
 - `fresh_provider_session_id`
 - `is_off`
 - provider session exclusion lists and other runtime-only resume helpers
+- provider session or resume flags embedded in `custom_args`
 - telemetry, terminal title, query count, log path, and status
 
 It does not copy:
@@ -165,4 +166,3 @@ E2E:
 
 - Browser E2E with mock provider for roster right-click fresh clone if the mock layer can prove the behavior.
 - Native E2E only if validating real provider spawn, filesystem projections, or PTY behavior.
-

--- a/docs/superpowers/plans/2026-04-30-agent-cloning.md
+++ b/docs/superpowers/plans/2026-04-30-agent-cloning.md
@@ -1,0 +1,130 @@
+# Agent Cloning Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add single-agent Fresh/Profile Clone actions to the agent context menu, backed by a Rust `clone_agent` command.
+
+**Architecture:** The Rust backend owns clone semantics: config sanitization, unique naming, provider session creation, optional profile file copying, state insertion, and update events. The React context menu only exposes the action for one targeted agent and delegates clone mode to `App.tsx`, which invokes the Tauri command and refreshes the roster.
+
+**Tech Stack:** Rust/Tauri commands and unit tests, React/TypeScript context menu wiring, Vitest/Testing Library for UI tests.
+
+---
+
+### Task 1: Backend Clone Helpers
+
+**Files:**
+- Modify: `src-tauri/src/commands/agent.rs`
+
+- [ ] **Step 1: Write failing Rust helper tests**
+
+Add tests for:
+- `unique_clone_name("Alpha", ["Alpha"]) == "Alpha-copy"`
+- `unique_clone_name("Alpha", ["Alpha", "Alpha-copy"]) == "Alpha-copy-2"`
+- `sanitize_clone_config` clears `session_id`, `resume_session`, `fresh_provider_session_id`, `codex_cleared_provider_sessions`, and `is_off`, while preserving provider/model/class/folder settings.
+- `copy_agent_profile_files` copies only `AGENTS.md` and `.agents/skills`, and excludes `habitat/` and `claude/permission-requests.jsonl`.
+
+Run: `cd src-tauri && cargo test commands::agent::tests::clone_ -- --test-threads=1`
+Expected: fail because helpers do not exist.
+
+- [ ] **Step 2: Implement helpers**
+
+Add:
+- `CloneAgentMode`
+- `CloneAgentRequest`
+- `unique_clone_name`
+- `sanitize_clone_config`
+- `copy_agent_profile_files`
+- focused recursive copy/link fallback helpers for profile skills.
+
+- [ ] **Step 3: Verify helper tests pass**
+
+Run: `cd src-tauri && cargo test commands::agent::tests::clone_ -- --test-threads=1`
+Expected: pass.
+
+### Task 2: Backend Command
+
+**Files:**
+- Modify: `src-tauri/src/commands/agent.rs`
+- Modify: `src-tauri/src/lib.rs`
+
+- [ ] **Step 1: Refactor spawn insertion**
+
+Extract the shared "register this prepared config as a new active agent" portion from `spawn_agent` into a private async helper so both normal spawn and clone use identical persistence/event behavior.
+
+- [ ] **Step 2: Implement `clone_agent`**
+
+Load the source config, generate a unique name, sanitize the clone config, create the new provider/Wardian session id using the same rules as normal spawn, copy profile files for `profile` mode before spawning, register the new agent, emit `agents-updated`, and return the new `AgentConfig`.
+
+- [ ] **Step 3: Register command**
+
+Add `commands::agent::clone_agent` to the Tauri invoke handler in `src-tauri/src/lib.rs`.
+
+- [ ] **Step 4: Verify backend targeted tests**
+
+Run: `cd src-tauri && cargo test commands::agent::tests::clone_ -- --test-threads=1`
+Expected: pass.
+
+### Task 3: Context Menu UI
+
+**Files:**
+- Modify: `src/components/AgentContextMenu.tsx`
+- Modify: `src/layout/watchlist/AgentWatchlist.tsx`
+- Modify: `src/views/GridView.tsx`
+- Modify: `src/views/App.tsx`
+- Modify: `src/layout/watchlist/AgentWatchlist.test.tsx`
+- Modify: `src/views/App.test.tsx`
+
+- [ ] **Step 1: Write failing UI tests**
+
+Add tests that:
+- A single-agent context menu shows `Clone`.
+- Clicking parent `Clone` calls `onClone(agentId, "fresh")`.
+- Hovering `Clone` exposes `Fresh Clone` and `Profile Clone`.
+- `Profile Clone` calls `onClone(agentId, "profile")`.
+- Bulk/team menus do not expose an active clone action.
+- `App.tsx` invokes `clone_agent` with `{ req: { source_session_id, mode } }` and refreshes agents.
+
+Run: `npm run test -- AgentWatchlist.test.tsx App.test.tsx`
+Expected: fail because clone UI does not exist.
+
+- [ ] **Step 2: Implement UI wiring**
+
+Add `onClone?: (agentId, mode) => MaybePromise` through the context menu callers. Render the clone submenu only when `!isBulk && !isTeam && onClone`. Add the `App.tsx` handler that invokes `clone_agent` then `fetchAgents()`.
+
+- [ ] **Step 3: Verify targeted frontend tests**
+
+Run: `npm run test -- AgentWatchlist.test.tsx App.test.tsx`
+Expected: pass.
+
+### Task 4: Final Verification
+
+**Files:**
+- No new files expected beyond this plan and the existing spec.
+
+- [ ] **Step 1: Run frontend checks**
+
+Run: `npm run lint`
+Expected: pass.
+
+Run: `npm run test`
+Expected: pass.
+
+Run: `npm run build`
+Expected: pass.
+
+- [ ] **Step 2: Run backend checks**
+
+Run: `cd src-tauri && cargo clippy`
+Expected: pass.
+
+Run: `cd src-tauri && cargo test`
+Expected: pass.
+
+Run: `cd src-tauri && cargo check`
+Expected: pass.
+
+- [ ] **Step 3: Inspect git state**
+
+Run: `git status --short`
+Expected: only intentional plan/spec/code/test files changed.
+

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -35,7 +35,10 @@ pub struct CloneAgentRequest {
     pub start: Option<bool>,
 }
 
-fn clone_unique_name(source_name: &str, existing_names: &std::collections::HashSet<String>) -> String {
+fn clone_unique_name(
+    source_name: &str,
+    existing_names: &std::collections::HashSet<String>,
+) -> String {
     let base = if source_name.trim().is_empty() {
         "agent"
     } else {
@@ -54,6 +57,52 @@ fn clone_unique_name(source_name: &str, existing_names: &std::collections::HashS
         }
         index += 1;
     }
+}
+
+fn clone_quote_custom_arg(arg: &str) -> String {
+    if !arg.is_empty()
+        && arg
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || "_-./:=,+".contains(ch))
+    {
+        return arg.to_string();
+    }
+    format!("'{}'", arg.replace('\'', "'\"'\"'"))
+}
+
+fn clone_custom_args_without_provider_memory(custom_args: Option<&str>) -> Option<String> {
+    let parsed = shlex::split(custom_args?.trim())?;
+    let mut filtered = Vec::with_capacity(parsed.len());
+    let mut iter = parsed.into_iter().peekable();
+    while let Some(arg) = iter.next() {
+        if matches!(arg.as_str(), "--resume" | "--session" | "--session-id" | "-r") {
+            let _ = iter.next();
+            continue;
+        }
+        if matches!(arg.as_str(), "--continue" | "-c") {
+            continue;
+        }
+        if arg.starts_with("--resume=")
+            || arg.starts_with("--session=")
+            || arg.starts_with("--session-id=")
+            || arg.starts_with("-r=")
+        {
+            continue;
+        }
+        if arg == "resume" {
+            let _ = iter.next_if(|next| !next.starts_with('-'));
+            continue;
+        }
+        filtered.push(arg);
+    }
+
+    (!filtered.is_empty()).then(|| {
+        filtered
+            .iter()
+            .map(|arg| clone_quote_custom_arg(arg))
+            .collect::<Vec<_>>()
+            .join(" ")
+    })
 }
 
 fn clone_sanitize_config(
@@ -81,6 +130,7 @@ fn clone_sanitize_config(
     config.codex_cleared_provider_sessions.clear();
     config.system_include_directories = None;
     config.opencode_port = None;
+    config.custom_args = clone_custom_args_without_provider_memory(config.custom_args.as_deref());
     config.is_off = !start;
     config
 }
@@ -97,6 +147,59 @@ fn clone_copy_file(source: &std::path::Path, destination: &std::path::Path) -> R
         .map_err(|e| e.to_string())
 }
 
+fn clone_remove_existing_path(path: &std::path::Path) {
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return;
+    };
+
+    if metadata.file_type().is_symlink() || std::fs::read_link(path).is_ok() {
+        let _ = std::fs::remove_dir(path).or_else(|_| std::fs::remove_file(path));
+        return;
+    }
+
+    if metadata.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(path) {
+            for entry in entries.flatten() {
+                clone_remove_existing_path(&entry.path());
+            }
+        }
+        let _ = std::fs::remove_dir(path);
+    } else {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+fn clone_resolve_link_target(
+    link_path: &std::path::Path,
+    link_target: std::path::PathBuf,
+) -> std::path::PathBuf {
+    if link_target.is_absolute() {
+        link_target
+    } else {
+        link_path
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new(""))
+            .join(link_target)
+    }
+}
+
+fn clone_copy_link_or_target(
+    source: &std::path::Path,
+    destination: &std::path::Path,
+) -> Result<bool, String> {
+    let Ok(link_target) = std::fs::read_link(source) else {
+        return Ok(false);
+    };
+    let resolved_target = clone_resolve_link_target(source, link_target);
+    clone_remove_existing_path(destination);
+    if resolved_target.is_dir() {
+        crate::utils::fs::create_directory_link(&resolved_target, destination)?;
+    } else if resolved_target.is_file() {
+        clone_copy_file(&resolved_target, destination)?;
+    }
+    Ok(true)
+}
+
 fn clone_copy_directory_recursive(
     source: &std::path::Path,
     destination: &std::path::Path,
@@ -104,15 +207,16 @@ fn clone_copy_directory_recursive(
     if !source.exists() {
         return Ok(());
     }
-    if destination.exists() || destination.symlink_metadata().is_ok() {
-        let _ = std::fs::remove_dir_all(destination).or_else(|_| std::fs::remove_file(destination));
-    }
+    clone_remove_existing_path(destination);
     std::fs::create_dir_all(destination).map_err(|e| e.to_string())?;
 
     for entry in std::fs::read_dir(source).map_err(|e| e.to_string())? {
         let entry = entry.map_err(|e| e.to_string())?;
         let source_path = entry.path();
         let destination_path = destination.join(entry.file_name());
+        if clone_copy_link_or_target(&source_path, &destination_path)? {
+            continue;
+        }
         let metadata = std::fs::symlink_metadata(&source_path).map_err(|e| e.to_string())?;
         if metadata.is_dir() {
             clone_copy_directory_recursive(&source_path, &destination_path)?;
@@ -133,11 +237,32 @@ fn clone_copy_agent_profile_files(
     let destination_root = wardian_home.join("agents").join(destination_session_id);
     std::fs::create_dir_all(&destination_root).map_err(|e| e.to_string())?;
 
-    clone_copy_file(&source_root.join("AGENTS.md"), &destination_root.join("AGENTS.md"))?;
+    clone_copy_file(
+        &source_root.join("AGENTS.md"),
+        &destination_root.join("AGENTS.md"),
+    )?;
     clone_copy_directory_recursive(
         &source_root.join(".agents").join("skills"),
         &destination_root.join(".agents").join("skills"),
     )
+}
+
+fn clone_ensure_profile_destination_available(
+    wardian_home: &std::path::Path,
+    destination_session_id: &str,
+    allowed_existing_session_id: Option<&str>,
+) -> Result<(), String> {
+    if allowed_existing_session_id == Some(destination_session_id) {
+        return Ok(());
+    }
+    let destination_root = wardian_home.join("agents").join(destination_session_id);
+    if destination_root.exists() || destination_root.symlink_metadata().is_ok() {
+        return Err(format!(
+            "Cannot clone profile into existing agent directory '{}'.",
+            destination_root.display()
+        ));
+    }
+    Ok(())
 }
 
 fn persisted_resume_session_for_provider(
@@ -284,18 +409,24 @@ async fn is_name_unique(state: &AppState, name: &str, exclude_session_id: Option
     })
 }
 
+async fn is_session_id_available(state: &AppState, session_id: &str) -> bool {
+    let agents = state.agents.lock().await;
+    !agents.contains_key(session_id)
+}
+
 async fn register_new_agent(
     mut config: AgentConfig,
     mut actual_resume: Option<String>,
     state: &AppState,
     app: &AppHandle,
+    clone_name_base: Option<&str>,
 ) -> Result<AgentConfig, String> {
     let session_id = config.session_id.clone();
     config.system_include_directories = Some(crate::utils::fs::resolve_system_include_directories(
         &config.agent_class,
         &session_id,
     ));
-    let active_agent = manager::spawn_agent(app.clone(), config.clone(), false, None).await?;
+    let mut active_agent = manager::spawn_agent(app.clone(), config.clone(), false, None).await?;
     // Propagate any fields that spawn_agent may have auto-assigned (e.g. opencode_port).
     if config.provider == "codex" && actual_resume.is_none() {
         for _ in 0..40 {
@@ -353,15 +484,36 @@ async fn register_new_agent(
         cfg.resume_session = persisted_resume;
     }
 
-    // Register input sender BEFORE locking agents map
+    let mut agents = state.agents.lock().await;
+    let mut order = state.agent_order.lock().await;
+    if agents.contains_key(&session_id) {
+        manager::terminate_active_agent_process(&mut active_agent);
+        return Err(format!("An agent with session ID '{}' already exists.", session_id));
+    }
+    let existing_names = agents
+        .values()
+        .map(|agent| agent.config.lock().unwrap().session_name.clone())
+        .collect::<std::collections::HashSet<_>>();
+    if existing_names.contains(&config.session_name) {
+        if let Some(base) = clone_name_base {
+            config.session_name = clone_unique_name(base, &existing_names);
+        } else {
+            manager::terminate_active_agent_process(&mut active_agent);
+            return Err(format!(
+                "An agent with the name '{}' already exists.",
+                config.session_name
+            ));
+        }
+    }
+    {
+        let mut cfg = active_agent.config.lock().unwrap();
+        cfg.session_name = config.session_name.clone();
+    }
     if let Some(ref tx) = active_agent.stdin_tx {
         if let Ok(mut senders) = state.input_senders.write() {
             senders.insert(session_id.clone(), tx.clone());
         }
     }
-
-    let mut agents = state.agents.lock().await;
-    let mut order = state.agent_order.lock().await;
     agents.insert(session_id.clone(), active_agent);
     order.push(session_id.clone());
     manager::save_state(app, &agents, &order);
@@ -440,7 +592,7 @@ pub async fn spawn_agent(
     config.folder = folder;
     config.resume_session = actual_resume.clone();
     config.is_off = is_off.unwrap_or(false);
-    register_new_agent(config, actual_resume, &state, &app).await
+    register_new_agent(config, actual_resume, &state, &app, None).await
 }
 
 #[tauri::command]
@@ -470,9 +622,9 @@ pub async fn clone_agent(
         (source, names)
     };
 
-    let session_name = req
-        .session_name
-        .filter(|name| !name.trim().is_empty())
+    let requested_session_name = req.session_name.filter(|name| !name.trim().is_empty());
+    let generated_session_name = requested_session_name.is_none();
+    let session_name = requested_session_name
         .unwrap_or_else(|| clone_unique_name(&source_config.session_name, &existing_names));
     if !is_valid_name(&session_name) {
         return Err("Invalid agent name. Names must contain only alphanumeric characters, underscores, or hyphens (no spaces).".to_string());
@@ -499,9 +651,40 @@ pub async fn clone_agent(
     );
     let provider_name = config.provider.clone();
     let mut actual_resume = None;
-    let session_id = if provider_uses_generated_session_id(&provider_name) {
-        uuid::Uuid::new_v4().to_string()
+    let profile_home = if req.mode == CloneAgentMode::Profile {
+        Some(
+            crate::utils::fs::get_wardian_home()
+                .ok_or_else(|| "Could not find Wardian home".to_string())?,
+        )
     } else {
+        None
+    };
+    let provisional_profile_session_id = (profile_home.is_some()
+        && !provider_uses_generated_session_id(&provider_name))
+    .then(|| uuid::Uuid::new_v4().to_string());
+
+    let session_id = if provider_uses_generated_session_id(&provider_name) {
+        let generated_session_id = uuid::Uuid::new_v4().to_string();
+        config.session_id = generated_session_id.clone();
+        if let Some(home) = profile_home.as_ref() {
+            clone_ensure_profile_destination_available(home, &generated_session_id, None)?;
+            clone_copy_agent_profile_files(home, &source_session_id, &generated_session_id)?;
+        }
+        generated_session_id
+    } else {
+        if let (Some(home), Some(provisional_session_id)) = (
+            profile_home.as_ref(),
+            provisional_profile_session_id.as_ref(),
+        ) {
+            config.session_id = provisional_session_id.clone();
+            clone_ensure_profile_destination_available(home, provisional_session_id, None)?;
+            clone_copy_agent_profile_files(home, &source_session_id, provisional_session_id)?;
+            config.system_include_directories =
+                Some(crate::utils::fs::resolve_system_include_directories(
+                    &config.agent_class,
+                    provisional_session_id,
+                ));
+        }
         let cwd = crate::utils::fs::resolve_cwd(&config.folder, "");
         let real_sid = manager::obtain_session_id(&cwd, Some(&config.agent_class), Some(&config))
             .await
@@ -517,13 +700,45 @@ pub async fn clone_agent(
     config.session_id = session_id.clone();
     config.resume_session = actual_resume.clone();
 
-    if req.mode == CloneAgentMode::Profile {
-        let home = crate::utils::fs::get_wardian_home()
-            .ok_or_else(|| "Could not find Wardian home".to_string())?;
-        clone_copy_agent_profile_files(&home, &source_session_id, &session_id)?;
+    if !is_session_id_available(&state, &session_id).await {
+        if let Some(home) = profile_home.as_ref() {
+            if let Some(provisional_session_id) = provisional_profile_session_id.as_deref() {
+                let provisional_root = home.join("agents").join(provisional_session_id);
+                clone_remove_existing_path(&provisional_root);
+            }
+        }
+        return Err(format!("An agent with session ID '{}' already exists.", session_id));
     }
 
-    register_new_agent(config, actual_resume, &state, &app).await
+    if let Some(home) = profile_home.as_ref() {
+        let allowed_existing_profile_session_id = if provider_uses_generated_session_id(&provider_name) {
+            Some(session_id.as_str())
+        } else {
+            provisional_profile_session_id.as_deref()
+        };
+        clone_ensure_profile_destination_available(
+            home,
+            &session_id,
+            allowed_existing_profile_session_id,
+        )?;
+        clone_copy_agent_profile_files(home, &source_session_id, &session_id)?;
+        if let Some(provisional_session_id) = provisional_profile_session_id
+            .as_deref()
+            .filter(|id| *id != session_id)
+        {
+            let provisional_root = home.join("agents").join(provisional_session_id);
+            clone_remove_existing_path(&provisional_root);
+        }
+    }
+
+    register_new_agent(
+        config,
+        actual_resume,
+        &state,
+        &app,
+        generated_session_name.then_some(source_config.session_name.as_str()),
+    )
+    .await
 }
 
 #[tauri::command]
@@ -981,13 +1196,15 @@ pub async fn reorder_agents(
 #[cfg(test)]
 mod tests {
     use super::{
-        clone_copy_agent_profile_files, clone_sanitize_config, clone_unique_name,
-        codex_provider_session_is_new, persisted_resume_session_for_provider, prepare_clear_config,
-        prepare_resume_config, provider_needs_obtain_session_id_on_clear,
-        provider_uses_generated_session_id, restore_runtime_state_after_resume,
+        clone_copy_agent_profile_files, clone_ensure_profile_destination_available,
+        clone_sanitize_config, clone_unique_name, codex_provider_session_is_new,
+        persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
+        provider_needs_obtain_session_id_on_clear, provider_uses_generated_session_id,
+        restore_runtime_state_after_resume,
     };
     use crate::models::{AgentConfig, AgentSessionPersistenceOverride};
     use crate::state::ActiveAgent;
+    use crate::utils::fs::create_directory_link;
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
 
@@ -1054,6 +1271,7 @@ mod tests {
             provider: "codex".to_string(),
             model: Some("gpt-5.4".to_string()),
             resume_session: Some("provider-session".to_string()),
+            git_worktree: Some(true),
             fresh_provider_session_id: Some("fresh-provider-session".to_string()),
             codex_cleared_provider_sessions: vec!["old-provider-session".to_string()],
             is_off: true,
@@ -1061,26 +1279,60 @@ mod tests {
             ..Default::default()
         };
 
-        let clone = clone_sanitize_config(
-            &source,
-            "Alpha-copy".to_string(),
-            None,
-            None,
-            None,
-            true,
-        );
+        let clone =
+            clone_sanitize_config(&source, "Alpha-copy".to_string(), None, None, None, true);
 
         assert_eq!(clone.session_id, "");
         assert_eq!(clone.session_name, "Alpha-copy");
         assert_eq!(clone.agent_class, "Coder");
         assert_eq!(clone.folder, "D:/Development/Wardian");
         assert_eq!(clone.provider, "codex");
+        assert_eq!(clone.git_worktree, Some(true));
         assert_eq!(clone.model.as_deref(), Some("gpt-5.4"));
         assert_eq!(clone.custom_args.as_deref(), Some("--verbose"));
         assert_eq!(clone.resume_session, None);
         assert_eq!(clone.fresh_provider_session_id, None);
         assert!(clone.codex_cleared_provider_sessions.is_empty());
         assert!(!clone.is_off);
+    }
+
+    #[test]
+    fn clone_sanitize_config_strips_custom_provider_session_args() {
+        let source = AgentConfig {
+            custom_args: Some(
+                "--verbose --resume old-gemini --session ses_old --session-id old-claude -r old-short --continue -c resume old-codex --model 'kept model'".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let clone =
+            clone_sanitize_config(&source, "Alpha-copy".to_string(), None, None, None, true);
+        let custom_args = clone.custom_args.expect("custom args");
+        let parsed = shlex::split(&custom_args).expect("parse sanitized custom args");
+
+        assert_eq!(
+            parsed,
+            vec![
+                "--verbose".to_string(),
+                "--model".to_string(),
+                "kept model".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn clone_sanitize_config_strips_equals_form_session_args() {
+        let source = AgentConfig {
+            custom_args: Some(
+                "--resume=old --session=ses_old --session-id=old -r=old --safe".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let clone =
+            clone_sanitize_config(&source, "Alpha-copy".to_string(), None, None, None, true);
+
+        assert_eq!(clone.custom_args.as_deref(), Some("--safe"));
     }
 
     #[test]
@@ -1121,14 +1373,21 @@ mod tests {
         std::fs::create_dir_all(source.join("claude")).expect("create claude dir");
         std::fs::write(source.join("AGENTS.md"), "# Agent Memory\n").expect("write agents");
         std::fs::write(
-            source.join(".agents").join("skills").join("skill-one").join("SKILL.md"),
+            source
+                .join(".agents")
+                .join("skills")
+                .join("skill-one")
+                .join("SKILL.md"),
             "# Skill\n",
         )
         .expect("write skill");
         std::fs::write(source.join("habitat").join("AGENTS.md"), "generated")
             .expect("write habitat");
-        std::fs::write(source.join("claude").join("permission-requests.jsonl"), "{}\n")
-            .expect("write log");
+        std::fs::write(
+            source.join("claude").join("permission-requests.jsonl"),
+            "{}\n",
+        )
+        .expect("write log");
 
         clone_copy_agent_profile_files(home, "source-agent", "dest-agent")
             .expect("copy profile files");
@@ -1148,7 +1407,77 @@ mod tests {
             "# Skill\n"
         );
         assert!(!dest.join("habitat").exists());
-        assert!(!dest.join("claude").join("permission-requests.jsonl").exists());
+        assert!(!dest
+            .join("claude")
+            .join("permission-requests.jsonl")
+            .exists());
+    }
+
+    #[test]
+    fn clone_profile_destination_rejects_existing_agent_directory() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let destination = home.join("agents").join("existing-agent");
+        std::fs::create_dir_all(&destination).expect("create destination");
+        std::fs::write(destination.join("AGENTS.md"), "existing").expect("write existing profile");
+
+        let err = clone_ensure_profile_destination_available(home, "existing-agent", None)
+            .expect_err("existing destination should be rejected");
+
+        assert!(err.contains("Cannot clone profile into existing agent directory"));
+        assert_eq!(
+            std::fs::read_to_string(destination.join("AGENTS.md")).expect("read existing profile"),
+            "existing"
+        );
+    }
+
+    #[test]
+    fn clone_profile_destination_allows_provisional_directory() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        std::fs::create_dir_all(home.join("agents").join("provisional-agent"))
+            .expect("create provisional destination");
+
+        clone_ensure_profile_destination_available(
+            home,
+            "provisional-agent",
+            Some("provisional-agent"),
+        )
+        .expect("matching provisional destination is allowed");
+    }
+
+    #[test]
+    fn clone_profile_copy_carries_linked_skills() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source = home.join("agents").join("source-agent");
+        let dest = home.join("agents").join("dest-agent");
+        let library_skill = home.join("library").join("skills").join("linked-skill");
+        let source_skills = source.join(".agents").join("skills");
+        let source_skill_link = source_skills.join("linked-skill");
+
+        std::fs::create_dir_all(&library_skill).expect("create library skill");
+        std::fs::create_dir_all(&source_skills).expect("create source skills");
+        std::fs::write(library_skill.join("SKILL.md"), "# Linked Skill\n")
+            .expect("write linked skill");
+        create_directory_link(&library_skill, &source_skill_link).expect("link source skill");
+
+        clone_copy_agent_profile_files(home, "source-agent", "dest-agent")
+            .expect("copy profile files");
+
+        assert_eq!(
+            std::fs::read_to_string(
+                dest.join(".agents")
+                    .join("skills")
+                    .join("linked-skill")
+                    .join("SKILL.md")
+            )
+            .expect("read copied linked skill"),
+            "# Linked Skill\n"
+        );
+        assert!(
+            std::fs::read_link(dest.join(".agents").join("skills").join("linked-skill")).is_ok()
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -16,6 +16,130 @@ pub struct SpawnAgentRequest {
     pub config_override: Option<AgentConfig>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloneAgentMode {
+    Fresh,
+    Profile,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CloneAgentRequest {
+    pub source_session_id: String,
+    pub mode: CloneAgentMode,
+    pub session_name: Option<String>,
+    pub provider: Option<String>,
+    pub folder: Option<String>,
+    pub agent_class: Option<String>,
+    pub start: Option<bool>,
+}
+
+fn clone_unique_name(source_name: &str, existing_names: &std::collections::HashSet<String>) -> String {
+    let base = if source_name.trim().is_empty() {
+        "agent"
+    } else {
+        source_name.trim()
+    };
+    let first = format!("{}-copy", base);
+    if !existing_names.contains(&first) {
+        return first;
+    }
+
+    let mut index = 2;
+    loop {
+        let candidate = format!("{}-copy-{}", base, index);
+        if !existing_names.contains(&candidate) {
+            return candidate;
+        }
+        index += 1;
+    }
+}
+
+fn clone_sanitize_config(
+    source: &AgentConfig,
+    session_name: String,
+    provider: Option<String>,
+    folder: Option<String>,
+    agent_class: Option<String>,
+    start: bool,
+) -> AgentConfig {
+    let mut config = source.clone();
+    config.session_id.clear();
+    config.session_name = session_name;
+    if let Some(provider) = provider.filter(|value| !value.trim().is_empty()) {
+        config.provider = provider;
+    }
+    if let Some(folder) = folder {
+        config.folder = folder;
+    }
+    if let Some(agent_class) = agent_class.filter(|value| !value.trim().is_empty()) {
+        config.agent_class = agent_class;
+    }
+    config.resume_session = None;
+    config.fresh_provider_session_id = None;
+    config.codex_cleared_provider_sessions.clear();
+    config.system_include_directories = None;
+    config.opencode_port = None;
+    config.is_off = !start;
+    config
+}
+
+fn clone_copy_file(source: &std::path::Path, destination: &std::path::Path) -> Result<(), String> {
+    if !source.is_file() {
+        return Ok(());
+    }
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::copy(source, destination)
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+fn clone_copy_directory_recursive(
+    source: &std::path::Path,
+    destination: &std::path::Path,
+) -> Result<(), String> {
+    if !source.exists() {
+        return Ok(());
+    }
+    if destination.exists() || destination.symlink_metadata().is_ok() {
+        let _ = std::fs::remove_dir_all(destination).or_else(|_| std::fs::remove_file(destination));
+    }
+    std::fs::create_dir_all(destination).map_err(|e| e.to_string())?;
+
+    for entry in std::fs::read_dir(source).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let metadata = std::fs::symlink_metadata(&source_path).map_err(|e| e.to_string())?;
+        if metadata.is_dir() {
+            clone_copy_directory_recursive(&source_path, &destination_path)?;
+        } else if metadata.is_file() {
+            clone_copy_file(&source_path, &destination_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn clone_copy_agent_profile_files(
+    wardian_home: &std::path::Path,
+    source_session_id: &str,
+    destination_session_id: &str,
+) -> Result<(), String> {
+    let source_root = wardian_home.join("agents").join(source_session_id);
+    let destination_root = wardian_home.join("agents").join(destination_session_id);
+    std::fs::create_dir_all(&destination_root).map_err(|e| e.to_string())?;
+
+    clone_copy_file(&source_root.join("AGENTS.md"), &destination_root.join("AGENTS.md"))?;
+    clone_copy_directory_recursive(
+        &source_root.join(".agents").join("skills"),
+        &destination_root.join(".agents").join("skills"),
+    )
+}
+
 fn persisted_resume_session_for_provider(
     provider_name: &str,
     actual_resume: Option<String>,
@@ -160,78 +284,15 @@ async fn is_name_unique(state: &AppState, name: &str, exclude_session_id: Option
     })
 }
 
-#[tauri::command]
-pub async fn spawn_agent(
-    req: SpawnAgentRequest,
-    state: State<'_, AppState>,
-    app: AppHandle,
+async fn register_new_agent(
+    mut config: AgentConfig,
+    mut actual_resume: Option<String>,
+    state: &AppState,
+    app: &AppHandle,
 ) -> Result<AgentConfig, String> {
-    let session_name = req.session_name;
-    let agent_class = req.agent_class;
-    let folder = req.folder;
-    let resume_session = req.resume_session;
-    let is_off = req.is_off;
-    let config_override = req.config_override;
-
-    if !is_valid_name(&session_name) {
-        return Err("Invalid agent name. Names must contain only alphanumeric characters, underscores, or hyphens (no spaces).".to_string());
-    }
-
-    if !is_name_unique(&state, &session_name, None).await {
-        return Err(format!(
-            "An agent with the name '{}' already exists.",
-            session_name
-        ));
-    }
-
-    manager::log_debug(&format!(
-        "[WARDIAN] spawn_agent called for session name: {}, class: {}",
-        session_name, agent_class
-    ));
-    let provider_name = config_override
-        .as_ref()
-        .map(|c| c.provider.clone())
-        .unwrap_or_else(|| "claude".to_string());
-    let mut actual_resume = resume_session.clone().filter(|s| !s.is_empty());
-
-    let mut session_id = actual_resume.clone();
-
-    if actual_resume.is_none() {
-        if provider_uses_generated_session_id(&provider_name) {
-            session_id = Some(uuid::Uuid::new_v4().to_string());
-        } else {
-            let cwd = crate::utils::fs::resolve_cwd(&folder, "");
-
-            match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref())
-                .await
-            {
-                Ok(real_sid) => {
-                    manager::log_debug(&format!(
-                        "[WARDIAN] Intercepted stream-json session ID for {}: {}",
-                        provider_name, real_sid
-                    ));
-                    // Properly set final_resume because manager::spawn_agent requires it to launch the persistent agent with --resume
-                    session_id = Some(real_sid.clone());
-                    actual_resume = Some(real_sid);
-                }
-                Err(e) => {
-                    return Err(format!("Failed to initialize the provider session: {}", e));
-                }
-            }
-        }
-    }
-
-    let session_id = session_id.ok_or_else(|| "Failed to determine session ID".to_string())?;
-
-    let mut config = config_override.unwrap_or_default();
-    config.session_id = session_id.clone();
-    config.session_name = session_name;
-    config.agent_class = agent_class.clone();
-    config.folder = folder;
-    config.resume_session = actual_resume.clone();
-    config.is_off = is_off.unwrap_or(false);
+    let session_id = config.session_id.clone();
     config.system_include_directories = Some(crate::utils::fs::resolve_system_include_directories(
-        &agent_class,
+        &config.agent_class,
         &session_id,
     ));
     let active_agent = manager::spawn_agent(app.clone(), config.clone(), false, None).await?;
@@ -303,9 +364,166 @@ pub async fn spawn_agent(
     let mut order = state.agent_order.lock().await;
     agents.insert(session_id.clone(), active_agent);
     order.push(session_id.clone());
-    manager::save_state(&app, &agents, &order);
+    manager::save_state(app, &agents, &order);
+    let _ = app.emit("agents-updated", ());
 
     Ok(config)
+}
+
+#[tauri::command]
+pub async fn spawn_agent(
+    req: SpawnAgentRequest,
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<AgentConfig, String> {
+    let session_name = req.session_name;
+    let agent_class = req.agent_class;
+    let folder = req.folder;
+    let resume_session = req.resume_session;
+    let is_off = req.is_off;
+    let config_override = req.config_override;
+
+    if !is_valid_name(&session_name) {
+        return Err("Invalid agent name. Names must contain only alphanumeric characters, underscores, or hyphens (no spaces).".to_string());
+    }
+
+    if !is_name_unique(&state, &session_name, None).await {
+        return Err(format!(
+            "An agent with the name '{}' already exists.",
+            session_name
+        ));
+    }
+
+    manager::log_debug(&format!(
+        "[WARDIAN] spawn_agent called for session name: {}, class: {}",
+        session_name, agent_class
+    ));
+    let provider_name = config_override
+        .as_ref()
+        .map(|c| c.provider.clone())
+        .unwrap_or_else(|| "claude".to_string());
+    let mut actual_resume = resume_session.clone().filter(|s| !s.is_empty());
+
+    let mut session_id = actual_resume.clone();
+
+    if actual_resume.is_none() {
+        if provider_uses_generated_session_id(&provider_name) {
+            session_id = Some(uuid::Uuid::new_v4().to_string());
+        } else {
+            let cwd = crate::utils::fs::resolve_cwd(&folder, "");
+
+            match manager::obtain_session_id(&cwd, Some(&agent_class), config_override.as_ref())
+                .await
+            {
+                Ok(real_sid) => {
+                    manager::log_debug(&format!(
+                        "[WARDIAN] Intercepted stream-json session ID for {}: {}",
+                        provider_name, real_sid
+                    ));
+                    // Properly set final_resume because manager::spawn_agent requires it to launch the persistent agent with --resume
+                    session_id = Some(real_sid.clone());
+                    actual_resume = Some(real_sid);
+                }
+                Err(e) => {
+                    return Err(format!("Failed to initialize the provider session: {}", e));
+                }
+            }
+        }
+    }
+
+    let session_id = session_id.ok_or_else(|| "Failed to determine session ID".to_string())?;
+
+    let mut config = config_override.unwrap_or_default();
+    config.session_id = session_id.clone();
+    config.session_name = session_name;
+    config.agent_class = agent_class.clone();
+    config.folder = folder;
+    config.resume_session = actual_resume.clone();
+    config.is_off = is_off.unwrap_or(false);
+    register_new_agent(config, actual_resume, &state, &app).await
+}
+
+#[tauri::command]
+pub async fn clone_agent(
+    req: CloneAgentRequest,
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<AgentConfig, String> {
+    let source_session_id = req.source_session_id.trim().to_string();
+    if source_session_id.is_empty() {
+        return Err("Source agent is required.".to_string());
+    }
+
+    let (source_config, existing_names) = {
+        let agents = state.agents.lock().await;
+        let source = agents
+            .get(&source_session_id)
+            .ok_or_else(|| format!("Agent {} not found", source_session_id))?
+            .config
+            .lock()
+            .unwrap()
+            .clone();
+        let names = agents
+            .values()
+            .map(|agent| agent.config.lock().unwrap().session_name.clone())
+            .collect::<std::collections::HashSet<_>>();
+        (source, names)
+    };
+
+    let session_name = req
+        .session_name
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| clone_unique_name(&source_config.session_name, &existing_names));
+    if !is_valid_name(&session_name) {
+        return Err("Invalid agent name. Names must contain only alphanumeric characters, underscores, or hyphens (no spaces).".to_string());
+    }
+    if existing_names.contains(&session_name) {
+        return Err(format!(
+            "An agent with the name '{}' already exists.",
+            session_name
+        ));
+    }
+
+    manager::log_debug(&format!(
+        "[WARDIAN] clone_agent called for source session: {}, mode: {:?}",
+        source_session_id, req.mode
+    ));
+
+    let mut config = clone_sanitize_config(
+        &source_config,
+        session_name,
+        req.provider,
+        req.folder,
+        req.agent_class,
+        req.start.unwrap_or(true),
+    );
+    let provider_name = config.provider.clone();
+    let mut actual_resume = None;
+    let session_id = if provider_uses_generated_session_id(&provider_name) {
+        uuid::Uuid::new_v4().to_string()
+    } else {
+        let cwd = crate::utils::fs::resolve_cwd(&config.folder, "");
+        let real_sid = manager::obtain_session_id(&cwd, Some(&config.agent_class), Some(&config))
+            .await
+            .map_err(|e| format!("Failed to initialize the provider session: {}", e))?;
+        manager::log_debug(&format!(
+            "[WARDIAN] Intercepted stream-json clone session ID for {}: {}",
+            provider_name, real_sid
+        ));
+        actual_resume = Some(real_sid.clone());
+        real_sid
+    };
+
+    config.session_id = session_id.clone();
+    config.resume_session = actual_resume.clone();
+
+    if req.mode == CloneAgentMode::Profile {
+        let home = crate::utils::fs::get_wardian_home()
+            .ok_or_else(|| "Could not find Wardian home".to_string())?;
+        clone_copy_agent_profile_files(&home, &source_session_id, &session_id)?;
+    }
+
+    register_new_agent(config, actual_resume, &state, &app).await
 }
 
 #[tauri::command]
@@ -763,12 +981,14 @@ pub async fn reorder_agents(
 #[cfg(test)]
 mod tests {
     use super::{
+        clone_copy_agent_profile_files, clone_sanitize_config, clone_unique_name,
         codex_provider_session_is_new, persisted_resume_session_for_provider, prepare_clear_config,
         prepare_resume_config, provider_needs_obtain_session_id_on_clear,
         provider_uses_generated_session_id, restore_runtime_state_after_resume,
     };
     use crate::models::{AgentConfig, AgentSessionPersistenceOverride};
     use crate::state::ActiveAgent;
+    use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
 
     fn make_test_agent() -> ActiveAgent {
@@ -802,6 +1022,133 @@ mod tests {
         })
         .expect("save shell settings");
         (guard, temp)
+    }
+
+    fn clone_name_set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|name| name.to_string()).collect()
+    }
+
+    #[test]
+    fn clone_unique_name_uses_copy_suffix_when_available() {
+        assert_eq!(
+            clone_unique_name("Alpha", &clone_name_set(&["Alpha"])),
+            "Alpha-copy"
+        );
+    }
+
+    #[test]
+    fn clone_unique_name_increments_copy_suffix_until_available() {
+        assert_eq!(
+            clone_unique_name("Alpha", &clone_name_set(&["Alpha", "Alpha-copy"])),
+            "Alpha-copy-2"
+        );
+    }
+
+    #[test]
+    fn clone_sanitize_config_preserves_visible_setup_and_clears_runtime_memory() {
+        let source = AgentConfig {
+            session_id: "source-session".to_string(),
+            session_name: "Alpha".to_string(),
+            agent_class: "Coder".to_string(),
+            folder: "D:/Development/Wardian".to_string(),
+            provider: "codex".to_string(),
+            model: Some("gpt-5.4".to_string()),
+            resume_session: Some("provider-session".to_string()),
+            fresh_provider_session_id: Some("fresh-provider-session".to_string()),
+            codex_cleared_provider_sessions: vec!["old-provider-session".to_string()],
+            is_off: true,
+            custom_args: Some("--verbose".to_string()),
+            ..Default::default()
+        };
+
+        let clone = clone_sanitize_config(
+            &source,
+            "Alpha-copy".to_string(),
+            None,
+            None,
+            None,
+            true,
+        );
+
+        assert_eq!(clone.session_id, "");
+        assert_eq!(clone.session_name, "Alpha-copy");
+        assert_eq!(clone.agent_class, "Coder");
+        assert_eq!(clone.folder, "D:/Development/Wardian");
+        assert_eq!(clone.provider, "codex");
+        assert_eq!(clone.model.as_deref(), Some("gpt-5.4"));
+        assert_eq!(clone.custom_args.as_deref(), Some("--verbose"));
+        assert_eq!(clone.resume_session, None);
+        assert_eq!(clone.fresh_provider_session_id, None);
+        assert!(clone.codex_cleared_provider_sessions.is_empty());
+        assert!(!clone.is_off);
+    }
+
+    #[test]
+    fn clone_sanitize_config_applies_custom_overrides() {
+        let source = AgentConfig {
+            session_name: "Alpha".to_string(),
+            agent_class: "Coder".to_string(),
+            folder: "D:/source".to_string(),
+            provider: "claude".to_string(),
+            ..Default::default()
+        };
+
+        let clone = clone_sanitize_config(
+            &source,
+            "Beta".to_string(),
+            Some("gemini".to_string()),
+            Some("D:/target".to_string()),
+            Some("Reviewer".to_string()),
+            false,
+        );
+
+        assert_eq!(clone.session_name, "Beta");
+        assert_eq!(clone.provider, "gemini");
+        assert_eq!(clone.folder, "D:/target");
+        assert_eq!(clone.agent_class, "Reviewer");
+        assert!(clone.is_off);
+    }
+
+    #[test]
+    fn clone_profile_copy_carries_whitelisted_files_and_excludes_runtime_files() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source = home.join("agents").join("source-agent");
+        let dest = home.join("agents").join("dest-agent");
+        std::fs::create_dir_all(source.join(".agents").join("skills").join("skill-one"))
+            .expect("create source skill");
+        std::fs::create_dir_all(source.join("habitat")).expect("create habitat");
+        std::fs::create_dir_all(source.join("claude")).expect("create claude dir");
+        std::fs::write(source.join("AGENTS.md"), "# Agent Memory\n").expect("write agents");
+        std::fs::write(
+            source.join(".agents").join("skills").join("skill-one").join("SKILL.md"),
+            "# Skill\n",
+        )
+        .expect("write skill");
+        std::fs::write(source.join("habitat").join("AGENTS.md"), "generated")
+            .expect("write habitat");
+        std::fs::write(source.join("claude").join("permission-requests.jsonl"), "{}\n")
+            .expect("write log");
+
+        clone_copy_agent_profile_files(home, "source-agent", "dest-agent")
+            .expect("copy profile files");
+
+        assert_eq!(
+            std::fs::read_to_string(dest.join("AGENTS.md")).expect("read copied agents"),
+            "# Agent Memory\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                dest.join(".agents")
+                    .join("skills")
+                    .join("skill-one")
+                    .join("SKILL.md")
+            )
+            .expect("read copied skill"),
+            "# Skill\n"
+        );
+        assert!(!dest.join("habitat").exists());
+        assert!(!dest.join("claude").join("permission-requests.jsonl").exists());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -223,6 +223,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::agent::spawn_agent,
+            commands::agent::clone_agent,
             commands::agent::list_agents,
             commands::agent::list_agent_metrics,
             commands::agent::kill_agent,

--- a/src-tauri/src/manager/headless.rs
+++ b/src-tauri/src/manager/headless.rs
@@ -385,7 +385,10 @@ pub async fn obtain_session_id(
             })
         })
         .unwrap_or("");
-    let habitat_root = prepare_provider_habitat(provider_name, cwd, class_name, None)?;
+    let bootstrap_session_id = config
+        .and_then(|cfg| (!cfg.session_id.trim().is_empty()).then_some(cfg.session_id.as_str()));
+    let habitat_root =
+        prepare_provider_habitat(provider_name, cwd, class_name, bootstrap_session_id)?;
     let codex_bootstrap = if provider_name == "codex" {
         let wardian_home = get_wardian_home().ok_or("Could not find Wardian home")?;
         Some(codex_bootstrap_launch_context(&wardian_home, cwd))
@@ -465,7 +468,7 @@ pub async fn obtain_session_id(
             cmd.env("CODEX_HOME", habitat_codex_home(root));
         }
     } else if provider_name == "opencode" {
-        for (key, value) in opencode_env(cwd, class_name, None, config)? {
+        for (key, value) in opencode_env(cwd, class_name, bootstrap_session_id, config)? {
             cmd.env(key, value);
         }
         cmd.stdin(std::process::Stdio::null());

--- a/src-tauri/src/models/agent_config.rs
+++ b/src-tauri/src/models/agent_config.rs
@@ -16,6 +16,8 @@ pub struct AgentConfig {
     pub agent_class: String,
     #[serde(default)]
     pub folder: String,
+    #[serde(default)]
+    pub git_worktree: Option<bool>,
     pub resume_session: Option<String>,
     #[serde(default)]
     pub is_off: bool,
@@ -117,6 +119,7 @@ mod tests {
             session_name: "TestAgent".into(),
             agent_class: "Coder".into(),
             folder: "C:/project".into(),
+            git_worktree: Some(true),
             resume_session: Some("def-456".into()),
             codex_cleared_provider_sessions: vec!["old-codex-session".into()],
             is_off: true,
@@ -128,6 +131,7 @@ mod tests {
         assert_eq!(config.session_name, deserialized.session_name);
         assert_eq!(config.agent_class, deserialized.agent_class);
         assert_eq!(config.folder, deserialized.folder);
+        assert_eq!(config.git_worktree, deserialized.git_worktree);
         assert_eq!(config.resume_session, deserialized.resume_session);
         assert_eq!(
             config.codex_cleared_provider_sessions,

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -580,7 +580,10 @@ fn escape_posix_single_quoted(value: &str) -> String {
     value.replace('\'', "'\"'\"'")
 }
 
-fn create_directory_link(target: &std::path::Path, link: &std::path::Path) -> Result<(), String> {
+pub(crate) fn create_directory_link(
+    target: &std::path::Path,
+    link: &std::path::Path,
+) -> Result<(), String> {
     #[cfg(windows)]
     {
         if let Some(parent) = link.parent() {

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -20,6 +20,7 @@ export interface AgentContextMenuProps {
   onPause: (agentId: string) => MaybePromise;
   onRestart: (agentId: string) => MaybePromise;
   onClear: (agentId: string) => MaybePromise;
+  onClone?: (agentId: string, mode: "fresh" | "profile") => MaybePromise;
   onAddToList: (listId: string, agentId: string) => MaybePromise;
   onRemoveFromList: (listId: string, agentId: string) => MaybePromise;
   onAddAgentsToList?: (listId: string, agentIds: string[]) => MaybePromise;
@@ -47,6 +48,7 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   onPause,
   onRestart,
   onClear,
+  onClone,
   onAddToList,
   onRemoveFromList,
   onAddAgentsToList,
@@ -65,6 +67,7 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
   const allTargetsOff = targetAgentIds.every((id) => offAgentIds.has(id));
   const anyTargetOff = targetAgentIds.some((id) => offAgentIds.has(id));
   const anyTargetRunning = targetAgentIds.some((id) => !offAgentIds.has(id));
+  const canClone = !isTeam && !isBulk && Boolean(onClone);
 
   const forEachTarget = async (handler: (id: string) => MaybePromise) => {
     for (const id of targetAgentIds) {
@@ -118,6 +121,45 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" /></svg>
         {isTeam ? 'Query Team' : isBulk ? 'Query Selected' : 'Query'}
       </button>
+
+      {canClone && (
+        <div className="context-menu-submenu">
+          <button
+            className="context-menu-item"
+            onMouseEnter={() => setSubMenuListId("clone")}
+            onClick={async () => {
+              await onClone?.(agentId, "fresh");
+              onClose();
+            }}
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 8h10a2 2 0 012 2v8a2 2 0 01-2 2H8a2 2 0 01-2-2V8zm0 0V6a2 2 0 012-2h8M4 14H3a1 1 0 01-1-1V4a2 2 0 012-2h9a1 1 0 011 1v1" /></svg>
+            Clone
+            <svg className="w-3 h-3 ml-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" /></svg>
+          </button>
+          {subMenuListId === "clone" && (
+            <div className={`context-submenu ${x > window.innerWidth / 2 ? 'flip-left' : ''}`}>
+              <button
+                className="context-menu-item"
+                onClick={async () => {
+                  await onClone?.(agentId, "fresh");
+                  onClose();
+                }}
+              >
+                Fresh Clone
+              </button>
+              <button
+                className="context-menu-item"
+                onClick={async () => {
+                  await onClone?.(agentId, "profile");
+                  onClose();
+                }}
+              >
+                Profile Clone
+              </button>
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="context-menu-divider" />
 

--- a/src/layout/watchlist/AgentWatchlist.test.tsx
+++ b/src/layout/watchlist/AgentWatchlist.test.tsx
@@ -30,6 +30,7 @@ describe('AgentWatchlist', () => {
   const mockOnClear = vi.fn();
   const mockOnDelete = vi.fn();
   const mockOnDeleteAgents = vi.fn();
+  const mockOnClone = vi.fn();
   const mockOnAddAgentsToList = vi.fn();
   const mockOnRemoveAgentsFromList = vi.fn();
   const mockOnCreateTeam = vi.fn();
@@ -73,6 +74,7 @@ describe('AgentWatchlist', () => {
     onClear: mockOnClear,
     onDelete: mockOnDelete,
     onDeleteAgents: mockOnDeleteAgents,
+    onClone: mockOnClone,
     onCreateTeam: mockOnCreateTeam,
     onUngroupTeam: mockOnUngroupTeam,
     onAddAgentToTeam: mockOnAddAgentToTeam,
@@ -164,6 +166,29 @@ describe('AgentWatchlist', () => {
     expect(mockOnClear).toHaveBeenCalledWith('agent-1');
   });
 
+  it('runs a fresh clone when clicking Clone from a single-agent context menu', async () => {
+    render(<AgentWatchlist {...defaultProps} />);
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row');
+
+    fireEvent.contextMenu(agentRow!);
+    fireEvent.click(within(screen.getByTestId('agent-context-menu')).getByRole('button', { name: 'Clone' }));
+
+    expect(mockOnClone).toHaveBeenCalledWith('agent-1', 'fresh');
+  });
+
+  it('offers fresh and profile clone modes from the clone submenu', async () => {
+    render(<AgentWatchlist {...defaultProps} />);
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row');
+
+    fireEvent.contextMenu(agentRow!);
+    fireEvent.mouseEnter(within(screen.getByTestId('agent-context-menu')).getByRole('button', { name: 'Clone' }));
+
+    expect(screen.getByRole('button', { name: 'Fresh Clone' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Profile Clone' }));
+
+    expect(mockOnClone).toHaveBeenCalledWith('agent-1', 'profile');
+  });
+
   it('uses a bulk context menu when right-clicking inside a multi-selection', async () => {
     render(
       <AgentWatchlist
@@ -178,6 +203,7 @@ describe('AgentWatchlist', () => {
     const menu = screen.getByTestId('agent-context-menu');
     expect(within(menu).getByRole('button', { name: 'Rename' })).toBeDisabled();
     expect(within(menu).getByRole('button', { name: 'Clear Selected' })).toBeInTheDocument();
+    expect(within(menu).queryByRole('button', { name: 'Clone' })).not.toBeInTheDocument();
 
     fireEvent.click(within(menu).getByRole('button', { name: 'Clear Selected' }));
 
@@ -300,6 +326,7 @@ describe('AgentWatchlist', () => {
 
     const menu = screen.getByTestId('agent-context-menu');
     expect(within(menu).getByRole('button', { name: 'Rename Team' })).toBeInTheDocument();
+    expect(within(menu).queryByRole('button', { name: 'Clone' })).not.toBeInTheDocument();
     fireEvent.click(within(menu).getByRole('button', { name: 'Query Team' }));
 
     await waitFor(() => {

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -74,6 +74,7 @@ interface AgentWatchlistProps {
   onPause: (agentId: string) => void;
   onRestart: (agentId: string) => void;
   onClear: (agentId: string) => void;
+  onClone?: (agentId: string, mode: "fresh" | "profile") => void;
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
   onAddAgentsToList?: (listId: string, agentIds: string[]) => void;
@@ -113,6 +114,7 @@ export default function AgentWatchlist({
   onPause,
   onRestart,
   onClear,
+  onClone,
   onAddToList,
   onRemoveFromList,
   onAddAgentsToList,
@@ -1018,6 +1020,7 @@ export default function AgentWatchlist({
           onPause={onPause}
           onRestart={onRestart}
           onClear={onClear}
+          onClone={onClone}
           onAddToList={(listId, agentId) => {
             onAddToList(listId, agentId);
             setContextMenu(p => ({ ...p, visible: false }));
@@ -1065,6 +1068,7 @@ export default function AgentWatchlist({
             onPause={onPause}
             onRestart={onRestart}
             onClear={onClear}
+            onClone={onClone}
             onAddToList={(listId, id) => {
               onAddToList(listId, id);
               setTeamContextMenu((p) => ({ ...p, visible: false }));

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -57,6 +57,23 @@ function setupDefaultMocks(agents: AgentConfig[] = [], classes: AgentClassDefini
           );
         }
         return null;
+      case "clone_agent":
+        if (args?.req?.source_session_id) {
+          const source = currentAgents.find(a => a.session_id === args.req.source_session_id);
+          if (source) {
+            currentAgents = [
+              ...currentAgents,
+              {
+                ...source,
+                session_id: "agent-clone",
+                session_name: `${source.session_name}-copy`,
+                resume_session: undefined,
+                is_off: false,
+              },
+            ];
+          }
+        }
+        return currentAgents[currentAgents.length - 1] ?? null;
       case "get_agent_metrics":
         return [];
       case "attach_agent_pty":
@@ -349,6 +366,32 @@ describe("Agent Watchlist Sidebar", () => {
       expect(screen.getAllByTestId("agent-card")).toHaveLength(2);
       expect(screen.getAllByText("Alpha").length).toBeGreaterThanOrEqual(2);
       expect(screen.getAllByText("Beta").length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it("invokes clone_agent from the single-agent context menu", async () => {
+    setupDefaultMocks(sampleAgents, defaultClasses);
+    render(<App />);
+
+    const alphaWatchlistRow = await waitFor(() => {
+      const row = screen
+        .getAllByText("Alpha")
+        .map((node) => node.closest("div.watchlist-row"))
+        .find((candidate): candidate is HTMLElement => Boolean(candidate));
+      if (!row) throw new Error("Alpha watchlist row not found");
+      return row;
+    });
+
+    fireEvent.contextMenu(alphaWatchlistRow);
+    fireEvent.click(within(screen.getByTestId("agent-context-menu")).getByRole("button", { name: "Clone" }));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("clone_agent", {
+        req: {
+          source_session_id: "agent-1",
+          mode: "fresh",
+        },
+      });
     });
   });
 

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -609,6 +609,21 @@ function AppBody() {
     }
   };
 
+  const onClone = async (id: string, mode: "fresh" | "profile") => {
+    try {
+      await invoke("clone_agent", {
+        req: {
+          source_session_id: id,
+          mode,
+        },
+      });
+      fetchAgents();
+    } catch (e) {
+      console.error(e);
+      alert(`Failed to clone agent: ${e}`);
+    }
+  };
+
   const onDelete = async (id: string) => {
     if (await confirm('Delete this agent?')) {
       try {
@@ -743,6 +758,7 @@ function AppBody() {
                 onPause={onPause}
                 onRestart={onRestart}
                 onClear={onClear}
+                onClone={onClone}
                 onMouseEnterCard={handleMouseEnterCard}
                 onMouseUp={handleMouseUp}
                 onMouseDown={handleMouseDown}
@@ -802,6 +818,7 @@ function AppBody() {
           onPause={onPause}
           onRestart={onRestart}
           onClear={onClear}
+          onClone={onClone}
           onDelete={onDelete}
           onDeleteAgents={onDeleteAgents}
           onAddToList={handleAddToList}

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -39,6 +39,7 @@ interface GridViewProps {
   onPause: (agentId: string) => void;
   onRestart: (agentId: string) => void;
   onClear: (agentId: string) => void;
+  onClone?: (agentId: string, mode: "fresh" | "profile") => void;
 }
 
 export const GridView: React.FC<GridViewProps> = ({
@@ -73,6 +74,7 @@ export const GridView: React.FC<GridViewProps> = ({
   onPause,
   onRestart,
   onClear,
+  onClone,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { layout, resetLayout, gridStacked } = useLayoutStore();
@@ -334,6 +336,7 @@ export const GridView: React.FC<GridViewProps> = ({
           onPause={onPause}
           onRestart={onRestart}
           onClear={onClear}
+          onClone={onClone}
           onAddToList={onAddToList}
           onRemoveFromList={onRemoveFromList}
           onDelete={onDelete}


### PR DESCRIPTION
## Description
Adds single-agent clone actions to the agent context menu:
- Fresh Clone is the direct `Clone` action and starts a new provider conversation from the source agent setup.
- Profile Clone copies whitelisted local profile files (`AGENTS.md`, `.agents/skills`) while still clearing provider memory.
- Backend-owned clone semantics now guard linked skills, session-bearing custom args, duplicate names/session ids, and existing profile directories.

## Related Issues
Refs #11

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test` (345 passed; existing AgentWatchlist `act(...)` warnings still print)
- [x] `npm run build` (passes; existing Vite chunk-size warning still prints)
- [x] `CARGO_TARGET_DIR=target\\codex-check cargo clippy`
- [x] `CARGO_TARGET_DIR=target\\codex-check cargo test` (267 unit + 4 integration passed)
- [x] `CARGO_TARGET_DIR=target\\codex-check cargo check`
- [x] `git diff --check`
- [x] Subagent review: final blocker-only review found no Critical or Important blockers

## Screenshots
Not captured locally. This change is a context-menu state covered by unit tests; no persistent visual layout changed.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable