### PR TITLE
fix(runtime): repair macOS build after spawn enablement

### DIFF
--- a/src-tauri/src/manager/headless.rs
+++ b/src-tauri/src/manager/headless.rs
@@ -36,6 +36,9 @@ pub(crate) fn headless_provider_launch(
         });
     }
 
+    #[cfg(not(windows))]
+    let _ = provider_name;
+
     build_program_launch(bin, provider_args)
 }
 

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -292,7 +292,7 @@ pub(crate) fn apply_agent_status_event(
 /// Volta, and other user-level tool installs. Prepend the common locations so that
 /// `claude`, `gemini`, and similar CLIs can be found when spawning child processes.
 #[cfg(target_os = "macos")]
-fn macos_extended_path() -> String {
+pub(crate) fn macos_extended_path() -> String {
     let home = std::env::var("HOME").unwrap_or_default();
     let existing = std::env::var("PATH").unwrap_or_default();
     let extra = format!(

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -20,6 +20,8 @@ use super::{
     interactive_provider_cwd, interactive_provider_launch, set_agent_status,
 };
 
+#[cfg(target_os = "macos")]
+use super::macos_extended_path;
 #[cfg(windows)]
 use super::{
     app_process_supervisor_active, assign_pid_to_job, cleanup_stale_session_processes,

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -511,6 +511,8 @@ pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
         let mut excluded_roots: BTreeSet<u32> = BTreeSet::new();
         for (session_id, process_id) in &agent_roots {
             excluded_roots.insert(*process_id);
+            #[cfg(not(windows))]
+            let _ = session_id;
             #[cfg(windows)]
             for discovered_pid in crate::utils::process::find_wardian_session_process_roots(
                 session_id,


### PR DESCRIPTION
## Summary
- make the macOS PATH helper visible to manager child modules
- import the helper in spawn.rs for the newly portable spawn path
- silence cfg-dependent unused-variable warnings in headless launch and telemetry on non-Windows builds

Fixes #176

## Verification
- cd src-tauri && cargo check
- cd src-tauri && cargo clippy -- -D warnings
- npm run test -- crossPlatformAudit spawnManager