### PR TITLE
fix(release): publish unified installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,81 +216,10 @@ jobs:
             src-tauri/target/*/release/bundle/**/*.deb
           if-no-files-found: warn
 
-  build-cli:
-    name: Build CLI (${{ matrix.platform.name }})
-    needs: [create-release, resolve-release]
-    if: always() && (needs.create-release.result == 'success' || needs.resolve-release.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true'))
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - os: windows-latest
-            name: x86_64-windows
-            rust-target: x86_64-pc-windows-msvc
-            exe: wardian-cli.exe
-            asset: wardian-cli-x86_64-windows.exe
-          - os: macos-latest
-            name: aarch64-macos
-            rust-target: aarch64-apple-darwin
-            exe: wardian-cli
-            asset: wardian-cli-aarch64-macos
-          - os: macos-latest
-            name: x86_64-macos
-            rust-target: x86_64-apple-darwin
-            exe: wardian-cli
-            asset: wardian-cli-x86_64-macos
-          - os: ubuntu-22.04
-            name: x86_64-linux
-            rust-target: x86_64-unknown-linux-gnu
-            exe: wardian-cli
-            asset: wardian-cli-x86_64-linux
-    runs-on: ${{ matrix.platform.os }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag || github.ref }}
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.platform.rust-target }}
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            src-tauri
-            crates/wardian-core
-            crates/wardian-cli
-
-      - name: Build CLI
-        shell: pwsh
-        run: |
-          cargo build --release -p wardian-cli --target "${{ matrix.platform.rust-target }}"
-          New-Item -ItemType Directory -Force dist-cli | Out-Null
-          $source = Join-Path "target/${{ matrix.platform.rust-target }}/release" "${{ matrix.platform.exe }}"
-          Copy-Item $source "dist-cli/${{ matrix.platform.asset }}"
-
-      - name: Upload CLI dry-run artifact
-        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.platform.asset }}
-          path: dist-cli/${{ matrix.platform.asset }}
-          if-no-files-found: error
-
-      - name: Upload CLI release asset
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true')
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.release_tag }}
-        run: gh release upload "$env:RELEASE_TAG" "dist-cli/${{ matrix.platform.asset }}" --clobber
-
   publish:
     name: Publish release
-    needs: [create-release, resolve-release, build, build-cli]
-    if: always() && needs.build.result == 'success' && needs.build-cli.result == 'success' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true'))
+    needs: [create-release, resolve-release, build]
+    if: always() && needs.build.result == 'success' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true'))
     runs-on: ubuntu-latest
     steps:
       - name: Publish the release

--- a/docs/specs/032-unified-release-installers.md
+++ b/docs/specs/032-unified-release-installers.md
@@ -1,0 +1,24 @@
+# Unified Release Installers
+
+## Status
+
+Accepted for v0.3.4 release packaging.
+
+## Context
+
+Wardian publishes desktop installers through the Tauri release workflow. The CLI is already built during the Tauri `beforeBuildCommand` through `npm run stage-cli`, copied into `src-tauri/resources/bin`, and bundled as an application resource. At runtime, the app installs that bundled CLI into the user's Wardian home `bin` directory.
+
+The release workflow also built and uploaded standalone `wardian-cli-*` assets. That made the GitHub release look like the main app and CLI were separate installation choices, even though the intended user experience is one Wardian install that includes both.
+
+## Decision
+
+The release workflow publishes only the Tauri installer artifacts. It no longer builds or uploads standalone CLI release assets.
+
+The Tauri build continues to pass `WARDIAN_CLI_TARGET` into `stage-cli`, so each installer includes the CLI binary for the platform being packaged.
+
+## Consequences
+
+- Users install Wardian once per platform and receive both the desktop app and CLI.
+- Release pages no longer contain separate CLI binaries.
+- CI spends less time on duplicate CLI-only release builds.
+- CLI packaging remains coupled to the Tauri bundle resource path, so changes to `stage-cli` or `src-tauri/tauri.conf.json` must preserve `resources/bin/*`.

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import releasePleaseConfig from "../../release-please-config.json";
 import releaseWorkflow from "../../.github/workflows/release.yml?raw";
 import releasePleaseWorkflow from "../../.github/workflows/release-please.yml?raw";
+import stageCliScript from "../../scripts/stage-cli.mjs?raw";
+import tauriConfig from "../../src-tauri/tauri.conf.json?raw";
 
 describe("release workflow contract", () => {
   it("keeps Release Please releases draft until assets are uploaded", () => {
@@ -33,24 +35,28 @@ describe("release workflow contract", () => {
     expect(releaseWorkflow).toContain("needs.resolve-release.outputs.release_id");
     expect(releaseWorkflow).toContain("Publish the release");
     expect(releaseWorkflow).toContain(
-      "always() && needs.build.result == 'success' && needs.build-cli.result == 'success'",
+      "always() && needs.build.result == 'success' && (github.event_name == 'push'",
     );
+    expect(releaseWorkflow).toContain("needs: [create-release, resolve-release, build]");
+    expect(releaseWorkflow).not.toContain("needs.build-cli");
   });
 
-  it("publishes standalone CLI binaries with dry-run artifact support", () => {
-    expect(releaseWorkflow).toContain("Build CLI");
-    expect(releaseWorkflow).toContain("cargo build --release -p wardian-cli --target");
-    expect(releaseWorkflow).toContain("wardian-cli-x86_64-windows.exe");
-    expect(releaseWorkflow).toContain("wardian-cli-aarch64-macos");
-    expect(releaseWorkflow).toContain("wardian-cli-x86_64-macos");
-    expect(releaseWorkflow).toContain("wardian-cli-x86_64-linux");
-    expect(releaseWorkflow).toContain("gh release upload");
-    expect(releaseWorkflow).toContain("Upload CLI dry-run artifact");
+  it("publishes unified installers that carry the staged CLI", () => {
+    expect(releaseWorkflow).not.toContain("Build CLI");
+    expect(releaseWorkflow).not.toContain("cargo build --release -p wardian-cli --target");
+    expect(releaseWorkflow).not.toContain("wardian-cli-x86_64-windows.exe");
+    expect(releaseWorkflow).not.toContain("wardian-cli-aarch64-macos");
+    expect(releaseWorkflow).not.toContain("wardian-cli-x86_64-macos");
+    expect(releaseWorkflow).not.toContain("wardian-cli-x86_64-linux");
+    expect(releaseWorkflow).not.toContain("gh release upload");
+    expect(releaseWorkflow).not.toContain("Upload CLI dry-run artifact");
     expect(releaseWorkflow).toContain("crates/wardian-cli");
     expect(releaseWorkflow).toContain("WARDIAN_CLI_TARGET: ${{ matrix.platform.rust-target || '' }}");
-    expect(releaseWorkflow).toContain('shell: pwsh');
-    expect(releaseWorkflow).toContain('gh release upload "$env:RELEASE_TAG"');
     expect(releaseWorkflow).toContain("target/release/bundle/**/*.exe");
     expect(releaseWorkflow).toContain("target/*/release/bundle/**/*.dmg");
+    expect(tauriConfig).toContain('"beforeBuildCommand": "npm run build && npm run stage-cli"');
+    expect(tauriConfig).toContain('"resources/bin/*"');
+    expect(stageCliScript).toContain("const buildArgs = ['build', '--release', '-p', 'wardian-cli'];");
+    expect(stageCliScript).toContain("const target = process.env.WARDIAN_CLI_TARGET?.trim();");
   });
 });


### PR DESCRIPTION
## Why

Wardian v0.3.4 should publish one installer per OS. The CLI is already staged into the Tauri resources during the app build, so standalone CLI release assets create a confusing second installation path.

Closes #205

## Summary

- Removed the standalone `build-cli` release job and CLI asset uploads.
- Updated the publish job to depend only on the main Tauri build.
- Updated the release workflow contract test for unified installers.
- Documented the unified installer packaging decision in `docs/specs/032-unified-release-installers.md`.

## Test Plan

- [x] `npm run lint`
- [x] `npm run test -- src/config/releaseWorkflow.test.ts`
- [x] `npm run test`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Parsed `.github/workflows/release.yml` with PyYAML and confirmed jobs are `create-release`, `resolve-release`, `build`, `publish`
- [x] Confirmed `publish.needs` is `create-release`, `resolve-release`, `build`
- [x] Confirmed removed CLI release/upload references are absent from `.github/workflows/release.yml`
- [x] Confirmed `stage-cli`, `WARDIAN_CLI_TARGET`, and `resources/bin/*` still remain in the Tauri app build path

## Release Note

After this merges, rerun the v0.3.4 release workflow for the existing tag/release using the manual backfill path so the release assets are replaced with unified installer-only artifacts.