### PR TITLE
feat(settings): add terminal font controls

### DIFF
--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { invoke } from '@tauri-apps/api/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsPanel } from './SettingsPanel';
@@ -13,6 +14,8 @@ describe('SettingsPanel', () => {
     useSettingsStore.setState({
       theme: 'system',
       autoPatchGemini: false,
+      terminalFontSize: 14,
+      terminalFontFamily: '',
       shell_id: 'auto',
       custom_executable: '',
       custom_args: '',
@@ -167,5 +170,56 @@ describe('SettingsPanel', () => {
     expect(await screen.findByText('Agent runtime updated.')).toBeInTheDocument();
     expect(screen.queryByText('Shell settings updated.')).not.toBeInTheDocument();
     expect(mockInvoke).not.toHaveBeenCalledWith('save_shell_settings', expect.anything());
+  });
+
+  it('adjusts the terminal font size preference', async () => {
+    render(<SettingsPanel />);
+
+    const input = await screen.findByLabelText('Terminal font size');
+    expect(input).toHaveValue(14);
+
+    fireEvent.change(input, { target: { value: '16' } });
+
+    expect(useSettingsStore.getState().terminalFontSize).toBe(16);
+    expect(input).toHaveValue(16);
+  });
+
+  it('keeps partial terminal font size edits local until they become valid', async () => {
+    const user = userEvent.setup();
+    render(<SettingsPanel />);
+
+    const input = await screen.findByLabelText('Terminal font size') as HTMLInputElement;
+
+    await user.clear(input);
+    expect(input.value).toBe('');
+    expect(useSettingsStore.getState().terminalFontSize).toBe(14);
+
+    await user.type(input, '1');
+    expect(input.value).toBe('1');
+    expect(useSettingsStore.getState().terminalFontSize).toBe(14);
+
+    await user.type(input, '2');
+    expect(input.value).toBe('12');
+    expect(useSettingsStore.getState().terminalFontSize).toBe(12);
+  });
+
+  it('adjusts the terminal font family preference from presets and custom input', async () => {
+    render(<SettingsPanel />);
+
+    const select = await screen.findByLabelText('Terminal font family');
+    expect(select).toHaveValue('');
+
+    fireEvent.change(select, { target: { value: 'JetBrains Mono, monospace' } });
+
+    expect(useSettingsStore.getState().terminalFontFamily).toBe('JetBrains Mono, monospace');
+    expect(select).toHaveValue('JetBrains Mono, monospace');
+
+    fireEvent.change(select, { target: { value: '__custom__' } });
+
+    const customInput = screen.getByLabelText('Custom terminal font family');
+    fireEvent.change(customInput, { target: { value: 'FiraCode Nerd Font, monospace' } });
+
+    expect(useSettingsStore.getState().terminalFontFamily).toBe('FiraCode Nerd Font, monospace');
+    expect(customInput).toHaveValue('FiraCode Nerd Font, monospace');
   });
 });

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -1,11 +1,25 @@
 import React, { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { useSettingsStore } from "../../store/useSettingsStore";
+import {
+  MAX_TERMINAL_FONT_SIZE,
+  MIN_TERMINAL_FONT_SIZE,
+  defaultTerminalFontFamily,
+  normalizeTerminalFontSize,
+  useSettingsStore,
+} from "../../store/useSettingsStore";
 
 interface SettingsPanelProps {}
 
 const windowsAutoShellIds = ['pwsh', 'powershell', 'cmd', 'git-bash', 'wsl', 'bash'];
 const posixAutoShellIds = ['zsh', 'bash', 'sh', 'fish'];
+const CUSTOM_TERMINAL_FONT_FAMILY_VALUE = '__custom__';
+const terminalFontFamilyOptions = [
+  { label: 'Consolas', value: 'Consolas, "Courier New", monospace' },
+  { label: 'Menlo', value: 'Menlo, Monaco, "Courier New", monospace' },
+  { label: 'Droid Sans Mono', value: '"Droid Sans Mono", monospace' },
+  { label: 'Cascadia Mono', value: '"Cascadia Mono", "Cascadia Code", Consolas, monospace' },
+  { label: 'JetBrains Mono', value: 'JetBrains Mono, monospace' },
+];
 
 const resolveAutoShell = <T extends { id: string }>(availableShells: T[]) => {
   const hasWindowsShell = availableShells.some((option) =>
@@ -23,6 +37,10 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     setTheme,
     autoPatchGemini,
     setAutoPatchGemini,
+    terminalFontSize,
+    setTerminalFontSize,
+    terminalFontFamily,
+    setTerminalFontFamily,
     shell_id,
     custom_executable,
     custom_args,
@@ -45,6 +63,12 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
   const [shellMessage, setShellMessage] = useState("");
   const [agentRuntimeStatus, setAgentRuntimeStatus] = useState<"idle" | "saving" | "success" | "error">("idle");
   const [agentRuntimeMessage, setAgentRuntimeMessage] = useState("");
+  const [terminalFontSizeDraft, setTerminalFontSizeDraft] = useState(() => String(terminalFontSize));
+  const [terminalFontFamilyMode, setTerminalFontFamilyMode] = useState<'preset' | 'custom'>(() =>
+    terminalFontFamily === '' || terminalFontFamilyOptions.some((option) => option.value === terminalFontFamily)
+      ? 'preset'
+      : 'custom',
+  );
 
   useEffect(() => {
     if (!shell_settings_loaded) {
@@ -54,6 +78,28 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
       loadAvailableShells();
     }
   }, [loadAvailableShells, loadShellSettings, shell_settings_loaded, shells_loaded]);
+
+  useEffect(() => {
+    setTerminalFontSizeDraft(String(terminalFontSize));
+  }, [terminalFontSize]);
+
+  const commitTerminalFontSizeDraft = () => {
+    const nextSize = normalizeTerminalFontSize(Number(terminalFontSizeDraft));
+    setTerminalFontSize(nextSize);
+    setTerminalFontSizeDraft(String(nextSize));
+  };
+
+  const handleTerminalFontSizeChange = (value: string) => {
+    setTerminalFontSizeDraft(value);
+    const nextSize = Number(value);
+    if (
+      Number.isFinite(nextSize) &&
+      nextSize >= MIN_TERMINAL_FONT_SIZE &&
+      nextSize <= MAX_TERMINAL_FONT_SIZE
+    ) {
+      setTerminalFontSize(nextSize);
+    }
+  };
 
   const handleRunPatch = async () => {
     setPatchStatus("running");
@@ -109,6 +155,11 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
   const selectedShell = available_shells.find((option) => option.id === shell_id);
   const autoSelectedShell = resolveAutoShell(available_shells);
   const displayedShell = shell_id === 'auto' ? autoSelectedShell : selectedShell;
+  const terminalFontFamilySelectValue = terminalFontFamilyMode === 'custom'
+    ? CUSTOM_TERMINAL_FONT_FAMILY_VALUE
+    : terminalFontFamily === '' || terminalFontFamilyOptions.some((option) => option.value === terminalFontFamily)
+    ? terminalFontFamily
+    : CUSTOM_TERMINAL_FONT_FAMILY_VALUE;
 
   return (
     <div data-testid="settings-panel" className="flex flex-col h-full">
@@ -217,95 +268,166 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
         </div>
 
         <div className="border-t border-wardian-border pt-6">
-          <h3 className="text-[10px] font-bold text-muted-neutral tracking-wide mb-4">Default Shell</h3>
+          <h3 className="text-[10px] font-bold text-muted-neutral tracking-wide mb-4">Terminal</h3>
 
-          <div className="bg-wardian-card-bg-muted border border-wardian-light/50 rounded-xl p-4 flex flex-col gap-3">
-            <label className="text-sm font-bold text-primary" htmlFor="default-shell-select">
-              Shell / Interpreter
-            </label>
-            <select
-              data-testid="shell-select"
-              id="default-shell-select"
-              value={shell_id}
-              onChange={(e) => setShellId(e.target.value)}
-              className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
-            >
-              <option value="auto">Auto</option>
-              {available_shells.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.label}
-                </option>
-              ))}
-              <option value="custom">Custom</option>
-            </select>
-
-            {shell_id === 'custom' ? (
-              <>
-                <label className="text-xs font-bold text-primary" htmlFor="custom-shell-executable">
-                  Custom executable
-                </label>
-                <input
-                  data-testid="custom-shell-executable"
-                  id="custom-shell-executable"
-                  type="text"
-                  value={custom_executable}
-                  onChange={(e) => setCustomExecutable(e.target.value)}
-                  placeholder={navigator.platform.toLowerCase().includes('win') ? 'C:/Program Files/PowerShell/7/pwsh.exe' : '/usr/local/bin/fish'}
-                  className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
-                />
-                <label className="text-xs font-bold text-primary" htmlFor="custom-shell-args">
-                  Command args
-                </label>
-                <input
-                  id="custom-shell-args"
-                  type="text"
-                  value={custom_args}
-                  onChange={(e) => setCustomArgs(e.target.value)}
-                  placeholder={navigator.platform.toLowerCase().includes('win') ? '-NoProfile -Command' : '-lc'}
-                  className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
-                />
-              </>
-            ) : (
-              <div className="rounded-lg border border-wardian-border bg-wardian-bg px-3 py-2">
-                <p className="text-[11px] font-bold text-primary">
-                  {shell_id === 'auto'
-                    ? (displayedShell ? `Auto: ${displayedShell.label}` : 'Auto: detecting shell...')
-                    : displayedShell?.label ?? 'Loading shell details...'}
-                </p>
-                {displayedShell && (
-                  <p className="text-[10px] text-muted-neutral mt-1 break-all">
-                    {displayedShell.executable}
-                  </p>
-                )}
-              </div>
-            )}
-
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-[10px] text-muted-neutral">
-                {shells_loaded ? `${available_shells.length} discovered shell${available_shells.length === 1 ? '' : 's'}` : 'Detecting installed shells...'}
-              </p>
-              <button
-                type="button"
-                onClick={handleSaveShell}
-                disabled={!shell_settings_loaded || shellStatus === 'saving'}
-                className={`px-4 py-2 text-xs font-bold rounded-lg border transition-all whitespace-nowrap ${
-                  shellStatus === 'saving'
-                    ? 'bg-wardian-border text-muted border-transparent cursor-not-allowed'
-                    : 'bg-wardian-bg border-wardian-light text-primary hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]'
-                }`}
+          <div className="flex flex-col gap-3">
+            <div className="bg-wardian-card-bg-muted border border-wardian-light/50 rounded-xl p-4 flex flex-col gap-3">
+              <h4 className="text-[10px] font-bold text-muted-neutral tracking-wide">Shell</h4>
+              <label className="text-sm font-bold text-primary" htmlFor="default-shell-select">
+                Shell / Interpreter
+              </label>
+              <select
+                data-testid="shell-select"
+                id="default-shell-select"
+                value={shell_id}
+                onChange={(e) => setShellId(e.target.value)}
+                className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
               >
-                {shellStatus === 'saving' ? 'Saving...' : 'Save Shell'}
-              </button>
+                <option value="auto">Auto</option>
+                {available_shells.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+                <option value="custom">Custom</option>
+              </select>
+
+              {shell_id === 'custom' ? (
+                <>
+                  <label className="text-xs font-bold text-primary" htmlFor="custom-shell-executable">
+                    Custom executable
+                  </label>
+                  <input
+                    data-testid="custom-shell-executable"
+                    id="custom-shell-executable"
+                    type="text"
+                    value={custom_executable}
+                    onChange={(e) => setCustomExecutable(e.target.value)}
+                    placeholder={navigator.platform.toLowerCase().includes('win') ? 'C:/Program Files/PowerShell/7/pwsh.exe' : '/usr/local/bin/fish'}
+                    className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+                  />
+                  <label className="text-xs font-bold text-primary" htmlFor="custom-shell-args">
+                    Command args
+                  </label>
+                  <input
+                    id="custom-shell-args"
+                    type="text"
+                    value={custom_args}
+                    onChange={(e) => setCustomArgs(e.target.value)}
+                    placeholder={navigator.platform.toLowerCase().includes('win') ? '-NoProfile -Command' : '-lc'}
+                    className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+                  />
+                </>
+              ) : (
+                <div className="rounded-lg border border-wardian-border bg-wardian-bg px-3 py-2">
+                  <p className="text-[11px] font-bold text-primary">
+                    {shell_id === 'auto'
+                      ? (displayedShell ? `Auto: ${displayedShell.label}` : 'Auto: detecting shell...')
+                      : displayedShell?.label ?? 'Loading shell details...'}
+                  </p>
+                  {displayedShell && (
+                    <p className="text-[10px] text-muted-neutral mt-1 break-all">
+                      {displayedShell.executable}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-[10px] text-muted-neutral">
+                  {shells_loaded ? `${available_shells.length} discovered shell${available_shells.length === 1 ? '' : 's'}` : 'Detecting installed shells...'}
+                </p>
+                <button
+                  type="button"
+                  onClick={handleSaveShell}
+                  disabled={!shell_settings_loaded || shellStatus === 'saving'}
+                  className={`px-4 py-2 text-xs font-bold rounded-lg border transition-all whitespace-nowrap ${
+                    shellStatus === 'saving'
+                      ? 'bg-wardian-border text-muted border-transparent cursor-not-allowed'
+                      : 'bg-wardian-bg border-wardian-light text-primary hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]'
+                  }`}
+                >
+                  {shellStatus === 'saving' ? 'Saving...' : 'Save Shell'}
+                </button>
+              </div>
+
+              {shellMessage && (
+                <div className={`p-2 mt-1 rounded border text-xs font-medium text-left ${
+                  shellStatus === 'success' ? 'bg-cyan-500/10 border-cyan-500/20 text-cyan-400' :
+                  'bg-red-500/10 border-red-500/20 text-red-400'
+                }`}>
+                  {shellMessage}
+                </div>
+              )}
             </div>
 
-            {shellMessage && (
-              <div className={`p-2 mt-1 rounded border text-xs font-medium text-left ${
-                shellStatus === 'success' ? 'bg-cyan-500/10 border-cyan-500/20 text-cyan-400' :
-                'bg-red-500/10 border-red-500/20 text-red-400'
-              }`}>
-                {shellMessage}
-              </div>
-            )}
+            <div className="bg-wardian-card-bg-muted border border-wardian-light/50 rounded-xl p-4 flex flex-col gap-3">
+              <h4 className="text-[10px] font-bold text-muted-neutral tracking-wide">Appearance</h4>
+              <label className="text-sm font-bold text-primary" htmlFor="terminal-font-size">
+                Terminal font size
+              </label>
+              <input
+                id="terminal-font-size"
+                type="number"
+                min={MIN_TERMINAL_FONT_SIZE}
+                max={MAX_TERMINAL_FONT_SIZE}
+                step={1}
+                value={terminalFontSizeDraft}
+                onBlur={commitTerminalFontSizeDraft}
+                onChange={(e) => handleTerminalFontSizeChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    commitTerminalFontSizeDraft();
+                  }
+                }}
+                className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+              />
+              <p className="text-[10px] text-muted-neutral leading-relaxed">
+                Applies immediately to embedded agent terminals.
+              </p>
+              <label className="text-sm font-bold text-primary" htmlFor="terminal-font-family">
+                Terminal font family
+              </label>
+              <select
+                id="terminal-font-family"
+                value={terminalFontFamilySelectValue}
+                onChange={(e) => {
+                  if (e.target.value === CUSTOM_TERMINAL_FONT_FAMILY_VALUE) {
+                    setTerminalFontFamilyMode('custom');
+                  } else {
+                    setTerminalFontFamilyMode('preset');
+                    setTerminalFontFamily(e.target.value);
+                  }
+                }}
+                className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+              >
+                <option value="">Auto</option>
+                {terminalFontFamilyOptions.map((option) => (
+                  <option key={option.label} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+                <option value={CUSTOM_TERMINAL_FONT_FAMILY_VALUE}>Custom...</option>
+              </select>
+              {terminalFontFamilySelectValue === CUSTOM_TERMINAL_FONT_FAMILY_VALUE && (
+                <>
+                  <label className="text-xs font-bold text-primary" htmlFor="custom-terminal-font-family">
+                    Custom terminal font family
+                  </label>
+                  <input
+                    id="custom-terminal-font-family"
+                    type="text"
+                    value={terminalFontFamily}
+                    onChange={(e) => setTerminalFontFamily(e.target.value)}
+                    placeholder={defaultTerminalFontFamily()}
+                    className="w-full rounded-lg border border-wardian-border bg-wardian-input-bg px-3 py-2 text-sm text-primary outline-none focus:border-[var(--color-wardian-accent)]"
+                  />
+                </>
+              )}
+              <p className="text-[10px] text-muted-neutral leading-relaxed">
+                Auto uses {defaultTerminalFontFamily()}.
+              </p>
+            </div>
           </div>
         </div>
 

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, cleanup } from "@testing-library/react";
+import { render, waitFor, cleanup, act } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Terminal } from "@xterm/xterm";
@@ -6,6 +6,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { AgentTerminal } from "./AgentTerminal";
+import { defaultTerminalFontFamily, useSettingsStore } from "../../store/useSettingsStore";
 
 const mockInvoke = vi.mocked(invoke);
 const mockListen = vi.mocked(listen);
@@ -24,6 +25,7 @@ describe("AgentTerminal scrollback", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useSettingsStore.setState({ terminalFontSize: 14, terminalFontFamily: "" });
     rectSpy = vi
       .spyOn(HTMLElement.prototype, "getBoundingClientRect")
       .mockReturnValue({
@@ -77,6 +79,7 @@ describe("AgentTerminal scrollback", () => {
         dispose: vi.fn(),
         focus: vi.fn(),
         scrollToBottom: vi.fn(),
+        buffer: { active: { baseY: 10, viewportY: 10 } },
         refresh: vi.fn(),
         cols: 80,
         rows: 24,
@@ -184,6 +187,27 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
+  it("scrolls to the bottom before forwarding text input when the user has scrolled up", async () => {
+    render(<AgentTerminal sessionId="codex-scroll-input" theme="dark" />);
+
+    await waitFor(() => {
+      expect(mockTerminal).toHaveBeenCalled();
+    });
+
+    const instance = getLatestTerminalInstance();
+    instance.buffer.active.viewportY = 2;
+    instance.buffer.active.baseY = 10;
+    const onData = instance.onData.mock.calls[0]?.[0] as ((data: string) => void);
+
+    onData("h");
+
+    expect(instance.scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-scroll-input",
+      input: "h",
+    });
+  });
+
   it("forwards codex enter as a plain carriage return", async () => {
     render(<AgentTerminal sessionId="codex-enter" provider="codex" theme="dark" />);
 
@@ -215,6 +239,90 @@ describe("AgentTerminal scrollback", () => {
     >;
     expect(terminalOptions.reflowCursorLine).toBe(false);
     expect("scrollOnEraseInDisplay" in terminalOptions).toBe(false);
+  });
+
+  it("applies the configured terminal font size and refits when it changes", async () => {
+    useSettingsStore.setState({ terminalFontSize: 16 });
+
+    render(<AgentTerminal sessionId="codex-font-size" provider="codex" theme="dark" />);
+
+    await waitFor(() => {
+      expect(mockTerminal).toHaveBeenCalled();
+    });
+
+    const terminalOptions = mockTerminal.mock.calls[mockTerminal.mock.calls.length - 1]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(terminalOptions.fontSize).toBe(16);
+
+    const instance = getLatestTerminalInstance();
+    const fitAddon = mockFitAddon.mock.results[mockFitAddon.mock.results.length - 1]?.value as {
+      proposeDimensions: ReturnType<typeof vi.fn>;
+    };
+    await waitFor(() => {
+      expect(fitAddon.proposeDimensions).toHaveBeenCalled();
+    });
+    const baselineFitCalls = fitAddon.proposeDimensions.mock.calls.length;
+
+    act(() => {
+      useSettingsStore.getState().setTerminalFontSize(12);
+    });
+
+    await waitFor(() => {
+      expect(instance.options.fontSize).toBe(12);
+      expect(instance.refresh).toHaveBeenCalledWith(0, 23);
+      expect(fitAddon.proposeDimensions.mock.calls.length).toBeGreaterThan(baselineFitCalls);
+    });
+  });
+
+  it("uses the current platform's VS Code-style terminal font stack by default", async () => {
+    render(<AgentTerminal sessionId="codex-default-font" provider="codex" theme="dark" />);
+
+    await waitFor(() => {
+      expect(mockTerminal).toHaveBeenCalled();
+    });
+
+    const terminalOptions = mockTerminal.mock.calls[mockTerminal.mock.calls.length - 1]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(terminalOptions.fontFamily).toBe(defaultTerminalFontFamily());
+  });
+
+  it("applies the configured terminal font family and refits when it changes", async () => {
+    useSettingsStore.setState({ terminalFontFamily: "JetBrains Mono, monospace" });
+
+    render(<AgentTerminal sessionId="codex-font-family" provider="codex" theme="dark" />);
+
+    await waitFor(() => {
+      expect(mockTerminal).toHaveBeenCalled();
+    });
+
+    const terminalOptions = mockTerminal.mock.calls[mockTerminal.mock.calls.length - 1]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(terminalOptions.fontFamily).toBe("JetBrains Mono, monospace");
+
+    const instance = getLatestTerminalInstance();
+    const fitAddon = mockFitAddon.mock.results[mockFitAddon.mock.results.length - 1]?.value as {
+      proposeDimensions: ReturnType<typeof vi.fn>;
+    };
+    await waitFor(() => {
+      expect(fitAddon.proposeDimensions).toHaveBeenCalled();
+    });
+    const baselineFitCalls = fitAddon.proposeDimensions.mock.calls.length;
+
+    act(() => {
+      useSettingsStore.getState().setTerminalFontFamily("Consolas, monospace");
+    });
+
+    await waitFor(() => {
+      expect(instance.options.fontFamily).toBe("Consolas, monospace");
+      expect(instance.refresh).toHaveBeenCalledWith(0, 23);
+      expect(fitAddon.proposeDimensions.mock.calls.length).toBeGreaterThan(baselineFitCalls);
+    });
   });
 
   it("loads the WebGL renderer so xterm custom glyphs render block art consistently", async () => {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -15,6 +15,7 @@ import {
   shouldSuppressDuplicateResizeRedraw,
   type TerminalOutputState,
 } from "./terminalCapabilities";
+import { effectiveTerminalFontFamily, useSettingsStore } from "../../store/useSettingsStore";
 
 const DARK_TERM_THEME = {
   background: "#020402",
@@ -464,11 +465,23 @@ function clearRendererTimers(renderer: TerminalRendererEntry) {
   }
 }
 
+function applyTerminalAppearance(
+  term: Terminal,
+  appearance: { fontSize: number; fontFamily: string },
+  refit: (options?: { force?: boolean }) => void,
+) {
+  term.options.fontSize = appearance.fontSize;
+  term.options.fontFamily = appearance.fontFamily;
+  term.refresh(0, Math.max(term.rows - 1, 0));
+  requestAnimationFrame(() => refit({ force: true }));
+}
+
 function createRenderer(sessionId: string, entry: TerminalSessionEntry) {
+  const { terminalFontFamily, terminalFontSize } = useSettingsStore.getState();
   const term = new Terminal({
     theme: entry.currentTheme,
-    fontFamily: '"Cascadia Mono", "Cascadia Code", "JetBrains Mono", Consolas, monospace',
-    fontSize: 14,
+    fontFamily: effectiveTerminalFontFamily(terminalFontFamily),
+    fontSize: terminalFontSize,
     customGlyphs: true,
     cursorBlink: true,
     scrollback: TERMINAL_SCROLLBACK_LINES,
@@ -515,6 +528,9 @@ function createRenderer(sessionId: string, entry: TerminalSessionEntry) {
   term.onData((data) => {
     if ((data === "\x1b[I" || data === "\x1b[O") && entry.provider !== "opencode") {
       return;
+    }
+    if (term.buffer.active.viewportY < term.buffer.active.baseY) {
+      term.scrollToBottom();
     }
     invoke("send_input_to_agent", {
       sessionId,
@@ -634,6 +650,8 @@ export const AgentTerminal = memo(function AgentTerminal({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const onTitleChangeRef = useRef(onTitleChange);
   const [initError, setInitError] = useState<string | null>(null);
+  const terminalFontSize = useSettingsStore((state) => state.terminalFontSize);
+  const terminalFontFamily = useSettingsStore((state) => state.terminalFontFamily);
 
   const [effectiveTheme, setEffectiveTheme] = useState<"dark" | "light">(() => {
     if (theme === "system") {
@@ -660,13 +678,13 @@ export const AgentTerminal = memo(function AgentTerminal({
     onTitleChangeRef.current = onTitleChange;
   }, [onTitleChange]);
 
-  const performFit = useCallback(() => {
+  const performFit = useCallback((options?: { force?: boolean }) => {
     const container = terminalRef.current;
     const entry = terminalSessionMap.get(sessionId);
     if (!entry || !xtermRef.current || !fitAddonRef.current || !container) {
       return;
     }
-    void fitTerminalToContainer(sessionId, entry, container);
+    void fitTerminalToContainer(sessionId, entry, container, options);
   }, [sessionId]);
 
   useEffect(() => {
@@ -787,6 +805,17 @@ export const AgentTerminal = memo(function AgentTerminal({
       clearTimeout(timer);
     };
   }, [sessionId, isMaximized, performFit]);
+
+  useEffect(() => {
+    const term = xtermRef.current;
+    if (!term) {
+      return;
+    }
+    applyTerminalAppearance(term, {
+      fontSize: terminalFontSize,
+      fontFamily: effectiveTerminalFontFamily(terminalFontFamily),
+    }, performFit);
+  }, [performFit, terminalFontFamily, terminalFontSize]);
 
   return (
     <div className="relative w-full h-full overflow-hidden">

--- a/src/store/useSettingsStore.test.ts
+++ b/src/store/useSettingsStore.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultTerminalFontFamily,
+  defaultTerminalFontSize,
+  LINUX_TERMINAL_FONT_FAMILY,
+  MACOS_TERMINAL_FONT_FAMILY,
+  WINDOWS_TERMINAL_FONT_FAMILY,
+} from './useSettingsStore';
+
+describe('terminal appearance defaults', () => {
+  it('matches VS Code font family defaults by platform', () => {
+    expect(defaultTerminalFontFamily('windows')).toBe(WINDOWS_TERMINAL_FONT_FAMILY);
+    expect(defaultTerminalFontFamily('macos')).toBe(MACOS_TERMINAL_FONT_FAMILY);
+    expect(defaultTerminalFontFamily('linux')).toBe(LINUX_TERMINAL_FONT_FAMILY);
+  });
+
+  it('matches VS Code terminal font size defaults by platform', () => {
+    expect(defaultTerminalFontSize('macos')).toBe(12);
+    expect(defaultTerminalFontSize('windows')).toBe(14);
+    expect(defaultTerminalFontSize('linux')).toBe(14);
+  });
+});

--- a/src/store/useSettingsStore.ts
+++ b/src/store/useSettingsStore.ts
@@ -3,9 +3,58 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { ShellOption, ShellSettings } from '../types/settings';
 
+export const MIN_TERMINAL_FONT_SIZE = 10;
+export const MAX_TERMINAL_FONT_SIZE = 20;
+export const WINDOWS_TERMINAL_FONT_FAMILY = 'Consolas, "Courier New", monospace';
+export const MACOS_TERMINAL_FONT_FAMILY = 'Menlo, Monaco, "Courier New", monospace';
+export const LINUX_TERMINAL_FONT_FAMILY = '"Droid Sans Mono", monospace';
+
+type TerminalPlatform = 'windows' | 'macos' | 'linux';
+
+function detectTerminalPlatform(): TerminalPlatform {
+  const platform = navigator.platform.toLowerCase();
+  const userAgent = navigator.userAgent.toLowerCase();
+  if (platform.includes('mac') || userAgent.includes('mac os')) {
+    return 'macos';
+  }
+  if (platform.includes('win') || userAgent.includes('windows')) {
+    return 'windows';
+  }
+  return 'linux';
+}
+
+export function defaultTerminalFontSize(platform: TerminalPlatform = detectTerminalPlatform()) {
+  return platform === 'macos' ? 12 : 14;
+}
+
+export function defaultTerminalFontFamily(platform: TerminalPlatform = detectTerminalPlatform()) {
+  switch (platform) {
+    case 'macos':
+      return MACOS_TERMINAL_FONT_FAMILY;
+    case 'windows':
+      return WINDOWS_TERMINAL_FONT_FAMILY;
+    default:
+      return LINUX_TERMINAL_FONT_FAMILY;
+  }
+}
+
+export function normalizeTerminalFontSize(value: number) {
+  if (!Number.isFinite(value)) {
+    return defaultTerminalFontSize();
+  }
+  return Math.min(MAX_TERMINAL_FONT_SIZE, Math.max(MIN_TERMINAL_FONT_SIZE, Math.round(value)));
+}
+
+export function effectiveTerminalFontFamily(value: string | null | undefined) {
+  const trimmed = value?.trim() ?? '';
+  return trimmed || defaultTerminalFontFamily();
+}
+
 interface SettingsState {
   theme: 'dark' | 'light' | 'system';
   autoPatchGemini: boolean;
+  terminalFontSize: number;
+  terminalFontFamily: string;
   shell_id: string;
   custom_executable: string;
   custom_args: string;
@@ -15,6 +64,8 @@ interface SettingsState {
   shells_loaded: boolean;
   setTheme: (theme: 'dark' | 'light' | 'system') => void;
   setAutoPatchGemini: (enabled: boolean) => void;
+  setTerminalFontSize: (value: number) => void;
+  setTerminalFontFamily: (value: string) => void;
   setShellId: (shellId: string) => void;
   setCustomExecutable: (value: string) => void;
   setCustomArgs: (value: string) => void;
@@ -37,6 +88,8 @@ export const useSettingsStore = create<SettingsState>()(
     (set, get) => ({
       theme: 'system',
       autoPatchGemini: false,
+      terminalFontSize: defaultTerminalFontSize(),
+      terminalFontFamily: '',
       shell_id: DEFAULT_SHELL_SETTINGS.shell_id,
       custom_executable: DEFAULT_SHELL_SETTINGS.custom_executable ?? '',
       custom_args: DEFAULT_SHELL_SETTINGS.custom_args ?? '',
@@ -46,6 +99,10 @@ export const useSettingsStore = create<SettingsState>()(
       shells_loaded: false,
       setTheme: (theme) => set({ theme }),
       setAutoPatchGemini: (autoPatchGemini) => set({ autoPatchGemini }),
+      setTerminalFontSize: (terminalFontSize) => set({
+        terminalFontSize: normalizeTerminalFontSize(terminalFontSize),
+      }),
+      setTerminalFontFamily: (terminalFontFamily) => set({ terminalFontFamily }),
       setShellId: (shell_id) => set({ shell_id }),
       setCustomExecutable: (custom_executable) => set({ custom_executable }),
       setCustomArgs: (custom_args) => set({ custom_args }),
@@ -114,6 +171,8 @@ export const useSettingsStore = create<SettingsState>()(
       partialize: (state) => ({
         theme: state.theme,
         autoPatchGemini: state.autoPatchGemini,
+        terminalFontSize: normalizeTerminalFontSize(state.terminalFontSize),
+        terminalFontFamily: state.terminalFontFamily.trim(),
       }),
     }
   )


### PR DESCRIPTION
## Description
Adds terminal appearance controls to Settings:

- Adds persistent terminal font size and font family preferences with OS-aware Auto defaults.
- Groups Shell and Appearance into separate blocks under the Terminal settings heading.
- Applies font size/family changes to live embedded agent terminals and forces a refit after changes.
- Preserves normal number-input typing by keeping partial font-size edits local until they are valid or committed.

## Related Issues
Fixes #185
Related to #184

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` — 34 files, 364 tests passed; existing `AgentWatchlist` React `act(...)` warnings still printed.
- `npm run build` — passed; existing Vite large chunk warning still printed.
- `cd src-tauri && cargo clippy`
- `cd src-tauri && cargo test` — 270 lib tests and 4 mock-provider tests passed.
- `cd src-tauri && cargo check`
- `git diff --check`

## Screenshots
Not attached from the CLI. The changed Settings interaction is covered by focused component tests for font size, partial number edits, preset font family selection, and custom font family entry.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable