### PR TITLE
fix(runtime): close non-Windows compatibility gaps

### DIFF
--- a/docs/developer/gemini-cli-patches.md
+++ b/docs/developer/gemini-cli-patches.md
@@ -3,7 +3,7 @@
 This document tracks custom patches applied to the **Gemini CLI** bundle to enable missing features or fix upstream bugs that haven't been resolved in the official distribution.
 
 ## ⚠️ Important Note
-These patches directly modify the `gemini.js` bundle within your `node_modules` (typically in `%APPDATA%\npm\node_modules\@google\gemini-cli`). 
+These patches directly modify the Gemini CLI bundle within your global package installation. Wardian discovers that installation from `GEMINI_CLI_DIR`, npm/pnpm global roots, or the resolved `gemini` executable on `PATH`.
 **Upgrading the Gemini CLI will overwrite these changes.** Wardian provides a setting to automatically re-apply these patches upon application launch.
 
 ---
@@ -20,7 +20,7 @@ The `gemini-patch-skills.cjs` script performs a surgical regex-based replacement
 3. Load and register those skills with appropriate precedence.
 
 ### File Location
-The script is located at: `D:\Development\Wardian\scripts\gemini-patch-skills.cjs`
+The script is located at: `scripts/gemini-patch-skills.cjs`
 
 ### Usage in Wardian
 To enable this patch at launch, toggle the **"Auto-patch Gemini CLI"** setting in the Wardian **Advanced Settings** panel.

--- a/scripts/gemini-patch-skills.cjs
+++ b/scripts/gemini-patch-skills.cjs
@@ -1,21 +1,108 @@
 const fs = require('fs');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
-function getCliDir() {
-    const target = 'C:\\nvm4w\\nodejs\\node_modules\\@google\\gemini-cli';
-    if (fs.existsSync(path.join(target, 'package.json'))) {
-        return target;
+function commandNames(command, platform = process.platform) {
+    if (platform === 'win32' && !/\.(exe|cmd|bat|ps1)$/i.test(command)) {
+        return [`${command}.exe`, `${command}.cmd`, `${command}.bat`, command];
+    }
+    return [command];
+}
+
+function resolveCommand(command, env = process.env, platform = process.platform) {
+    const pathValue = env.PATH || '';
+    const entries = pathValue.split(path.delimiter).filter(Boolean);
+    for (const dir of entries) {
+        for (const name of commandNames(command, platform)) {
+            const candidate = path.join(dir, name);
+            if (fs.existsSync(candidate)) {
+                return candidate;
+            }
+        }
     }
     return null;
 }
 
-const cliDir = getCliDir();
-if (!cliDir) {
-    console.error('Could not find gemini-cli installation.');
-    process.exit(1);
+function packageRootFrom(startPath) {
+    let current = fs.existsSync(startPath) ? fs.realpathSync(startPath) : startPath;
+    if (!fs.existsSync(current)) {
+        return null;
+    }
+    if (!fs.statSync(current).isDirectory()) {
+        current = path.dirname(current);
+    }
+
+    while (true) {
+        const packageJson = path.join(current, 'package.json');
+        if (fs.existsSync(packageJson)) {
+            try {
+                const pkg = JSON.parse(fs.readFileSync(packageJson, 'utf8'));
+                if (pkg.name === '@google/gemini-cli' || pkg.name === 'gemini-cli') {
+                    return current;
+                }
+            } catch {
+                // Keep walking; malformed package metadata should not stop discovery.
+            }
+        }
+
+        const parent = path.dirname(current);
+        if (parent === current) {
+            return null;
+        }
+        current = parent;
+    }
 }
 
-console.log(`Found CLI dir at ${cliDir}`);
+function packageRootsFromManagers() {
+    const managers = [
+        ['npm', ['root', '-g']],
+        ['pnpm', ['root', '-g']],
+    ];
+    const roots = [];
+    for (const [manager, args] of managers) {
+        const result = spawnSync(manager, args, {
+            encoding: 'utf8',
+            shell: process.platform === 'win32',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        if (result.status === 0 && result.stdout.trim()) {
+            roots.push(result.stdout.trim());
+        }
+    }
+    return roots;
+}
+
+function getCliDir() {
+    const candidates = [];
+
+    if (process.env.GEMINI_CLI_DIR) {
+        candidates.push(process.env.GEMINI_CLI_DIR);
+    }
+
+    for (const root of packageRootsFromManagers()) {
+        candidates.push(path.join(root, '@google', 'gemini-cli'));
+        candidates.push(path.join(root, 'gemini-cli'));
+    }
+
+    const geminiCommand = resolveCommand('gemini');
+    if (geminiCommand) {
+        const packageRoot = packageRootFrom(geminiCommand);
+        if (packageRoot) {
+            candidates.push(packageRoot);
+        }
+    }
+
+    // Backward-compatible fallback for the original Windows nvm layout.
+    candidates.push('C:\\nvm4w\\nodejs\\node_modules\\@google\\gemini-cli');
+
+    for (const candidate of candidates) {
+        if (candidate && fs.existsSync(path.join(candidate, 'package.json'))) {
+            return candidate;
+        }
+    }
+
+    return null;
+}
 
 function findFiles(dir, filter) {
     let results = [];
@@ -34,46 +121,55 @@ function findFiles(dir, filter) {
     return results;
 }
 
-// Support bundled (<=0.34.0-preview, >=0.35.0) and unbundled (0.34.0 stable) structures
-let searchDirs = [
-    path.join(cliDir, 'bundle'),
-    path.join(cliDir, 'dist'),
-    path.join(cliDir, 'node_modules', '@google', 'gemini-cli-core', 'dist')
-];
-
-let allJsFiles = [];
-for (const dir of searchDirs) {
-    if (fs.existsSync(dir)) {
-        allJsFiles = allJsFiles.concat(findFiles(dir, f => f.endsWith('.js')));
-    }
-}
-
-let patchedFiles = 0;
-
-for (const file of allJsFiles) {
-    let content = fs.readFileSync(file, 'utf8');
-    let changed = false;
-
-    if (content.includes('// Treat included directories as secondary workspaces')) {
-        console.log(`Already patched: ${file}`);
-        continue;
+function main() {
+    const cliDir = getCliDir();
+    if (!cliDir) {
+        console.error('Could not find gemini-cli installation.');
+        process.exit(1);
     }
 
-    // 1. Patch discoverSkills method definition dynamically
-    const sigRegex = /(async\s+discoverSkills\s*\([^)]*)(\)\s*\{)/;
-    const anchorRegex = /(const\s+(\w+)\s*=\s*await\s+loadSkillsFromDir\(.*?getUserSkillsDir\(\)\);)/;
-    
-    if (sigRegex.test(content) && anchorRegex.test(content)) {
-        console.log(`Patching discoverSkills definition in ${file}`);
-        
-        const pathAliasMatch = content.match(/const\s+builtinDir\s*=\s*(path\w*)\.join\(/);
-        const pathAlias = pathAliasMatch ? pathAliasMatch[1] : 'path';
+    console.log(`Found CLI dir at ${cliDir}`);
 
-        // Update signature to accept new parameters
-        content = content.replace(sigRegex, '$1, includeDirectories = [], loadFromIncludeDirectories = false$2');
-        
-        // Inject logic right before User Skills are loaded
-        const injection = `
+    // Support bundled (<=0.34.0-preview, >=0.35.0) and unbundled (0.34.0 stable) structures
+    let searchDirs = [
+        path.join(cliDir, 'bundle'),
+        path.join(cliDir, 'dist'),
+        path.join(cliDir, 'node_modules', '@google', 'gemini-cli-core', 'dist')
+    ];
+
+    let allJsFiles = [];
+    for (const dir of searchDirs) {
+        if (fs.existsSync(dir)) {
+            allJsFiles = allJsFiles.concat(findFiles(dir, f => f.endsWith('.js')));
+        }
+    }
+
+    let patchedFiles = 0;
+
+    for (const file of allJsFiles) {
+        let content = fs.readFileSync(file, 'utf8');
+        let changed = false;
+
+        if (content.includes('// Treat included directories as secondary workspaces')) {
+            console.log(`Already patched: ${file}`);
+            continue;
+        }
+
+        // 1. Patch discoverSkills method definition dynamically
+        const sigRegex = /(async\s+discoverSkills\s*\([^)]*)(\)\s*\{)/;
+        const anchorRegex = /(const\s+(\w+)\s*=\s*await\s+loadSkillsFromDir\(.*?getUserSkillsDir\(\)\);)/;
+
+        if (sigRegex.test(content) && anchorRegex.test(content)) {
+            console.log(`Patching discoverSkills definition in ${file}`);
+
+            const pathAliasMatch = content.match(/const\s+builtinDir\s*=\s*(path\w*)\.join\(/);
+            const pathAlias = pathAliasMatch ? pathAliasMatch[1] : 'path';
+
+            // Update signature to accept new parameters
+            content = content.replace(sigRegex, '$1, includeDirectories = [], loadFromIncludeDirectories = false$2');
+
+            // Inject logic right before User Skills are loaded
+            const injection = `
         // Treat included directories as secondary workspaces
         if (loadFromIncludeDirectories && includeDirectories.length > 0) {
           for (const dir of includeDirectories) {
@@ -84,27 +180,41 @@ for (const file of allJsFiles) {
           }
         }
         $1`;
-        content = content.replace(anchorRegex, injection);
-        changed = true;
+            content = content.replace(anchorRegex, injection);
+            changed = true;
+        }
+
+        // 2. Patch call sites robustly
+        // Matches up to the closing parenthesis before a semicolon or bracket
+        const callSiteRegex = /await\s+this\.getSkillManager\(\)\.discoverSkills\([\s\S]*?\)(?=;|\s+\{)/g;
+        if (callSiteRegex.test(content)) {
+            console.log(`Patching discoverSkills call sites in ${file}`);
+            content = content.replace(callSiteRegex, `await this.getSkillManager().discoverSkills(this.storage, this.getExtensions(), this.isTrustedFolder(), this.workspaceContext.getDirectories(), this.loadMemoryFromIncludeDirectories)`);
+            changed = true;
+        }
+
+        if (changed) {
+            fs.writeFileSync(file, content);
+            patchedFiles++;
+        }
     }
 
-    // 2. Patch call sites robustly
-    // Matches up to the closing parenthesis before a semicolon or bracket
-    const callSiteRegex = /await\s+this\.getSkillManager\(\)\.discoverSkills\([\s\S]*?\)(?=;|\s+\{)/g;
-    if (callSiteRegex.test(content)) {
-        console.log(`Patching discoverSkills call sites in ${file}`);
-        content = content.replace(callSiteRegex, `await this.getSkillManager().discoverSkills(this.storage, this.getExtensions(), this.isTrustedFolder(), this.workspaceContext.getDirectories(), this.loadMemoryFromIncludeDirectories)`);
-        changed = true;
-    }
-
-    if (changed) {
-        fs.writeFileSync(file, content);
-        patchedFiles++;
+    if (patchedFiles > 0) {
+        console.log(`Successfully patched ${patchedFiles} file(s).`);
+    } else {
+        console.log('No files needed patching. The environment might already be patched or the structure is unrecognized.');
     }
 }
 
-if (patchedFiles > 0) {
-    console.log(`Successfully patched ${patchedFiles} file(s).`);
-} else {
-    console.log('No files needed patching. The environment might already be patched or the structure is unrecognized.');
+module.exports = {
+    commandNames,
+    findFiles,
+    getCliDir,
+    main,
+    packageRootFrom,
+    resolveCommand,
+};
+
+if (require.main === module) {
+    main();
 }

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -96,8 +96,14 @@ pub async fn reveal_in_explorer(path: String) -> Result<(), String> {
     }
     #[cfg(target_os = "linux")]
     {
+        let reveal_path = Path::new(&path);
+        let open_path = if reveal_path.is_file() {
+            reveal_path.parent().unwrap_or(reveal_path)
+        } else {
+            reveal_path
+        };
         std::process::Command::new("xdg-open")
-            .arg(&path)
+            .arg(open_path)
             .spawn()
             .map_err(|e| e.to_string())?;
     }

--- a/src-tauri/src/manager/headless.rs
+++ b/src-tauri/src/manager/headless.rs
@@ -231,6 +231,10 @@ pub async fn run_headless_with_options(
             cmd.env("WARDIAN_MOCK_SCRIPT", script);
         }
     }
+
+    #[cfg(target_os = "macos")]
+    cmd.env("PATH", macos_extended_path());
+
     cmd.current_dir(&provider_cwd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());

--- a/src/config/crossPlatformAudit.test.ts
+++ b/src/config/crossPlatformAudit.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import headlessManager from "../../src-tauri/src/manager/headless.rs?raw";
+import geminiPatchScript from "../../scripts/gemini-patch-skills.cjs?raw";
+
+describe("cross-platform runtime contracts", () => {
+  it("applies the macOS GUI PATH repair to every headless provider launch path", () => {
+    const pathRepairs = headlessManager.match(/cmd\.env\("PATH", macos_extended_path\(\)\)/g) ?? [];
+
+    expect(pathRepairs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("discovers Gemini CLI installs instead of assuming a Windows-only npm path", () => {
+    expect(geminiPatchScript).toContain("process.env.GEMINI_CLI_DIR");
+    expect(geminiPatchScript).toContain("npm");
+    expect(geminiPatchScript).toContain("pnpm");
+    expect(geminiPatchScript).toContain("resolveCommand('gemini')");
+    expect(geminiPatchScript).toContain("require.main === module");
+  });
+});


### PR DESCRIPTION
## Summary
- apply the macOS GUI PATH repair to regular headless provider runs, not only interactive/bootstrap launches
- make the Gemini CLI patch script discover installs via GEMINI_CLI_DIR, npm/pnpm global roots, or the resolved gemini executable instead of a Windows-only nvm path
- make Linux reveal-in-explorer open the parent folder for files
- add lightweight cross-platform contract tests and update Gemini patch docs

Fixes #174

## Verification
- npm run lint
- npm run test
- npm run build
- cd src-tauri && cargo check
- cd src-tauri && cargo test
- cd src-tauri && cargo clippy -- -D warnings
- node -e "const patch=require('./scripts/gemini-patch-skills.cjs'); console.log(patch.commandNames('gemini','linux').join(',')); console.log(patch.commandNames('gemini','win32').join(','));"

## Audit Notes
- The spawn-specific non-Windows blocker is handled separately in #173.
- CI has Linux compile coverage and Windows full tests, but no macOS compile job; macOS-specific regressions can still escape until release builds.