### PR TITLE
fix(library): list linked deployed skills

### DIFF
--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -407,6 +407,25 @@ fn deploy_skill_from_library(
     deploy_skill_dir_with_linker(&src_dir, &dst_dir, link_skill_dir).map_err(|e| e.to_string())
 }
 
+fn list_deployed_skill_names(target_type: &str, target_id: &str) -> Result<Vec<String>, String> {
+    let target_skills_dir = get_target_skills_dir(target_type, target_id)?;
+    let mut skills = Vec::new();
+
+    if !target_skills_dir.exists() {
+        return Ok(skills);
+    }
+
+    let entries = fs::read_dir(target_skills_dir).map_err(|e| e.to_string())?;
+    for entry in entries.flatten() {
+        if entry.path().is_dir() {
+            skills.push(entry.file_name().to_string_lossy().to_string());
+        }
+    }
+    skills.sort();
+
+    Ok(skills)
+}
+
 #[tauri::command]
 pub async fn deploy_skill(
     _app: AppHandle,
@@ -440,22 +459,7 @@ pub async fn list_deployed_skills(
     target_type: String,
     target_id: String,
 ) -> Result<Vec<String>, String> {
-    let target_skills_dir = get_target_skills_dir(&target_type, &target_id)?;
-    let mut skills = Vec::new();
-
-    if target_skills_dir.exists() {
-        if let Ok(entries) = fs::read_dir(target_skills_dir) {
-            for entry in entries.flatten() {
-                if let Ok(file_type) = entry.file_type() {
-                    if file_type.is_dir() {
-                        skills.push(entry.file_name().to_string_lossy().to_string());
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(skills)
+    list_deployed_skill_names(&target_type, &target_id)
 }
 
 #[tauri::command]
@@ -575,6 +579,25 @@ mod tests {
             "updated",
             "expected live-linked skill content; debug log:\n{}",
             debug_log
+        );
+    }
+
+    #[test]
+    fn list_deployed_skills_includes_linked_skill_directories() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _env_guard = WardianHomeGuard;
+
+        let source_dir = temp.path().join("library").join("skills").join("planner");
+        fs::create_dir_all(&source_dir).expect("source skill dir");
+        fs::write(source_dir.join("SKILL.md"), "linked").expect("source skill");
+
+        deploy_skill_from_library("planner", "agent", "agent-1").expect("deploy skill");
+
+        assert_eq!(
+            list_deployed_skill_names("agent", "agent-1").expect("list skills"),
+            vec!["planner".to_string()]
         );
     }
 


### PR DESCRIPTION
## Description
Fixes Agent Config showing `No skills currently deployed` for agents whose skills are deployed as live symlinks/junctions instead of copied directories.

The backend scanner used `DirEntry::file_type().is_dir()`, which can miss linked directory deployments. The command now lists deployed skill names through a helper that follows directory links with `entry.path().is_dir()`, keeps the existing frontend contract, and returns a deterministic sorted list.

## Related Issues
Fixes #165

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` (347 passed; existing AgentWatchlist React act warnings still print)
- `npm run build` (passes; existing Vite chunk-size warning still prints)
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test commands::library::tests`
- `cd src-tauri && cargo test` (268 lib/main tests + 4 mock provider tests passed)
- `cd src-tauri && cargo clippy -- -D warnings`
- `git diff --check`

## Screenshots
No visual styling changed. This is a backend listing fix for the existing Agent Config Manage Skills UI.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable