### PR TITLE
ci(release): dispatch asset build with repo

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,7 @@ jobs:
           RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
         run: |
           gh workflow run release.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref main \
             -f dry_run=false \
             -f tag="$RELEASE_TAG" \

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -12,6 +12,7 @@ describe("release workflow contract", () => {
     expect(releasePleaseWorkflow).toContain("actions: write");
     expect(releasePleaseWorkflow).toContain("Dispatch asset build");
     expect(releasePleaseWorkflow).toContain("gh workflow run release.yml");
+    expect(releasePleaseWorkflow).toContain("--repo \"$GITHUB_REPOSITORY\"");
     expect(releasePleaseWorkflow).toContain("steps.release.outputs.tag_name");
   });
 


### PR DESCRIPTION
## Description
Fixes the failed Release Please follow-up dispatch after release creation.

The `release-please` job does not check out the repository before running `gh workflow run release.yml`. Without an explicit repo, `gh` tries to infer the repository from git and fails with `fatal: not a git repository`. This PR passes `--repo "$GITHUB_REPOSITORY"` to the dispatch command and adds a workflow contract test for that behavior.

## Related Issues
Fixes #167

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run test -- src/config/releaseWorkflow.test.ts` failed before the workflow change and passed after it
- `npm run lint`
- `git diff --check`

## Screenshots
Not applicable. This is a CI workflow fix.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable