### PR TITLE
feat(sidebar): add terminal navigation item

### DIFF
--- a/src/layout/SidebarContentPane.tsx
+++ b/src/layout/SidebarContentPane.tsx
@@ -118,6 +118,17 @@ export const SidebarContentPane: React.FC<SidebarContentPaneProps> = ({
           />
         )}
 
+        {activeTab === "terminal" && (
+          <div data-testid="terminal-panel" className="flex flex-col h-full">
+            <div className="flex items-center gap-4">
+              <h2 className="text-xl font-bold text-primary tracking-tight">Terminal</h2>
+            </div>
+            <div className="flex flex-1 items-center justify-center text-center p-6">
+              <p className="text-xs text-muted italic px-4">Terminal tools are coming soon.</p>
+            </div>
+          </div>
+        )}
+
         {activeTab === "settings" && (
           <SettingsPanel />
         )}

--- a/src/layout/SidebarIconRail.tsx
+++ b/src/layout/SidebarIconRail.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Folder } from "lucide-react";
+import { Folder, MessageSquareCode } from "lucide-react";
 
-export type SidebarTab = "explorer" | "git" | "agent-config" | "command" | "classes" | "workflows" | "ssh" | "settings";
+export type SidebarTab = "explorer" | "git" | "agent-config" | "command" | "classes" | "workflows" | "ssh" | "terminal" | "settings";
 
 interface SidebarIconRailProps {
   activeTab: SidebarTab;
@@ -64,7 +64,7 @@ export const SidebarIconRail: React.FC<SidebarIconRailProps> = ({
         title="Command"
       >
         {activeTab === "command" && <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-[var(--color-wardian-accent)] rounded-r-full" />}
-        <svg className="w-6 h-6 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+        <MessageSquareCode className="w-6 h-6 group-hover:scale-110 transition-transform" strokeWidth={2} />
       </button>
 
       <button
@@ -101,6 +101,16 @@ export const SidebarIconRail: React.FC<SidebarIconRailProps> = ({
       </button>
 
       <div className="mt-auto flex flex-col gap-4">
+        <button
+          data-testid="sidebar-tab-terminal"
+          onClick={() => handleTabClick("terminal")}
+          className={`relative p-3 rounded-xl transition-all group ${activeTab === "terminal" ? "bg-wardian-card-bg-muted text-[var(--color-wardian-accent)]" : "text-muted-neutral hover:text-bright-neutral"}`}
+          title="Terminal"
+        >
+          {activeTab === "terminal" && <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-6 bg-[var(--color-wardian-accent)] rounded-r-full" />}
+          <svg className="w-6 h-6 group-hover:scale-110 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+        </button>
+
         <button
           data-testid="sidebar-tab-settings"
           onClick={() => handleTabClick("settings")}

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -658,11 +658,23 @@ describe("Sidebar Navigation", () => {
     setupDefaultMocks([], defaultClasses);
     render(<App />);
     await screen.findByText("No Active Instances");
-    const buttons = screen.getAllByRole("button");
+    const buttons = within(screen.getByTestId("sidebar-icon-rail")).getAllByRole("button");
     const titles = buttons.map(b => b.getAttribute("title")).filter(Boolean);
     expect(titles).toContain("Agent Configuration");
     expect(titles).toContain("Command");
+    expect(titles).toContain("Terminal");
     expect(titles).toContain("Application Settings");
+    expect(titles.indexOf("Terminal")).toBeLessThan(titles.indexOf("Application Settings"));
+  });
+
+  it("opens the Terminal panel from the sidebar", async () => {
+    setupDefaultMocks([], defaultClasses);
+    render(<App />);
+    await screen.findByText("No Active Instances");
+
+    fireEvent.click(screen.getByTitle("Terminal"));
+
+    expect(await screen.findByTestId("terminal-panel")).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Description
Adds a dedicated Terminal sidebar item and moves the old Command terminal icon to that new item.

## Related Issues
Fixes #194

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` (passes; existing React `act(...)` warnings still print from unrelated watchlist/ManageSkills tests)
- `npm run build` (passes; existing Vite large chunk warning still prints)
- Review requested for commit `08c8cc9`; reviewer assessed it as ready to merge with no Critical or Important issues.

## Screenshots
Not captured. This is a small sidebar icon/navigation placement change covered by targeted navigation tests.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable