### PR TITLE
fix(git): restore source control status

### DIFF
--- a/e2e-native/tests/git-panel-native.test.mjs
+++ b/e2e-native/tests/git-panel-native.test.mjs
@@ -1,0 +1,161 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { By, until } from "selenium-webdriver";
+
+import {
+  createNativeHarness,
+  ensureNativeAppBuilt,
+  prepareIsolatedHome,
+  startNativeSession,
+  waitForAppShell,
+} from "../lib/harness.mjs";
+
+const skipNativeBuild = process.env.WARDIAN_NATIVE_SKIP_BUILD === "1";
+const RUN_ID = `${process.pid}-${Date.now()}`;
+const SESSION_ID = `e2e-git-${RUN_ID}`;
+const SESSION_NAME = `E2E-Git-${RUN_ID}`;
+
+function runGit(repoPath, args) {
+  const result = spawnSync("git", args, {
+    cwd: repoPath,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed\n${result.stderr || result.stdout}`);
+  }
+}
+
+function seedGitRepo(harness) {
+  const repoPath = path.join(harness.isolatedHome, "git-fixture-repo");
+  fs.mkdirSync(repoPath, { recursive: true });
+
+  runGit(repoPath, ["init"]);
+  runGit(repoPath, ["checkout", "-b", "main"]);
+  fs.writeFileSync(path.join(repoPath, "tracked.txt"), "initial\n");
+  runGit(repoPath, ["add", "tracked.txt"]);
+  runGit(repoPath, [
+    "-c",
+    "user.name=Wardian E2E",
+    "-c",
+    "user.email=wardian-e2e@example.invalid",
+    "commit",
+    "-m",
+    "Initial commit",
+  ]);
+
+  fs.writeFileSync(path.join(repoPath, "tracked.txt"), "changed\n");
+  fs.writeFileSync(path.join(repoPath, "untracked.txt"), "new\n");
+
+  return repoPath;
+}
+
+async function createOffMockAgent(driver, repoPath) {
+  const result = await driver.executeAsyncScript((sessionId, sessionName, folder, done) => {
+    window.__TAURI_INTERNALS__.invoke("spawn_agent", {
+      req: {
+        sessionName,
+        agentClass: "TestClass",
+        folder,
+        resumeSession: sessionId,
+        isOff: true,
+        configOverride: { provider: "mock" },
+      },
+    }).then(
+      (agent) => done(agent),
+      (error) => done({ error: String(error) }),
+    );
+  }, SESSION_ID, SESSION_NAME, repoPath);
+
+  assert.equal(result?.error, undefined, `Failed to create E2E agent: ${result?.error}`);
+}
+
+async function invokeTauri(driver, command, args = {}) {
+  const result = await driver.executeAsyncScript((cmd, payload, done) => {
+    window.__TAURI_INTERNALS__.invoke(cmd, payload).then(
+      (value) => done({ ok: true, value }),
+      (error) => done({ ok: false, error: String(error) }),
+    );
+  }, command, args);
+
+  assert.equal(result.ok, true, `${command} failed: ${result.error}`);
+  return result.value;
+}
+
+async function clickWatchlistAgent(driver) {
+  const agentName = await driver.wait(
+    until.elementLocated(By.xpath(`//p[normalize-space(.)=${JSON.stringify(SESSION_NAME)}]`)),
+    20000,
+  );
+  await driver.wait(until.elementIsVisible(agentName), 20000);
+  await agentName.click();
+}
+
+async function waitForExactText(driver, text, timeoutMs = 15000) {
+  try {
+    await driver.wait(until.elementLocated(By.xpath(`//*[normalize-space(.)=${JSON.stringify(text)}]`)), timeoutMs);
+  } catch (error) {
+    const bodyText = await driver.executeScript(() => document.body?.innerText ?? "");
+    throw new Error(`Expected text "${text}" was not rendered.\nBody: ${bodyText.slice(0, 2500)}\n${error}`);
+  }
+}
+
+test("source control panel renders git files and history for a seeded repo", { timeout: 180000 }, async (t) => {
+  const harness = await createNativeHarness();
+  assert.ok(harness.appPath);
+
+  try {
+    if (!skipNativeBuild) {
+      ensureNativeAppBuilt(harness);
+    }
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  prepareIsolatedHome(harness);
+
+  let repoPath;
+  try {
+    repoPath = seedGitRepo(harness);
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  let session;
+  try {
+    session = await startNativeSession(harness);
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  t.after(async () => {
+    await session.close();
+  });
+
+  const { driver } = session;
+  await waitForAppShell(driver, 20000);
+  await createOffMockAgent(driver, repoPath);
+  const rootPath = await invokeTauri(driver, "get_explorer_root", { sessionId: SESSION_ID });
+  assert.equal(rootPath, repoPath);
+  const status = await invokeTauri(driver, "git_status", { cwd: rootPath });
+  assert.equal(status.branch, "main");
+  assert.ok(status.files.some((file) => file.path === "tracked.txt"));
+  assert.ok(status.files.some((file) => file.path === "untracked.txt"));
+  await driver.navigate().refresh();
+  await waitForAppShell(driver, 20000);
+
+  await clickWatchlistAgent(driver);
+  await driver.findElement(By.css('[data-testid="sidebar-tab-git"]')).click();
+
+  await waitForExactText(driver, "Source Control");
+  await waitForExactText(driver, "main");
+  await waitForExactText(driver, "tracked.txt");
+  await waitForExactText(driver, "untracked.txt");
+  await waitForExactText(driver, "Initial commit");
+});

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,28 +1,61 @@
 use crate::models::git::{GitFileEntry, GitLogEntry, GitStatusResult};
 use crate::state::AppState;
-use crate::utils::process::new_headless_std_command;
 use notify::Watcher;
+use std::process::{Command, Stdio};
 use tauri::{AppHandle, Emitter};
 
 /// Run a git command in the given directory and return stdout as a String.
 ///
-/// Uses `new_headless_std_command` so no console window flashes on Windows.
+/// Uses a direct command with `CREATE_NO_WINDOW` on Windows so stdout can be
+/// captured without flashing a console window.
 /// Sets `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS=echo` so git never blocks
 /// waiting for credential input (mirrors VS Code's git extension behaviour).
 fn run_git(cwd: &str, args: &[&str]) -> Result<String, String> {
-    let output = new_headless_std_command("git")
+    let mut command = Command::new("git");
+    command
         .args(args)
         .current_dir(cwd)
+        .stdin(Stdio::null())
         .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_ASKPASS", "echo")
+        .env("GIT_ASKPASS", "echo");
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x08000000);
+    }
+
+    let output = command
         .output()
         .map_err(|e| format!("Failed to execute git: {}", e))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(stderr.trim().to_string());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        return Err(git_failure_message(
+            output.status.code(),
+            stdout.as_ref(),
+            stderr.as_ref(),
+        ));
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn git_failure_message(status_code: Option<i32>, stdout: &str, stderr: &str) -> String {
+    let stderr = stderr.trim();
+    if !stderr.is_empty() {
+        return stderr.to_string();
+    }
+
+    let stdout = stdout.trim();
+    if !stdout.is_empty() {
+        return stdout.to_string();
+    }
+
+    match status_code {
+        Some(code) => format!("git exited with status {}", code),
+        None => "git exited unsuccessfully".to_string(),
+    }
 }
 
 /// Parse `git status --porcelain=v1 -b` output into a GitStatusResult.
@@ -353,5 +386,27 @@ mod tests {
         assert_eq!(result.files.len(), 1);
         assert_eq!(result.files[0].path, "new/path.rs");
         assert!(result.files[0].is_staged);
+    }
+
+    #[test]
+    fn run_git_captures_stdout() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().to_str().unwrap();
+
+        run_git(cwd, &["init"]).unwrap();
+        let output = run_git(cwd, &["status", "--porcelain=v1", "-b"]).unwrap();
+
+        assert!(
+            output.contains("## "),
+            "expected porcelain status on stdout, got: {output:?}"
+        );
+    }
+
+    #[test]
+    fn git_failure_message_never_returns_empty_error() {
+        assert_eq!(
+            git_failure_message(Some(1), "", ""),
+            "git exited with status 1"
+        );
     }
 }

--- a/src/features/git/GitPanel.test.tsx
+++ b/src/features/git/GitPanel.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from "@testing-library/react";
+import { invoke } from "@tauri-apps/api/core";
+import { GitPanel } from "./GitPanel";
+import { ConfirmProvider } from "../../components/ConfirmDialog";
+import type { AgentConfig, AgentTelemetry } from "../../types";
+
+const mockInvoke = vi.mocked(invoke);
+
+const agent: AgentConfig = {
+  session_id: "agent-1",
+  session_name: "Repo Agent",
+  agent_class: "Coder",
+  folder: "C:/repo",
+  is_off: false,
+};
+
+const telemetry: Record<string, AgentTelemetry> = {
+  "agent-1": {
+    session_id: "agent-1",
+    cpu_usage: 0,
+    memory_mb: 0,
+    uptime_seconds: 0,
+    query_count: 0,
+    init_timestamp: null,
+    current_status: "Idle",
+    log_path: null,
+  },
+};
+
+function renderGitPanel() {
+  render(
+    <ConfirmProvider>
+      <GitPanel
+        selectedAgentIds={new Set(["agent-1"])}
+        agents={[agent]}
+        onAgentsUpdated={vi.fn()}
+        telemetry={telemetry}
+      />
+    </ConfirmProvider>,
+  );
+}
+
+describe("GitPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows an error instead of loading forever when the workspace cannot be resolved", async () => {
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === "get_explorer_root") throw new Error("Agent not found");
+      return null;
+    });
+
+    renderGitPanel();
+
+    expect(await screen.findByText("Unable to Load Source Control")).toBeInTheDocument();
+    expect(screen.getByText("Agent not found")).toBeInTheDocument();
+    expect(screen.queryByText("Loading git status...")).not.toBeInTheDocument();
+  });
+
+  it("shows a not-a-repository state when git status reports a non-git workspace", async () => {
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === "get_explorer_root") return "C:/not-a-repo";
+      if (command === "git_status") throw new Error("fatal: not a git repository (or any of the parent directories): .git");
+      if (command === "git_log") return [];
+      return null;
+    });
+
+    renderGitPanel();
+
+    expect(await screen.findByText("Not a Git Repository")).toBeInTheDocument();
+    expect(screen.getByText("The agent's workspace is not initialized as a git repository.")).toBeInTheDocument();
+    expect(screen.queryByText("Loading git status...")).not.toBeInTheDocument();
+  });
+
+  it("shows a fallback error instead of loading forever when git status returns an empty error", async () => {
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === "get_explorer_root") return "C:/repo";
+      if (command === "git_status") throw "";
+      if (command === "git_log") return [];
+      return null;
+    });
+
+    renderGitPanel();
+
+    expect(await screen.findByText("Unable to Load Source Control")).toBeInTheDocument();
+    expect(screen.getByText("Unable to load git status.")).toBeInTheDocument();
+    expect(screen.queryByText("Loading git status...")).not.toBeInTheDocument();
+  });
+
+  it("renders changed files and commit history for a loaded repository", async () => {
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === "get_explorer_root") return "C:/repo";
+      if (command === "git_status") {
+        return {
+          branch: "main",
+          ahead: 1,
+          behind: 0,
+          files: [
+            { path: "src/changed.ts", status: "M", is_staged: false },
+            { path: "README.md", status: "A", is_staged: true },
+          ],
+        };
+      }
+      if (command === "git_log") {
+        return [
+          {
+            hash: "1234567890abcdef",
+            message: "Initial commit",
+            author: "Tester",
+            date: "2026-04-30 00:00:00 -0400",
+          },
+        ];
+      }
+      return null;
+    });
+
+    renderGitPanel();
+
+    expect(await screen.findByText("main")).toBeInTheDocument();
+    expect(screen.getByText("changed.ts")).toBeInTheDocument();
+    expect(screen.getByText("README.md")).toBeInTheDocument();
+    expect(screen.getByText("Initial commit")).toBeInTheDocument();
+  });
+
+  it("keeps file status visible when commit history cannot be loaded", async () => {
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === "get_explorer_root") return "C:/repo";
+      if (command === "git_status") {
+        return {
+          branch: "main",
+          ahead: 0,
+          behind: 0,
+          files: [{ path: "src/changed.ts", status: "M", is_staged: false }],
+        };
+      }
+      if (command === "git_log") throw new Error("fatal: your current branch does not have any commits yet");
+      return null;
+    });
+
+    renderGitPanel();
+
+    expect(await screen.findByText("changed.ts")).toBeInTheDocument();
+    expect(screen.getByText("History unavailable")).toBeInTheDocument();
+  });
+});

--- a/src/features/git/GitPanel.tsx
+++ b/src/features/git/GitPanel.tsx
@@ -6,6 +6,8 @@ import { GitFileList } from "./GitFileList";
 import { GitDiffView } from "./GitDiffView";
 import { useConfirm } from "../../components/ConfirmDialog";
 
+const DEFAULT_GIT_ERROR = "Unable to load git status.";
+
 interface GitPanelProps {
   selectedAgentIds: Set<string>;
   agents: AgentConfig[];
@@ -32,27 +34,44 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
 
   // Commit history
   const [history, setHistory] = useState<GitLogEntry[]>([]);
+  const [historyError, setHistoryError] = useState<string | null>(null);
 
   const selectedAgentId = selectedAgentIds.size === 1 ? Array.from(selectedAgentIds)[0] : null;
   const selectedAgent = agents.find((a) => a.session_id === selectedAgentId) ?? null;
-  const isNotGitRepoError = (error ?? "").toLowerCase().includes("not a git repository");
+  const errorMessage = error === null ? "" : error.trim() || DEFAULT_GIT_ERROR;
+  const isNotGitRepoError =
+    errorMessage.toLowerCase().includes("not a git repository") ||
+    errorMessage.toLowerCase().includes("not a git directory");
   // Branch starts with "wardian/" when the agent is actively running inside a worktree
   const isWorktreeActive = status?.branch?.startsWith("wardian/") ?? false;
   const isAgentRunning = (telemetry[selectedAgentId ?? ""]?.current_status ?? "Off") !== "Off";
 
+  const formatError = (err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    return message.trim() || DEFAULT_GIT_ERROR;
+  };
 
   // Resolve the agent's working directory
   useEffect(() => {
     const fetchPath = async () => {
+      setStatus(null);
+      setHistory([]);
+      setHistoryError(null);
+      setError(null);
+      setRootPath(null);
+
       if (!selectedAgentId) {
-        setRootPath(null);
         return;
       }
       try {
         const path = await invoke<string>("get_explorer_root", { sessionId: selectedAgentId });
+        if (!path.trim()) {
+          setError("Agent workspace is not configured.");
+          return;
+        }
         setRootPath(path);
-      } catch {
-        setRootPath(null);
+      } catch (err) {
+        setError(formatError(err));
       }
     };
     fetchPath();
@@ -67,7 +86,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
       setError(null);
     } catch (err) {
       setStatus(null);
-      setError(String(err));
+      setError(formatError(err));
     }
   }, [rootPath]);
 
@@ -77,8 +96,10 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
     try {
       const log = await invoke<GitLogEntry[]>("git_log", { cwd: rootPath, count: 50 });
       setHistory(log);
-    } catch {
+      setHistoryError(null);
+    } catch (err) {
       setHistory([]);
+      setHistoryError(formatError(err));
     }
   }, [rootPath]);
 
@@ -250,7 +271,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
   }
 
   // Not a git repo or error
-  if (error) {
+  if (error !== null) {
     return (
       <div className="flex flex-col h-full w-full">
         <h2 className="text-xl font-bold text-primary tracking-tight mb-4">Source Control</h2>
@@ -267,7 +288,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
           <p className="text-xs text-muted italic px-4">
             {isNotGitRepoError
               ? "The agent's workspace is not initialized as a git repository."
-              : error}
+              : errorMessage}
           </p>
         </div>
       </div>
@@ -395,14 +416,16 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
         {/* Staged Changes */}
         {stagedFiles.length > 0 && (
           <section>
-            <button
-              onClick={() => setStagedOpen(!stagedOpen)}
-              className="flex items-center gap-1.5 w-full text-left py-1 group"
-            >
-              <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${stagedOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-              </svg>
-              <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Staged Changes</span>
+            <div className="flex items-center gap-1.5 w-full py-1 group">
+              <button
+                onClick={() => setStagedOpen(!stagedOpen)}
+                className="flex items-center gap-1.5 flex-1 min-w-0 text-left"
+              >
+                <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${stagedOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                </svg>
+                <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Staged Changes</span>
+              </button>
               <div className="flex-1" />
               <button
                 onClick={(e) => { e.stopPropagation(); handleUnstageAll(); }}
@@ -416,7 +439,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
               <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
                 {stagedFiles.length}
               </span>
-            </button>
+            </div>
             {stagedOpen && (
               <GitFileList
                 files={stagedFiles}
@@ -430,14 +453,16 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
         {/* Changes (unstaged tracked) */}
         {unstagedTracked.length > 0 && (
           <section>
-            <button
-              onClick={() => setChangesOpen(!changesOpen)}
-              className="flex items-center gap-1.5 w-full text-left py-1 group"
-            >
-              <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${changesOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-              </svg>
-              <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Changes</span>
+            <div className="flex items-center gap-1.5 w-full py-1 group">
+              <button
+                onClick={() => setChangesOpen(!changesOpen)}
+                className="flex items-center gap-1.5 flex-1 min-w-0 text-left"
+              >
+                <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${changesOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                </svg>
+                <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Changes</span>
+              </button>
               <div className="flex-1" />
               <button
                 onClick={(e) => { e.stopPropagation(); handleStageAll(); }}
@@ -451,7 +476,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
               <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
                 {unstagedTracked.length}
               </span>
-            </button>
+            </div>
             {changesOpen && (
               <GitFileList
                 files={unstagedTracked}
@@ -466,14 +491,16 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
         {/* Untracked Files */}
         {untrackedFiles.length > 0 && (
           <section>
-            <button
-              onClick={() => setUntrackedOpen(!untrackedOpen)}
-              className="flex items-center gap-1.5 w-full text-left py-1 group"
-            >
-              <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${untrackedOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
-              </svg>
-              <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Untracked</span>
+            <div className="flex items-center gap-1.5 w-full py-1 group">
+              <button
+                onClick={() => setUntrackedOpen(!untrackedOpen)}
+                className="flex items-center gap-1.5 flex-1 min-w-0 text-left"
+              >
+                <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${untrackedOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                </svg>
+                <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Untracked</span>
+              </button>
               <div className="flex-1" />
               <button
                 onClick={(e) => { e.stopPropagation(); handleStageAll(); }}
@@ -487,7 +514,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
               <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
                 {untrackedFiles.length}
               </span>
-            </button>
+            </div>
             {untrackedOpen && (
               <GitFileList
                 files={untrackedFiles}
@@ -509,7 +536,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
         )}
 
         {/* Commit History */}
-        {history.length > 0 && (
+        {(history.length > 0 || historyError) && (
           <section className="mt-1 border-t border-wardian-border/30 pt-2">
             <button
               onClick={() => setHistoryOpen(!historyOpen)}
@@ -520,22 +547,28 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
               </svg>
               <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">History</span>
               <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
-                {history.length}
+                {historyError ? "!" : history.length}
               </span>
             </button>
             {historyOpen && (
               <div className="flex flex-col">
-                {history.map((entry, i) => (
-                  <div key={entry.hash} className="flex items-center gap-2 py-[3px] px-1 hover:bg-wardian-card-bg-muted rounded group cursor-default">
-                    <div className="relative flex flex-col items-center shrink-0" style={{ width: 12 }}>
-                      {i > 0 && <div className="absolute top-0 left-1/2 -translate-x-1/2 w-px bg-wardian-border/50" style={{ height: '50%' }} />}
-                      <div className={`w-2 h-2 rounded-full border shrink-0 z-10 ${i === 0 ? 'bg-[var(--color-wardian-accent)] border-[var(--color-wardian-accent)]' : 'bg-transparent border-[var(--color-wardian-text-muted)]'}`} />
-                      {i < history.length - 1 && <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-px bg-wardian-border/50" style={{ height: '50%' }} />}
-                    </div>
-                    <span className="text-[11px] text-primary truncate flex-1 leading-snug">{entry.message}</span>
-                    <span className="text-[9px] font-mono text-[var(--color-wardian-text-muted)] shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">{entry.hash.slice(0, 7)}</span>
+                {historyError ? (
+                  <div className="px-1 py-2 text-[11px] text-[var(--color-wardian-text-muted)]">
+                    History unavailable
                   </div>
-                ))}
+                ) : (
+                  history.map((entry, i) => (
+                    <div key={entry.hash} className="flex items-center gap-2 py-[3px] px-1 hover:bg-wardian-card-bg-muted rounded group cursor-default">
+                      <div className="relative flex flex-col items-center shrink-0" style={{ width: 12 }}>
+                        {i > 0 && <div className="absolute top-0 left-1/2 -translate-x-1/2 w-px bg-wardian-border/50" style={{ height: '50%' }} />}
+                        <div className={`w-2 h-2 rounded-full border shrink-0 z-10 ${i === 0 ? 'bg-[var(--color-wardian-accent)] border-[var(--color-wardian-accent)]' : 'bg-transparent border-[var(--color-wardian-text-muted)]'}`} />
+                        {i < history.length - 1 && <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-px bg-wardian-border/50" style={{ height: '50%' }} />}
+                      </div>
+                      <span className="text-[11px] text-primary truncate flex-1 leading-snug">{entry.message}</span>
+                      <span className="text-[9px] font-mono text-[var(--color-wardian-text-muted)] shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">{entry.hash.slice(0, 7)}</span>
+                    </div>
+                  ))
+                )}
               </div>
             )}
           </section>


### PR DESCRIPTION
## Description
Fixes the Source Control panel getting stuck on `Loading git status...` when an agent workspace cannot be resolved, and restores missing git branch/file/history data for real repositories.

The root backend issue was that git commands used a headless helper that nulled stdout/stderr before calling `.output()`, so `git status` and `git log` returned empty output even when the commands succeeded. This PR uses a capture-capable git command setup while preserving no-window behavior on Windows, and normalizes git failures so empty stderr cannot put the panel back into a loading state.

## Related Issues
Fixes #163

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` (352 passed; existing AgentWatchlist React act warnings still print)
- `npm run build` via native E2E build step (passes; existing Vite chunk-size warning still prints)
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test` (269 lib/main tests + 4 mock provider tests passed)
- `cd src-tauri && cargo clippy -- -D warnings`
- `node --test --test-concurrency=1 e2e-native/tests/git-panel-native.test.mjs`
- `git diff --check`

## Screenshots
Native E2E covers the rendered Source Control state with a seeded real git repository. No static screenshot is embedded for this hotfix.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable