### PR TITLE
fix(terminal): refine scroll behavior for TUI agents

### DIFF
--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, cleanup } from "@testing-library/react";
+import { render, waitFor, cleanup, screen } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Terminal } from "@xterm/xterm";
@@ -77,6 +77,7 @@ describe("AgentTerminal scrollback", () => {
         dispose: vi.fn(),
         focus: vi.fn(),
         scrollToBottom: vi.fn(),
+        buffer: { active: { baseY: 10, viewportY: 10 } },
         refresh: vi.fn(),
         cols: 80,
         rows: 24,
@@ -182,6 +183,76 @@ describe("AgentTerminal scrollback", () => {
       sessionId: "codex-text",
       input: "abc",
     });
+  });
+
+  it("scrolls to the bottom before forwarding text input when the user has scrolled up", async () => {
+    render(<AgentTerminal sessionId="codex-scroll-input" theme="dark" />);
+
+    await waitFor(() => {
+      expect(mockTerminal).toHaveBeenCalled();
+    });
+
+    const instance = getLatestTerminalInstance();
+    instance.buffer.active.viewportY = 2;
+    instance.buffer.active.baseY = 10;
+    instance.scrollToBottom.mockClear();
+    mockInvoke.mockClear();
+    const onData = instance.onData.mock.calls[0]?.[0] as ((data: string) => void);
+
+    onData("h");
+
+    expect(instance.scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-scroll-input",
+      input: "h",
+    });
+  });
+
+  it("does not force OpenCode terminals to scroll when forwarding text input", async () => {
+    render(<AgentTerminal sessionId="opencode-scroll-input" provider="opencode" theme="dark" />);
+
+    await waitFor(() => {
+      expect(mockTerminal).toHaveBeenCalled();
+    });
+
+    const instance = getLatestTerminalInstance();
+    instance.buffer.active.viewportY = 2;
+    instance.buffer.active.baseY = 10;
+    instance.scrollToBottom.mockClear();
+    mockInvoke.mockClear();
+    const onData = instance.onData.mock.calls[0]?.[0] as ((data: string) => void);
+
+    onData("h");
+
+    expect(instance.scrollToBottom).not.toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "opencode-scroll-input",
+      input: "h",
+    });
+  });
+
+  it("marks OpenCode terminals as TUI-owned scroll surfaces", async () => {
+    render(<AgentTerminal sessionId="opencode-scroll-owner" provider="opencode" theme="dark" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("agent-terminal-host")).toHaveClass("wardian-terminal--tui-owned-scroll");
+    });
+  });
+
+  it("keeps the OpenCode xterm viewport scrollable while hiding terminal scroll chrome", async () => {
+    // @ts-expect-error Vitest runs in Node, but the frontend tsconfig intentionally omits Node types.
+    const { readFileSync } = await import("node:fs");
+    // @ts-expect-error Vitest runs in Node, but the frontend tsconfig intentionally omits Node types.
+    const { cwd } = await import("node:process");
+    const appStyles = readFileSync(`${cwd()}/src/styles/App.css`, "utf8") as string;
+    const selector = ".wardian-terminal--tui-owned-scroll .xterm-viewport";
+    const ruleStart = appStyles.indexOf(selector);
+    const ruleEnd = appStyles.indexOf("}", ruleStart);
+    const viewportRule = appStyles.slice(ruleStart, ruleEnd);
+
+    expect(ruleStart).toBeGreaterThanOrEqual(0);
+    expect(viewportRule).toContain("scrollbar-width: none");
+    expect(viewportRule).not.toContain("overflow-y: hidden");
   });
 
   it("forwards codex enter as a plain carriage return", async () => {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -516,6 +516,9 @@ function createRenderer(sessionId: string, entry: TerminalSessionEntry) {
     if ((data === "\x1b[I" || data === "\x1b[O") && entry.provider !== "opencode") {
       return;
     }
+    if (entry.provider !== "opencode" && term.buffer.active.viewportY !== term.buffer.active.baseY) {
+      term.scrollToBottom();
+    }
     invoke("send_input_to_agent", {
       sessionId,
       input: data,
@@ -798,8 +801,11 @@ export const AgentTerminal = memo(function AgentTerminal({
       )}
       <div
         ref={terminalRef}
+        data-testid="agent-terminal-host"
         onClick={() => xtermRef.current?.focus()}
-        className="w-full h-full overflow-hidden"
+        className={`w-full h-full overflow-hidden ${
+          provider === "opencode" ? "wardian-terminal--tui-owned-scroll" : ""
+        }`}
       />
     </div>
   );

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -404,6 +404,19 @@
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
+.wardian-terminal--tui-owned-scroll .xterm-viewport {
+  scrollbar-width: none;
+}
+
+.wardian-terminal--tui-owned-scroll .xterm-viewport::-webkit-scrollbar {
+  display: none;
+}
+
+.wardian-terminal--tui-owned-scroll .xterm-scrollable-element > .scrollbar {
+  display: none !important;
+}
+
 /* Hide xterm baseline cursor to stop duplicate ghosting since conpty renders its own */
 .xterm-cursor-layer {
   display: none !important;


### PR DESCRIPTION
## Description
Refines terminal scroll behavior so non-TUI terminals return to live output when the user starts typing after scrolling up, while OpenCode keeps ownership of its TUI scroll state.

## Related Issues
Fixes #187

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run test -- src/features/terminal/AgentTerminal.test.tsx` - 20 tests passed
- `npm run lint` - passed
- `npm run test` - 33 files, 359 tests passed; existing AgentWatchlist React `act(...)` warnings still print
- `npm run build` - passed; existing large chunk warning still prints

## Screenshots
Not captured. This change is terminal scroll/input behavior and the current automated coverage verifies the affected code paths; no app runtime was launched during final verification.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable