### PR TITLE
fix(terminal): select agent on terminal focus

### DIFF
--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -241,6 +241,22 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
+  it("reports terminal focus while still focusing the xterm instance on click", async () => {
+    const onTerminalFocus = vi.fn();
+    render(<AgentTerminal sessionId="codex-focus" theme="dark" onTerminalFocus={onTerminalFocus} />);
+
+    await waitFor(() => {
+      expect(mockTerminal).toHaveBeenCalled();
+    });
+
+    const host = screen.getByTestId("agent-terminal-host");
+    host.focus();
+    host.click();
+
+    expect(onTerminalFocus).toHaveBeenCalledTimes(1);
+    expect(getLatestTerminalInstance().focus).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the OpenCode xterm viewport scrollable while hiding terminal scroll chrome", async () => {
     // @ts-expect-error Vitest runs in Node, but the frontend tsconfig intentionally omits Node types.
     const { readFileSync } = await import("node:fs");

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -638,12 +638,14 @@ export const AgentTerminal = memo(function AgentTerminal({
   isMaximized,
   theme,
   onTitleChange,
+  onTerminalFocus,
 }: {
   sessionId: string;
   provider?: string;
   isMaximized?: boolean;
   theme: "dark" | "light" | "system";
   onTitleChange?: (title: string) => void;
+  onTerminalFocus?: () => void;
 }) {
   const terminalRef = useRef<HTMLDivElement>(null);
   const xtermRef = useRef<Terminal | null>(null);
@@ -686,6 +688,10 @@ export const AgentTerminal = memo(function AgentTerminal({
     }
     void fitTerminalToContainer(sessionId, entry, container, options);
   }, [sessionId]);
+
+  const focusTerminal = useCallback(() => {
+    xtermRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     if (!sessionId || !terminalRef.current) {
@@ -828,7 +834,9 @@ export const AgentTerminal = memo(function AgentTerminal({
       <div
         ref={terminalRef}
         data-testid="agent-terminal-host"
-        onClick={() => xtermRef.current?.focus()}
+        tabIndex={-1}
+        onFocusCapture={onTerminalFocus}
+        onClick={focusTerminal}
         className={`w-full h-full overflow-hidden ${
           provider === "opencode" ? "wardian-terminal--tui-owned-scroll" : ""
         }`}

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -23,7 +23,21 @@ Object.defineProperty(window, 'matchMedia', {
 });
 
 vi.mock("../features/terminal/AgentTerminal", () => ({
-  AgentTerminal: ({ sessionId }: { sessionId: string }) => <div data-testid={`terminal-${sessionId}`}>Terminal {sessionId}</div>
+  AgentTerminal: ({
+    sessionId,
+    onTerminalFocus,
+  }: {
+    sessionId: string;
+    onTerminalFocus?: () => void;
+  }) => (
+    <div
+      data-testid={`terminal-${sessionId}`}
+      tabIndex={0}
+      onFocus={onTerminalFocus}
+    >
+      Terminal {sessionId}
+    </div>
+  )
 }));
 
 // Cast invoke to mock for test control
@@ -541,6 +555,26 @@ describe("Agent Watchlist Sidebar", () => {
       expect(screen.queryByTestId("terminal-agent-1")).not.toBeInTheDocument();
       expect(screen.getByTestId("terminal-agent-2")).toBeInTheDocument();
     });
+  });
+
+  it("selects only the owning agent when a terminal receives focus", async () => {
+    setupDefaultMocks(sampleAgents, defaultClasses);
+    render(<App />);
+
+    const alphaTerminal = await screen.findByTestId("terminal-agent-1");
+    const betaTerminal = await screen.findByTestId("terminal-agent-2");
+    const alphaCard = alphaTerminal.closest('[data-testid="agent-card"]');
+    const betaCard = betaTerminal.closest('[data-testid="agent-card"]');
+    if (!alphaCard || !betaCard) throw new Error("Expected terminal cards to render");
+
+    fireEvent.click(alphaCard.querySelector(".border-b") ?? alphaCard);
+    expect(alphaCard.className).toContain("ring-1");
+    expect(betaCard.className).not.toContain("ring-1");
+
+    fireEvent.focus(betaTerminal);
+
+    expect(alphaCard.className).not.toContain("ring-1");
+    expect(betaCard.className).toContain("ring-1");
   });
 });
 

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -395,6 +395,16 @@ function AppBody() {
       }
   }, [filteredAgents, selectedAgentIds]);
 
+  const selectSingleAgent = useCallback((agentId: string) => {
+    setSelectedAgentIds((prev) => {
+      if (prev.size === 1 && prev.has(agentId)) {
+        return prev;
+      }
+      return new Set([agentId]);
+    });
+    lastSelectedIdRef.current = agentId;
+  }, []);
+
   const handleMouseDown = (agentId: string) => setDraggedAgentId(agentId);
   const handleMouseEnterCard = (agentId: string) => {
     if (draggedAgentId && draggedAgentId !== agentId) setDragOverAgentId(agentId);
@@ -833,6 +843,7 @@ function AppBody() {
                 onMouseUp={handleMouseUp}
                 onMouseDown={handleMouseDown}
                 onCardClick={handleAgentCardClick}
+                onTerminalFocus={selectSingleAgent}
                 onMaximize={setMaximizedAgentId}
                 onDelete={onDelete}
                 onRename={renameAgent}

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -5,7 +5,21 @@ import type { AgentConfig, AgentTelemetry } from '../types';
 import { useLayoutStore } from '../store/useLayoutStore';
 
 vi.mock('../features/terminal/AgentTerminal', () => ({
-  AgentTerminal: ({ sessionId }: { sessionId: string }) => <div data-testid={`terminal-${sessionId}`}>Terminal {sessionId}</div>,
+  AgentTerminal: ({
+    sessionId,
+    onTerminalFocus,
+  }: {
+    sessionId: string;
+    onTerminalFocus?: () => void;
+  }) => (
+    <div
+      data-testid={`terminal-${sessionId}`}
+      tabIndex={0}
+      onFocus={onTerminalFocus}
+    >
+      Terminal {sessionId}
+    </div>
+  ),
 }));
 
 const agents: AgentConfig[] = [
@@ -15,7 +29,11 @@ const agents: AgentConfig[] = [
 
 const telemetry: Record<string, AgentTelemetry> = {};
 
-function renderGrid(maximizedAgentId: string | null, filteredAgents: AgentConfig[] = agents) {
+function renderGrid(
+  maximizedAgentId: string | null,
+  filteredAgents: AgentConfig[] = agents,
+  onTerminalFocus = vi.fn(),
+) {
   return render(
     <GridView
       filteredAgents={filteredAgents}
@@ -49,11 +67,21 @@ function renderGrid(maximizedAgentId: string | null, filteredAgents: AgentConfig
       onPause={vi.fn()}
       onRestart={vi.fn()}
       onClear={vi.fn()}
+      onTerminalFocus={onTerminalFocus}
     />
   );
 }
 
 describe('GridView maximize behavior', () => {
+  it('reports the owning agent when its terminal receives focus', () => {
+    const onTerminalFocus = vi.fn();
+    renderGrid(null, agents, onTerminalFocus);
+
+    screen.getByTestId('terminal-agent-2').focus();
+
+    expect(onTerminalFocus).toHaveBeenCalledWith('agent-2');
+  });
+
   it('does not size each mobile card to the full viewport height', () => {
     const originalWidth = window.innerWidth;
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 800 });

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -40,6 +40,7 @@ interface GridViewProps {
   onRestart: (agentId: string) => void;
   onClear: (agentId: string) => void;
   onClone?: (agentId: string, mode: "fresh" | "profile") => void;
+  onTerminalFocus?: (agentId: string) => void;
 }
 
 export const GridView: React.FC<GridViewProps> = ({
@@ -75,6 +76,7 @@ export const GridView: React.FC<GridViewProps> = ({
   onRestart,
   onClear,
   onClone,
+  onTerminalFocus,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { layout, resetLayout, gridStacked } = useLayoutStore();
@@ -236,6 +238,7 @@ export const GridView: React.FC<GridViewProps> = ({
                   provider={agent.provider}
                   isMaximized={isAgentMaximized}
                   theme={theme}
+                  onTerminalFocus={() => onTerminalFocus?.(agentId)}
                   onTitleChange={(title) => handleTitleChange(agentId, title)} 
                 />
               </div>


### PR DESCRIPTION
## Description
Selecting/typing into a grid terminal now updates Wardian's global selected-agent state to that terminal's owning agent. The focus signal is captured in `AgentTerminal`, threaded through `GridView`, and handled in `App` as an idempotent single-agent selection.

## Related Issues
Fixes #181

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run test -- src/features/terminal/AgentTerminal.test.tsx -t "reports terminal focus"`
- `npm run test -- src/views/GridView.test.tsx -t "reports the owning agent"`
- `npm run test -- src/views/App.test.tsx -t "selects only the owning agent"`
- `npm run test -- src/features/terminal/AgentTerminal.test.tsx src/views/GridView.test.tsx src/views/App.test.tsx`
- `npm run lint`
- `npm run test:e2e` (37 passed, 17 skipped)
- `npm run test` (34 files, 370 tests passed; existing React act warnings still print from watchlist/app tests)
- `npm run build` (succeeds; existing Vite chunk-size warning still prints)

## Screenshots
Not applicable. This changes focus/selection behavior and is covered by targeted automated interaction tests rather than a new static visual state.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas or left self-explanatory code uncommented
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable
