### PR TITLE
fix(release): resolve draft releases for manual backfill

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,16 +84,29 @@ jobs:
     steps:
       - name: Resolve existing release
         id: lookup
+        uses: actions/github-script@v7
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          if [ -z "$RELEASE_TAG" ]; then
-            echo "release_tag is required when dry_run=false" >&2
-            exit 1
-          fi
-          RELEASE_ID="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" --jq .id)"
-          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+        with:
+          script: |
+            const releaseTag = process.env.RELEASE_TAG;
+            if (!releaseTag) {
+              core.setFailed('release_tag is required when dry_run=false');
+              return;
+            }
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const release = releases.find((candidate) => candidate.tag_name === releaseTag);
+            if (!release) {
+              core.setFailed(`Release ${releaseTag} was not found`);
+              return;
+            }
+
+            core.setOutput('release_id', String(release.id));
 
   build:
     name: Build (${{ matrix.platform.os }}${{ matrix.platform.arch && format(' / {0}', matrix.platform.arch) || '' }})
@@ -191,7 +204,7 @@ jobs:
   publish:
     name: Publish release
     needs: [create-release, resolve-release, build]
-    if: needs.build.result == 'success' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true'))
+    if: always() && needs.build.result == 'success' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true'))
     runs-on: ubuntu-latest
     steps:
       - name: Publish the release

--- a/docs/specs/027-release-artifact-ownership.md
+++ b/docs/specs/027-release-artifact-ownership.md
@@ -10,7 +10,7 @@ Release Please owns version calculation, changelog updates, release PRs, and tag
 
 To enforce that split without requiring a personal access token, `release-please-config.json` creates GitHub releases as drafts. When Release Please reports a created release, `.github/workflows/release-please.yml` dispatches `.github/workflows/release.yml` through `workflow_dispatch`, passing the tag as both the build ref and the existing release tag. The release workflow resolves that draft release, uploads platform bundles through `tauri-apps/tauri-action`, and publishes the release only after the build matrix succeeds.
 
-Manual `workflow_dispatch` runs may also backfill assets onto an existing release. In that mode, the workflow checks out the requested `tag`, resolves the existing GitHub release from `release_tag`, and uploads artifacts to that release ID. Dry runs still build and retain Actions artifacts without mutating a GitHub release.
+Manual `workflow_dispatch` runs may also backfill assets onto an existing release. In that mode, the workflow checks out the requested `tag`, resolves the existing GitHub release from `release_tag`, and uploads artifacts to that release ID. Because Release Please leaves releases as drafts until artifacts are ready, the resolver must list releases and match by `tag_name`; GitHub's get-release-by-tag endpoint does not return draft releases. Dry runs still build and retain Actions artifacts without mutating a GitHub release.
 
 ## Verification
 

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -24,12 +24,14 @@ describe("release workflow contract", () => {
     expect(releaseWorkflow).toContain("Publish release");
   });
 
-  it("can manually backfill assets onto an existing release", () => {
+  it("can manually backfill assets onto an existing draft release", () => {
     expect(releaseWorkflow).toContain("tag:");
     expect(releaseWorkflow).toContain("release_tag:");
     expect(releaseWorkflow).toContain("Resolve existing release");
-    expect(releaseWorkflow).toContain("/releases/tags/");
+    expect(releaseWorkflow).toContain("github.rest.repos.listReleases");
+    expect(releaseWorkflow).toContain("candidate.tag_name === releaseTag");
     expect(releaseWorkflow).toContain("needs.resolve-release.outputs.release_id");
     expect(releaseWorkflow).toContain("Publish the release");
+    expect(releaseWorkflow).toContain("always() && needs.build.result == 'success'");
   });
 });


### PR DESCRIPTION
## Summary
- resolve manual release backfills by listing releases so draft releases are included
- keep the release workflow contract test aligned with draft-release backfills
- document why draft releases cannot use the get-release-by-tag endpoint

Fixes #169

## Verification
- npm run test -- releaseWorkflow
- npm run lint