### PR TITLE
test(frontend): increase coverage across core UI

### DIFF
--- a/src/components/ContextMenu.test.tsx
+++ b/src/components/ContextMenu.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ContextMenu } from './ContextMenu';
+
+describe('ContextMenu', () => {
+  it('runs item actions and closes the menu', async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <ContextMenu
+        x={20}
+        y={30}
+        onClose={onClose}
+        items={[
+          { label: 'Copy', onClick: onAction },
+          { divider: true },
+          { label: 'Delete', danger: true, onClick: onAction },
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Copy' }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens submenus and closes on outside interactions', async () => {
+    const user = userEvent.setup();
+    const subAction = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <ContextMenu
+        x={window.innerWidth + 200}
+        y={window.innerHeight + 200}
+        onClose={onClose}
+        items={[
+          {
+            label: 'Insert Variable',
+            subItems: [{ label: 'Base Output', onClick: subAction }],
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'Insert Variable' }).parentElement!);
+    await user.click(await screen.findByRole('button', { name: 'Base Output' }));
+    expect(subAction).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+const ProblemChild = () => {
+  throw new Error('render failed');
+};
+
+describe('ErrorBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when no error is thrown', () => {
+    render(
+      <ErrorBoundary>
+        <div>Healthy UI</div>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Healthy UI')).toBeInTheDocument();
+  });
+
+  it('shows the fatal error fallback and reloads the app', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const reload = vi.fn();
+    vi.spyOn(window, 'location', 'get').mockReturnValue({
+      ...window.location,
+      reload,
+    } as Location);
+
+    render(
+      <ErrorBoundary>
+        <ProblemChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Fatal UI Rendering Error')).toBeInTheDocument();
+    expect(screen.getByText('Error: render failed')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Reload Wardian' }));
+    expect(reload).toHaveBeenCalled();
+  });
+});

--- a/src/components/ListEditor.test.tsx
+++ b/src/components/ListEditor.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfirmProvider } from './ConfirmDialog';
+import { ListEditor } from './ListEditor';
+
+describe('ListEditor', () => {
+  it('adds, edits, and removes user values', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ListEditor label="Paths" values={['C:/project']} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Add paths/i }));
+    expect(onChange).toHaveBeenLastCalledWith(['C:/project', '']);
+
+    rerender(<ListEditor label="Paths" values={['C:/project', '']} onChange={onChange} />);
+    fireEvent.change(screen.getAllByRole('textbox')[1], { target: { value: 'D:/workspace' } });
+    expect(onChange).toHaveBeenLastCalledWith(['C:/project', 'D:/workspace']);
+
+    rerender(<ListEditor label="Paths" values={['C:/project', 'D:/workspace']} onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: 'Remove paths value 1' }));
+    expect(onChange).toHaveBeenLastCalledWith(['D:/workspace']);
+  });
+
+  it('validates values and keeps read-only system values from editing directly', async () => {
+    const validate = vi.fn(async (value: string) => value.startsWith('C:/'));
+    const onChange = vi.fn();
+
+    render(
+      <ListEditor
+        label="Include Directories"
+        values={['D:/invalid']}
+        systemValues={['C:/system']}
+        onChange={onChange}
+        validate={validate}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTitle('Valid path')).toBeInTheDocument();
+      expect(screen.getByTitle('Invalid or missing path')).toBeInTheDocument();
+    });
+
+    const systemInput = screen.getByDisplayValue('C:/system');
+    await userEvent.type(systemInput, 'ignored');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('confirms before deleting a system value', async () => {
+    const user = userEvent.setup();
+    const onSystemValueDelete = vi.fn();
+
+    render(
+      <ConfirmProvider>
+        <ListEditor
+          label="Include Directories"
+          values={[]}
+          systemValues={['C:/system']}
+          onChange={() => {}}
+          onSystemValueDelete={onSystemValueDelete}
+        />
+      </ConfirmProvider>,
+    );
+
+    await user.click(screen.getByTitle('Remove system directory'));
+    expect(screen.getByText(/system-managed directory/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onSystemValueDelete).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/components/ListEditor.tsx
+++ b/src/components/ListEditor.tsx
@@ -111,6 +111,8 @@ export const ListEditor: React.FC<ListEditorProps> = ({
               type="button"
               onClick={() => onChange(safeValues.filter((_, i) => i !== idx))}
               className="text-muted-neutral hover:text-red-400 p-0.5 transition-colors shrink-0"
+              aria-label={`Remove ${label.toLowerCase()} value ${idx + 1}`}
+              title={`Remove ${label.toLowerCase()} value ${idx + 1}`}
             >
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />

--- a/src/components/RenderableInput.test.tsx
+++ b/src/components/RenderableInput.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { RenderableInput } from './RenderableInput';
+
+describe('RenderableInput', () => {
+  it('shows a placeholder when empty', () => {
+    render(<RenderableInput value="" onChange={() => {}} placeholder="Describe input" />);
+
+    expect(screen.getByText('Describe input')).toBeInTheDocument();
+  });
+
+  it('renders variable tags and switches to an editable input on click', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <RenderableInput
+        value="Run {{trigger.payload.id}}"
+        onChange={onChange}
+        placeholder="Describe input"
+      />,
+    );
+
+    expect(screen.getByText('Run')).toBeInTheDocument();
+    expect(screen.getByText('Trigger')).toBeInTheDocument();
+    expect(screen.getByText('payload.id')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Run'));
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('Run {{trigger.payload.id}}');
+
+    fireEvent.change(input, { target: { value: 'Run {{storage.release.version}}' } });
+    expect(onChange).toHaveBeenCalledWith('Run {{storage.release.version}}');
+  });
+
+  it('uses a textarea for multiline editing', async () => {
+    const user = userEvent.setup();
+    render(<RenderableInput value="line one" onChange={() => {}} multiline />);
+
+    await user.click(screen.getByText('line one'));
+
+    expect(screen.getByRole('textbox').tagName).toBe('TEXTAREA');
+  });
+});

--- a/src/components/SchemaEditor.test.tsx
+++ b/src/components/SchemaEditor.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { SchemaEditor } from './SchemaEditor';
+
+vi.mock('./RenderableInput', () => ({
+  RenderableInput: ({ value, onChange }: { value: string; onChange: (value: string) => void }) => (
+    <textarea
+      aria-label="JSON schema source"
+      value={value}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
+  ),
+}));
+
+const lastSchemaChange = (onChange: ReturnType<typeof vi.fn>) =>
+  JSON.parse(onChange.mock.calls[onChange.mock.calls.length - 1]?.[0] as string);
+
+describe('SchemaEditor', () => {
+  it('adds, renames, and removes top-level properties', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SchemaEditor value='{"type":"object","properties":{}}' onChange={onChange} nodeId="node-1" />);
+
+    expect(screen.getByText('No Fields Defined')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Add Property/i }));
+
+    expect(lastSchemaChange(onChange).properties).toHaveProperty('field_1');
+    const nameInput = screen.getByDisplayValue('field_1');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'summary');
+    fireEvent.blur(nameInput);
+
+    expect(lastSchemaChange(onChange).properties).toHaveProperty('summary');
+    expect(lastSchemaChange(onChange).properties).not.toHaveProperty('field_1');
+
+    await user.click(screen.getByRole('button', { name: 'Remove summary' }));
+    expect(lastSchemaChange(onChange).properties).not.toHaveProperty('summary');
+  });
+
+  it('creates nested object fields and avoids rename collisions', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SchemaEditor
+        value={JSON.stringify({
+          type: 'object',
+          properties: {
+            existing: { type: 'string' },
+            nested: { type: 'object', properties: {} },
+          },
+        })}
+        onChange={onChange}
+        nodeId="node-1"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Add Subfield/i }));
+    expect(lastSchemaChange(onChange).properties.nested.properties).toHaveProperty('field_1');
+
+    const nestedInput = screen.getByDisplayValue('nested');
+    await user.clear(nestedInput);
+    await user.type(nestedInput, 'existing');
+    fireEvent.blur(nestedInput);
+
+    const schema = lastSchemaChange(onChange);
+    expect(schema.properties).toHaveProperty('existing');
+    expect(schema.properties).toHaveProperty('existing_1');
+    expect(schema.properties).not.toHaveProperty('nested');
+  });
+
+  it('switches to JSON editing and forwards source changes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SchemaEditor value='{"type":"object","properties":{}}' onChange={onChange} nodeId="node-1" />);
+
+    await user.click(screen.getByRole('button', { name: 'JSON' }));
+    await user.clear(screen.getByLabelText('JSON schema source'));
+    fireEvent.change(screen.getByLabelText('JSON schema source'), {
+      target: { value: '{"type":"object"}' },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith('{"type":"object"}');
+  });
+});

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -68,6 +68,8 @@ const PropertyRow: React.FC<PropertyRowProps> = ({
         <button 
           onClick={() => onRemove(propKey)}
           className="p-1 text-muted-neutral hover:text-red-500 transition-colors cursor-pointer"
+          aria-label={`Remove ${propKey}`}
+          title={`Remove ${propKey}`}
         >
           <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
         </button>

--- a/src/components/VariablePill.test.tsx
+++ b/src/components/VariablePill.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useWorkflowStore } from '../store/useWorkflowStore';
+import { VariablePill } from './VariablePill';
+
+describe('VariablePill', () => {
+  beforeEach(() => {
+    useWorkflowStore.setState({ nodes: [], edges: [] });
+  });
+
+  it('renders node variables with the node label and nested path', () => {
+    useWorkflowStore.setState({
+      nodes: [
+        {
+          id: 'cmd',
+          type: 'command',
+          data: { label: 'Build Step' },
+        } as any,
+      ],
+    });
+
+    render(<VariablePill path="{{nodes.cmd.output.stdout}}" isPrevious />);
+
+    expect(screen.getByTitle('{{nodes.cmd.output.stdout}}')).toBeInTheDocument();
+    expect(screen.getByText('Build Step')).toBeInTheDocument();
+    expect(screen.getByText('output.stdout')).toBeInTheDocument();
+    expect(screen.getByText('PREV')).toBeInTheDocument();
+  });
+
+  it('renders trigger, storage, and fallback variables', () => {
+    const { rerender } = render(<VariablePill path="trigger.payload.id" />);
+    expect(screen.getByText('Trigger')).toBeInTheDocument();
+    expect(screen.getByText('payload.id')).toBeInTheDocument();
+
+    rerender(<VariablePill path="storage.release.version" />);
+    expect(screen.getByText('Storage')).toBeInTheDocument();
+    expect(screen.getByText('release.version')).toBeInTheDocument();
+
+    rerender(<VariablePill path="customValue" />);
+    expect(screen.getByText('customValue')).toBeInTheDocument();
+  });
+});

--- a/src/features/commands/CommandPanel.test.tsx
+++ b/src/features/commands/CommandPanel.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { invoke } from "@tauri-apps/api/core";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { ConfirmProvider } from "../../components/ConfirmDialog";
+import { useLibraryStore } from "../../store/useLibraryStore";
+import type { LibraryFolder } from "../../types";
+import { CommandPanel } from "./CommandPanel";
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: vi.fn(),
+}));
+
+const mockInvoke = vi.mocked(invoke);
+const mockWriteText = vi.mocked(writeText);
+const originalState = useLibraryStore.getState();
+
+function promptTree(): LibraryFolder {
+  return {
+    type: "Folder",
+    path: "",
+    name: "Prompts",
+    children: [
+      {
+        type: "Prompt",
+        path: "quick/ship.md",
+        name: "Ship Summary",
+        content: "Ship it\nwith notes",
+        metadata: { id: "prompt-1", tags: [], is_starred: true },
+      },
+      {
+        type: "Prompt",
+        path: "draft.md",
+        name: "Draft",
+        content: "Hidden prompt",
+        metadata: { id: "prompt-2", tags: [], is_starred: false },
+      },
+      {
+        type: "Folder",
+        path: "nested",
+        name: "Nested",
+        children: [
+          {
+            type: "Prompt",
+            path: "nested/review.md",
+            name: "Review Notes",
+            content: "Review this",
+            metadata: { id: "prompt-3", tags: [], is_starred: true },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function renderCommandPanel(options?: {
+  selectedAgentIds?: Set<string>;
+  broadcastMessage?: string;
+  setBroadcastMessage?: (message: string) => void;
+  onBroadcast?: (event: React.FormEvent) => void;
+}) {
+  const props = {
+    selectedAgentIds: options?.selectedAgentIds ?? new Set(["agent-1"]),
+    broadcastMessage: options?.broadcastMessage ?? "",
+    setBroadcastMessage: options?.setBroadcastMessage ?? vi.fn(),
+    onBroadcast: options?.onBroadcast ?? vi.fn(),
+  };
+
+  render(
+    <ConfirmProvider>
+      <CommandPanel {...props} />
+    </ConfirmProvider>,
+  );
+
+  return props;
+}
+
+describe("CommandPanel", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockWriteText.mockReset();
+    useLibraryStore.setState({
+      ...originalState,
+      promptTree: promptTree(),
+      skillTree: null,
+      activeTab: "prompts",
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterAll(() => {
+    useLibraryStore.setState(originalState);
+  });
+
+  it("lists starred prompts from nested folders and omits unstarred prompts", () => {
+    renderCommandPanel();
+
+    expect(screen.getByText("Ship Summary")).toBeInTheDocument();
+    expect(screen.getByText("Review Notes")).toBeInTheDocument();
+    expect(screen.queryByText("Draft")).not.toBeInTheDocument();
+  });
+
+  it("flattens and injects a quick prompt into selected agents", async () => {
+    const user = userEvent.setup();
+
+    renderCommandPanel({ selectedAgentIds: new Set(["agent-1", "agent-2"]) });
+    await user.click(screen.getByRole("button", { name: /Ship Summary/i }));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("submit_prompt_to_agent", {
+        sessionId: "agent-1",
+        prompt: "Ship it with notes",
+      });
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("submit_prompt_to_agent", {
+      sessionId: "agent-2",
+      prompt: "Ship it with notes",
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("list_agents");
+  });
+
+  it("confirms before broadcasting a quick prompt when no agents are selected", async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === "list_agents") {
+        return [
+          { session_id: "agent-1", session_name: "One", agent_class: "Coder", folder: "C:/repo", is_off: false },
+          { session_id: "agent-2", session_name: "Two", agent_class: "Coder", folder: "C:/repo", is_off: false },
+        ];
+      }
+      return null;
+    });
+
+    renderCommandPanel({ selectedAgentIds: new Set() });
+    await user.click(screen.getByRole("button", { name: /Review Notes/i }));
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("list_agents");
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("submit_prompt_to_agent", {
+      sessionId: "agent-1",
+      prompt: "Review this",
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("submit_prompt_to_agent", {
+      sessionId: "agent-2",
+      prompt: "Review this",
+    });
+  });
+
+  it("copies prompt content without injecting it", async () => {
+    const user = userEvent.setup();
+
+    renderCommandPanel();
+    await user.click(screen.getAllByTitle("Copy to clipboard")[0]);
+
+    expect(mockWriteText).toHaveBeenCalledWith("Ship it\nwith notes");
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("confirms empty-selection broadcasts before submitting", async () => {
+    const user = userEvent.setup();
+    const onBroadcast = vi.fn();
+
+    renderCommandPanel({
+      selectedAgentIds: new Set(),
+      broadcastMessage: "Status?",
+      onBroadcast,
+    });
+    await user.click(screen.getByTestId("broadcast-submit"));
+    expect(onBroadcast).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(onBroadcast).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/git/GitDiffView.test.tsx
+++ b/src/features/git/GitDiffView.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { GitDiffView } from './GitDiffView';
+
+describe('GitDiffView', () => {
+  it('renders highlighted diff lines and closes from the backdrop or button', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <GitDiffView
+        filePath="src/app.tsx"
+        onClose={onClose}
+        diff={['diff --git a/src/app.tsx b/src/app.tsx', '@@ -1 +1 @@', '-old', '+new'].join('\n')}
+      />,
+    );
+
+    expect(screen.getByText('src/app.tsx')).toBeInTheDocument();
+    expect(screen.getByText('@@ -1 +1 @@')).toHaveStyle({
+      color: 'var(--color-wardian-processing)',
+    });
+    expect(screen.getByText('-old')).toHaveStyle({ color: 'var(--color-wardian-error)' });
+    expect(screen.getByText('+new')).toHaveStyle({ color: 'var(--color-wardian-success)' });
+
+    await user.click(screen.getByRole('button', { name: 'Close diff' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByText('src/app.tsx'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTestId('git-diff-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders an empty state when there is no diff', () => {
+    render(<GitDiffView filePath="README.md" diff="" onClose={() => {}} />);
+
+    expect(screen.getByText('No differences to display.')).toBeInTheDocument();
+  });
+});

--- a/src/features/git/GitDiffView.tsx
+++ b/src/features/git/GitDiffView.tsx
@@ -11,6 +11,7 @@ export const GitDiffView: React.FC<GitDiffViewProps> = ({ diff, filePath, onClos
 
   return (
     <div
+      data-testid="git-diff-backdrop"
       className="fixed inset-0 z-[100] bg-black/60 flex items-center justify-center p-8 backdrop-blur-sm animate-in fade-in"
       onClick={onClose}
     >
@@ -24,6 +25,8 @@ export const GitDiffView: React.FC<GitDiffViewProps> = ({ diff, filePath, onClos
           </h3>
           <button
             onClick={onClose}
+            aria-label="Close diff"
+            title="Close diff"
             className="text-[var(--color-wardian-text-muted)] hover:text-wardian-error font-bold transition-colors w-8 h-8 flex items-center justify-center rounded-md hover:bg-wardian-error/10"
           >
             ✕

--- a/src/features/git/GitFileList.test.tsx
+++ b/src/features/git/GitFileList.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { GitFileEntry } from '../../types';
+import { GitFileList } from './GitFileList';
+
+const files: GitFileEntry[] = [
+  { path: 'src/app.tsx', status: 'M', is_staged: false },
+  { path: 'README.md', status: '?', is_staged: false },
+  { path: 'src/main.ts', status: 'A', is_staged: true },
+];
+
+describe('GitFileList', () => {
+  it('renders nothing for empty file lists', () => {
+    const { container } = render(<GitFileList files={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('routes file and action clicks to the right callbacks', async () => {
+    const user = userEvent.setup();
+    const onDiff = vi.fn();
+    const onStage = vi.fn();
+    const onUnstage = vi.fn();
+    const onDiscard = vi.fn();
+
+    render(
+      <GitFileList
+        files={files}
+        onDiff={onDiff}
+        onStage={onStage}
+        onUnstage={onUnstage}
+        onDiscard={onDiscard}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'View diff for src/app.tsx' }));
+    expect(onDiff).toHaveBeenCalledWith('src/app.tsx', false);
+
+    await user.click(screen.getByRole('button', { name: 'Stage src/app.tsx' }));
+    expect(onStage).toHaveBeenCalledWith('src/app.tsx');
+
+    await user.click(screen.getByRole('button', { name: 'Discard changes to src/app.tsx' }));
+    expect(onDiscard).toHaveBeenCalledWith('src/app.tsx');
+
+    await user.click(screen.getByRole('button', { name: 'Unstage src/main.ts' }));
+    expect(onUnstage).toHaveBeenCalledWith('src/main.ts');
+  });
+});

--- a/src/features/git/GitFileList.tsx
+++ b/src/features/git/GitFileList.tsx
@@ -44,6 +44,7 @@ export const GitFileList: React.FC<GitFileListProps> = ({
           >
             <button
               className="flex-1 min-w-0 text-left truncate text-primary hover:underline cursor-pointer"
+              aria-label={`View diff for ${file.path}`}
               title={file.path}
               onClick={() => onDiff?.(file.path, file.is_staged)}
             >
@@ -56,6 +57,7 @@ export const GitFileList: React.FC<GitFileListProps> = ({
               {file.is_staged && onUnstage && (
                 <button
                   className="p-0.5 rounded hover:bg-wardian-card text-[var(--color-wardian-text-muted)] hover:text-primary transition-colors"
+                  aria-label={`Unstage ${file.path}`}
                   title="Unstage"
                   onClick={() => onUnstage(file.path)}
                 >
@@ -67,6 +69,7 @@ export const GitFileList: React.FC<GitFileListProps> = ({
               {!file.is_staged && onStage && (
                 <button
                   className="p-0.5 rounded hover:bg-wardian-card text-[var(--color-wardian-text-muted)] hover:text-primary transition-colors"
+                  aria-label={`Stage ${file.path}`}
                   title="Stage"
                   onClick={() => onStage(file.path)}
                 >
@@ -78,6 +81,7 @@ export const GitFileList: React.FC<GitFileListProps> = ({
               {!file.is_staged && onDiscard && file.status !== "?" && (
                 <button
                   className="p-0.5 rounded hover:bg-[color-mix(in_srgb,var(--color-wardian-error),transparent_80%)] text-[var(--color-wardian-text-muted)] hover:text-[var(--color-wardian-error)] transition-colors"
+                  aria-label={`Discard changes to ${file.path}`}
                   title="Discard Changes"
                   onClick={() => onDiscard(file.path)}
                 >

--- a/src/features/library/AssignPromptModal.test.tsx
+++ b/src/features/library/AssignPromptModal.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { invoke } from '@tauri-apps/api/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentConfig, LibraryPrompt } from '../../types';
+import { submitInputToAgent } from '../../utils/terminalInput';
+import { AssignPromptModal } from './AssignPromptModal';
+
+vi.mock('../../utils/terminalInput', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/terminalInput')>();
+  return {
+    ...actual,
+    submitInputToAgent: vi.fn(),
+  };
+});
+
+const mockInvoke = vi.mocked(invoke);
+const mockSubmitInputToAgent = vi.mocked(submitInputToAgent);
+
+const prompt: LibraryPrompt = {
+  type: 'Prompt',
+  path: 'prompts/review.md',
+  name: 'Review Prompt',
+  content: '# Review\n\nCheck the implementation.',
+  metadata: { id: 'prompt-1', tags: [], is_starred: false },
+};
+
+const agent = (overrides: Partial<AgentConfig> = {}): AgentConfig => ({
+  session_id: 'agent-1',
+  session_name: 'Coder One',
+  agent_class: 'Coder',
+  folder: 'C:/work/app',
+  is_off: false,
+  provider: 'mock',
+  ...overrides,
+});
+
+describe('AssignPromptModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubmitInputToAgent.mockResolvedValue(undefined);
+  });
+
+  it('loads active agents and runs the prompt against the selected agent', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    mockInvoke.mockResolvedValue([
+      agent(),
+      agent({ session_id: 'agent-2', session_name: 'Reviewer Two', agent_class: 'Reviewer' }),
+    ]);
+
+    render(<AssignPromptModal prompt={prompt} isOpen onClose={onClose} />);
+
+    expect(await screen.findByRole('option', { name: 'Coder One (Coder)' })).toBeInTheDocument();
+    await user.selectOptions(screen.getByRole('combobox'), 'agent-2');
+    await user.click(screen.getByRole('button', { name: 'Run Prompt' }));
+
+    expect(mockSubmitInputToAgent).toHaveBeenCalledWith(
+      'agent-2',
+      '# Review  Check the implementation.',
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables running when no active agents are available', async () => {
+    mockInvoke.mockResolvedValue([]);
+
+    render(<AssignPromptModal prompt={prompt} isOpen onClose={() => {}} />);
+
+    expect(await screen.findByRole('option', { name: 'No active agents' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run Prompt' })).toBeDisabled();
+  });
+
+  it('does not render while closed', () => {
+    render(<AssignPromptModal prompt={prompt} isOpen={false} onClose={() => {}} />);
+
+    expect(screen.queryByText('Run Review Prompt')).not.toBeInTheDocument();
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('keeps the modal open and reports injection errors', async () => {
+    const user = userEvent.setup();
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onClose = vi.fn();
+    mockInvoke.mockResolvedValue([agent()]);
+    mockSubmitInputToAgent.mockRejectedValue(new Error('terminal unavailable'));
+
+    render(<AssignPromptModal prompt={prompt} isOpen onClose={onClose} />);
+
+    await screen.findByRole('option', { name: 'Coder One (Coder)' });
+    await user.click(screen.getByRole('button', { name: 'Run Prompt' }));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('terminal unavailable'));
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+    consoleError.mockRestore();
+  });
+});

--- a/src/features/library/AssignPromptModal.tsx
+++ b/src/features/library/AssignPromptModal.tsx
@@ -10,6 +10,7 @@ interface AssignPromptModalProps {
 }
 
 export const AssignPromptModal: React.FC<AssignPromptModalProps> = ({ prompt, isOpen, onClose }) => {
+    const agentSelectId = React.useId();
     const [selectedTargetId, setSelectedTargetId] = useState<string>('');
     const [isInjecting, setIsInjecting] = useState(false);
     const [agents, setAgents] = useState<AgentConfig[]>([]);
@@ -60,8 +61,9 @@ export const AssignPromptModal: React.FC<AssignPromptModalProps> = ({ prompt, is
                 
                 <div className="p-5 flex flex-col gap-4">
                     <div className="flex flex-col gap-2">
-                        <label className="text-xs font-bold text-muted uppercase tracking-widest">Select Agent</label>
+                        <label htmlFor={agentSelectId} className="text-xs font-bold text-muted uppercase tracking-widest">Select Agent</label>
                         <select 
+                            id={agentSelectId}
                             value={selectedTargetId}
                             onChange={(e) => setSelectedTargetId(e.target.value)}
                             disabled={isInjecting || agents.length === 0}

--- a/src/features/library/AssignSkillModal.test.tsx
+++ b/src/features/library/AssignSkillModal.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { invoke } from '@tauri-apps/api/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentClassDefinition, AgentConfig, LibrarySkill } from '../../types';
+import { useLibraryStore } from '../../store/useLibraryStore';
+import { AssignSkillModal } from './AssignSkillModal';
+
+const mockInvoke = vi.mocked(invoke);
+
+const skill: LibrarySkill = {
+  type: 'Skill',
+  path: 'skills/planner',
+  name: 'planner',
+  description: '# planner',
+  content: '# planner',
+  metadata: { id: 'skill-1', tags: [], is_starred: false },
+};
+
+const agent = (overrides: Partial<AgentConfig> = {}): AgentConfig => ({
+  session_id: 'agent-1',
+  session_name: 'Coder One',
+  agent_class: 'Coder',
+  folder: 'C:/work/app',
+  is_off: false,
+  provider: 'mock',
+  ...overrides,
+});
+
+const agentClass = (overrides: Partial<AgentClassDefinition> = {}): AgentClassDefinition => ({
+  name: 'Coder',
+  description: 'Writes code',
+  is_default: true,
+  ...overrides,
+});
+
+describe('AssignSkillModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useLibraryStore.setState({
+      promptTree: null,
+      skillTree: null,
+      isLoading: false,
+      error: null,
+      activeTab: 'skills',
+    });
+    mockInvoke.mockImplementation(async (command, args) => {
+      if (command === 'list_agents') return [agent()];
+      if (command === 'list_agent_classes') return [agentClass(), agentClass({ name: 'Reviewer' })];
+      if (command === 'list_skill_deployments') {
+        expect(args).toEqual({ skillName: 'planner', sourcePath: 'skills/planner' });
+        return [{ target_type: 'agent', target_id: 'agent-1' }];
+      }
+      return undefined;
+    });
+  });
+
+  it('loads deployments and deploys to the selected class target', async () => {
+    const user = userEvent.setup();
+
+    render(<AssignSkillModal skill={skill} isOpen onClose={() => {}} />);
+
+    expect(await screen.findByText('Coder One')).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Target Scope'), 'class');
+    expect(screen.getByLabelText('Select Class')).toHaveValue('Coder');
+    await user.selectOptions(screen.getByLabelText('Select Class'), 'Reviewer');
+    await user.click(screen.getByRole('button', { name: 'Deploy Skill' }));
+
+    expect(mockInvoke).toHaveBeenCalledWith('deploy_skill', {
+      sourcePath: 'skills/planner',
+      targetType: 'class',
+      targetId: 'Reviewer',
+    });
+  });
+
+  it('defaults agent scope to the first active agent and removes deployments', async () => {
+    const user = userEvent.setup();
+
+    render(<AssignSkillModal skill={skill} isOpen onClose={() => {}} />);
+
+    expect(await screen.findByText('Coder One')).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Target Scope'), 'agent');
+    expect(screen.getByLabelText('Select Agent')).toHaveValue('agent-1');
+    await user.click(screen.getByRole('button', { name: 'Deploy Skill' }));
+
+    expect(mockInvoke).toHaveBeenCalledWith('deploy_skill', {
+      sourcePath: 'skills/planner',
+      targetType: 'agent',
+      targetId: 'agent-1',
+    });
+
+    await user.click(screen.getByTitle('Remove Deployment'));
+    expect(mockInvoke).toHaveBeenCalledWith('remove_deployed_skill', {
+      targetType: 'agent',
+      targetId: 'agent-1',
+      skillName: 'planner',
+    });
+  });
+
+  it('shows empty target options and disables deploy when class list is empty', async () => {
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'list_agents') return [];
+      if (command === 'list_agent_classes') return [];
+      if (command === 'list_skill_deployments') return [];
+      return undefined;
+    });
+    const user = userEvent.setup();
+
+    render(<AssignSkillModal skill={skill} isOpen onClose={() => {}} />);
+
+    expect(await screen.findByText('Skill is not deployed anywhere.')).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('Target Scope'), 'class');
+
+    expect(screen.getByRole('option', { name: 'No custom classes available' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Deploy Skill' })).toBeDisabled();
+  });
+
+  it('does not render while closed', () => {
+    render(<AssignSkillModal skill={skill} isOpen={false} onClose={() => {}} />);
+
+    expect(screen.queryByText('Manage planner')).not.toBeInTheDocument();
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it('surfaces deploy errors without closing the modal', async () => {
+    const user = userEvent.setup();
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockInvoke.mockImplementation(async (command) => {
+      if (command === 'list_agents') return [agent()];
+      if (command === 'list_agent_classes') return [agentClass()];
+      if (command === 'list_skill_deployments') return [];
+      if (command === 'deploy_skill') throw new Error('deploy failed');
+      return undefined;
+    });
+
+    render(<AssignSkillModal skill={skill} isOpen onClose={() => {}} />);
+
+    await screen.findByRole('button', { name: 'Deploy Skill' });
+    await user.click(screen.getByRole('button', { name: 'Deploy Skill' }));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('deploy failed'));
+    });
+    expect(screen.getByText('Manage planner')).toBeInTheDocument();
+
+    alertSpy.mockRestore();
+    consoleError.mockRestore();
+  });
+});

--- a/src/features/library/AssignSkillModal.tsx
+++ b/src/features/library/AssignSkillModal.tsx
@@ -11,6 +11,9 @@ interface AssignSkillModalProps {
 
 export const AssignSkillModal: React.FC<AssignSkillModalProps> = ({ skill, isOpen, onClose }) => {
     const { deploySkill, listSkillDeployments, removeDeployedSkill } = useLibraryStore();
+    const targetScopeId = React.useId();
+    const classSelectId = React.useId();
+    const agentSelectId = React.useId();
     const [targetType, setTargetType] = useState<'user' | 'class' | 'agent'>('user');
     const [selectedTargetId, setSelectedTargetId] = useState<string>('global');
     const [isDeploying, setIsDeploying] = useState(false);
@@ -130,8 +133,9 @@ export const AssignSkillModal: React.FC<AssignSkillModalProps> = ({ skill, isOpe
                     <div className="flex flex-col gap-3">
                         <h3 className="text-xs font-bold text-muted uppercase tracking-widest">New Deployment</h3>
                         <div className="flex flex-col gap-2">
-                            <label className="text-xs font-bold text-muted-neutral">Target Scope</label>
+                            <label htmlFor={targetScopeId} className="text-xs font-bold text-muted-neutral">Target Scope</label>
                             <select 
+                                id={targetScopeId}
                                 value={targetType}
                                 onChange={(e) => setTargetType(e.target.value as any)}
                                 disabled={isDeploying}
@@ -145,8 +149,9 @@ export const AssignSkillModal: React.FC<AssignSkillModalProps> = ({ skill, isOpe
 
                         {targetType === 'class' && (
                             <div className="flex flex-col gap-2 animate-in slide-in-from-top-2 duration-200">
-                                <label className="text-xs font-bold text-muted-neutral">Select Class</label>
+                                <label htmlFor={classSelectId} className="text-xs font-bold text-muted-neutral">Select Class</label>
                                 <select 
+                                    id={classSelectId}
                                     value={selectedTargetId}
                                     onChange={(e) => setSelectedTargetId(e.target.value)}
                                     disabled={isDeploying || classes.length === 0}
@@ -162,8 +167,9 @@ export const AssignSkillModal: React.FC<AssignSkillModalProps> = ({ skill, isOpe
 
                         {targetType === 'agent' && (
                             <div className="flex flex-col gap-2 animate-in slide-in-from-top-2 duration-200">
-                                <label className="text-xs font-bold text-muted-neutral">Select Agent</label>
+                                <label htmlFor={agentSelectId} className="text-xs font-bold text-muted-neutral">Select Agent</label>
                                 <select 
+                                    id={agentSelectId}
                                     value={selectedTargetId}
                                     onChange={(e) => setSelectedTargetId(e.target.value)}
                                     disabled={isDeploying || agents.length === 0}

--- a/src/features/library/ItemEditorModal.test.tsx
+++ b/src/features/library/ItemEditorModal.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { LibraryPrompt } from '../../types';
+import { ItemEditorModal } from './ItemEditorModal';
+
+const prompt: LibraryPrompt = {
+  type: 'Prompt',
+  path: 'prompts/review.md',
+  name: 'Review Prompt',
+  content: 'Original content',
+  metadata: {
+    id: 'prompt-1',
+    tags: ['review', 'code'],
+    is_starred: false,
+    last_used: '2026-05-04T12:00:00Z',
+  },
+};
+
+describe('ItemEditorModal', () => {
+  it('does not render while closed', () => {
+    render(<ItemEditorModal item={prompt} isOpen={false} onClose={() => {}} onSave={() => {}} />);
+
+    expect(screen.queryByText('Review Prompt')).not.toBeInTheDocument();
+  });
+
+  it('saves edited content, parsed tags, and starred state', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const onSave = vi.fn();
+    render(<ItemEditorModal item={prompt} isOpen onClose={onClose} onSave={onSave} />);
+
+    fireEvent.change(screen.getByLabelText('Content'), { target: { value: 'Updated content' } });
+    fireEvent.change(screen.getByLabelText('Tags (comma separated)'), {
+      target: { value: 'review, coverage, , scheduler ' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Star item' }));
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    expect(onSave).toHaveBeenCalledWith('prompts/review.md', 'Updated content', {
+      id: 'prompt-1',
+      tags: ['review', 'coverage', 'scheduler'],
+      is_starred: true,
+      last_used: '2026-05-04T12:00:00Z',
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('resets local edits when reopened', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ItemEditorModal item={prompt} isOpen onClose={() => {}} onSave={() => {}} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Content'), { target: { value: 'Unsaved edit' } });
+    fireEvent.change(screen.getByLabelText('Tags (comma separated)'), {
+      target: { value: 'unsaved' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Star item' }));
+    expect(screen.getByRole('button', { name: 'Unstar item' })).toBeInTheDocument();
+
+    rerender(<ItemEditorModal item={prompt} isOpen={false} onClose={() => {}} onSave={() => {}} />);
+    expect(screen.queryByText('Review Prompt')).not.toBeInTheDocument();
+
+    rerender(<ItemEditorModal item={prompt} isOpen onClose={() => {}} onSave={() => {}} />);
+
+    expect(screen.getByLabelText('Content')).toHaveValue('Original content');
+    expect(screen.getByLabelText('Tags (comma separated)')).toHaveValue('review, code');
+    expect(screen.getByRole('button', { name: 'Star item' })).toBeInTheDocument();
+  });
+});

--- a/src/features/library/ItemEditorModal.tsx
+++ b/src/features/library/ItemEditorModal.tsx
@@ -9,6 +9,8 @@ interface ItemEditorModalProps {
 }
 
 export const ItemEditorModal: React.FC<ItemEditorModalProps> = ({ item, isOpen, onClose, onSave }) => {
+    const contentInputId = React.useId();
+    const tagsInputId = React.useId();
     const [content, setContent] = useState(item.content);
     const [tagsText, setTagsText] = useState(item.metadata.tags.join(', '));
     const [isStarred, setIsStarred] = useState(item.metadata.is_starred);
@@ -40,6 +42,8 @@ export const ItemEditorModal: React.FC<ItemEditorModalProps> = ({ item, isOpen, 
                     <div className="flex items-center gap-2">
                         <button 
                             onClick={() => setIsStarred(!isStarred)}
+                            aria-label={isStarred ? 'Unstar item' : 'Star item'}
+                            title={isStarred ? 'Unstar item' : 'Star item'}
                             className={`transition-colors ${isStarred ? 'text-yellow-400 hover:text-yellow-300' : 'text-muted-neutral hover:text-primary'}`}
                         >
                             <svg className="w-5 h-5" fill={isStarred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
@@ -48,15 +52,16 @@ export const ItemEditorModal: React.FC<ItemEditorModalProps> = ({ item, isOpen, 
                         </button>
                         <h2 className="text-xl font-bold text-primary">{item.name}</h2>
                     </div>
-                    <button onClick={onClose} className="text-muted hover:text-primary transition-colors">
+                    <button onClick={onClose} aria-label="Close editor" title="Close editor" className="text-muted hover:text-primary transition-colors">
                         <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path></svg>
                     </button>
                 </div>
                 
                 <div className="flex-1 overflow-y-auto p-4 flex flex-col gap-4">
                     <div className="flex flex-col gap-1">
-                        <label className="text-xs font-bold text-muted tracking-wide border-b border-wardian-border/20 pb-1 mb-1">Content</label>
+                        <label htmlFor={contentInputId} className="text-xs font-bold text-muted tracking-wide border-b border-wardian-border/20 pb-1 mb-1">Content</label>
                         <textarea
+                            id={contentInputId}
                             className="w-full h-64 bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded p-3 text-primary text-sm focus:outline-none focus:border-[var(--color-wardian-accent)] font-mono resize-y"
                             value={content}
                             onChange={e => setContent(e.target.value)}
@@ -64,8 +69,9 @@ export const ItemEditorModal: React.FC<ItemEditorModalProps> = ({ item, isOpen, 
                     </div>
                     
                     <div className="flex flex-col gap-1">
-                        <label className="text-xs font-bold text-muted tracking-wide border-b border-wardian-border/20 pb-1 mb-1">Tags (comma separated)</label>
+                        <label htmlFor={tagsInputId} className="text-xs font-bold text-muted tracking-wide border-b border-wardian-border/20 pb-1 mb-1">Tags (comma separated)</label>
                         <input
+                            id={tagsInputId}
                             type="text"
                             className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded px-3 py-2 text-primary text-sm focus:outline-none focus:border-[var(--color-wardian-accent)]"
                             value={tagsText}

--- a/src/features/library/LibraryCard.tsx
+++ b/src/features/library/LibraryCard.tsx
@@ -53,6 +53,8 @@ export const LibraryCard: React.FC<LibraryCardProps> = ({ item, onClick, onToggl
                     <button 
                         onClick={(e) => { e.stopPropagation(); onToggleStar(e); }}
                         className={`p-1.5 rounded-md transition-colors z-10 ${item.metadata.is_starred ? 'text-yellow-400 hover:text-yellow-300' : 'text-muted-neutral opacity-0 group-hover:opacity-100 hover:text-primary'}`}
+                        aria-label={`Toggle star for ${item.name}`}
+                        title={`Toggle star for ${item.name}`}
                     >
                         <svg className="w-5 h-5" fill={item.metadata.is_starred ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />

--- a/src/features/library/LibraryGrid.test.tsx
+++ b/src/features/library/LibraryGrid.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { LibraryFolder, LibrarySkill } from '../../types';
+import { LibraryGrid } from './LibraryGrid';
+
+const skill = (name: string, path = name): LibrarySkill => ({
+  type: 'Skill',
+  path,
+  name,
+  description: `# ${name}`,
+  content: `${name} content`,
+  metadata: {
+    id: path,
+    tags: ['tag'],
+    is_starred: false,
+  },
+});
+
+describe('LibraryGrid', () => {
+  it('sorts folders before items and sorts names within each group', () => {
+    const folder: LibraryFolder = {
+      type: 'Folder',
+      path: '',
+      name: 'root',
+      children: [
+        skill('Zulu'),
+        { type: 'Folder', path: 'beta', name: 'Beta', children: [] },
+        skill('Alpha'),
+        { type: 'Folder', path: 'alpha', name: 'Alpha Folder', children: [] },
+      ],
+    };
+
+    render(
+      <LibraryGrid
+        folder={folder}
+        onItemClick={() => {}}
+        onToggleStar={() => {}}
+        onFolderClick={() => {}}
+        onItemAction={() => {}}
+      />,
+    );
+
+    const labels = screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent);
+    expect(labels).toEqual(['Alpha Folder', 'Beta', 'Alpha', 'Zulu']);
+  });
+
+  it('routes folder, item action, edit, and star interactions to the right callbacks', async () => {
+    const user = userEvent.setup();
+    const item = skill('Planner');
+    const childFolder: LibraryFolder = { type: 'Folder', path: 'plans', name: 'Plans', children: [] };
+    const onFolderClick = vi.fn();
+    const onItemAction = vi.fn();
+    const onItemClick = vi.fn();
+    const onToggleStar = vi.fn();
+
+    render(
+      <LibraryGrid
+        folder={{ type: 'Folder', path: '', name: 'root', children: [item, childFolder] }}
+        onItemClick={onItemClick}
+        onToggleStar={onToggleStar}
+        onFolderClick={onFolderClick}
+        onItemAction={onItemAction}
+      />,
+    );
+
+    await user.click(screen.getByText('Plans'));
+    expect(onFolderClick).toHaveBeenCalledWith(childFolder);
+
+    await user.click(screen.getByText('Planner'));
+    expect(onItemAction).toHaveBeenCalledWith(item);
+
+    await user.click(screen.getByTitle('Edit Item'));
+    expect(onItemClick).toHaveBeenCalledWith(item);
+
+    await user.click(screen.getByRole('button', { name: 'Toggle star for Planner' }));
+    expect(onToggleStar).toHaveBeenCalledWith(item);
+  });
+
+  it('shows an empty-folder message', () => {
+    render(
+      <LibraryGrid
+        folder={{ type: 'Folder', path: '', name: 'root', children: [] }}
+        onItemClick={() => {}}
+        onToggleStar={() => {}}
+        onFolderClick={() => {}}
+        onItemAction={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('This folder is empty.')).toBeInTheDocument();
+  });
+});

--- a/src/features/workflows/ScheduleEditor.test.tsx
+++ b/src/features/workflows/ScheduleEditor.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ScheduleEditor } from './ScheduleEditor';
+
+const lastChange = (onChange: ReturnType<typeof vi.fn>) => onChange.mock.calls[onChange.mock.calls.length - 1][0];
+
+describe('ScheduleEditor', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('converts interval values between hours and minutes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { rerender } = render(<ScheduleEditor value={{ schedule_type: 'interval', interval_minutes: 120 }} onChange={onChange} />);
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '3' } });
+    expect(lastChange(onChange)).toMatchObject({ schedule_type: 'interval', interval_minutes: 180 });
+
+    rerender(<ScheduleEditor value={{ schedule_type: 'interval', interval_minutes: 180 }} onChange={onChange} />);
+    await user.selectOptions(screen.getAllByRole('combobox')[1], 'minutes');
+    expect(lastChange(onChange)).toMatchObject({ schedule_type: 'interval', interval_minutes: 180 });
+  });
+
+  it('updates weekly days, repeat count, time, and end conditions', async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-05-04T12:00:00Z'));
+    const onChange = vi.fn();
+    render(
+      <ScheduleEditor
+        value={{
+          schedule_type: 'weekly',
+          days_of_week: ['Mon'],
+          repeat_every: 1,
+          time_of_day: '09:00',
+          active: true,
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Wed' }));
+    expect(lastChange(onChange)).toMatchObject({ days_of_week: ['Mon', 'Wed'] });
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '2' } });
+    expect(lastChange(onChange)).toMatchObject({ repeat_every: 2 });
+
+    fireEvent.change(screen.getByDisplayValue('09:00'), { target: { value: '14:30' } });
+    expect(lastChange(onChange)).toMatchObject({ time_of_day: '14:30' });
+
+    await user.click(screen.getByRole('radio', { name: 'On date' }));
+    expect(lastChange(onChange)).toMatchObject({ end_condition: 'on_date', end_date: '2026-05-04' });
+  });
+
+  it('sorts monthly day toggles', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ScheduleEditor value={{ schedule_type: 'monthly', days_of_month: [15] }} onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: '1' }));
+
+    expect(lastChange(onChange)).toMatchObject({ days_of_month: [1, 15] });
+  });
+
+  it('adds, edits, and removes specific dates without rendering end conditions', async () => {
+    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date('2026-05-04T12:00:00Z'));
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <ScheduleEditor
+        value={{ schedule_type: 'specific_dates', specific_dates: [], time_of_day: '09:00' }}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Add Date/i }));
+    expect(lastChange(onChange)).toMatchObject({ specific_dates: ['2026-05-04'] });
+
+    rerender(
+      <ScheduleEditor
+        value={{ schedule_type: 'specific_dates', specific_dates: ['2026-05-04'], time_of_day: '09:00' }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.change(screen.getByDisplayValue('2026-05-04'), { target: { value: '2026-05-05' } });
+    expect(lastChange(onChange)).toMatchObject({ specific_dates: ['2026-05-05'] });
+
+    rerender(
+      <ScheduleEditor
+        value={{ schedule_type: 'specific_dates', specific_dates: ['2026-05-05'], time_of_day: '09:00' }}
+        onChange={onChange}
+      />,
+    );
+    await user.click(within(screen.getByDisplayValue('2026-05-05').closest('div')!).getByRole('button'));
+    expect(lastChange(onChange)).toMatchObject({ specific_dates: [] });
+    expect(screen.queryByText('Ends')).not.toBeInTheDocument();
+  });
+
+  it('updates one-time run datetime and hides end conditions', () => {
+    const onChange = vi.fn();
+    render(<ScheduleEditor value={{ schedule_type: 'one_time', run_at: '' }} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText('Date & Time'), {
+      target: { value: '2026-05-04T14:30' },
+    });
+
+    expect(lastChange(onChange)).toMatchObject({ run_at: '2026-05-04T14:30' });
+    expect(screen.queryByText('Ends')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/workflows/ScheduleEditor.tsx
+++ b/src/features/workflows/ScheduleEditor.tsx
@@ -280,6 +280,7 @@ export const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ value, onChange,
           <label className={labelClass}>Date & Time</label>
           <input
             type="datetime-local"
+            aria-label="Date & Time"
             value={value.run_at || ''}
             onChange={(e) => update({ run_at: e.target.value })}
             className={inputClass}
@@ -304,6 +305,7 @@ export const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ value, onChange,
                     if (ec === 'on_date' && !value.end_date) payload.end_date = new Date().toISOString().split('T')[0];
                     update(payload);
                   }}
+                  aria-label={label}
                   className="accent-[var(--color-wardian-accent)] cursor-pointer"
                 />
                 <span className="text-[11px] text-[var(--color-wardian-text)]">{label}</span>

--- a/src/layout/titlebar/RightWindowControls.test.tsx
+++ b/src/layout/titlebar/RightWindowControls.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+const mockGetCurrentWindow = vi.mocked(getCurrentWindow);
+
+async function loadRightWindowControls(options?: { tauri?: boolean; maximized?: boolean }) {
+  const resizeListeners: Array<() => void> = [];
+  const unlisten = vi.fn();
+  const appWindow = {
+    isMaximized: vi.fn().mockResolvedValue(options?.maximized ?? false),
+    onResized: vi.fn((listener: () => void) => {
+      resizeListeners.push(listener);
+      return Promise.resolve(unlisten);
+    }),
+    minimize: vi.fn(() => Promise.resolve()),
+    toggleMaximize: vi.fn(() => Promise.resolve()),
+    close: vi.fn(() => Promise.resolve()),
+  };
+
+  if (options?.tauri) {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    mockGetCurrentWindow.mockReturnValue(appWindow as unknown as ReturnType<typeof getCurrentWindow>);
+  } else {
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    mockGetCurrentWindow.mockClear();
+  }
+
+  vi.resetModules();
+  const module = await import("./RightWindowControls");
+  return { RightWindowControls: module.RightWindowControls, appWindow, resizeListeners, unlisten };
+}
+
+describe("RightWindowControls", () => {
+  afterEach(() => {
+    mockGetCurrentWindow.mockReset();
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("toggles the agent roster titlebar control", async () => {
+    const user = userEvent.setup();
+    const setRightCollapsed = vi.fn();
+    const { RightWindowControls } = await loadRightWindowControls();
+
+    render(<RightWindowControls rightCollapsed={false} setRightCollapsed={setRightCollapsed} />);
+    await user.click(screen.getByTitle("Hide Agent Roster"));
+
+    expect(setRightCollapsed).toHaveBeenCalledWith(true);
+  });
+
+  it("renders fallback window controls outside Tauri", async () => {
+    const { RightWindowControls } = await loadRightWindowControls();
+
+    render(<RightWindowControls rightCollapsed setRightCollapsed={vi.fn()} />);
+
+    expect(screen.getByTitle("Show Agent Roster")).toBeInTheDocument();
+    expect(screen.getByTitle("Minimize")).toBeInTheDocument();
+    expect(screen.getByTitle("Maximize")).toBeInTheDocument();
+    expect(screen.getByTitle("Close")).toBeInTheDocument();
+  });
+
+  it("routes Tauri window controls and updates maximized state after resize", async () => {
+    const user = userEvent.setup();
+    const { RightWindowControls, appWindow, resizeListeners, unlisten } = await loadRightWindowControls({
+      tauri: true,
+    });
+
+    const { unmount } = render(<RightWindowControls rightCollapsed setRightCollapsed={vi.fn()} />);
+
+    expect(await screen.findByTitle("Maximize")).toBeInTheDocument();
+    await user.click(screen.getByTitle("Minimize"));
+    await user.click(screen.getByTitle("Maximize"));
+    await user.click(screen.getByTitle("Close"));
+
+    expect(appWindow.minimize).toHaveBeenCalledTimes(1);
+    expect(appWindow.toggleMaximize).toHaveBeenCalledTimes(1);
+    expect(appWindow.close).toHaveBeenCalledTimes(1);
+
+    appWindow.isMaximized.mockResolvedValue(true);
+    resizeListeners[0]();
+    expect(await screen.findByTitle("Restore Down")).toBeInTheDocument();
+
+    unmount();
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/layout/watchlist/ColumnPicker.test.tsx
+++ b/src/layout/watchlist/ColumnPicker.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ColumnPicker } from './ColumnPicker';
+import { DEFAULT_WATCHLIST_PREFS } from './types';
+
+describe('ColumnPicker', () => {
+  it('toggles optional columns without closing the picker', async () => {
+    const user = userEvent.setup();
+    const onPrefsChange = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <ColumnPicker
+        prefs={DEFAULT_WATCHLIST_PREFS}
+        onPrefsChange={onPrefsChange}
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Status' }));
+
+    expect(onPrefsChange).toHaveBeenCalledWith({
+      ...DEFAULT_WATCHLIST_PREFS,
+      columns: DEFAULT_WATCHLIST_PREFS.columns.map((column) =>
+        column.id === 'status_label' ? { ...column, visible: false } : column,
+      ),
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('toggles sorted team grouping and closes on outside click', async () => {
+    const user = userEvent.setup();
+    const onPrefsChange = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <ColumnPicker
+        prefs={DEFAULT_WATCHLIST_PREFS}
+        onPrefsChange={onPrefsChange}
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: 'Preserve Teams While Sorted' }));
+    expect(onPrefsChange).toHaveBeenCalledWith({
+      ...DEFAULT_WATCHLIST_PREFS,
+      preserve_team_grouping_when_sorted: true,
+    });
+
+    await user.click(document.body);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+
+const reactDomMock = vi.hoisted(() => {
+  const renderRoot = vi.fn();
+  return {
+    createRoot: vi.fn(() => ({ render: renderRoot })),
+    renderRoot,
+  };
+});
+
+vi.mock("react-dom/client", () => ({
+  default: {
+    createRoot: reactDomMock.createRoot,
+  },
+  createRoot: reactDomMock.createRoot,
+}));
+
+vi.mock("./views/App", () => ({
+  default: () => <div data-testid="app-root" />,
+}));
+
+vi.mock("./components/ConfirmDialog", () => ({
+  ConfirmProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="confirm-provider">{children}</div>
+  ),
+}));
+
+describe("main", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    reactDomMock.createRoot.mockClear();
+    reactDomMock.renderRoot.mockClear();
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  it("mounts the app inside the confirm provider", async () => {
+    await import("./main");
+
+    expect(reactDomMock.createRoot).toHaveBeenCalledWith(document.getElementById("root"));
+    expect(reactDomMock.renderRoot).toHaveBeenCalledTimes(1);
+
+    render(reactDomMock.renderRoot.mock.calls[0][0]);
+    expect(screen.getByTestId("confirm-provider")).toContainElement(screen.getByTestId("app-root"));
+  });
+});

--- a/src/store/useWorkflowStore.test.ts
+++ b/src/store/useWorkflowStore.test.ts
@@ -4,7 +4,7 @@ import { useWorkflowStore } from './useWorkflowStore';
 
 const mockedInvoke = vi.mocked(invoke);
 
-describe('useWorkflowStore scheduled run commands', () => {
+describe('useWorkflowStore', () => {
   beforeEach(() => {
     mockedInvoke.mockReset();
     mockedInvoke.mockResolvedValue([]);
@@ -32,5 +32,195 @@ describe('useWorkflowStore scheduled run commands', () => {
     await useWorkflowStore.getState().deleteScheduledRun('sched-1');
 
     expect(mockedInvoke).toHaveBeenCalledWith('delete_scheduled_run', { runId: 'sched-1' });
+  });
+
+  it('loads workflow nodes with dependency and legacy edges', () => {
+    useWorkflowStore.getState().loadWorkflow({
+      id: 'wf-1',
+      name: 'Coverage Workflow',
+      settings: { max_iterations: 3, on_limit_reached: 'pause' },
+      nodes: [
+        {
+          id: 'start',
+          type: 'trigger',
+          name: 'Manual Trigger',
+          config: {},
+          position: { x: 10, y: 20 },
+        },
+        {
+          id: 'command',
+          type: 'command',
+          name: 'Shell Command',
+          config: { command: 'npm test' },
+          dependencies: [{ node_id: 'start', port: 'default' }],
+        },
+        {
+          id: 'legacy',
+          type: 'agent',
+          name: 'Legacy Agent',
+          config: {},
+          depends_on: ['command'],
+        } as any,
+      ],
+    });
+
+    const { activeWorkflowId, nodes, edges, nodeStatuses } = useWorkflowStore.getState();
+    expect(activeWorkflowId).toBe('wf-1');
+    expect(nodeStatuses).toEqual({});
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0].position).toEqual({ x: 10, y: 20 });
+    expect(nodes[1].position).toEqual({ x: 350, y: 150 });
+    expect(edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'e-start-command-default',
+          source: 'start',
+          sourceHandle: 'default',
+          target: 'command',
+        }),
+        expect.objectContaining({
+          id: 'e-command-legacy-default',
+          source: 'command',
+          sourceHandle: 'default',
+          target: 'legacy',
+        }),
+      ]),
+    );
+  });
+
+  it('updates node status and highlights only fired outgoing ports', () => {
+    useWorkflowStore.setState({
+      edges: [
+        {
+          id: 'incoming',
+          source: 'trigger',
+          target: 'logic',
+          sourceHandle: 'default',
+          style: { stroke: '#4b5563', strokeWidth: 2 },
+        },
+        {
+          id: 'true-port',
+          source: 'logic',
+          target: 'success',
+          sourceHandle: 'on_true',
+          style: { stroke: '#4b5563', strokeWidth: 2 },
+        },
+        {
+          id: 'false-port',
+          source: 'logic',
+          target: 'failure',
+          sourceHandle: 'on_false',
+          style: { stroke: '#4b5563', strokeWidth: 2 },
+        },
+      ],
+    });
+
+    useWorkflowStore.getState().updateNodeStatus('logic', 'processing');
+    expect(useWorkflowStore.getState().edges[0].animated).toBe(true);
+
+    useWorkflowStore.getState().updateNodeStatus('logic', 'completed', ['on_true']);
+
+    const { edges, nodeStatuses } = useWorkflowStore.getState();
+    expect(nodeStatuses.logic).toBe('completed');
+    expect(edges.find((edge) => edge.id === 'true-port')).toMatchObject({
+      animated: true,
+      style: { stroke: '#10b981', strokeWidth: 3 },
+    });
+    expect(edges.find((edge) => edge.id === 'false-port')).toMatchObject({
+      animated: false,
+      className: '',
+      style: { stroke: '#4b5563', strokeWidth: 2 },
+    });
+  });
+
+  it('tracks workflow progress and removes runs on terminal statuses', () => {
+    useWorkflowStore.setState({
+      availableWorkflows: [
+        {
+          id: 'wf-1',
+          name: 'Nightly Build',
+          settings: { max_iterations: 1, on_limit_reached: 'terminate' },
+          nodes: [],
+        },
+      ],
+    });
+
+    useWorkflowStore.getState().handleStatusUpdate({
+      workflow_id: 'wf-1',
+      run_instance_id: 'run-1',
+      scheduled_run_id: 'sched-1',
+      status: 'running',
+    });
+    useWorkflowStore.getState().handleProgress({
+      workflow_id: 'wf-1',
+      run_instance_id: 'run-1',
+      scheduled_run_id: 'sched-1',
+      current_step: 2,
+      total_steps: 5,
+      active_node_name: 'Compile',
+    });
+
+    expect(useWorkflowStore.getState().activeRuns).toEqual([
+      {
+        run_instance_id: 'run-1',
+        scheduled_run_id: 'sched-1',
+        workflow_id: 'wf-1',
+        workflow_name: 'Nightly Build',
+        current_step: 2,
+        total_steps: 5,
+        active_node_name: 'Compile',
+      },
+    ]);
+
+    useWorkflowStore.getState().handleStatusUpdate({
+      workflow_id: 'wf-1',
+      run_instance_id: 'run-1',
+      status: 'completed',
+    });
+
+    expect(useWorkflowStore.getState().activeRuns).toEqual([]);
+  });
+
+  it('optimistically toggles scheduled runs and reloads after failures', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    useWorkflowStore.setState({
+      scheduledRuns: [
+        {
+          id: 'sched-1',
+          workflow_id: 'wf-1',
+          workflow_name: 'Nightly Build',
+          schedule: { schedule_type: 'daily', active: true },
+          role_mappings: {},
+          next_run_epoch_ms: null,
+          is_paused: false,
+        },
+      ],
+    });
+    mockedInvoke.mockImplementation(async (command) => {
+      if (command === 'toggle_scheduled_run') {
+        expect(useWorkflowStore.getState().scheduledRuns[0].is_paused).toBe(true);
+        throw new Error('backend unavailable');
+      }
+      if (command === 'list_scheduled_runs') {
+        return [
+          {
+            id: 'sched-1',
+            workflow_id: 'wf-1',
+            workflow_name: 'Nightly Build',
+            schedule: { schedule_type: 'daily', active: true },
+            role_mappings: {},
+            next_run_epoch_ms: null,
+            is_paused: false,
+          },
+        ];
+      }
+      return [];
+    });
+
+    await useWorkflowStore.getState().toggleScheduledRun('sched-1');
+
+    expect(mockedInvoke).toHaveBeenCalledWith('list_scheduled_runs');
+    expect(useWorkflowStore.getState().scheduledRuns[0].is_paused).toBe(false);
+    consoleError.mockRestore();
   });
 });

--- a/src/views/DashboardView.test.tsx
+++ b/src/views/DashboardView.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentConfig, AgentTelemetry } from '../types';
+import { DashboardView } from './DashboardView';
+
+const agent = (overrides: Partial<AgentConfig> = {}): AgentConfig => ({
+  session_id: 'agent-1',
+  session_name: 'Coder One',
+  agent_class: 'Coder',
+  folder: 'C:/work/app',
+  is_off: false,
+  provider: 'mock',
+  ...overrides,
+});
+
+const telemetry = (overrides: Partial<AgentTelemetry> = {}): AgentTelemetry => ({
+  session_id: 'agent-1',
+  cpu_usage: 12.34,
+  memory_mb: 256.7,
+  uptime_seconds: 30,
+  query_count: 4,
+  init_timestamp: '2026-05-04T10:15:00Z',
+  current_status: 'Processing...',
+  log_path: null,
+  ...overrides,
+});
+
+const renderDashboard = (props: Partial<ComponentProps<typeof DashboardView>> = {}) => {
+  const defaults: ComponentProps<typeof DashboardView> = {
+    filteredAgents: [agent()],
+    telemetry: { 'agent-1': telemetry() },
+    terminalTitles: { 'agent-1': 'Running tests' },
+    currentThoughts: { 'agent-1': 'Validating changes' },
+    selectedAgentIds: new Set(),
+    offAgentIds: new Set(),
+    draggedAgentId: null,
+    dragOverAgentId: null,
+    onMouseEnterCard: vi.fn(),
+    onMouseUp: vi.fn(),
+    onMouseDown: vi.fn(),
+    onCardClick: vi.fn(),
+    onPause: vi.fn(),
+    onRestart: vi.fn(),
+    onDelete: vi.fn(),
+    onQuery: vi.fn(),
+    deriveCurrentThought: vi.fn(() => ({ thought: 'Derived thought', status: 'Processing...' })),
+    getStatusColorClass: vi.fn(() => 'bg-wardian-processing'),
+  };
+
+  const merged = { ...defaults, ...props };
+  render(<DashboardView {...merged} />);
+  return merged;
+};
+
+describe('DashboardView', () => {
+  it('renders active agent telemetry and derived status', () => {
+    const props = renderDashboard();
+
+    expect(screen.getByText('Coder One')).toBeInTheDocument();
+    expect(screen.getByText('Coder')).toBeInTheDocument();
+    expect(screen.getByText('12.3% CPU')).toBeInTheDocument();
+    expect(screen.getByText('257 MB')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('Derived thought')).toBeInTheDocument();
+    expect(props.deriveCurrentThought).toHaveBeenCalledWith(
+      'Running tests',
+      'Validating changes',
+      props.telemetry['agent-1'],
+      false,
+    );
+    expect(props.getStatusColorClass).toHaveBeenCalledWith('Processing...');
+  });
+
+  it('omits off agents and shows the empty state when no agents are filtered in', () => {
+    renderDashboard({
+      filteredAgents: [agent({ session_id: 'off-1', session_name: 'Off Agent' })],
+      telemetry: {},
+      terminalTitles: {},
+      currentThoughts: {},
+      offAgentIds: new Set(['off-1']),
+    });
+    expect(screen.queryByText('Off Agent')).not.toBeInTheDocument();
+
+    renderDashboard({ filteredAgents: [] });
+    expect(screen.getByText('No Active Instances')).toBeInTheDocument();
+  });
+
+  it('routes card and control interactions to agent callbacks', async () => {
+    const user = userEvent.setup();
+    const props = renderDashboard();
+
+    fireEvent.mouseEnter(document.getElementById('agent-card-agent-1')!);
+    expect(props.onMouseEnterCard).toHaveBeenCalledWith('agent-1');
+
+    await user.click(screen.getByText('Coder One'));
+    expect(props.onCardClick).toHaveBeenCalledWith(expect.any(Object), 'agent-1');
+
+    await user.click(screen.getByRole('button', { name: 'Pause' }));
+    expect(props.onPause).toHaveBeenCalledWith('agent-1');
+
+    await user.click(screen.getByRole('button', { name: 'Restart' }));
+    expect(props.onRestart).toHaveBeenCalledWith('agent-1');
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(props.onDelete).toHaveBeenCalledWith('agent-1');
+  });
+
+  it('runs canned queries and resets the query select', () => {
+    const props = renderDashboard();
+    const querySelect = screen.getByRole('combobox');
+
+    fireEvent.change(querySelect, { target: { value: 'Validate your recent changes and run tests.' } });
+
+    expect(props.onQuery).toHaveBeenCalledWith('agent-1', 'Validate your recent changes and run tests.');
+    expect(querySelect).toHaveValue('');
+  });
+
+});

--- a/src/views/PlaceholderView.test.tsx
+++ b/src/views/PlaceholderView.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { PlaceholderView } from "./PlaceholderView";
+
+describe("PlaceholderView", () => {
+  it.each([
+    ["queue", "Queue", "Advanced human-in-the-loop features coming in Phase 3.", "Phase 3"],
+    ["workflow-builder", "Workflow Builder", "Advanced workflow-builder features coming in Phase 3.", "Phase 3"],
+    ["graph", "Graph", "Advanced graph features coming in Phase 5.", "Phase 5"],
+    ["garden", "Garden", "Advanced garden features coming in Phase 5.", "Phase 5"],
+  ])("renders the %s placeholder copy", (viewMode, heading, description, phase) => {
+    render(<PlaceholderView viewMode={viewMode} />);
+
+    expect(screen.getByRole("heading", { name: heading })).toBeInTheDocument();
+    expect(screen.getByText(description)).toBeInTheDocument();
+    expect(screen.getByText("Planned")).toBeInTheDocument();
+    expect(screen.getByText(phase)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description
Expands frontend regression coverage across core views, shared editors, library assignment flows, git UI, command panel behavior, titlebar controls, and app bootstrap wiring. This raises frontend line/statement coverage to 70.12% while keeping the changes focused on tests plus small accessibility/testability labels.

## Related Issues
Fixes #199

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test coverage / quality

## How Has This Been Tested?
- `npm run lint` - passed
- `npm run test` - passed, 56 test files / 446 tests
- `npm run build` - passed; existing Vite chunk-size warning remains
- `npm run test:coverage` - passed; 70.12% line/statement coverage

Known existing warnings:
- React `act(...)` warnings remain in existing `AgentWatchlist` / `App` tests.
- Vite still warns that the main bundle chunk is larger than 500 kB after minification.

## Screenshots
Not applicable; this PR does not change visual behavior.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, or they are not applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable