### PR TITLE
docs: add README status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@
 
 **Local command center for multi-agent CLI workflows** — see every session, swap skills on the fly, and chain agents into deterministic pipelines.
 
-[![Frontend Coverage](https://codecov.io/gh/tangemicioglu/Wardian/branch/main/graph/badge.svg?flag=frontend)](https://codecov.io/gh/tangemicioglu/Wardian)
-[![Backend Coverage](https://codecov.io/gh/tangemicioglu/Wardian/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/tangemicioglu/Wardian)
+[![CI](https://github.com/tangemicioglu/Wardian/actions/workflows/ci.yml/badge.svg)](https://github.com/tangemicioglu/Wardian/actions/workflows/ci.yml)
+[![Frontend Coverage](https://codecov.io/gh/tangemicioglu/Wardian/branch/main/graph/badge.svg?flag=frontend&label=frontend%20coverage)](https://codecov.io/gh/tangemicioglu/Wardian)
+[![Backend Coverage](https://codecov.io/gh/tangemicioglu/Wardian/branch/main/graph/badge.svg?flag=backend&label=backend%20coverage)](https://codecov.io/gh/tangemicioglu/Wardian)
+[![Release](https://img.shields.io/github/v/release/tangemicioglu/Wardian?label=release)](https://github.com/tangemicioglu/Wardian/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/tangemicioglu/Wardian/total?label=downloads)](https://github.com/tangemicioglu/Wardian/releases)
+![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-555)
 
 [![Wardian Demo](public/demo.gif)](public/demo.gif)
 


### PR DESCRIPTION
## Description
Adds a compact README badge row for project health and distribution metadata:

- CI status
- clearly labeled frontend/backend coverage
- latest release
- total release downloads
- supported platforms

## Related Issues
Fixes #182

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `git diff --check -- README.md`
- Reviewed rendered Markdown source in `README.md`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable