### PR TITLE
Fix workflow run modal placement

### DIFF
--- a/src/features/workflows/WorkflowSidebar.test.tsx
+++ b/src/features/workflows/WorkflowSidebar.test.tsx
@@ -124,18 +124,19 @@ describe('WorkflowSidebar', () => {
     expect(mockResumeAllTriggers).toHaveBeenCalled();
   });
 
-  it('creates a new scheduled run from the sidebar instead of launching an immediate execution', async () => {
-    renderWithProvider(<WorkflowSidebar />);
+  it('delegates configurable workflow runs to the main view instead of opening the modal in the sidebar', async () => {
+    const mockOpenRunModalInMain = vi.fn();
+    renderWithProvider(<WorkflowSidebar onOpenRunModalInMain={mockOpenRunModalInMain} />);
 
     fireEvent.click(screen.getByText('Alpha Workflow'));
 
-    // Because it's a scheduled trigger, it will open the RunPayloadModal first
-    await waitFor(() => expect(screen.getByRole('button', { name: /Schedule Workflow/i })).toBeInTheDocument());
-    
-    // Submit the modal to actually schedule it
-    fireEvent.click(screen.getByRole('button', { name: /Schedule Workflow/i }));
-
-    await waitFor(() => expect(mockCreateScheduledRun).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockOpenRunModalInMain).toHaveBeenCalledTimes(1));
+    expect(mockOpenRunModalInMain).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'wf-1' }),
+      'scheduled',
+    );
+    expect(screen.queryByRole('button', { name: /Schedule Workflow/i })).not.toBeInTheDocument();
+    expect(mockCreateScheduledRun).not.toHaveBeenCalled();
     expect(mockRunWorkflowById).not.toHaveBeenCalled();
   });
 

--- a/src/features/workflows/WorkflowSidebar.tsx
+++ b/src/features/workflows/WorkflowSidebar.tsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { useWorkflowStore } from '../../store/useWorkflowStore';
 import { WorkflowLibrary } from './WorkflowLibrary';
 import { ActiveMonitoring } from './ActiveMonitoring';
-import { RunPayloadModal, getManualTriggerSchema } from './RunPayloadModal';
+import { getManualTriggerSchema } from './RunPayloadModal';
 import type { WorkflowDefinition } from '../../types/workflow';
 import { useConfirm } from '../../components/ConfirmDialog';
 import {
@@ -21,14 +21,13 @@ const SearchIcon = () => <svg className="w-4 h-4" fill="none" stroke="currentCol
 
 interface WorkflowSidebarProps {
   onOpenWorkflowBuilder?: () => void;
+  onOpenRunModalInMain?: (workflow: WorkflowDefinition, kind: WorkflowLaunchKind) => void;
 }
 
-interface PendingWorkflowLaunch {
-  workflow: WorkflowDefinition;
-  kind: WorkflowLaunchKind;
-}
-
-export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = ({ onOpenWorkflowBuilder }) => {
+export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = ({
+  onOpenWorkflowBuilder,
+  onOpenRunModalInMain,
+}) => {
   const {
     availableWorkflows,
     fetchWorkflows,
@@ -53,7 +52,6 @@ export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = ({ onOpenWorkflow
 
   const confirm = useConfirm();
   const [searchQuery, setSearchQuery] = useState('');
-  const [pendingLaunch, setPendingLaunch] = useState<PendingWorkflowLaunch | null>(null);
 
   const executeWorkflowLaunch = async (
     workflow: WorkflowDefinition,
@@ -113,7 +111,7 @@ export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = ({ onOpenWorkflow
     const requiresConfig = workflowNeedsRunConfig(normalized, Boolean(getManualTriggerSchema(normalized)));
 
     if (requiresConfig) {
-      setPendingLaunch({ workflow: normalized, kind });
+      onOpenRunModalInMain?.(normalized, kind);
       return;
     }
 
@@ -274,19 +272,6 @@ export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = ({ onOpenWorkflow
           />
         </div>
       </div>
-
-      {pendingLaunch && (
-        <RunPayloadModal
-          workflow={pendingLaunch.workflow}
-          isOpen={true}
-          agents={agents.map(a => ({ session_id: a.session_id, session_name: a.session_name }))}
-          onRun={async (payload) => {
-            await executeWorkflowLaunch(pendingLaunch.workflow, pendingLaunch.kind, payload);
-            setPendingLaunch(null);
-          }}
-          onCancel={() => setPendingLaunch(null)}
-        />
-      )}
     </div>
   );
 };

--- a/src/layout/SidebarContentPane.tsx
+++ b/src/layout/SidebarContentPane.tsx
@@ -11,6 +11,8 @@ import { SettingsPanel } from "../features/settings/SettingsPanel";
 import { WorkflowSidebar } from "../features/workflows/WorkflowSidebar";
 import { ExplorerPanel } from "../features/explorer/ExplorerPanel";
 import { GitPanel } from "../features/git/GitPanel";
+import type { WorkflowDefinition } from "../types/workflow";
+import type { WorkflowLaunchKind } from "../features/workflows/workflowLaunch";
 
 interface SidebarContentPaneProps {
   activeTab: SidebarTab;
@@ -26,9 +28,10 @@ interface SidebarContentPaneProps {
   setBroadcastMessage: (msg: string) => void;
   onBroadcast: (e: React.FormEvent) => void;
   onOpenWorkflowBuilder: () => void;
-  }
+  onOpenWorkflowRunModalInMain?: (workflow: WorkflowDefinition, kind: WorkflowLaunchKind) => void;
+}
 
-  export const SidebarContentPane: React.FC<SidebarContentPaneProps> = ({
+export const SidebarContentPane: React.FC<SidebarContentPaneProps> = ({
   activeTab,
   leftCollapsed,
   selectedAgentIds,
@@ -42,10 +45,11 @@ interface SidebarContentPaneProps {
   setBroadcastMessage,
   onBroadcast,
   onOpenWorkflowBuilder,
-  }) => {
-    return (
-      <aside className={`relative h-full bg-[var(--color-wardian-sidebar-secondary)]/30 border-r border-wardian-border sidebar-transition overflow-hidden flex flex-col ${leftCollapsed ? 'w-0' : 'w-[var(--sidebar-content-width)]'}`}>
-        <div className="px-4 py-6 flex-1 overflow-y-auto no-scrollbar min-w-[var(--sidebar-content-width)] flex flex-col min-h-0 h-full">
+  onOpenWorkflowRunModalInMain,
+}) => {
+  return (
+    <aside className={`relative h-full bg-[var(--color-wardian-sidebar-secondary)]/30 border-r border-wardian-border sidebar-transition overflow-hidden flex flex-col ${leftCollapsed ? 'w-0' : 'w-[var(--sidebar-content-width)]'}`}>
+      <div className="px-4 py-6 flex-1 overflow-y-auto no-scrollbar min-w-[var(--sidebar-content-width)] flex flex-col min-h-0 h-full">
         {activeTab === "explorer" && (
           <ExplorerPanel selectedAgentIds={selectedAgentIds} />
         )}
@@ -108,7 +112,10 @@ interface SidebarContentPaneProps {
         )}
 
         {activeTab === "workflows" && (
-          <WorkflowSidebar onOpenWorkflowBuilder={onOpenWorkflowBuilder} />
+          <WorkflowSidebar
+            onOpenWorkflowBuilder={onOpenWorkflowBuilder}
+            onOpenRunModalInMain={onOpenWorkflowRunModalInMain}
+          />
         )}
 
         {activeTab === "settings" && (

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -37,6 +37,14 @@ import { useLibraryStore } from "../store/useLibraryStore";
 import { useSettingsStore } from "../store/useSettingsStore";
 import { useLayoutStore } from "../store/useLayoutStore";
 import { submitInputToAgent, submitInputToAgents } from "../utils/terminalInput";
+import { RunPayloadModal } from "../features/workflows/RunPayloadModal";
+import {
+  buildScheduledRunFromWorkflow,
+  normalizeWorkflowForLaunch,
+  setWorkflowTriggerStatus,
+  type WorkflowLaunchKind,
+} from "../features/workflows/workflowLaunch";
+import type { WorkflowDefinition } from "../types/workflow";
 
 declare global {
   interface Window {
@@ -68,6 +76,10 @@ function AppBody() {
   const handleWorkflowStatusUpdate = useWorkflowStore(s => s.handleStatusUpdate);
   const fetchWorkflows = useWorkflowStore(s => s.fetchWorkflows);
   const loadScheduledRuns = useWorkflowStore(s => s.loadScheduledRuns);
+  const loadWorkflow = useWorkflowStore(s => s.loadWorkflow);
+  const saveWorkflow = useWorkflowStore(s => s.saveWorkflow);
+  const runWorkflowById = useWorkflowStore(s => s.runWorkflowById);
+  const createScheduledRun = useWorkflowStore(s => s.createScheduledRun);
   const fetchLibraryTree = useLibraryStore(s => s.fetchLibraryTree);
 
   useEffect(() => {
@@ -137,6 +149,10 @@ function AppBody() {
   const [activeListId, setActiveListId] = useState<string>("all");
   const [watchlistPrefs, setWatchlistPrefs] = useState<WatchlistPrefs>(DEFAULT_WATCHLIST_PREFS);
   const [agentInteractions, setAgentInteractions] = useState<AgentInteractions>({});
+  const [sidebarPendingWorkflowLaunch, setSidebarPendingWorkflowLaunch] = useState<{
+    workflow: WorkflowDefinition;
+    kind: WorkflowLaunchKind;
+  } | null>(null);
   const hasAutoPatched = useRef(false);
 
   useEffect(() => {
@@ -569,6 +585,58 @@ function AppBody() {
     } catch (e) { console.error(e); }
   }
 
+  const openWorkflowRunModalInMain = useCallback((workflow: WorkflowDefinition, kind: WorkflowLaunchKind) => {
+    loadWorkflow(workflow);
+    setActiveTab("workflows");
+    setViewMode("workflow-builder");
+    setSidebarPendingWorkflowLaunch({ workflow, kind });
+  }, [loadWorkflow]);
+
+  const executeSidebarWorkflowLaunch = useCallback(async (
+    workflow: WorkflowDefinition,
+    kind: WorkflowLaunchKind,
+    payload?: Record<string, any>,
+  ) => {
+    const mergedRoleMappings = payload?.role_mappings && typeof payload.role_mappings === 'object'
+      ? { ...(workflow.role_mappings || {}), ...payload.role_mappings }
+      : workflow.role_mappings || {};
+
+    const configuredWorkflow = normalizeWorkflowForLaunch({
+      ...workflow,
+      role_mappings: mergedRoleMappings,
+    });
+
+    if (kind === 'scheduled') {
+      let workflowForSchedule = configuredWorkflow;
+      if (payload?.schedule) {
+        workflowForSchedule = {
+          ...configuredWorkflow,
+          nodes: configuredWorkflow.nodes.map(n => {
+            if (n.type === 'trigger' && n.name === 'Scheduled Trigger') {
+              return { ...n, config: { ...n.config, schedule: { ...n.config?.schedule, ...payload.schedule } } };
+            }
+            return n;
+          }),
+        };
+        await saveWorkflow(workflowForSchedule);
+      }
+
+      const scheduledRun = buildScheduledRunFromWorkflow(workflowForSchedule);
+      if (scheduledRun) {
+        await createScheduledRun(scheduledRun);
+      }
+      return;
+    }
+
+    if (kind === 'listener') {
+      await saveWorkflow(setWorkflowTriggerStatus(configuredWorkflow, 'active'));
+      await fetchWorkflows();
+      return;
+    }
+
+    await runWorkflowById(configuredWorkflow.id, payload);
+  }, [createScheduledRun, fetchWorkflows, runWorkflowById, saveWorkflow]);
+
   const onPause = async (id: string) => {
     try {
       await invoke('pause_agent', { sessionId: id });
@@ -699,6 +767,7 @@ function AppBody() {
             setActiveTab("workflows");
             setViewMode("workflow-builder");
           }}
+          onOpenWorkflowRunModalInMain={openWorkflowRunModalInMain}
         />
 
         <main className="flex-1 h-full flex flex-col overflow-hidden relative">
@@ -781,6 +850,22 @@ function AppBody() {
               />
             )}
           </div>
+          {sidebarPendingWorkflowLaunch && (
+            <RunPayloadModal
+              workflow={sidebarPendingWorkflowLaunch.workflow}
+              isOpen={true}
+              agents={agents.map(a => ({ session_id: a.session_id, session_name: a.session_name }))}
+              onRun={async (payload) => {
+                await executeSidebarWorkflowLaunch(
+                  sidebarPendingWorkflowLaunch.workflow,
+                  sidebarPendingWorkflowLaunch.kind,
+                  payload,
+                );
+                setSidebarPendingWorkflowLaunch(null);
+              }}
+              onCancel={() => setSidebarPendingWorkflowLaunch(null)}
+            />
+          )}
         </main>
 
         <AgentWatchlist


### PR DESCRIPTION
## Description
- Moves workflow sidebar run configuration requests up to `App` so `RunPayloadModal` renders inside the main view instead of the sidebar.
- Keeps immediate, no-config workflow launches in the sidebar path.
- Adds a regression test that proves configurable sidebar launches delegate upward and do not render the modal locally.

## Related Issues
Fixes #161

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] `npm run test -- src/features/workflows/WorkflowSidebar.test.tsx` - 7 passed
- [x] `npm run lint` - passed
- [x] `npm run test` - 342 passed; existing `AgentWatchlist` `act(...)` warnings still print
- [x] `npm run build` - passed; existing Vite chunk-size warning still prints
- [x] `git diff --check` - passed
- [x] `cargo check` - passed
- [x] `cargo test` - 257 unit tests and 4 mock-provider tests passed
- [x] `cargo clippy` - passed

## Screenshots
Not captured for this hotfix. The changed behavior is covered by the focused regression test asserting the sidebar no longer renders the modal locally.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable