### PR TITLE
fix(agent): enable spawn on non-Windows

### DIFF
--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -25,7 +25,6 @@ use super::{
     app_process_supervisor_active, assign_pid_to_job, cleanup_stale_session_processes,
     create_kill_on_close_job,
 };
-#[cfg(windows)]
 pub async fn spawn_agent(
     app: AppHandle,
     config: AgentConfig,
@@ -942,16 +941,6 @@ pub async fn spawn_agent(
         #[cfg(windows)]
         job_object,
     })
-}
-
-#[cfg(not(windows))]
-pub async fn spawn_agent(
-    _app: AppHandle,
-    _config: AgentConfig,
-    _is_restored: bool,
-    _initial_timestamp: Option<String>,
-) -> Result<ActiveAgent, String> {
-    Err("Interactive agent spawning is only supported on Windows".to_string())
 }
 
 pub async fn resize_pty(

--- a/src/config/spawnManager.test.ts
+++ b/src/config/spawnManager.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import spawnManager from "../../src-tauri/src/manager/spawn.rs?raw";
+
+describe("agent spawn manager contract", () => {
+  it("keeps interactive agent spawning enabled on non-Windows platforms", () => {
+    expect(spawnManager).not.toContain("#[cfg(not(windows))]\npub async fn spawn_agent");
+    expect(spawnManager).not.toContain(
+      "Interactive agent spawning is only supported on Windows",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- remove the non-Windows spawn_agent stub so the portable-pty spawn path is used on macOS/Linux
- keep Windows process-tree cleanup guarded behind existing cfg(windows) checks
- add a contract test that blocks reintroducing the non-Windows unsupported spawn error

Fixes #172

## Verification
- npm run lint
- npm run test
- npm run build
- cd src-tauri && cargo check
- cd src-tauri && cargo test
- cd src-tauri && cargo clippy -- -D warnings

## Notes
- Cross-target checks from this Windows host were blocked by missing cross C compilers: macOS failed before Wardian code in objc2-exception-helper due missing cc, Linux failed before Wardian code in libsqlite3-sys due missing x86_64-linux-gnu-gcc.