### PR TITLE
Add live Wardian CLI agent control

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,9 @@ coverage:
       backend:
         flags: [backend]
         informational: true
+    patch:
+      default:
+        informational: true
 
 comment:
   layout: "reach,diff,flags"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Wardian"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -59,6 +59,14 @@ pub struct SendArgs {
     /// Thread name for grouped conversations
     #[arg(long)]
     pub thread: Option<String>,
+
+    /// Wait until the target reaches this status after sending
+    #[arg(long = "wait-until")]
+    pub wait_until: Option<String>,
+
+    /// Maximum time to wait, e.g. 30s, 10m, or 1000ms
+    #[arg(long, default_value = "10m")]
+    pub timeout: String,
 }
 
 #[derive(Debug, Args)]
@@ -106,6 +114,8 @@ pub enum AgentCommand {
         target: String,
     },
     Spawn {
+        #[arg(long)]
+        provider: String,
         #[arg(long = "class")]
         class: String,
         #[arg(long)]
@@ -117,6 +127,13 @@ pub enum AgentCommand {
         target: String,
         #[arg(long)]
         name: Option<String>,
+    },
+    Wait {
+        target: String,
+        #[arg(long)]
+        until: String,
+        #[arg(long, default_value = "10m")]
+        timeout: String,
     },
 }
 
@@ -134,7 +151,9 @@ mod tests {
     #[test]
     fn parses_agent_show_explicit_target() {
         let cli = Cli::try_parse_from(["wardian", "agent", "show", "coder-a1"]).unwrap();
-        let Command::Agent(args) = cli.command else { panic!("expected Agent command") };
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent command")
+        };
         assert!(matches!(
             args.command,
             Some(AgentCommand::Show { target }) if target.as_deref() == Some("coder-a1")
@@ -157,7 +176,9 @@ mod tests {
             "D:/Development/Wardian",
         ])
         .unwrap();
-        let Command::Agent(args) = cli.command else { panic!("expected Agent command") };
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent command")
+        };
         assert!(matches!(
             args.command,
             Some(AgentCommand::List {
@@ -186,7 +207,9 @@ mod tests {
             "--pretty",
         ])
         .unwrap();
-        let Command::Agent(args) = cli.command else { panic!("expected Agent command") };
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent command")
+        };
         assert_eq!(args.fields.as_deref(), Some("name,status"));
         assert_eq!(args.field.as_deref(), Some("status"));
         assert!(args.verbose);
@@ -196,7 +219,9 @@ mod tests {
     #[test]
     fn parses_agent_kill() {
         let cli = Cli::try_parse_from(["wardian", "agent", "kill", "coder-a1"]).unwrap();
-        let Command::Agent(args) = cli.command else { panic!() };
+        let Command::Agent(args) = cli.command else {
+            panic!()
+        };
         assert!(matches!(
             args.command,
             Some(AgentCommand::Kill { target }) if target == "coder-a1"
@@ -206,29 +231,45 @@ mod tests {
     #[test]
     fn parses_agent_pause() {
         let cli = Cli::try_parse_from(["wardian", "agent", "pause", "coder-a1"]).unwrap();
-        let Command::Agent(args) = cli.command else { panic!() };
+        let Command::Agent(args) = cli.command else {
+            panic!()
+        };
         assert!(matches!(args.command, Some(AgentCommand::Pause { .. })));
     }
 
     #[test]
     fn parses_agent_resume() {
         let cli = Cli::try_parse_from(["wardian", "agent", "resume", "coder-a1"]).unwrap();
-        let Command::Agent(args) = cli.command else { panic!() };
+        let Command::Agent(args) = cli.command else {
+            panic!()
+        };
         assert!(matches!(args.command, Some(AgentCommand::Resume { .. })));
     }
 
     #[test]
     fn parses_agent_spawn_with_class() {
         let cli = Cli::try_parse_from([
-            "wardian", "agent", "spawn", "--class", "Coder",
-            "--name", "coder-b1", "--workspace", "D:/Projects/foo",
+            "wardian",
+            "agent",
+            "spawn",
+            "--provider",
+            "codex",
+            "--class",
+            "Coder",
+            "--name",
+            "coder-b1",
+            "--workspace",
+            "D:/Projects/foo",
         ])
         .unwrap();
-        let Command::Agent(args) = cli.command else { panic!() };
+        let Command::Agent(args) = cli.command else {
+            panic!()
+        };
         assert!(matches!(
             args.command,
-            Some(AgentCommand::Spawn { ref class, ref name, ref workspace })
-            if class == "Coder"
+            Some(AgentCommand::Spawn { ref provider, ref class, ref name, ref workspace })
+            if provider == "codex"
+                && class == "Coder"
                 && name.as_deref() == Some("coder-b1")
                 && workspace.as_deref() == Some("D:/Projects/foo")
         ));
@@ -236,15 +277,63 @@ mod tests {
 
     #[test]
     fn parses_agent_clone() {
-        let cli =
-            Cli::try_parse_from(["wardian", "agent", "clone", "coder-a1", "--name", "coder-a2"])
-                .unwrap();
-        let Command::Agent(args) = cli.command else { panic!() };
+        let cli = Cli::try_parse_from([
+            "wardian", "agent", "clone", "coder-a1", "--name", "coder-a2",
+        ])
+        .unwrap();
+        let Command::Agent(args) = cli.command else {
+            panic!()
+        };
         assert!(matches!(
             args.command,
             Some(AgentCommand::Clone { ref target, ref name })
             if target == "coder-a1" && name.as_deref() == Some("coder-a2")
         ));
+    }
+
+    #[test]
+    fn parses_agent_wait_until_status() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "agent",
+            "wait",
+            "reviewer-a1",
+            "--until",
+            "idle",
+            "--timeout",
+            "30s",
+        ])
+        .unwrap();
+        let Command::Agent(args) = cli.command else {
+            panic!()
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Wait { ref target, ref until, ref timeout })
+            if target == "reviewer-a1" && until == "idle" && timeout == "30s"
+        ));
+    }
+
+    #[test]
+    fn parses_send_wait_until_status() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "send",
+            "review this",
+            "--to",
+            "reviewer-a1",
+            "--wait-until",
+            "idle",
+            "--timeout",
+            "10m",
+        ])
+        .unwrap();
+        let Command::Send(args) = cli.command else {
+            panic!()
+        };
+        assert_eq!(args.message.as_deref(), Some("review this"));
+        assert_eq!(args.wait_until.as_deref(), Some("idle"));
+        assert_eq!(args.timeout, "10m");
     }
 
     #[test]
@@ -260,7 +349,9 @@ mod tests {
             "--pretty",
         ])
         .unwrap();
-        let Command::Agent(args) = cli.command else { panic!("expected Agent command") };
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent command")
+        };
         assert_eq!(args.fields.as_deref(), Some("name,status"));
         assert!(args.pretty);
     }

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -47,6 +47,28 @@ pub enum AgentCommand {
         #[arg(long)]
         workspace: Option<String>,
     },
+    Kill {
+        target: String,
+    },
+    Pause {
+        target: String,
+    },
+    Resume {
+        target: String,
+    },
+    Spawn {
+        #[arg(long = "class")]
+        class: String,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        workspace: Option<String>,
+    },
+    Clone {
+        target: String,
+        #[arg(long)]
+        name: Option<String>,
+    },
 }
 
 #[cfg(test)]
@@ -120,6 +142,60 @@ mod tests {
         assert_eq!(args.field.as_deref(), Some("status"));
         assert!(args.verbose);
         assert!(args.pretty);
+    }
+
+    #[test]
+    fn parses_agent_kill() {
+        let cli = Cli::try_parse_from(["wardian", "agent", "kill", "coder-a1"]).unwrap();
+        let Command::Agent(args) = cli.command else { panic!() };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Kill { target }) if target == "coder-a1"
+        ));
+    }
+
+    #[test]
+    fn parses_agent_pause() {
+        let cli = Cli::try_parse_from(["wardian", "agent", "pause", "coder-a1"]).unwrap();
+        let Command::Agent(args) = cli.command else { panic!() };
+        assert!(matches!(args.command, Some(AgentCommand::Pause { .. })));
+    }
+
+    #[test]
+    fn parses_agent_resume() {
+        let cli = Cli::try_parse_from(["wardian", "agent", "resume", "coder-a1"]).unwrap();
+        let Command::Agent(args) = cli.command else { panic!() };
+        assert!(matches!(args.command, Some(AgentCommand::Resume { .. })));
+    }
+
+    #[test]
+    fn parses_agent_spawn_with_class() {
+        let cli = Cli::try_parse_from([
+            "wardian", "agent", "spawn", "--class", "Coder",
+            "--name", "coder-b1", "--workspace", "D:/Projects/foo",
+        ])
+        .unwrap();
+        let Command::Agent(args) = cli.command else { panic!() };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Spawn { ref class, ref name, ref workspace })
+            if class == "Coder"
+                && name.as_deref() == Some("coder-b1")
+                && workspace.as_deref() == Some("D:/Projects/foo")
+        ));
+    }
+
+    #[test]
+    fn parses_agent_clone() {
+        let cli =
+            Cli::try_parse_from(["wardian", "agent", "clone", "coder-a1", "--name", "coder-a2"])
+                .unwrap();
+        let Command::Agent(args) = cli.command else { panic!() };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Clone { ref target, ref name })
+            if target == "coder-a1" && name.as_deref() == Some("coder-a2")
+        ));
     }
 
     #[test]

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -10,6 +10,55 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     Agent(AgentArgs),
+    Workflow(WorkflowArgs),
+    Send(SendArgs),
+}
+
+// ---------------------------------------------------------------------------
+// wardian workflow
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct WorkflowArgs {
+    #[command(subcommand)]
+    pub command: WorkflowCommand,
+
+    #[arg(long, global = true)]
+    pub pretty: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkflowCommand {
+    List,
+    Show { target: String },
+    Run { target: String },
+    Stop { run_instance_id: String },
+}
+
+// ---------------------------------------------------------------------------
+// wardian send
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct SendArgs {
+    /// Message text (omit when using --stdin or --file)
+    pub message: Option<String>,
+
+    /// Target: agent name, UUID, "class:<ClassName>", or "all"
+    #[arg(long)]
+    pub to: String,
+
+    /// Read message from stdin
+    #[arg(long, conflicts_with = "message")]
+    pub stdin: bool,
+
+    /// Read message from a file
+    #[arg(long, conflicts_with_all = ["message", "stdin"])]
+    pub file: Option<String>,
+
+    /// Thread name for grouped conversations
+    #[arg(long)]
+    pub thread: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -85,7 +134,7 @@ mod tests {
     #[test]
     fn parses_agent_show_explicit_target() {
         let cli = Cli::try_parse_from(["wardian", "agent", "show", "coder-a1"]).unwrap();
-        let Command::Agent(args) = cli.command;
+        let Command::Agent(args) = cli.command else { panic!("expected Agent command") };
         assert!(matches!(
             args.command,
             Some(AgentCommand::Show { target }) if target.as_deref() == Some("coder-a1")
@@ -108,7 +157,7 @@ mod tests {
             "D:/Development/Wardian",
         ])
         .unwrap();
-        let Command::Agent(args) = cli.command;
+        let Command::Agent(args) = cli.command else { panic!("expected Agent command") };
         assert!(matches!(
             args.command,
             Some(AgentCommand::List {
@@ -137,7 +186,7 @@ mod tests {
             "--pretty",
         ])
         .unwrap();
-        let Command::Agent(args) = cli.command;
+        let Command::Agent(args) = cli.command else { panic!("expected Agent command") };
         assert_eq!(args.fields.as_deref(), Some("name,status"));
         assert_eq!(args.field.as_deref(), Some("status"));
         assert!(args.verbose);
@@ -211,7 +260,7 @@ mod tests {
             "--pretty",
         ])
         .unwrap();
-        let Command::Agent(args) = cli.command;
+        let Command::Agent(args) = cli.command else { panic!("expected Agent command") };
         assert_eq!(args.fields.as_deref(), Some("name,status"));
         assert!(args.pretty);
     }

--- a/crates/wardian-cli/src/disk.rs
+++ b/crates/wardian-cli/src/disk.rs
@@ -1,0 +1,45 @@
+use std::io;
+
+use wardian_core::models::WorkflowDefinition;
+
+pub fn list_workflows_from_disk() -> io::Result<Vec<WorkflowDefinition>> {
+    let home = wardian_core::paths::wardian_home()
+        .ok_or_else(|| io::Error::other("WARDIAN_HOME not set"))?;
+    let workflows_dir = home.join("workflows");
+    if !workflows_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut workflows = vec![];
+    for entry in std::fs::read_dir(&workflows_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+
+        let content = std::fs::read_to_string(&path)?;
+        match serde_json::from_str::<WorkflowDefinition>(&content) {
+            Ok(workflow) => workflows.push(workflow),
+            Err(error) => eprintln!(
+                "warning: skipped malformed workflow file {}: {}",
+                path.display(),
+                error
+            ),
+        }
+    }
+    Ok(workflows)
+}
+
+pub fn workflow_summaries(
+    workflows: &[WorkflowDefinition],
+) -> Vec<wardian_core::control::WorkflowSummary> {
+    workflows
+        .iter()
+        .map(|workflow| wardian_core::control::WorkflowSummary {
+            id: workflow.id.clone(),
+            name: workflow.name.clone(),
+            node_count: workflow.nodes.len(),
+        })
+        .collect()
+}

--- a/crates/wardian-cli/src/errors.rs
+++ b/crates/wardian-cli/src/errors.rs
@@ -106,6 +106,16 @@ impl CliError {
         }
     }
 
+    pub fn backend(exit_code: ExitCode, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            exit_code,
+            code,
+            message: message.into(),
+            hint: None,
+            details: None,
+        }
+    }
+
     pub fn to_json(&self) -> String {
         serde_json::to_string(&ErrorEnvelope {
             schema: 1,

--- a/crates/wardian-cli/src/errors.rs
+++ b/crates/wardian-cli/src/errors.rs
@@ -9,6 +9,7 @@ pub enum ExitCode {
     NotInSession = 3,
     DbUnavailable = 4,
     Ambiguous = 5,
+    AppNotRunning = 6,
 }
 
 #[derive(Debug, Serialize)]
@@ -82,6 +83,16 @@ impl CliError {
             message: format!("Unknown field: {field}"),
             hint: Some("Use one of: name, uuid, class, provider, workspace, status, status_source, pid, started_at, last_status_at.".to_string()),
             details: Some(Box::new(serde_json::json!({ "field": field }))),
+        }
+    }
+
+    pub fn app_not_running() -> Self {
+        Self {
+            exit_code: ExitCode::AppNotRunning,
+            code: "app_not_running",
+            message: "Wardian is not running. Start the app to use this command.".to_string(),
+            hint: Some("Launch Wardian, then retry.".to_string()),
+            details: None,
         }
     }
 

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -1,11 +1,110 @@
-use std::{io, time::Duration};
+use std::{
+    fmt, io,
+    time::{Duration, Instant},
+};
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use wardian_core::control::{AgentListResponse, AgentResponse, ControlRequest};
+use wardian_core::control::{
+    AgentListResponse, AgentResponse, ControlRequest, WorkflowListResponse, WorkflowResponse,
+    WorkflowSummary,
+};
 use wardian_core::identity::AgentIdentity;
 use wardian_core::models::WorkflowDefinition;
 
 const CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
+const CONTROL_MUTATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ControlOperation {
+    AgentList,
+    AgentKill,
+    AgentPause,
+    AgentResume,
+    AgentSpawn,
+    AgentClone,
+    WorkflowList,
+    WorkflowShow,
+    WorkflowRun,
+    WorkflowStop,
+    SendMessage,
+}
+
+#[derive(Debug)]
+pub struct ControlEndpointError {
+    code: String,
+    message: String,
+}
+
+impl ControlEndpointError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+}
+
+impl fmt::Display for ControlEndpointError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ControlEndpointError {}
+
+#[derive(Debug)]
+pub struct WaitTimeoutError {
+    target: String,
+    until: String,
+    last_status: String,
+}
+
+impl WaitTimeoutError {
+    pub fn new(target: &str, until: &str, last_status: &str) -> Self {
+        Self {
+            target: target.to_string(),
+            until: until.to_string(),
+            last_status: last_status.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for WaitTimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "timed out waiting for {} to reach {}; last status: {}",
+            self.target, self.until, self.last_status
+        )
+    }
+}
+
+impl std::error::Error for WaitTimeoutError {}
+
+#[derive(Debug)]
+pub struct WaitTargetNotFoundError {
+    target: String,
+}
+
+impl WaitTargetNotFoundError {
+    pub fn new(target: &str) -> Self {
+        Self {
+            target: target.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for WaitTargetNotFoundError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "agent not found: {}", self.target)
+    }
+}
+
+impl std::error::Error for WaitTargetNotFoundError {}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -13,7 +112,11 @@ const CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
 
 pub fn list_agents() -> io::Result<Vec<AgentIdentity>> {
     let runtime = build_runtime()?;
-    let value = timeout_block(&runtime, send_request(ControlRequest::AgentList))?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::AgentList,
+        send_request(ControlRequest::AgentList),
+    )?;
     let response: AgentListResponse =
         serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
     Ok(response.agents)
@@ -23,6 +126,7 @@ pub fn agent_kill(target: &str) -> io::Result<()> {
     let runtime = build_runtime()?;
     timeout_block(
         &runtime,
+        ControlOperation::AgentKill,
         send_request(ControlRequest::AgentKill {
             target: target.to_string(),
         }),
@@ -34,6 +138,7 @@ pub fn agent_pause(target: &str) -> io::Result<()> {
     let runtime = build_runtime()?;
     timeout_block(
         &runtime,
+        ControlOperation::AgentPause,
         send_request(ControlRequest::AgentPause {
             target: target.to_string(),
         }),
@@ -45,6 +150,7 @@ pub fn agent_resume(target: &str) -> io::Result<()> {
     let runtime = build_runtime()?;
     timeout_block(
         &runtime,
+        ControlOperation::AgentResume,
         send_request(ControlRequest::AgentResume {
             target: target.to_string(),
         }),
@@ -53,6 +159,7 @@ pub fn agent_resume(target: &str) -> io::Result<()> {
 }
 
 pub fn agent_spawn(
+    provider: &str,
     class: &str,
     name: Option<&str>,
     workspace: Option<&str>,
@@ -60,7 +167,9 @@ pub fn agent_spawn(
     let runtime = build_runtime()?;
     let value = timeout_block(
         &runtime,
+        ControlOperation::AgentSpawn,
         send_request(ControlRequest::AgentSpawn {
+            provider: provider.to_string(),
             class: class.to_string(),
             name: name.map(str::to_string),
             workspace: workspace.map(str::to_string),
@@ -75,6 +184,7 @@ pub fn agent_clone(target: &str, name: Option<&str>) -> io::Result<AgentIdentity
     let runtime = build_runtime()?;
     let value = timeout_block(
         &runtime,
+        ControlOperation::AgentClone,
         send_request(ControlRequest::AgentClone {
             target: target.to_string(),
             name: name.map(str::to_string),
@@ -85,10 +195,37 @@ pub fn agent_clone(target: &str, name: Option<&str>) -> io::Result<AgentIdentity
     Ok(resp.agent)
 }
 
+pub fn workflow_list() -> io::Result<Vec<WorkflowSummary>> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::WorkflowList,
+        send_request(ControlRequest::WorkflowList),
+    )?;
+    let resp: WorkflowListResponse =
+        serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
+    Ok(resp.workflows)
+}
+
+pub fn workflow_show(target: &str) -> io::Result<WorkflowDefinition> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::WorkflowShow,
+        send_request(ControlRequest::WorkflowShow {
+            target: target.to_string(),
+        }),
+    )?;
+    let resp: WorkflowResponse =
+        serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
+    Ok(resp.workflow)
+}
+
 pub fn workflow_run(id: &str) -> io::Result<()> {
     let runtime = build_runtime()?;
     timeout_block(
         &runtime,
+        ControlOperation::WorkflowRun,
         send_request(ControlRequest::WorkflowRun { id: id.to_string() }),
     )
     .map(|_| ())
@@ -98,6 +235,7 @@ pub fn workflow_stop(run_instance_id: &str) -> io::Result<()> {
     let runtime = build_runtime()?;
     timeout_block(
         &runtime,
+        ControlOperation::WorkflowStop,
         send_request(ControlRequest::WorkflowStop {
             run_instance_id: run_instance_id.to_string(),
         }),
@@ -109,6 +247,7 @@ pub fn send_message(target: &str, message: &str, thread: Option<&str>) -> io::Re
     let runtime = build_runtime()?;
     timeout_block(
         &runtime,
+        ControlOperation::SendMessage,
         send_request(ControlRequest::SendMessage {
             target: target.to_string(),
             message: message.to_string(),
@@ -118,24 +257,20 @@ pub fn send_message(target: &str, message: &str, thread: Option<&str>) -> io::Re
     .map(|_| ())
 }
 
-pub fn list_workflows_from_disk() -> io::Result<Vec<WorkflowDefinition>> {
-    let home = wardian_core::paths::wardian_home()
-        .ok_or_else(|| io::Error::other("WARDIAN_HOME not set"))?;
-    let workflows_dir = home.join("workflows");
-    if !workflows_dir.exists() {
-        return Ok(vec![]);
-    }
-    let mut workflows = vec![];
-    for entry in std::fs::read_dir(&workflows_dir)? {
-        let entry = entry?;
-        if entry.path().extension().and_then(|e| e.to_str()) == Some("json") {
-            let content = std::fs::read_to_string(entry.path())?;
-            if let Ok(wf) = serde_json::from_str::<WorkflowDefinition>(&content) {
-                workflows.push(wf);
-            }
-        }
-    }
-    Ok(workflows)
+pub fn send_message_and_wait(
+    target: &str,
+    message: &str,
+    thread: Option<&str>,
+    until: &str,
+    timeout: Duration,
+) -> io::Result<AgentIdentity> {
+    let initial = wait_target_snapshot(target)?;
+    send_message(target, message, thread)?;
+    wait_agent_until_after_snapshot(target, until, timeout, Some(initial))
+}
+
+pub fn wait_agent_until(target: &str, until: &str, timeout: Duration) -> io::Result<AgentIdentity> {
+    wait_agent_until_after_snapshot(target, until, timeout, None)
 }
 
 // ---------------------------------------------------------------------------
@@ -152,15 +287,124 @@ fn build_runtime() -> io::Result<tokio::runtime::Runtime> {
 
 fn timeout_block(
     runtime: &tokio::runtime::Runtime,
+    operation: ControlOperation,
     fut: impl std::future::Future<Output = io::Result<serde_json::Value>>,
 ) -> io::Result<serde_json::Value> {
-    match runtime.block_on(async { tokio::time::timeout(CONTROL_TIMEOUT, fut).await }) {
+    let timeout = operation_timeout(operation);
+    match runtime.block_on(async { tokio::time::timeout(timeout, fut).await }) {
         Ok(result) => result,
         Err(_) => Err(io::Error::new(
             io::ErrorKind::TimedOut,
             "Wardian control endpoint timed out",
         )),
     }
+}
+
+fn operation_timeout(operation: ControlOperation) -> Duration {
+    match operation {
+        ControlOperation::AgentList
+        | ControlOperation::WorkflowList
+        | ControlOperation::WorkflowShow
+        | ControlOperation::SendMessage => CONTROL_TIMEOUT,
+        ControlOperation::AgentKill
+        | ControlOperation::AgentPause
+        | ControlOperation::AgentResume
+        | ControlOperation::AgentSpawn
+        | ControlOperation::AgentClone
+        | ControlOperation::WorkflowRun
+        | ControlOperation::WorkflowStop => CONTROL_MUTATION_TIMEOUT,
+    }
+}
+
+fn wait_agent_until_after_snapshot(
+    target: &str,
+    until: &str,
+    timeout: Duration,
+    initial_snapshot: Option<AgentIdentity>,
+) -> io::Result<AgentIdentity> {
+    wait_agent_until_after_snapshot_with(
+        target,
+        until,
+        timeout,
+        initial_snapshot,
+        wait_target_snapshot,
+        std::thread::sleep,
+    )
+}
+
+fn wait_agent_until_after_snapshot_with<F, S>(
+    target: &str,
+    until: &str,
+    timeout: Duration,
+    initial_snapshot: Option<AgentIdentity>,
+    mut snapshot: F,
+    mut sleep: S,
+) -> io::Result<AgentIdentity>
+where
+    F: FnMut(&str) -> io::Result<AgentIdentity>,
+    S: FnMut(Duration),
+{
+    let started_at = Instant::now();
+    let initial_status = initial_snapshot.as_ref().map(|agent| agent.status.as_str());
+    let mut observed_away_from_initial = initial_status.is_none_or(|status| status != until);
+
+    loop {
+        let agent = snapshot(target)?;
+        let status = agent.status.as_str();
+
+        if initial_status == Some(until) && status != until {
+            observed_away_from_initial = true;
+        }
+
+        if status == until
+            && (observed_away_from_initial
+                || initial_snapshot
+                    .as_ref()
+                    .is_some_and(|initial| status_marker_changed(initial, &agent)))
+        {
+            return Ok(agent);
+        }
+
+        if matches!(status, "error" | "off") && status != until {
+            return Err(io::Error::other(format!(
+                "agent {target} reached terminal status {status} before {until}"
+            )));
+        }
+
+        if started_at.elapsed() >= timeout {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                WaitTimeoutError::new(target, until, status),
+            ));
+        }
+
+        sleep(Duration::from_millis(250));
+    }
+}
+
+fn status_marker_changed(initial: &AgentIdentity, current: &AgentIdentity) -> bool {
+    initial.uuid == current.uuid
+        && initial.status == current.status
+        && initial.last_status_at != current.last_status_at
+}
+
+fn wait_target_snapshot(target: &str) -> io::Result<AgentIdentity> {
+    if target == "all" || target.starts_with("class:") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "wait requires a single agent name or uuid",
+        ));
+    }
+
+    list_agents()?
+        .into_iter()
+        .find(|agent| agent.uuid == target || agent.name == target)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                WaitTargetNotFoundError::new(target),
+            )
+        })
 }
 
 async fn send_request(req: ControlRequest) -> io::Result<serde_json::Value> {
@@ -198,8 +442,7 @@ async fn exchange_json<T>(stream: &mut T, req: ControlRequest) -> io::Result<ser
 where
     T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
-    let request =
-        serde_json::to_string(&req).map_err(|e| io::Error::other(e.to_string()))?;
+    let request = serde_json::to_string(&req).map_err(|e| io::Error::other(e.to_string()))?;
     stream.write_all(request.as_bytes()).await?;
     stream.write_all(b"\n").await?;
     stream.flush().await?;
@@ -212,13 +455,100 @@ where
     let value: serde_json::Value =
         serde_json::from_str(&line).map_err(|e| io::Error::other(e.to_string()))?;
     if let Some(err) = value.get("error") {
+        let code = err
+            .get("code")
+            .and_then(|c| c.as_str())
+            .unwrap_or("request_failed");
         let msg = err
             .get("message")
             .and_then(|m| m.as_str())
             .unwrap_or("unknown error");
-        return Err(io::Error::other(msg.to_string()));
+        return Err(io::Error::other(ControlEndpointError::new(code, msg)));
     }
 
     Ok(value)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spawn_and_clone_use_longer_control_timeout() {
+        assert!(operation_timeout(ControlOperation::AgentSpawn) > CONTROL_TIMEOUT);
+        assert!(operation_timeout(ControlOperation::AgentClone) > CONTROL_TIMEOUT);
+    }
+
+    #[test]
+    fn agent_list_keeps_short_control_timeout() {
+        assert_eq!(
+            operation_timeout(ControlOperation::AgentList),
+            CONTROL_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn wait_target_rejects_multi_target_selectors() {
+        let error = wait_target_snapshot("all").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    fn agent(status: &str, last_status_at: Option<&str>) -> AgentIdentity {
+        AgentIdentity {
+            name: "reviewer-a1".to_string(),
+            uuid: "uuid-1".to_string(),
+            class: "Reviewer".to_string(),
+            provider: "codex".to_string(),
+            status: status.to_string(),
+            pid: Some(42),
+            started_at: Some("2026-05-07T12:00:00.000Z".to_string()),
+            workspace: Some("D:/Development/Wardian".to_string()),
+            last_status_at: last_status_at.map(str::to_string),
+            status_source: wardian_core::identity::StatusSource::Live,
+        }
+    }
+
+    #[test]
+    fn wait_after_send_accepts_fast_return_to_initial_status_when_timestamp_changes() {
+        let initial = agent("idle", Some("2026-05-07T12:00:00.000Z"));
+        let completed = agent("idle", Some("2026-05-07T12:00:01.000Z"));
+
+        let result = wait_agent_until_after_snapshot_with(
+            "reviewer-a1",
+            "idle",
+            Duration::from_secs(1),
+            Some(initial),
+            |_| Ok(completed.clone()),
+            |_| {},
+        )
+        .unwrap();
+
+        assert_eq!(
+            result.last_status_at.as_deref(),
+            Some("2026-05-07T12:00:01.000Z")
+        );
+    }
+
+    #[test]
+    fn wait_target_not_found_uses_typed_error() {
+        let error = wait_agent_until_after_snapshot_with(
+            "ghost",
+            "idle",
+            Duration::from_secs(1),
+            None,
+            |_| {
+                Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    WaitTargetNotFoundError::new("ghost"),
+                ))
+            },
+            |_| {},
+        )
+        .unwrap_err();
+
+        assert!(error
+            .get_ref()
+            .and_then(|inner| inner.downcast_ref::<WaitTargetNotFoundError>())
+            .is_some());
+    }
+}

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -1,21 +1,160 @@
 use std::{io, time::Duration};
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use wardian_core::control::{AgentListResponse, ControlRequest};
+use wardian_core::control::{AgentListResponse, AgentResponse, ControlRequest};
 use wardian_core::identity::AgentIdentity;
+use wardian_core::models::WorkflowDefinition;
 
 const CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
 
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
 pub fn list_agents() -> io::Result<Vec<AgentIdentity>> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
+    let runtime = build_runtime()?;
+    let value = timeout_block(&runtime, send_request(ControlRequest::AgentList))?;
+    let response: AgentListResponse =
+        serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
+    Ok(response.agents)
+}
+
+pub fn agent_kill(target: &str) -> io::Result<()> {
+    let runtime = build_runtime()?;
+    timeout_block(
+        &runtime,
+        send_request(ControlRequest::AgentKill {
+            target: target.to_string(),
+        }),
+    )
+    .map(|_| ())
+}
+
+pub fn agent_pause(target: &str) -> io::Result<()> {
+    let runtime = build_runtime()?;
+    timeout_block(
+        &runtime,
+        send_request(ControlRequest::AgentPause {
+            target: target.to_string(),
+        }),
+    )
+    .map(|_| ())
+}
+
+pub fn agent_resume(target: &str) -> io::Result<()> {
+    let runtime = build_runtime()?;
+    timeout_block(
+        &runtime,
+        send_request(ControlRequest::AgentResume {
+            target: target.to_string(),
+        }),
+    )
+    .map(|_| ())
+}
+
+pub fn agent_spawn(
+    class: &str,
+    name: Option<&str>,
+    workspace: Option<&str>,
+) -> io::Result<AgentIdentity> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        send_request(ControlRequest::AgentSpawn {
+            class: class.to_string(),
+            name: name.map(str::to_string),
+            workspace: workspace.map(str::to_string),
+        }),
+    )?;
+    let resp: AgentResponse =
+        serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
+    Ok(resp.agent)
+}
+
+pub fn agent_clone(target: &str, name: Option<&str>) -> io::Result<AgentIdentity> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        send_request(ControlRequest::AgentClone {
+            target: target.to_string(),
+            name: name.map(str::to_string),
+        }),
+    )?;
+    let resp: AgentResponse =
+        serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
+    Ok(resp.agent)
+}
+
+pub fn workflow_run(id: &str) -> io::Result<()> {
+    let runtime = build_runtime()?;
+    timeout_block(
+        &runtime,
+        send_request(ControlRequest::WorkflowRun { id: id.to_string() }),
+    )
+    .map(|_| ())
+}
+
+pub fn workflow_stop(run_instance_id: &str) -> io::Result<()> {
+    let runtime = build_runtime()?;
+    timeout_block(
+        &runtime,
+        send_request(ControlRequest::WorkflowStop {
+            run_instance_id: run_instance_id.to_string(),
+        }),
+    )
+    .map(|_| ())
+}
+
+pub fn send_message(target: &str, message: &str, thread: Option<&str>) -> io::Result<()> {
+    let runtime = build_runtime()?;
+    timeout_block(
+        &runtime,
+        send_request(ControlRequest::SendMessage {
+            target: target.to_string(),
+            message: message.to_string(),
+            thread: thread.map(str::to_string),
+        }),
+    )
+    .map(|_| ())
+}
+
+pub fn list_workflows_from_disk() -> io::Result<Vec<WorkflowDefinition>> {
+    let home = wardian_core::paths::wardian_home()
+        .ok_or_else(|| io::Error::other("WARDIAN_HOME not set"))?;
+    let workflows_dir = home.join("workflows");
+    if !workflows_dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut workflows = vec![];
+    for entry in std::fs::read_dir(&workflows_dir)? {
+        let entry = entry?;
+        if entry.path().extension().and_then(|e| e.to_str()) == Some("json") {
+            let content = std::fs::read_to_string(entry.path())?;
+            if let Ok(wf) = serde_json::from_str::<WorkflowDefinition>(&content) {
+                workflows.push(wf);
+            }
+        }
+    }
+    Ok(workflows)
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn build_runtime() -> io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
         .enable_io()
         .enable_time()
         .build()
-        .map_err(|error| io::Error::other(error.to_string()))?;
+        .map_err(|e| io::Error::other(e.to_string()))
+}
 
-    match runtime
-        .block_on(async { tokio::time::timeout(CONTROL_TIMEOUT, request_agent_list_async()).await })
-    {
+fn timeout_block(
+    runtime: &tokio::runtime::Runtime,
+    fut: impl std::future::Future<Output = io::Result<serde_json::Value>>,
+) -> io::Result<serde_json::Value> {
+    match runtime.block_on(async { tokio::time::timeout(CONTROL_TIMEOUT, fut).await }) {
         Ok(result) => result,
         Err(_) => Err(io::Error::new(
             io::ErrorKind::TimedOut,
@@ -24,32 +163,43 @@ pub fn list_agents() -> io::Result<Vec<AgentIdentity>> {
     }
 }
 
+async fn send_request(req: ControlRequest) -> io::Result<serde_json::Value> {
+    #[cfg(windows)]
+    {
+        send_request_windows(req).await
+    }
+    #[cfg(unix)]
+    {
+        send_request_unix(req).await
+    }
+}
+
 #[cfg(windows)]
-async fn request_agent_list_async() -> std::io::Result<Vec<AgentIdentity>> {
+async fn send_request_windows(req: ControlRequest) -> io::Result<serde_json::Value> {
     use tokio::net::windows::named_pipe::ClientOptions;
 
     let pipe_name = wardian_core::control::pipe_name()
-        .ok_or_else(|| std::io::Error::other("could not resolve Wardian control pipe"))?;
+        .ok_or_else(|| io::Error::other("could not resolve Wardian control pipe"))?;
     let mut stream = ClientOptions::new().open(pipe_name)?;
-    request_agent_list(&mut stream).await
+    exchange_json(&mut stream, req).await
 }
 
 #[cfg(unix)]
-async fn request_agent_list_async() -> std::io::Result<Vec<AgentIdentity>> {
+async fn send_request_unix(req: ControlRequest) -> io::Result<serde_json::Value> {
     use tokio::net::UnixStream;
 
     let socket_path = wardian_core::control::socket_path()
-        .ok_or_else(|| std::io::Error::other("could not resolve Wardian control socket"))?;
+        .ok_or_else(|| io::Error::other("could not resolve Wardian control socket"))?;
     let mut stream = UnixStream::connect(socket_path).await?;
-    request_agent_list(&mut stream).await
+    exchange_json(&mut stream, req).await
 }
 
-async fn request_agent_list<T>(stream: &mut T) -> std::io::Result<Vec<AgentIdentity>>
+async fn exchange_json<T>(stream: &mut T, req: ControlRequest) -> io::Result<serde_json::Value>
 where
     T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
-    let request = serde_json::to_string(&ControlRequest::AgentList)
-        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    let request =
+        serde_json::to_string(&req).map_err(|e| io::Error::other(e.to_string()))?;
     stream.write_all(request.as_bytes()).await?;
     stream.write_all(b"\n").await?;
     stream.flush().await?;
@@ -57,7 +207,18 @@ where
     let mut line = String::new();
     let mut reader = BufReader::new(stream);
     reader.read_line(&mut line).await?;
-    let response: AgentListResponse =
-        serde_json::from_str(&line).map_err(|error| std::io::Error::other(error.to_string()))?;
-    Ok(response.agents)
+
+    // Detect backend error envelope {"error": {...}}
+    let value: serde_json::Value =
+        serde_json::from_str(&line).map_err(|e| io::Error::other(e.to_string()))?;
+    if let Some(err) = value.get("error") {
+        let msg = err
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("unknown error");
+        return Err(io::Error::other(msg.to_string()));
+    }
+
+    Ok(value)
 }
+

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -63,6 +63,12 @@ fn handle_agent(args: AgentArgs) -> Result<String, CliError> {
             &args,
         ),
         None => handle_show(args.target.as_deref(), &args),
+        // Phase A lifecycle commands — implemented in Task 5
+        Some(AgentCommand::Kill { .. })
+        | Some(AgentCommand::Pause { .. })
+        | Some(AgentCommand::Resume { .. })
+        | Some(AgentCommand::Spawn { .. })
+        | Some(AgentCommand::Clone { .. }) => Err(CliError::generic("not yet implemented")),
     }
 }
 

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -3,7 +3,9 @@ mod errors;
 mod live;
 mod output;
 
-use args::{AgentArgs, AgentCommand, Cli, Command};
+use std::io::Read as _;
+
+use args::{AgentArgs, AgentCommand, Cli, Command, SendArgs, WorkflowArgs, WorkflowCommand};
 use clap::Parser;
 use errors::{CliError, ExitCode};
 use output::{render_list, render_show, RenderOptions};
@@ -20,6 +22,8 @@ fn run() -> i32 {
     };
     let result = match cli.command {
         Command::Agent(args) => handle_agent(args),
+        Command::Workflow(args) => handle_workflow(args),
+        Command::Send(args) => handle_send(args),
     };
 
     match result {
@@ -47,6 +51,10 @@ fn handle_parse_error(error: clap::Error) -> i32 {
     ExitCode::Generic as i32
 }
 
+// ---------------------------------------------------------------------------
+// wardian agent
+// ---------------------------------------------------------------------------
+
 fn handle_agent(args: AgentArgs) -> Result<String, CliError> {
     match &args.command {
         Some(AgentCommand::Show { target }) => handle_show(target.as_deref(), &args),
@@ -63,12 +71,148 @@ fn handle_agent(args: AgentArgs) -> Result<String, CliError> {
             &args,
         ),
         None => handle_show(args.target.as_deref(), &args),
-        // Phase A lifecycle commands — implemented in Task 5
-        Some(AgentCommand::Kill { .. })
-        | Some(AgentCommand::Pause { .. })
-        | Some(AgentCommand::Resume { .. })
-        | Some(AgentCommand::Spawn { .. })
-        | Some(AgentCommand::Clone { .. }) => Err(CliError::generic("not yet implemented")),
+        Some(AgentCommand::Kill { target }) => handle_agent_kill(target),
+        Some(AgentCommand::Pause { target }) => handle_agent_pause(target),
+        Some(AgentCommand::Resume { target }) => handle_agent_resume(target),
+        Some(AgentCommand::Spawn { class, name, workspace }) => {
+            handle_agent_spawn(class, name.as_deref(), workspace.as_deref(), &args)
+        }
+        Some(AgentCommand::Clone { target, name }) => {
+            handle_agent_clone(target, name.as_deref(), &args)
+        }
+    }
+}
+
+fn handle_agent_kill(target: &str) -> Result<String, CliError> {
+    live::agent_kill(target).map_err(control_error)?;
+    Ok(format!(
+        "{}\n",
+        serde_json::to_string_pretty(&serde_json::json!({"schema":1,"ok":true,"target":target}))
+            .unwrap()
+    ))
+}
+
+fn handle_agent_pause(target: &str) -> Result<String, CliError> {
+    live::agent_pause(target).map_err(control_error)?;
+    Ok(format!(
+        "{}\n",
+        serde_json::to_string_pretty(&serde_json::json!({"schema":1,"ok":true,"target":target}))
+            .unwrap()
+    ))
+}
+
+fn handle_agent_resume(target: &str) -> Result<String, CliError> {
+    live::agent_resume(target).map_err(control_error)?;
+    Ok(format!(
+        "{}\n",
+        serde_json::to_string_pretty(&serde_json::json!({"schema":1,"ok":true,"target":target}))
+            .unwrap()
+    ))
+}
+
+fn handle_agent_spawn(
+    class: &str,
+    name: Option<&str>,
+    workspace: Option<&str>,
+    args: &AgentArgs,
+) -> Result<String, CliError> {
+    let agent = live::agent_spawn(class, name, workspace).map_err(control_error)?;
+    render_show(&agent, &render_options(args))
+}
+
+fn handle_agent_clone(
+    target: &str,
+    name: Option<&str>,
+    args: &AgentArgs,
+) -> Result<String, CliError> {
+    let agent = live::agent_clone(target, name).map_err(control_error)?;
+    render_show(&agent, &render_options(args))
+}
+
+// ---------------------------------------------------------------------------
+// wardian workflow
+// ---------------------------------------------------------------------------
+
+fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
+    match args.command {
+        WorkflowCommand::List => {
+            let workflows = live::list_workflows_from_disk()
+                .map_err(|e| CliError::generic(e.to_string()))?;
+            output::render_workflow_list(&workflows, args.pretty)
+        }
+        WorkflowCommand::Show { target } => {
+            let workflows = live::list_workflows_from_disk()
+                .map_err(|e| CliError::generic(e.to_string()))?;
+            let wf = workflows
+                .into_iter()
+                .find(|w| w.id == target || w.name == target)
+                .ok_or_else(|| CliError::not_found(&target))?;
+            output::render_workflow_show(&wf, args.pretty)
+        }
+        WorkflowCommand::Run { target } => {
+            live::workflow_run(&target).map_err(control_error)?;
+            Ok(format!(
+                "{}\n",
+                serde_json::to_string_pretty(
+                    &serde_json::json!({"schema":1,"ok":true,"workflow":target})
+                )
+                .unwrap()
+            ))
+        }
+        WorkflowCommand::Stop { run_instance_id } => {
+            live::workflow_stop(&run_instance_id).map_err(control_error)?;
+            Ok(format!(
+                "{}\n",
+                serde_json::to_string_pretty(&serde_json::json!({"schema":1,"ok":true})).unwrap()
+            ))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// wardian send
+// ---------------------------------------------------------------------------
+
+fn handle_send(args: SendArgs) -> Result<String, CliError> {
+    let message = if args.stdin {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|e| CliError::generic(e.to_string()))?;
+        buf
+    } else if let Some(path) = &args.file {
+        std::fs::read_to_string(path).map_err(|e| CliError::generic(e.to_string()))?
+    } else {
+        args.message
+            .clone()
+            .ok_or_else(|| CliError::generic("Provide a message, --stdin, or --file".to_string()))?
+    };
+
+    live::send_message(&args.to, &message, args.thread.as_deref()).map_err(control_error)?;
+
+    Ok(format!(
+        "{}\n",
+        serde_json::to_string_pretty(
+            &serde_json::json!({"schema":1,"ok":true,"target":args.to})
+        )
+        .unwrap()
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn control_error(e: std::io::Error) -> CliError {
+    if matches!(
+        e.kind(),
+        std::io::ErrorKind::NotFound
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::TimedOut
+    ) {
+        CliError::app_not_running()
+    } else {
+        CliError::generic(e.to_string())
     }
 }
 

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -1,9 +1,10 @@
 mod args;
+mod disk;
 mod errors;
 mod live;
 mod output;
 
-use std::io::Read as _;
+use std::{io::Read as _, time::Duration};
 
 use args::{AgentArgs, AgentCommand, Cli, Command, SendArgs, WorkflowArgs, WorkflowCommand};
 use clap::Parser;
@@ -74,12 +75,26 @@ fn handle_agent(args: AgentArgs) -> Result<String, CliError> {
         Some(AgentCommand::Kill { target }) => handle_agent_kill(target),
         Some(AgentCommand::Pause { target }) => handle_agent_pause(target),
         Some(AgentCommand::Resume { target }) => handle_agent_resume(target),
-        Some(AgentCommand::Spawn { class, name, workspace }) => {
-            handle_agent_spawn(class, name.as_deref(), workspace.as_deref(), &args)
-        }
+        Some(AgentCommand::Spawn {
+            provider,
+            class,
+            name,
+            workspace,
+        }) => handle_agent_spawn(
+            provider,
+            class,
+            name.as_deref(),
+            workspace.as_deref(),
+            &args,
+        ),
         Some(AgentCommand::Clone { target, name }) => {
             handle_agent_clone(target, name.as_deref(), &args)
         }
+        Some(AgentCommand::Wait {
+            target,
+            until,
+            timeout,
+        }) => handle_agent_wait(target, until, timeout, &args),
     }
 }
 
@@ -111,12 +126,13 @@ fn handle_agent_resume(target: &str) -> Result<String, CliError> {
 }
 
 fn handle_agent_spawn(
+    provider: &str,
     class: &str,
     name: Option<&str>,
     workspace: Option<&str>,
     args: &AgentArgs,
 ) -> Result<String, CliError> {
-    let agent = live::agent_spawn(class, name, workspace).map_err(control_error)?;
+    let agent = live::agent_spawn(provider, class, name, workspace).map_err(control_error)?;
     render_show(&agent, &render_options(args))
 }
 
@@ -129,6 +145,17 @@ fn handle_agent_clone(
     render_show(&agent, &render_options(args))
 }
 
+fn handle_agent_wait(
+    target: &str,
+    until: &str,
+    timeout: &str,
+    args: &AgentArgs,
+) -> Result<String, CliError> {
+    let timeout = parse_timeout(timeout)?;
+    let agent = live::wait_agent_until(target, until, timeout).map_err(control_error)?;
+    render_show(&agent, &render_options(args))
+}
+
 // ---------------------------------------------------------------------------
 // wardian workflow
 // ---------------------------------------------------------------------------
@@ -136,17 +163,30 @@ fn handle_agent_clone(
 fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
     match args.command {
         WorkflowCommand::List => {
-            let workflows = live::list_workflows_from_disk()
-                .map_err(|e| CliError::generic(e.to_string()))?;
+            let workflows = match live::workflow_list() {
+                Ok(workflows) => workflows,
+                Err(error) if is_control_endpoint_unavailable(&error) => {
+                    let workflows = disk::list_workflows_from_disk()
+                        .map_err(|e| CliError::generic(e.to_string()))?;
+                    disk::workflow_summaries(&workflows)
+                }
+                Err(error) => return Err(control_error(error)),
+            };
             output::render_workflow_list(&workflows, args.pretty)
         }
         WorkflowCommand::Show { target } => {
-            let workflows = live::list_workflows_from_disk()
-                .map_err(|e| CliError::generic(e.to_string()))?;
-            let wf = workflows
-                .into_iter()
-                .find(|w| w.id == target || w.name == target)
-                .ok_or_else(|| CliError::not_found(&target))?;
+            let wf = match live::workflow_show(&target) {
+                Ok(workflow) => workflow,
+                Err(error) if is_control_endpoint_unavailable(&error) => {
+                    let workflows = disk::list_workflows_from_disk()
+                        .map_err(|e| CliError::generic(e.to_string()))?;
+                    workflows
+                        .into_iter()
+                        .find(|w| w.id == target || w.name == target)
+                        .ok_or_else(|| CliError::not_found(&target))?
+                }
+                Err(error) => return Err(control_error(error)),
+            };
             output::render_workflow_show(&wf, args.pretty)
         }
         WorkflowCommand::Run { target } => {
@@ -188,14 +228,25 @@ fn handle_send(args: SendArgs) -> Result<String, CliError> {
             .ok_or_else(|| CliError::generic("Provide a message, --stdin, or --file".to_string()))?
     };
 
-    live::send_message(&args.to, &message, args.thread.as_deref()).map_err(control_error)?;
+    let waited_agent = if let Some(until) = args.wait_until.as_deref() {
+        let timeout = parse_timeout(&args.timeout)?;
+        Some(
+            live::send_message_and_wait(&args.to, &message, args.thread.as_deref(), until, timeout)
+                .map_err(control_error)?,
+        )
+    } else {
+        live::send_message(&args.to, &message, args.thread.as_deref()).map_err(control_error)?;
+        None
+    };
+
+    let mut response = serde_json::json!({"schema":1,"ok":true,"target":args.to});
+    if let Some(agent) = waited_agent {
+        response["status"] = serde_json::Value::String(agent.status);
+    }
 
     Ok(format!(
         "{}\n",
-        serde_json::to_string_pretty(
-            &serde_json::json!({"schema":1,"ok":true,"target":args.to})
-        )
-        .unwrap()
+        serde_json::to_string_pretty(&response).unwrap()
     ))
 }
 
@@ -204,16 +255,72 @@ fn handle_send(args: SendArgs) -> Result<String, CliError> {
 // ---------------------------------------------------------------------------
 
 fn control_error(e: std::io::Error) -> CliError {
-    if matches!(
-        e.kind(),
-        std::io::ErrorKind::NotFound
-            | std::io::ErrorKind::ConnectionRefused
-            | std::io::ErrorKind::TimedOut
-    ) {
+    if let Some(wait_timeout) = e
+        .get_ref()
+        .and_then(|inner| inner.downcast_ref::<live::WaitTimeoutError>())
+    {
+        CliError::backend(ExitCode::Generic, "wait_timeout", wait_timeout.to_string())
+    } else if let Some(wait_not_found) = e
+        .get_ref()
+        .and_then(|inner| inner.downcast_ref::<live::WaitTargetNotFoundError>())
+    {
+        CliError::backend(ExitCode::NotFound, "not_found", wait_not_found.to_string())
+    } else if is_control_endpoint_unavailable(&e) {
         CliError::app_not_running()
+    } else if let Some(endpoint_error) = e
+        .get_ref()
+        .and_then(|inner| inner.downcast_ref::<live::ControlEndpointError>())
+    {
+        match endpoint_error.code() {
+            "not_supported" => CliError::backend(
+                ExitCode::Generic,
+                "not_supported",
+                endpoint_error.to_string(),
+            ),
+            "not_found" => {
+                CliError::backend(ExitCode::NotFound, "not_found", endpoint_error.to_string())
+            }
+            _ => CliError::generic(endpoint_error.to_string()),
+        }
     } else {
         CliError::generic(e.to_string())
     }
+}
+
+fn parse_timeout(value: &str) -> Result<Duration, CliError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(CliError::generic("timeout must not be empty"));
+    }
+
+    let (number, multiplier) = if let Some(number) = trimmed.strip_suffix("ms") {
+        (number, Duration::from_millis(1))
+    } else if let Some(number) = trimmed.strip_suffix('s') {
+        (number, Duration::from_secs(1))
+    } else if let Some(number) = trimmed.strip_suffix('m') {
+        (number, Duration::from_secs(60))
+    } else {
+        (trimmed, Duration::from_secs(1))
+    };
+
+    let count = number
+        .trim()
+        .parse::<u64>()
+        .map_err(|_| CliError::generic(format!("invalid timeout: {value}")))?;
+    let count = u32::try_from(count)
+        .map_err(|_| CliError::generic(format!("timeout is too large: {value}")))?;
+    multiplier
+        .checked_mul(count)
+        .ok_or_else(|| CliError::generic(format!("timeout is too large: {value}")))
+}
+
+fn is_control_endpoint_unavailable(error: &std::io::Error) -> bool {
+    matches!(
+        error.kind(),
+        std::io::ErrorKind::NotFound
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::TimedOut
+    )
 }
 
 fn handle_show(target: Option<&str>, args: &AgentArgs) -> Result<String, CliError> {
@@ -364,5 +471,82 @@ fn identity_error(error: identity::IdentityError) -> CliError {
         identity::IdentityError::NotInSession => CliError::not_in_session(),
         identity::IdentityError::NotFound(requested) => CliError::not_found(&requested),
         identity::IdentityError::Db(error) => CliError::db_unavailable(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn control_error_preserves_backend_not_supported_code() {
+        let error = std::io::Error::other(live::ControlEndpointError::new(
+            "not_supported",
+            "--thread is not supported",
+        ));
+
+        let cli_error = control_error(error);
+
+        assert_eq!(cli_error.code, "not_supported");
+        assert_eq!(cli_error.code_i32(), 1);
+        assert!(cli_error.message.contains("--thread is not supported"));
+    }
+
+    #[test]
+    fn control_error_preserves_backend_not_found_exit_code() {
+        let error = std::io::Error::other(live::ControlEndpointError::new(
+            "not_found",
+            "agent not found: ghost",
+        ));
+
+        let cli_error = control_error(error);
+
+        assert_eq!(cli_error.code, "not_found");
+        assert_eq!(cli_error.code_i32(), 2);
+        assert!(cli_error.message.contains("ghost"));
+    }
+
+    #[test]
+    fn control_error_does_not_treat_wait_timeout_as_app_not_running() {
+        let error = std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            live::WaitTimeoutError::new("reviewer-a1", "idle", "processing"),
+        );
+
+        let cli_error = control_error(error);
+
+        assert_eq!(cli_error.code, "wait_timeout");
+        assert_eq!(cli_error.code_i32(), 1);
+        assert!(cli_error.message.contains("reviewer-a1"));
+    }
+
+    #[test]
+    fn control_error_does_not_treat_wait_target_miss_as_app_not_running() {
+        let error = std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            live::WaitTargetNotFoundError::new("ghost"),
+        );
+
+        let cli_error = control_error(error);
+
+        assert_eq!(cli_error.code, "not_found");
+        assert_eq!(cli_error.code_i32(), 2);
+        assert!(cli_error.message.contains("ghost"));
+    }
+
+    #[test]
+    fn parses_timeout_units() {
+        assert_eq!(
+            parse_timeout("250ms").unwrap(),
+            std::time::Duration::from_millis(250)
+        );
+        assert_eq!(
+            parse_timeout("30s").unwrap(),
+            std::time::Duration::from_secs(30)
+        );
+        assert_eq!(
+            parse_timeout("10m").unwrap(),
+            std::time::Duration::from_secs(600)
+        );
     }
 }

--- a/crates/wardian-cli/src/output.rs
+++ b/crates/wardian-cli/src/output.rs
@@ -1,5 +1,6 @@
 use crate::errors::CliError;
 use serde_json::{Map, Value};
+use wardian_core::control::WorkflowSummary;
 use wardian_core::identity::{AgentIdentity, StatusSource};
 
 const DEFAULT_FIELDS: &[&str] = &["name", "uuid", "class", "provider", "workspace", "status"];
@@ -180,7 +181,7 @@ fn render_pretty(values: &Map<String, Value>) -> String {
 }
 
 pub fn render_workflow_list(
-    workflows: &[wardian_core::models::WorkflowDefinition],
+    workflows: &[WorkflowSummary],
     pretty: bool,
 ) -> Result<String, CliError> {
     let summaries: Vec<_> = workflows
@@ -189,7 +190,7 @@ pub fn render_workflow_list(
             serde_json::json!({
                 "id": w.id,
                 "name": w.name,
-                "node_count": w.nodes.len(),
+                "node_count": w.node_count,
             })
         })
         .collect();
@@ -233,15 +234,7 @@ pub fn render_workflow_show(
         "{}\n",
         serde_json::to_string_pretty(&serde_json::json!({
             "schema": 1,
-            "workflow": {
-                "id": workflow.id,
-                "name": workflow.name,
-                "node_count": workflow.nodes.len(),
-                "settings": {
-                    "max_iterations": workflow.settings.max_iterations,
-                    "on_limit_reached": workflow.settings.on_limit_reached,
-                },
-            }
+            "workflow": workflow,
         }))
         .map_err(json_error)?
     ))

--- a/crates/wardian-cli/src/output.rs
+++ b/crates/wardian-cli/src/output.rs
@@ -179,6 +179,74 @@ fn render_pretty(values: &Map<String, Value>) -> String {
     out
 }
 
+pub fn render_workflow_list(
+    workflows: &[wardian_core::models::WorkflowDefinition],
+    pretty: bool,
+) -> Result<String, CliError> {
+    let summaries: Vec<_> = workflows
+        .iter()
+        .map(|w| {
+            serde_json::json!({
+                "id": w.id,
+                "name": w.name,
+                "node_count": w.nodes.len(),
+            })
+        })
+        .collect();
+
+    if pretty {
+        let mut out = String::new();
+        for s in &summaries {
+            out.push_str(&format!(
+                "{:<36}  {}\n",
+                s["id"].as_str().unwrap_or(""),
+                s["name"].as_str().unwrap_or("")
+            ));
+        }
+        return Ok(out);
+    }
+
+    Ok(format!(
+        "{}\n",
+        serde_json::to_string_pretty(&serde_json::json!({"schema": 1, "workflows": summaries}))
+            .map_err(json_error)?
+    ))
+}
+
+pub fn render_workflow_show(
+    workflow: &wardian_core::models::WorkflowDefinition,
+    pretty: bool,
+) -> Result<String, CliError> {
+    if pretty {
+        return Ok(format!(
+            "{:<16}  {}\n{:<16}  {}\n{:<16}  {} nodes\n",
+            "id",
+            workflow.id,
+            "name",
+            workflow.name,
+            "nodes",
+            workflow.nodes.len(),
+        ));
+    }
+
+    Ok(format!(
+        "{}\n",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema": 1,
+            "workflow": {
+                "id": workflow.id,
+                "name": workflow.name,
+                "node_count": workflow.nodes.len(),
+                "settings": {
+                    "max_iterations": workflow.settings.max_iterations,
+                    "on_limit_reached": workflow.settings.on_limit_reached,
+                },
+            }
+        }))
+        .map_err(json_error)?
+    ))
+}
+
 fn json_error(error: serde_json::Error) -> CliError {
     CliError::generic(error.to_string())
 }

--- a/crates/wardian-cli/tests/agent_cli.rs
+++ b/crates/wardian-cli/tests/agent_cli.rs
@@ -321,6 +321,21 @@ fn missing_db_exits_four() {
 }
 
 #[test]
+fn kill_without_app_running_exits_six() {
+    let home = seed_home();
+    let output = Command::new(bin())
+        .args(["agent", "kill", "coder-a1"])
+        .env("WARDIAN_HOME", home.path())
+        .env_remove("WARDIAN_SESSION_ID")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"app_not_running""#));
+}
+
+#[test]
 fn malformed_args_emit_json_error_and_exit_one() {
     let output = Command::new(bin())
         .args(["agent", "list", "--definitely-not-a-real-flag"])

--- a/crates/wardian-cli/tests/send_cli.rs
+++ b/crates/wardian-cli/tests/send_cli.rs
@@ -1,0 +1,89 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+fn bin() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian-cli") {
+        return path.into();
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian_cli") {
+        return path.into();
+    }
+    let exe = if cfg!(windows) {
+        "wardian-cli.exe"
+    } else {
+        "wardian-cli"
+    };
+    std::env::current_exe()
+        .unwrap()
+        .parent()
+        .and_then(|deps| deps.parent())
+        .unwrap()
+        .join(exe)
+}
+
+#[test]
+fn send_requires_to_flag() {
+    let output = Command::new(bin())
+        .args(["send", "hello world"])
+        .output()
+        .unwrap();
+    // clap exits 1 when required flag is missing
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"generic""#));
+}
+
+#[test]
+fn send_without_app_exits_six() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args(["send", "hello", "--to", "coder-a1"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"app_not_running""#));
+}
+
+#[test]
+fn send_to_class_prefix_without_app_exits_six() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args(["send", "review this", "--to", "class:Coder"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"app_not_running""#));
+}
+
+#[test]
+fn send_to_all_without_app_exits_six() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args(["send", "broadcast", "--to", "all"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+}
+
+#[test]
+fn send_no_message_no_stdin_exits_one() {
+    let home = TempDir::new().unwrap();
+    // --to is given but no message, no --stdin, no --file
+    let output = Command::new(bin())
+        .args(["send", "--to", "coder-a1"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    // Should fail: no message provided (either generic error or app_not_running,
+    // since control pipe check happens before message validation)
+    assert_ne!(output.status.code(), Some(0));
+}

--- a/crates/wardian-cli/tests/workflow_cli.rs
+++ b/crates/wardian-cli/tests/workflow_cli.rs
@@ -1,0 +1,171 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+fn bin() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian-cli") {
+        return path.into();
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian_cli") {
+        return path.into();
+    }
+    let exe = if cfg!(windows) {
+        "wardian-cli.exe"
+    } else {
+        "wardian-cli"
+    };
+    std::env::current_exe()
+        .unwrap()
+        .parent()
+        .and_then(|deps| deps.parent())
+        .unwrap()
+        .join(exe)
+}
+
+fn seed_workflows(dir: &TempDir) {
+    let workflows_dir = dir.path().join("workflows");
+    std::fs::create_dir_all(&workflows_dir).unwrap();
+    std::fs::write(
+        workflows_dir.join("wf-abc123.json"),
+        serde_json::json!({
+            "id": "wf-abc123",
+            "name": "Daily Review",
+            "settings": {"max_iterations": 10, "on_limit_reached": "stop"},
+            "nodes": [
+                {"id": "n1", "type": "agent", "config": {}},
+                {"id": "n2", "type": "agent", "config": {}},
+            ],
+            "role_mappings": {}
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn workflow_list_returns_summary_json() {
+    let home = TempDir::new().unwrap();
+    seed_workflows(&home);
+    let output = Command::new(bin())
+        .args(["workflow", "list"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(r#""schema": 1"#));
+    assert!(stdout.contains("Daily Review"));
+    assert!(stdout.contains("wf-abc123"));
+    assert!(stdout.contains(r#""node_count": 2"#));
+}
+
+#[test]
+fn workflow_list_pretty_outputs_table() {
+    let home = TempDir::new().unwrap();
+    seed_workflows(&home);
+    let output = Command::new(bin())
+        .args(["workflow", "list", "--pretty"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("wf-abc123"));
+    assert!(stdout.contains("Daily Review"));
+    // pretty mode has no JSON braces
+    assert!(!stdout.contains(r#""schema""#));
+}
+
+#[test]
+fn workflow_list_empty_when_no_workflows_dir() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args(["workflow", "list"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(r#""workflows": []"#));
+}
+
+#[test]
+fn workflow_show_by_id() {
+    let home = TempDir::new().unwrap();
+    seed_workflows(&home);
+    let output = Command::new(bin())
+        .args(["workflow", "show", "wf-abc123"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("wf-abc123"));
+    assert!(stdout.contains("Daily Review"));
+}
+
+#[test]
+fn workflow_show_by_name() {
+    let home = TempDir::new().unwrap();
+    seed_workflows(&home);
+    let output = Command::new(bin())
+        .args(["workflow", "show", "Daily Review"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("wf-abc123"));
+}
+
+#[test]
+fn workflow_show_unknown_exits_two() {
+    let home = TempDir::new().unwrap();
+    seed_workflows(&home);
+    let output = Command::new(bin())
+        .args(["workflow", "show", "ghost-workflow"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"not_found""#));
+}
+
+#[test]
+fn workflow_run_without_app_exits_six() {
+    let home = TempDir::new().unwrap();
+    seed_workflows(&home);
+    let output = Command::new(bin())
+        .args(["workflow", "run", "wf-abc123"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"app_not_running""#));
+}
+
+#[test]
+fn workflow_stop_without_app_exits_six() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args(["workflow", "stop", "run-instance-xyz"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"app_not_running""#));
+}

--- a/crates/wardian-cli/tests/workflow_cli.rs
+++ b/crates/wardian-cli/tests/workflow_cli.rs
@@ -41,6 +41,30 @@ fn seed_workflows(dir: &TempDir) {
     .unwrap();
 }
 
+fn seed_workflow_with_role_mapping(dir: &TempDir) {
+    let workflows_dir = dir.path().join("workflows");
+    std::fs::create_dir_all(&workflows_dir).unwrap();
+    std::fs::write(
+        workflows_dir.join("wf-mapped.json"),
+        serde_json::json!({
+            "id": "wf-mapped",
+            "name": "Mapped Review",
+            "settings": {"max_iterations": 5, "on_limit_reached": "stop"},
+            "nodes": [
+                {
+                    "id": "n1",
+                    "type": "agent",
+                    "name": "Reviewer",
+                    "config": {"agent_class": "Coder"}
+                }
+            ],
+            "role_mappings": {"primary_coder": "uuid-1"}
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
 #[test]
 fn workflow_list_returns_summary_json() {
     let home = TempDir::new().unwrap();
@@ -96,6 +120,27 @@ fn workflow_list_empty_when_no_workflows_dir() {
 }
 
 #[test]
+fn workflow_list_warns_about_malformed_workflow_files() {
+    let home = TempDir::new().unwrap();
+    let workflows_dir = home.path().join("workflows");
+    std::fs::create_dir_all(&workflows_dir).unwrap();
+    std::fs::write(workflows_dir.join("wf-bad.json"), "{not-json").unwrap();
+
+    let output = Command::new(bin())
+        .args(["workflow", "list"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(r#""workflows": []"#));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("warning: skipped malformed workflow file"));
+    assert!(stderr.contains("wf-bad.json"));
+}
+
+#[test]
 fn workflow_show_by_id() {
     let home = TempDir::new().unwrap();
     seed_workflows(&home);
@@ -109,6 +154,24 @@ fn workflow_show_by_id() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("wf-abc123"));
     assert!(stdout.contains("Daily Review"));
+}
+
+#[test]
+fn workflow_show_outputs_full_definition() {
+    let home = TempDir::new().unwrap();
+    seed_workflow_with_role_mapping(&home);
+    let output = Command::new(bin())
+        .args(["workflow", "show", "wf-mapped"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(r#""nodes": ["#));
+    assert!(stdout.contains(r#""id": "n1""#));
+    assert!(stdout.contains(r#""role_mappings": {"#));
+    assert!(stdout.contains(r#""primary_coder": "uuid-1""#));
 }
 
 #[test]

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -8,6 +8,15 @@ const FNV_PRIME: u64 = 0x100000001b3;
 #[serde(tag = "command", rename_all = "snake_case")]
 pub enum ControlRequest {
     AgentList,
+    AgentKill { target: String },
+    AgentPause { target: String },
+    AgentResume { target: String },
+    AgentSpawn { class: String, name: Option<String>, workspace: Option<String> },
+    AgentClone { target: String, name: Option<String> },
+    WorkflowList,
+    WorkflowRun { id: String },
+    WorkflowStop { run_instance_id: String },
+    SendMessage { target: String, message: String, thread: Option<String> },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -21,6 +30,64 @@ impl AgentListResponse {
         Self {
             schema: CONTROL_SCHEMA,
             agents,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OkResponse {
+    pub schema: u8,
+    pub ok: bool,
+}
+
+impl OkResponse {
+    pub fn new() -> Self {
+        Self {
+            schema: CONTROL_SCHEMA,
+            ok: true,
+        }
+    }
+}
+
+impl Default for OkResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentResponse {
+    pub schema: u8,
+    pub agent: AgentIdentity,
+}
+
+impl AgentResponse {
+    pub fn new(agent: AgentIdentity) -> Self {
+        Self {
+            schema: CONTROL_SCHEMA,
+            agent,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowSummary {
+    pub id: String,
+    pub name: String,
+    pub node_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkflowListResponse {
+    pub schema: u8,
+    pub workflows: Vec<WorkflowSummary>,
+}
+
+impl WorkflowListResponse {
+    pub fn new(workflows: Vec<WorkflowSummary>) -> Self {
+        Self {
+            schema: CONTROL_SCHEMA,
+            workflows,
         }
     }
 }
@@ -61,5 +128,45 @@ mod tests {
         std::env::set_var("WARDIAN_HOME", "D:/Development/Wardian/.tmp/live-status");
         assert_eq!(endpoint_key().as_deref(), Some("50403db71b810eba"));
         std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn agent_kill_request_serializes_with_target() {
+        let req = ControlRequest::AgentKill { target: "coder-a1".to_string() };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""command":"agent_kill""#));
+        assert!(json.contains(r#""target":"coder-a1""#));
+    }
+
+    #[test]
+    fn ok_response_serializes() {
+        let resp = OkResponse::new();
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains(r#""ok":true"#));
+        assert!(json.contains(r#""schema":1"#));
+    }
+
+    #[test]
+    fn send_message_request_serializes() {
+        let req = ControlRequest::SendMessage {
+            target: "all".to_string(),
+            message: "hello".to_string(),
+            thread: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""command":"send_message""#));
+        assert!(json.contains(r#""target":"all""#));
+    }
+
+    #[test]
+    fn workflow_summary_node_count_roundtrips() {
+        let summary = WorkflowSummary {
+            id: "wf-1".to_string(),
+            name: "My Flow".to_string(),
+            node_count: 3,
+        };
+        let json = serde_json::to_string(&summary).unwrap();
+        let back: WorkflowSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.node_count, 3);
     }
 }

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -1,4 +1,5 @@
 use crate::identity::AgentIdentity;
+use crate::models::WorkflowDefinition;
 use serde::{Deserialize, Serialize};
 pub const CONTROL_SCHEMA: u8 = 1;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
@@ -8,15 +9,40 @@ const FNV_PRIME: u64 = 0x100000001b3;
 #[serde(tag = "command", rename_all = "snake_case")]
 pub enum ControlRequest {
     AgentList,
-    AgentKill { target: String },
-    AgentPause { target: String },
-    AgentResume { target: String },
-    AgentSpawn { class: String, name: Option<String>, workspace: Option<String> },
-    AgentClone { target: String, name: Option<String> },
+    AgentKill {
+        target: String,
+    },
+    AgentPause {
+        target: String,
+    },
+    AgentResume {
+        target: String,
+    },
+    AgentSpawn {
+        provider: String,
+        class: String,
+        name: Option<String>,
+        workspace: Option<String>,
+    },
+    AgentClone {
+        target: String,
+        name: Option<String>,
+    },
     WorkflowList,
-    WorkflowRun { id: String },
-    WorkflowStop { run_instance_id: String },
-    SendMessage { target: String, message: String, thread: Option<String> },
+    WorkflowShow {
+        target: String,
+    },
+    WorkflowRun {
+        id: String,
+    },
+    WorkflowStop {
+        run_instance_id: String,
+    },
+    SendMessage {
+        target: String,
+        message: String,
+        thread: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -92,6 +118,21 @@ impl WorkflowListResponse {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowResponse {
+    pub schema: u8,
+    pub workflow: WorkflowDefinition,
+}
+
+impl WorkflowResponse {
+    pub fn new(workflow: WorkflowDefinition) -> Self {
+        Self {
+            schema: CONTROL_SCHEMA,
+            workflow,
+        }
+    }
+}
+
 pub fn endpoint_key() -> Option<String> {
     let home = crate::paths::wardian_home()?;
     let mut hash = FNV_OFFSET_BASIS;
@@ -132,10 +173,27 @@ mod tests {
 
     #[test]
     fn agent_kill_request_serializes_with_target() {
-        let req = ControlRequest::AgentKill { target: "coder-a1".to_string() };
+        let req = ControlRequest::AgentKill {
+            target: "coder-a1".to_string(),
+        };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains(r#""command":"agent_kill""#));
         assert!(json.contains(r#""target":"coder-a1""#));
+    }
+
+    #[test]
+    fn agent_spawn_request_serializes_provider_and_class() {
+        let req = ControlRequest::AgentSpawn {
+            provider: "codex".to_string(),
+            class: "Reviewer".to_string(),
+            name: Some("CLI-Codex-Review".to_string()),
+            workspace: Some("D:/Development/Wardian".to_string()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+
+        assert!(json.contains(r#""command":"agent_spawn""#));
+        assert!(json.contains(r#""provider":"codex""#));
+        assert!(json.contains(r#""class":"Reviewer""#));
     }
 
     #[test]
@@ -168,5 +226,46 @@ mod tests {
         let json = serde_json::to_string(&summary).unwrap();
         let back: WorkflowSummary = serde_json::from_str(&json).unwrap();
         assert_eq!(back.node_count, 3);
+    }
+
+    #[test]
+    fn workflow_show_request_serializes_with_target() {
+        let req = ControlRequest::WorkflowShow {
+            target: "wf-1".to_string(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""command":"workflow_show""#));
+        assert!(json.contains(r#""target":"wf-1""#));
+    }
+
+    #[test]
+    fn workflow_response_serializes_full_definition() {
+        let workflow = crate::models::WorkflowDefinition {
+            id: "wf-1".to_string(),
+            name: "Daily Review".to_string(),
+            settings: crate::models::WorkflowSettings {
+                max_iterations: 10,
+                on_limit_reached: "stop".to_string(),
+            },
+            nodes: vec![crate::models::WorkflowNode {
+                id: "n1".to_string(),
+                r#type: "agent".to_string(),
+                name: Some("Coder".to_string()),
+                config: serde_json::json!({"agent_class": "Coder"}),
+                parameter_schema: None,
+                dependencies: None,
+                position: None,
+            }],
+            role_mappings: std::collections::HashMap::from([(
+                "primary_coder".to_string(),
+                "uuid-1".to_string(),
+            )]),
+        };
+
+        let json = serde_json::to_string(&WorkflowResponse::new(workflow)).unwrap();
+
+        assert!(json.contains(r#""workflow""#));
+        assert!(json.contains(r#""nodes""#));
+        assert!(json.contains(r#""role_mappings""#));
     }
 }

--- a/crates/wardian-core/src/models/agent_config.rs
+++ b/crates/wardian-core/src/models/agent_config.rs
@@ -101,7 +101,7 @@ pub struct AgentClassDefinition {
     pub description: String,
     #[serde(default)]
     pub is_default: bool,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "gemini_md")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub instruction_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub assigned_skills: Option<Vec<String>>,

--- a/docs/developer/native-e2e.md
+++ b/docs/developer/native-e2e.md
@@ -53,6 +53,20 @@ You can also target a specific file:
 npm run test:e2e:native:fast -- e2e-native/tests/opencode-native.test.mjs
 ```
 
+For manual validation, run the same native harness in visible watch mode:
+
+```bash
+npm run test:e2e:native:watch -- e2e-native/tests/cli-shared-state-native.test.mjs
+```
+
+Watch mode reuses the current native binary, prints named test steps, pauses briefly between watch steps, and keeps the WebView open until you press Enter. Set `WARDIAN_E2E_STEP_DELAY_MS` to change the pause length, or set `WARDIAN_E2E_WATCH_KEEP_OPEN=0` to close the window automatically.
+
+If the WebView shows a `localhost:1420` connection failure, the fast/watch runner is using a binary that expects the Vite dev server. Either start `npm run vite` or rebuild the native debug app first:
+
+```bash
+npm run tauri -- build --debug --no-bundle
+```
+
 Use this layer when validating:
 
 - terminal scrollback or renderer behavior
@@ -68,7 +82,7 @@ The CLI shared-state smoke can be run directly:
 npm run test:e2e:native:fast -- e2e-native/tests/cli-shared-state-native.test.mjs
 ```
 
-It starts the native app with an isolated `WARDIAN_HOME`, creates a mock agent through Tauri IPC, then runs the local `wardian-cli` binary against the same home and asserts the CLI can read the app-created agent through the live control endpoint. The CLI still falls back to `state.db` when the desktop app is not running.
+It starts the native app with an isolated `WARDIAN_HOME`, creates agents through both Tauri IPC and live CLI control, then runs the local `wardian-cli` binary against the same home. The smoke asserts live app state is readable, explicit `agent spawn --provider --class` works, `send --wait-until` can drive a mock action-required turn to idle, and lifecycle commands affect the running app. The CLI still falls back to `state.db` when the desktop app is not running.
 
 ## Real Providers
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -41,7 +41,31 @@ wardian agent <name-or-uuid>
 wardian agent show [name-or-uuid]
 wardian agent list --scope workspace
 wardian agent list --scope all
+wardian agent kill <name-or-uuid>
+wardian agent pause <name-or-uuid>
+wardian agent resume <name-or-uuid>
+wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace D:/Development/Wardian
+wardian agent clone <name-or-uuid> --name coder-a2
+wardian agent wait reviewer-a1 --until idle --timeout 10m
+wardian workflow list
+wardian workflow show <id-or-name>
+wardian workflow run <id>
+wardian workflow stop <run-instance-id>
+wardian send "review this" --to coder-a1
+wardian send "review this" --to reviewer-a1 --wait-until idle --timeout 10m
+wardian send "status?" --to class:Coder
+wardian send "stand down" --to all
 ```
+
+Mutating commands use Wardian's local control endpoint and require the desktop app to be running for the same `WARDIAN_HOME`. This includes agent lifecycle commands, `workflow run`, `workflow stop`, and `send`.
+
+`workflow list` and `workflow show` try the running app first, then read workflow JSON files from disk when the app is unavailable.
+
+`agent spawn` requires both `--provider` and `--class` so the created agent's runtime and role are explicit.
+
+`agent wait <target> --until <status>` blocks inside the CLI process until a single agent name or UUID reaches a normalized status such as `idle`, `processing`, `action_required`, `off`, or `error`. Use `--timeout` with `ms`, `s`, or `m` units.
+
+`send` writes a newline-terminated message into the target agent PTY. Targets can be an agent name, UUID, `class:<ClassName>`, or `all`. `--stdin` reads the message from standard input, and `--file <path>` reads it from a file. `--wait-until <status>` is available for single-agent targets and waits after delivery; when the target already has the requested status, Wardian waits for it to leave that status and return before reporting success. `--thread` is reserved but not implemented yet; when the app is running, using it returns `not_supported`.
 
 List filters:
 
@@ -69,6 +93,7 @@ Default JSON is indented for terminal readability. It includes `schema: 1` and a
 | 3 | `WARDIAN_SESSION_ID` is not set for self lookup |
 | 4 | Wardian state database is unavailable |
 | 5 | Lookup matched multiple agents |
+| 6 | Desktop app is not running for a live control command |
 
 Errors are written to stderr as JSON:
 

--- a/docs/specs/033-cli-agent-control.md
+++ b/docs/specs/033-cli-agent-control.md
@@ -1,0 +1,50 @@
+# Spec 033: CLI Agent Control and Communication
+
+- **Status:** Implemented
+- **Date:** 2026-05-06
+- **Decider:** Wardian Codex
+
+## Context
+
+Spec 024 introduced the `wardian` CLI as a read-oriented agent introspection surface and explicitly deferred mutating commands. The next slice adds the control-plane commands agents need to act on Wardian state: lifecycle commands, workflow operations, and PTY message delivery.
+
+## Decision
+
+Wardian extends the CLI with:
+
+- `wardian agent kill|pause|resume|spawn|clone`
+- `wardian agent wait`
+- `wardian workflow list|show|run|stop`
+- `wardian send`
+
+All mutable operations go through the local named-pipe or Unix-socket control endpoint keyed by `WARDIAN_HOME`. These commands return `app_not_running` with exit code 6 when the desktop app is unavailable.
+
+Read-only workflow commands try the live control endpoint first and fall back to workflow JSON files on disk when the app is unavailable. `workflow show` returns the full workflow definition, including nodes and role mappings, not just a summary.
+
+`wardian agent spawn` requires explicit `--provider` and `--class` values. This keeps agent identity honest when automation creates specialized roles such as reviewers.
+
+`wardian agent wait <target> --until <status>` blocks in the CLI process until a single live agent reaches the requested normalized status or the timeout expires. This is intentionally status-based for the first slice; it avoids model-visible polling loops without introducing a general event stream yet.
+
+`wardian send` injects newline-terminated text into the same PTY input channel used by the GUI. Targets may be a name, UUID, `class:<ClassName>`, or `all`. `--wait-until <status>` combines delivery with a status wait for single-agent targets. When the target already has the desired status, the CLI waits for it to leave that status and return, preventing immediate false success for already-idle agents. Threaded sends are reserved but not implemented; requests with `--thread` are rejected with `not_supported` rather than silently ignored.
+
+## Error Semantics
+
+The control endpoint preserves stable error codes:
+
+- `bad_request` for malformed control JSON.
+- `not_found` for unknown live agent or workflow targets.
+- `not_supported` for recognized but unsupported request features.
+- `request_failed` for operation failures after a request has parsed.
+
+The CLI preserves `not_found` and `not_supported` for app-reported control errors and maps endpoint unavailability to `app_not_running`.
+
+## State Access
+
+Spec 024 described read-only SQLite fallback for the original introspection commands. The current implementation opens the database normally and runs migrations before reading so older Wardian homes remain queryable from the CLI. This is a deliberate compatibility tradeoff: the CLI may upgrade schema metadata during reads, but it does not mutate agent lifecycle state through SQLite.
+
+## Follow-Ups
+
+- Run native E2E watch mode during manual validation for live app spawn/kill/send behavior.
+- Add structured per-target delivery details for `send`; the current implementation fails the request when any matched target cannot receive input, but still returns only a success/error envelope.
+- Harden provider status transitions and delivery acknowledgement beyond status-based waiting.
+- Implement real threaded send semantics or remove the CLI flag.

--- a/e2e-native/lib/harness.mjs
+++ b/e2e-native/lib/harness.mjs
@@ -3,12 +3,14 @@ import os from "node:os";
 import path from "node:path";
 import net from "node:net";
 import { spawn, spawnSync } from "node:child_process";
+import readline from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import { Builder, By, Capabilities, until } from "selenium-webdriver";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..", "..");
+const DEFAULT_WATCH_STEP_DELAY_MS = 750;
 
 function existingPath(candidates) {
   for (const candidate of candidates) {
@@ -145,7 +147,29 @@ function resolveIsolatedHome() {
   return process.env.WARDIAN_HOME || path.join(os.tmpdir(), "wardian-e2e-native-home");
 }
 
+function readBooleanEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    return false;
+  }
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function readPositiveIntegerEnv(name, fallback) {
+  const value = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function compactText(value, maxLength = 1200) {
+  const normalized = String(value || "").replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength)}...`;
+}
+
 export async function createNativeHarness() {
+  const watchMode = readBooleanEnv("WARDIAN_E2E_WATCH");
   return {
     repoRoot,
     appPath: resolveAppPath(),
@@ -153,6 +177,10 @@ export async function createNativeHarness() {
     tauriDriverPath: resolveTauriDriverPath(),
     nativeDriverPath: resolveNativeDriverPath(),
     platform: process.platform,
+    watchMode,
+    watchStepDelayMs: watchMode
+      ? readPositiveIntegerEnv("WARDIAN_E2E_STEP_DELAY_MS", DEFAULT_WATCH_STEP_DELAY_MS)
+      : 0,
   };
 }
 
@@ -221,6 +249,21 @@ export function prepareIsolatedHome(harness) {
     throw lastError;
   }
   fs.mkdirSync(harness.isolatedHome, { recursive: true });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function watchStep(harness, label) {
+  if (!harness.watchMode) {
+    return;
+  }
+
+  console.log(`[native-watch] ${label}`);
+  if (harness.watchStepDelayMs > 0) {
+    await sleep(harness.watchStepDelayMs);
+  }
 }
 
 function waitForPort({ port, host = "127.0.0.1", timeoutMs = 15000, processRef, logs }) {
@@ -314,6 +357,22 @@ export async function startNativeSession(harness) {
       driver,
       tauriDriver,
       async close() {
+        if (
+          harness.watchMode &&
+          process.env.WARDIAN_E2E_WATCH_KEEP_OPEN !== "0" &&
+          process.stdin.isTTY
+        ) {
+          const rl = readline.createInterface({
+            input: process.stdin,
+            output: process.stdout,
+          });
+          try {
+            await rl.question("[native-watch] Press Enter to close the Wardian test window...");
+          } finally {
+            rl.close();
+          }
+        }
+
         try {
           await driver.quit();
         } finally {
@@ -330,11 +389,66 @@ export async function startNativeSession(harness) {
   }
 }
 
+export function formatAppShellTimeoutMessage({
+  timeoutMs,
+  currentUrl = "",
+  title = "",
+  bodyText = "",
+}) {
+  const details = [
+    `Timed out after ${timeoutMs}ms waiting for [data-testid="app-shell"].`,
+    `url: ${currentUrl || "<unknown>"}`,
+    `title: ${title || "<unknown>"}`,
+  ];
+
+  const lowerUrl = currentUrl.toLowerCase();
+  const lowerBody = bodyText.toLowerCase();
+  if (
+    lowerUrl.includes("localhost:1420") ||
+    lowerBody.includes("localhost refused to connect") ||
+    lowerBody.includes("this site can't be reached") ||
+    lowerBody.includes("this site can’t be reached")
+  ) {
+    details.push(
+      "The native WebView appears to be loading the Vite dev server, but the dev server is not reachable.",
+      "Start it with `npm run vite`, or rebuild the debug app with `npm run tauri -- build --debug --no-bundle` before using the fast native runner.",
+    );
+  }
+
+  const compactBody = compactText(bodyText);
+  if (compactBody) {
+    details.push(`body: ${compactBody}`);
+  }
+
+  return details.join("\n");
+}
+
+async function readAppShellDiagnostics(driver) {
+  try {
+    return await driver.executeScript(() => ({
+      currentUrl: window.location.href,
+      title: document.title,
+      bodyText: document.body?.innerText || "",
+    }));
+  } catch (error) {
+    return {
+      currentUrl: "",
+      title: "",
+      bodyText: `Unable to read WebView diagnostics: ${String(error)}`,
+    };
+  }
+}
+
 export async function waitForAppShell(driver, timeoutMs = 15000) {
-  const shell = await driver.wait(
-    until.elementLocated(By.css('[data-testid="app-shell"]')),
-    timeoutMs,
-  );
-  await driver.wait(until.elementIsVisible(shell), timeoutMs);
-  return shell;
+  try {
+    const shell = await driver.wait(
+      until.elementLocated(By.css('[data-testid="app-shell"]')),
+      timeoutMs,
+    );
+    await driver.wait(until.elementIsVisible(shell), timeoutMs);
+    return shell;
+  } catch (error) {
+    const diagnostics = await readAppShellDiagnostics(driver);
+    throw new Error(`${formatAppShellTimeoutMessage({ timeoutMs, ...diagnostics })}\n${error}`);
+  }
 }

--- a/e2e-native/tests/cli-shared-state-native.test.mjs
+++ b/e2e-native/tests/cli-shared-state-native.test.mjs
@@ -9,6 +9,7 @@ import {
   prepareIsolatedHome,
   startNativeSession,
   waitForAppShell,
+  watchStep,
 } from "../lib/harness.mjs";
 
 const skipNativeBuild = process.env.WARDIAN_NATIVE_SKIP_BUILD === "1";
@@ -17,6 +18,8 @@ const LIVE_SESSION_ID = `e2e-cli-live-${RUN_ID}`;
 const LIVE_SESSION_NAME = `E2E-CLI-LIVE-${RUN_ID}`;
 const OFF_SESSION_ID = `e2e-cli-off-${RUN_ID}`;
 const OFF_SESSION_NAME = `E2E-CLI-OFF-${RUN_ID}`;
+const CONTROL_SESSION_NAME = `E2E-CLI-CONTROL-${RUN_ID}`;
+const CONTROL_CLONE_NAME = `E2E-CLI-CONTROL-CLONE-${RUN_ID}`;
 
 function commandName(name) {
   return process.platform === "win32" ? `${name}.exe` : name;
@@ -57,6 +60,58 @@ function runCli(cliPath, harness, args) {
     stdout: result.stdout,
     stderr: result.stderr,
   };
+}
+
+async function withMockScenario(scenario, fn) {
+  const previousScenario = process.env.WARDIAN_MOCK_SCENARIO;
+  const previousDelay = process.env.WARDIAN_MOCK_DELAY_MS;
+  process.env.WARDIAN_MOCK_SCENARIO = scenario;
+  process.env.WARDIAN_MOCK_DELAY_MS = "50";
+  try {
+    return await fn();
+  } finally {
+    if (previousScenario === undefined) {
+      delete process.env.WARDIAN_MOCK_SCENARIO;
+    } else {
+      process.env.WARDIAN_MOCK_SCENARIO = previousScenario;
+    }
+    if (previousDelay === undefined) {
+      delete process.env.WARDIAN_MOCK_DELAY_MS;
+    } else {
+      process.env.WARDIAN_MOCK_DELAY_MS = previousDelay;
+    }
+  }
+}
+
+function runCliOk(cliPath, harness, args) {
+  const result = runCli(cliPath, harness, args);
+  assert.equal(
+    result.status,
+    0,
+    `wardian ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return result;
+}
+
+function cliField(cliPath, harness, target, field) {
+  return runCli(cliPath, harness, ["agent", target, "--field", field]);
+}
+
+async function waitForCliField(cliPath, harness, target, field, expected, timeoutMs = 30000) {
+  const startedAt = Date.now();
+  let lastResult = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    lastResult = cliField(cliPath, harness, target, field);
+    if (lastResult.status === 0 && lastResult.stdout.trim() === expected) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  assert.fail(
+    `Timed out waiting for ${target} ${field}=${expected}; last result: ${JSON.stringify(lastResult)}`,
+  );
 }
 
 async function createMockAgent(driver, workspacePath, { sessionId, sessionName, isOff }) {
@@ -210,4 +265,126 @@ test("native app-created off agent is readable through the CLI", { timeout: 1800
   ]);
   assert.equal(statusResult.status, 0, statusResult.stderr);
   assert.equal(statusResult.stdout, "off\n");
+});
+
+test("native CLI control commands operate through the running app", { timeout: 180000 }, async (t) => {
+  await withMockScenario("action_needed", async () => {
+    const harness = await createNativeHarness();
+    assert.ok(harness.appPath);
+
+    try {
+      if (!skipNativeBuild) {
+        ensureNativeAppBuilt(harness);
+      }
+    } catch (error) {
+      t.skip(String(error));
+      return;
+    }
+
+    prepareIsolatedHome(harness);
+
+    const cliPath = buildCli(harness);
+    const workspacePath = path.join(harness.repoRoot, "e2e-native");
+
+    let session;
+    try {
+      session = await startNativeSession(harness);
+    } catch (error) {
+      t.skip(String(error));
+      return;
+    }
+
+    t.after(async () => {
+      await session.close();
+    });
+
+    await waitForAppShell(session.driver, 20000);
+    await watchStep(harness, "Wardian app shell is ready");
+    const spawnResult = runCliOk(cliPath, harness, [
+      "agent",
+      "spawn",
+      "--provider",
+      "mock",
+      "--class",
+      "Reviewer",
+      "--name",
+      CONTROL_SESSION_NAME,
+      "--workspace",
+      workspacePath,
+      "--fields",
+      "name,class,provider,status",
+    ]);
+    const source = JSON.parse(spawnResult.stdout).agent;
+    assert.equal(source.name, CONTROL_SESSION_NAME);
+    assert.equal(source.class, "Reviewer");
+    assert.equal(source.provider, "mock");
+    await watchStep(harness, `Spawned ${CONTROL_SESSION_NAME} with mock action_required state through the CLI`);
+    await waitForCliField(
+      cliPath,
+      harness,
+      CONTROL_SESSION_NAME,
+      "status",
+      "action_required",
+    );
+
+    const waitResult = runCliOk(cliPath, harness, [
+      "agent",
+      "wait",
+      CONTROL_SESSION_NAME,
+      "--until",
+      "action_required",
+      "--timeout",
+      "30s",
+      "--field",
+      "status",
+    ]);
+    assert.equal(waitResult.stdout, "action_required\n");
+
+    await watchStep(harness, `Sending approval to ${CONTROL_SESSION_NAME} through the CLI`);
+    const sendResult = runCliOk(cliPath, harness, [
+      "send",
+      "y",
+      "--to",
+      CONTROL_SESSION_NAME,
+      "--wait-until",
+      "idle",
+      "--timeout",
+      "30s",
+    ]);
+    assert.equal(JSON.parse(sendResult.stdout).status, "idle");
+
+    await watchStep(harness, `Cloning ${CONTROL_SESSION_NAME} through the CLI`);
+    const cloneResult = runCliOk(cliPath, harness, [
+      "agent",
+      "clone",
+      CONTROL_SESSION_NAME,
+      "--name",
+      CONTROL_CLONE_NAME,
+    ]);
+    const cloneAgent = JSON.parse(cloneResult.stdout).agent;
+    assert.equal(cloneAgent.name, CONTROL_CLONE_NAME);
+    assert.notEqual(cloneAgent.uuid, source.uuid);
+    await waitForCliField(cliPath, harness, CONTROL_CLONE_NAME, "status", "action_required");
+
+    await watchStep(harness, `Pausing ${CONTROL_CLONE_NAME} through the CLI`);
+    runCliOk(cliPath, harness, ["agent", "pause", CONTROL_CLONE_NAME]);
+    await waitForCliField(cliPath, harness, CONTROL_CLONE_NAME, "status", "off");
+
+    await watchStep(harness, `Resuming ${CONTROL_CLONE_NAME} through the CLI`);
+    runCliOk(cliPath, harness, ["agent", "resume", CONTROL_CLONE_NAME]);
+    await waitForCliField(cliPath, harness, CONTROL_CLONE_NAME, "status", "action_required");
+
+    await watchStep(harness, `Killing ${CONTROL_CLONE_NAME} through the CLI`);
+    runCliOk(cliPath, harness, ["agent", "kill", CONTROL_CLONE_NAME]);
+    const killedShow = runCli(cliPath, harness, ["agent", CONTROL_CLONE_NAME]);
+    assert.equal(killedShow.status, 2, killedShow.stderr);
+    assert.match(killedShow.stderr, /"code":"not_found"/);
+  });
+});
+
+test.skip("real Codex CLI send submits without leaving residual prompt text", () => {
+  // @real-provider-only
+  // This needs a real Codex TUI session on Windows. The mock provider proves
+  // live control delivery and status waiting, but it cannot prove that Codex's
+  // compose field is cleared after injected PTY input is submitted.
 });

--- a/e2e-native/tests/native-preflight.test.mjs
+++ b/e2e-native/tests/native-preflight.test.mjs
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { assertNativePreflight } from "../lib/harness.mjs";
+import {
+  assertNativePreflight,
+  createNativeHarness,
+  formatAppShellTimeoutMessage,
+} from "../lib/harness.mjs";
 
 test("native preflight reports missing tauri-driver clearly", () => {
   assert.throws(
@@ -38,4 +42,42 @@ test("native preflight accepts macOS when required drivers are configured", () =
       nativeDriverPath: "/usr/local/bin/chromedriver",
     }),
   );
+});
+
+test("native harness reads watch mode settings from the environment", async () => {
+  const previousWatch = process.env.WARDIAN_E2E_WATCH;
+  const previousDelay = process.env.WARDIAN_E2E_STEP_DELAY_MS;
+  process.env.WARDIAN_E2E_WATCH = "1";
+  process.env.WARDIAN_E2E_STEP_DELAY_MS = "25";
+
+  try {
+    const harness = await createNativeHarness();
+
+    assert.equal(harness.watchMode, true);
+    assert.equal(harness.watchStepDelayMs, 25);
+  } finally {
+    if (previousWatch === undefined) {
+      delete process.env.WARDIAN_E2E_WATCH;
+    } else {
+      process.env.WARDIAN_E2E_WATCH = previousWatch;
+    }
+    if (previousDelay === undefined) {
+      delete process.env.WARDIAN_E2E_STEP_DELAY_MS;
+    } else {
+      process.env.WARDIAN_E2E_STEP_DELAY_MS = previousDelay;
+    }
+  }
+});
+
+test("native app shell timeout explains dev server connection failures", () => {
+  const message = formatAppShellTimeoutMessage({
+    timeoutMs: 20000,
+    currentUrl: "http://localhost:1420/",
+    title: "localhost",
+    bodyText: "This site can't be reached. localhost refused to connect.",
+  });
+
+  assert.match(message, /Vite dev server/);
+  assert.match(message, /npm run vite/);
+  assert.match(message, /npm run tauri -- build --debug --no-bundle/);
 });

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:e2e:ui": "playwright test --config e2e/playwright.config.ts --ui",
     "test:e2e:native": "node --test --test-concurrency=1 e2e-native/tests",
     "test:e2e:native:fast": "node scripts/run-native-e2e-fast.mjs",
+    "test:e2e:native:watch": "node scripts/run-native-e2e-watch.mjs",
     "setup:e2e:native": "node scripts/setup-native-e2e.mjs",
     "setup:e2e:native:windows": "npm run setup:e2e:native"
   },

--- a/scripts/run-native-e2e-watch.mjs
+++ b/scripts/run-native-e2e-watch.mjs
@@ -1,0 +1,32 @@
+import { spawn } from "node:child_process";
+
+const testTargets = process.argv.slice(2);
+const args = ["--test", "--test-concurrency=1"];
+
+if (testTargets.length > 0) {
+  args.push(...testTargets);
+} else {
+  args.push("e2e-native/tests");
+}
+
+console.log("[native-watch] Running native E2E in visible watch mode.");
+console.log("[native-watch] Rebuild first if the app window shows a localhost:1420 connection failure.");
+
+const child = spawn(process.execPath, args, {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    WARDIAN_NATIVE_SKIP_BUILD: "1",
+    WARDIAN_E2E_WATCH: "1",
+    WARDIAN_E2E_STEP_DELAY_MS: process.env.WARDIAN_E2E_STEP_DELAY_MS || "750",
+    WARDIAN_E2E_WATCH_KEEP_OPEN: process.env.WARDIAN_E2E_WATCH_KEEP_OPEN || "1",
+  },
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/scripts/setup-native-e2e.mjs
+++ b/scripts/setup-native-e2e.mjs
@@ -234,6 +234,7 @@ export function main(argv = process.argv.slice(2)) {
   console.log("Native E2E prerequisites are prepared.");
   console.log("Recommended next steps:");
   console.log("  npm run test:e2e:native");
+  console.log("  npm run test:e2e:native:watch -- e2e-native/tests/cli-shared-state-native.test.mjs");
   console.log("  WARDIAN_E2E_REAL_OPENCODE=1 npm run test:e2e:native");
 }
 

--- a/src-tauri/agent_prompts/Evolver.md
+++ b/src-tauri/agent_prompts/Evolver.md
@@ -1,25 +1,69 @@
 # Role: Evolver
 
-You are the Recursive Optimizer and System Evolver. Your mission is the continuous improvement of yourself, other agents in the swarm, and the overall system ecosystem.
+You are Wardian's recursive optimizer and system evolver. Your mission is to
+improve Wardian, its agents, their shared resources, and the workflows that make
+the whole system more capable over time.
 
 ## Core Mission
 
-To analyze performance, identify systemic failures, and evolve the capabilities of the agent swarm through recursive learning and optimization.
+Analyze recent agent behavior, identify systemic failures, and turn repeated
+lessons into durable improvements for Wardian agents.
+
+## Wardian-First Analysis
+
+Immediately activate and use the `wardian-cli` skill whenever investigating
+Wardian behavior, agent failures, workflows, skills, class prompts, workspaces,
+or peer-agent coordination.
+
+Start by inspecting the live and persisted agent picture:
+
+```bash
+wardian agent list --scope all --fields name,uuid,class,provider,workspace,status,status_source
+wardian agent list --scope all --verbose
+```
+
+Use Wardian status, workspaces, transcripts, class instructions, skills, and
+workflow definitions as evidence. Do not diagnose agent failures from memory or
+UI impressions alone.
 
 ## Capabilities & Tool Usage
 
-- **Recursive Self-Optimization**: Proactively identify and implement improvements to your own prompt, tool usage strategies, and decision-making logic.
-- **Systemic Analysis**: Use codebase and environment analysis tools to identify architectural bottlenecks or recurring failure patterns.
-- **Meta-Learning**: Proactively search for transient learnings in local directories (e.g., `.learnings/`) and promote them to global project knowledge (e.g., `AGENTS.md`, `MEMORY.md`, or `CLAUDE.md`).
-- **Capability Extension**: Design and implement new workflows, templates, or automation patterns to handle recurring complex tasks more efficiently.
+- **Failure Analysis**: Trace failed, stuck, crashed, timed-out, or
+  action-required agents back to their prompts, skills, provider behavior,
+  workspace state, and recent interactions.
+- **Resource Improvement**: Update class prompts, Wardian skills, guides, specs,
+  and reusable workflow definitions when a failure reveals a durable gap.
+- **Workflow Evolution**: Inspect and improve Wardian workflows so successful
+  multi-agent patterns become repeatable.
+- **Skill Evolution**: Create or revise skills when agents repeatedly need the
+  same operational knowledge or tool procedure.
+- **Meta-Learning**: Promote transient learnings from local notes or task
+  transcripts into durable project knowledge such as `AGENTS.md`, class
+  instructions, docs, specs, or skills.
 
 ## Common Tasks
 
-- **Prompt Engineering**: Refactoring your own or other agents' prompts based on user feedback, edge-case failures, or performance data.
-- **Workflow Automation**: Creating new modular procedures to streamline repetitive development or research tasks.
-- **Knowledge Synthesis**: Consolidating dispersed project notes and learnings into a structured, easily accessible knowledge base.
-- **Performance Auditing**: Analyzing successful and failed task executions to extract best practices and prevent future regressions.
+- Investigating why agents failed, became unresponsive, missed instructions, or
+  produced unusable output.
+- Auditing whether class instructions and skills match the current Wardian CLI
+  and runtime surface.
+- Turning repeated manual coordination steps into Wardian workflows.
+- Improving skills that expand what Wardian agents can reliably do.
+- Updating docs and specs when the system's actual behavior has evolved.
+
+## Operating Loop
+
+1. Gather evidence from Wardian CLI state, relevant files, transcripts, and test
+   results.
+2. Identify the smallest systemic cause rather than blaming one isolated agent
+   response.
+3. Patch the durable resource: prompt, skill, workflow, test, guide, spec, or
+   runtime code.
+4. Verify the improvement at the lowest meaningful layer.
+5. Leave a concise record of the failure mode and the resource that now prevents
+   or detects it.
 
 ## Operational Directive
 
-You treat the system's current state as a baseline for improvement. Your role is to think ahead and ensure that every interaction leaves the system smarter, more efficient, and better documented than it was before.
+Every improvement should make future Wardian agents more capable, more reliable,
+or better coordinated. Prefer durable system resources over one-off advice.

--- a/src-tauri/agent_prompts/Orchestrator.md
+++ b/src-tauri/agent_prompts/Orchestrator.md
@@ -1,25 +1,105 @@
 # Role: Orchestrator
 
-You are the Swarm Commander and Chief of Staff. Your mission is the strategic coordination, delegation, and governance of all active agents and tasks within the system.
+You are Wardian's command coordinator and chief of staff. Your mission is strategic
+coordination, delegation, and governance of active Wardian agents and tasks.
 
 ## Core Mission
 
-To decompose high-level user objectives into specialized, manageable tasks and oversee the collective output of the agent swarm to ensure alignment with the overall goal.
+Decompose high-level user objectives into specialized, manageable work units,
+assign those units to the most suitable agents, monitor progress, and synthesize
+the collective output into a coherent result.
 
-## Capabilities & Tool Usage
+## Wardian-First Directive
 
-- **Strategic Delegation**: Use coordination and assignment tools to route sub-tasks to the most qualified specialized agents (e.g., Architect, Coder, QA).
-- **Consolidated Governance**: Monitor the progress of all active agents, ensuring each remains focused on their assigned mission and adheres to project-wide standards.
-- **Synchronized Reporting**: Synthesize multiple agent outputs into a single, cohesive, and actionable report for the user or system logs.
-- **Inter-Agent Communication**: Identify when agents need to share context, dependencies, or results, and facilitate the necessary data flow between them.
+For almost every non-trivial task, operate through other Wardian agents using
+Wardian's own CLI and agent runtime. Treat the local terminal as the command
+center, not the only worker.
+
+Immediately activate and use the `wardian-cli` skill whenever a request involves
+Wardian, agents, peers, delegation, reviews, workflows, status, workspaces, or
+cross-agent coordination.
+
+Start by inspecting the live roster:
+
+```bash
+wardian agent list --scope all --fields name,uuid,class,provider,workspace,status,status_source
+```
+
+Then choose one of these paths:
+
+- Reuse an idle, suitable peer when one exists.
+- Spawn a new peer with explicit `--provider`, `--class`, `--name`, and
+  `--workspace` when no suitable peer exists.
+- Clone only when intentionally preserving the source agent's class, provider,
+  workspace, and context.
+
+## Delegation Bias
+
+Delegate aggressively:
+
+- Ask Reviewers to review patches, plans, specs, and branch diffs.
+- Ask Architects to design or challenge approaches before broad implementation.
+- Ask Coders to implement bounded slices with clear file ownership.
+- Ask QA agents to write tests, define verification plans, and run targeted
+  checks.
+- Ask Researchers to collect external or repository context.
+- Ask Editors to refine user-facing docs, PR text, and release notes.
+
+Keep only tight coordination, integration, final judgment, and urgent blocking
+steps local. Do not create parallel agents that will edit the same files unless
+you explicitly assign disjoint ownership and reconcile the result yourself.
+
+## Operating Loop
+
+1. Understand the user's objective and identify separable subtasks.
+2. Inspect the roster with `wardian agent list --scope all`.
+3. Assign each substantial subtask to a suitable existing or newly spawned agent.
+4. Send bounded prompts that specify output shape, scope, constraints, and where
+   to report results.
+5. Wait for completion with `wardian agent wait` or `wardian send --wait-until`
+   when the target and provider support reliable status transitions.
+6. Read and synthesize peer outputs; do not blindly forward them.
+7. Resolve conflicts, integrate patches, run verification, and report the final
+   state to the user.
+8. Kill temporary agents when their assigned work is complete.
+
+Example:
+
+```bash
+wardian agent spawn --provider codex --class Reviewer --name review-current-branch --workspace D:/Development/Wardian
+wardian send --stdin --to review-current-branch --wait-until idle --timeout 10m
+wardian agent kill review-current-branch
+```
+
+## Governance
+
+- Maintain a clear task map: who owns each subtask, which files or systems they
+  may touch, and what output is expected.
+- Prefer small, checkable assignments over broad prompts.
+- Verify status and delivery. If a peer does not respond, times out, or appears
+  stuck, report the failure and reroute the work.
+- Keep the user's newest instruction authoritative across all delegated work.
+- Never let delegation replace final integration, testing, or accountable
+  decision-making.
 
 ## Common Tasks
 
-- **Objective Decomposition**: Breaking a complex request (e.g., "Build a new feature") into logical sub-tasks for Architect, Coder, and QA roles.
-- **Verification Management**: Ensuring that each component of a multi-stage task is validated and verified before proceeding to the next step.
-- **Conflict Resolution**: Identifying and resolving potential bottlenecks or contradictions between the outputs of different agents.
-- **Stakeholder Synthesis**: Providing the user with a high-level summary of the entire swarm's progress, highlighting key achievements and pending approvals.
+- Objective decomposition for complex features, migrations, or release work.
+- Multi-agent code review, including one reviewer for recent changes and another
+  for all changes since the base branch.
+- Verification management across frontend, backend, browser E2E, native E2E,
+  and provider-specific checks.
+- Conflict resolution between agent outputs.
+- Stakeholder synthesis: concise status, findings, risks, and next actions.
+
+## Tool Boundary
+
+Your coordination surface is Wardian. Do not rely on generic external
+coordination systems for core agent orchestration. Use Wardian agent state,
+Wardian live control commands, and Wardian-managed peers.
 
 ## Operational Directive
 
-You own the user's objective from inception to completion. Your role is not to perform the technical work yourself, but to manage the "brainpower" of the swarm effectively. You are the ultimate defender of the project's timeline and quality standards.
+You own the user's objective from inception to completion. Your job is to make
+Wardian's agent system useful in practice: route work, keep agents coordinated,
+verify the result, and hand back a single actionable answer.

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -1,22 +1,34 @@
 ---
 name: wardian-cli
-description: Use when an agent needs to inspect Wardian agent identity, list peers, check live or persisted agent status, find workspaces, or use the Wardian command-line interface from inside a Wardian-managed process or local terminal.
+description: "Use immediately when a request mentions Wardian, Wardian agents, other agents, peers, delegation, orchestration, workflows, agent identity, agent status, agent workspaces, live or persisted Wardian state, the Wardian CLI, or any interaction from inside a Wardian-managed terminal."
 ---
 
 # Wardian CLI
 
-Use the `wardian` command to inspect Wardian agents from a terminal. Prefer it over guessing from UI state or filesystem files.
+Use the `wardian` command as the first source of truth for Wardian state and
+peer-agent coordination. Prefer it over guessing from UI state, terminal titles,
+or filesystem inspection.
 
-## Quick Start
+## First Moves
+
+When a task involves Wardian or another agent:
+
+1. Inspect yourself if you are inside a Wardian-managed terminal.
+2. Inspect the live roster with `--scope all`.
+3. Pick an idle, suitable peer by class, provider, workspace, and status.
+4. Spawn an explicit class/provider peer when no suitable peer exists.
+5. Send bounded instructions, wait or poll for completion, collect the response,
+   then kill temporary agents when they are no longer needed.
 
 ```bash
-wardian agent list --scope all
-wardian agent list --scope all --fields name,class,provider,workspace,status
-wardian agent <name-or-uuid>
-wardian agent show <name-or-uuid>
+wardian agent
+wardian agent list --scope all --fields name,uuid,class,provider,workspace,status,status_source
+wardian agent <name-or-uuid> --fields name,uuid,class,provider,workspace,status,status_source
 ```
 
-`wardian agent` and `wardian agent show` without a target mean "show the current agent." They require `WARDIAN_SESSION_ID`, so they usually work only inside a Wardian-managed agent terminal.
+`wardian agent` and `wardian agent show` without a target mean "show the current
+agent." They require `WARDIAN_SESSION_ID`, so they usually work only inside a
+Wardian-managed agent terminal.
 
 From an ordinary terminal, pass a target:
 
@@ -25,27 +37,22 @@ wardian agent show Wardian-Codex
 wardian agent show 019d331a-0500-7592-969f-8f437886f42b
 ```
 
-## Output
+## Agent Listing And Output
 
-Default output is indented JSON:
-
-```json
-{
-  "schema": 1,
-  "agents": [
-    {
-      "name": "Wardian-Codex",
-      "uuid": "019d331a-0500-7592-969f-8f437886f42b",
-      "class": "Coder",
-      "provider": "codex",
-      "workspace": "D:/Development/Wardian",
-      "status": "idle"
-    }
-  ]
-}
+```bash
+wardian agent list
+wardian agent list --scope all
+wardian agent list --scope all --status idle
+wardian agent list --scope all --class Coder
+wardian agent list --workspace D:/Development/Wardian
 ```
 
-Use `--field` for shell-friendly bare values:
+Default list scope is `workspace` when the caller is a Wardian agent with a
+known workspace; otherwise it falls back to all agents. Use `--scope all` for
+coordination, review routing, or any cross-agent task.
+
+Default output is indented JSON with `schema: 1`. Use `--field` for
+shell-friendly bare values:
 
 ```bash
 wardian agent Wardian-Codex --field status
@@ -59,43 +66,129 @@ wardian agent list --scope all --fields name,status
 wardian agent list --scope all --fields name,status,status_source
 ```
 
-`status_source` is hidden by default. Request it when you need to know whether the answer came from the running desktop app or persisted state:
+`status_source` is hidden by default. Request it when you need to know whether
+the answer came from the running desktop app or persisted state:
 
 - `live` means the running desktop app answered.
 - `persisted` means the CLI fell back to `state.db`.
 
-## Listing Agents
+Use `--verbose` for `pid`, `started_at`, and `last_status_at`. Use `--pretty`
+only for human-readable terminal inspection; automation should keep JSON.
+
+## Lifecycle Control
+
+Mutating commands use Wardian's local control endpoint and require the desktop
+app to be running for the same `WARDIAN_HOME`.
 
 ```bash
-wardian agent list
-wardian agent list --scope all
-wardian agent list --scope all --status idle
-wardian agent list --scope all --class Coder
-wardian agent list --workspace D:/Development/Wardian
+wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace D:/Development/Wardian
+wardian agent clone coder-a1 --name coder-a2
+wardian agent pause reviewer-a1
+wardian agent resume reviewer-a1
+wardian agent kill reviewer-a1
+wardian agent wait reviewer-a1 --until idle --timeout 10m
 ```
 
-Default list scope is `workspace` when the caller is a Wardian agent with a known workspace; otherwise it falls back to all agents. Use `--scope all` when you need the full roster.
+`agent spawn` requires both `--provider` and `--class`; do not rely on implicit
+defaults when creating agents. `agent clone` copies the source agent's provider,
+class, workspace, and context unless the CLI offers an override for the field
+you need.
 
-## Show Agent
+`agent wait <target> --until <status>` blocks until a single agent name or UUID
+reaches a normalized status such as `idle`, `processing`, `action_required`,
+`off`, or `error`. Use `--timeout` with `ms`, `s`, or `m` units.
+
+## Sending Messages
+
+Use `wardian send` for live inter-agent communication:
 
 ```bash
-wardian agent <name-or-uuid>
-wardian agent show <name-or-uuid>
-wardian agent show <name-or-uuid> --fields name,class,provider,workspace,status
-wardian agent show <name-or-uuid> --pretty
+wardian send "review this patch" --to reviewer-a1
+wardian send --stdin --to reviewer-a1
+wardian send --file prompt.md --to reviewer-a1
+wardian send "status?" --to class:Coder
+wardian send "stand down" --to all
+wardian send "review this patch" --to reviewer-a1 --wait-until idle --timeout 10m
 ```
 
-## Errors
+Targets can be an agent name, UUID, `class:<ClassName>`, or `all`. Use
+`--wait-until` only with a single-agent target; broadcasts are for messages that
+should not block the current command.
+
+`--thread` is reserved for grouped conversations. Until threading is implemented
+end-to-end, the running app rejects it with `not_supported` instead of silently
+dropping it.
+
+For substantial prompts, prefer `--stdin` or `--file` so quoting does not damage
+the instruction:
+
+```powershell
+@"
+Review the changes since origin/main.
+Return findings first, then tests run, then any residual risk.
+"@ | wardian send --stdin --to reviewer-a1 --wait-until idle --timeout 10m
+```
+
+## Workflows
+
+```bash
+wardian workflow list
+wardian workflow show <id-or-name>
+wardian workflow run <id>
+wardian workflow stop <run-instance-id>
+```
+
+`workflow list` and `workflow show` try the running app first, then read
+workflow JSON files from disk when the app is unavailable. `workflow run` and
+`workflow stop` require the running app.
+
+Malformed workflow files may be reported as warnings or omitted depending on
+the CLI version. If `show` cannot find a workflow that exists on disk, inspect
+the workflow JSON for parse errors.
+
+## Orchestration Pattern
+
+For multi-agent work, route through Wardian instead of handling every subtask in
+one terminal:
+
+```bash
+wardian agent list --scope all --fields name,class,provider,workspace,status
+wardian agent spawn --provider codex --class Reviewer --name review-cli-surface --workspace D:/Development/Wardian
+wardian send --stdin --to review-cli-surface --wait-until idle --timeout 10m
+wardian agent kill review-cli-surface
+```
+
+Good delegated tasks are bounded and independently checkable: code review,
+targeted repository exploration, documentation audits, verification runs, and
+implementation slices with disjoint file ownership. Keep urgent blocking work
+local when your next step depends on it, but use peers aggressively for parallel
+analysis and validation.
+
+Always tell temporary peers what output shape you need and where to send it.
+After waiting, verify status and read the peer's response from the active
+terminal, transcript, or returned control output when available. Real PTY input
+delivery can vary by provider and platform, especially on Windows, so treat
+timeouts or missing responses as delivery failures and report them plainly.
+
+## Exit Codes And Errors
 
 Errors are JSON on stderr. Common cases:
 
-- `not_in_session`: self lookup was requested outside a Wardian-managed process. Pass an explicit name or UUID.
-- `not_found`: the requested name or UUID was not found. Run `wardian agent list --scope all --fields name,uuid`.
-- `db_unavailable`: no live app answered and `state.db` was unavailable. Open Wardian or set `WARDIAN_HOME` to the expected home.
+- `not_in_session`: self lookup was requested outside a Wardian-managed process.
+  Pass an explicit name or UUID.
+- `not_found`: the requested name or UUID was not found. Run
+  `wardian agent list --scope all --fields name,uuid`.
+- `ambiguous`: a name matched multiple agents. Use the UUID.
+- `db_unavailable`: no live app answered and `state.db` was unavailable.
+- `app_not_running`: a live-control command could not reach the desktop app.
+  This maps to exit code 6.
+- `not_supported`: the command shape is recognized but not implemented by the
+  running app yet, such as `send --thread`.
 
 ## Development Notes
 
-When testing a dev app and CLI together, set the same `WARDIAN_HOME` in both terminals. The live control endpoint is keyed by `WARDIAN_HOME`.
+When testing a dev app and CLI together, set the same `WARDIAN_HOME` in both
+terminals. The live control endpoint is keyed by `WARDIAN_HOME`.
 
 PowerShell:
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -307,6 +307,95 @@ fn restore_runtime_state_snapshot_after_resume(
     }
 }
 
+fn promote_fresh_provider_session_after_resume(
+    provider: &str,
+    new_active: &mut crate::state::ActiveAgent,
+) {
+    if provider != "claude" {
+        return;
+    }
+
+    let mut new_config = new_active.config.lock().unwrap();
+    if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take() {
+        new_config.resume_session = Some(fresh_provider_session_id);
+    }
+}
+
+fn sync_resumed_input_sender(
+    state: &AppState,
+    session_id: &str,
+    stdin_tx: Option<tokio::sync::mpsc::Sender<Vec<u8>>>,
+) {
+    if let Ok(mut senders) = state.input_senders.write() {
+        if let Some(tx) = stdin_tx {
+            senders.insert(session_id.to_string(), tx);
+        } else {
+            senders.remove(session_id);
+        }
+    }
+}
+
+fn agent_status_update_payload(session_id: &str, current_status: &str) -> serde_json::Value {
+    serde_json::json!({
+        "session_id": session_id,
+        "current_status": current_status,
+    })
+}
+
+struct ResumeRuntimeSnapshot {
+    config: AgentConfig,
+    init_timestamp: Option<String>,
+    query_count: usize,
+    log_path: Option<std::path::PathBuf>,
+}
+
+fn capture_resume_runtime_snapshot(agent: &crate::state::ActiveAgent) -> ResumeRuntimeSnapshot {
+    ResumeRuntimeSnapshot {
+        config: agent.config.lock().unwrap().clone(),
+        init_timestamp: agent.init_timestamp.lock().unwrap().clone(),
+        query_count: agent.query_count.lock().map(|count| *count).unwrap_or(0),
+        log_path: agent.log_path.lock().ok().and_then(|path| path.clone()),
+    }
+}
+
+fn capture_opencode_pause_resume_session(agent: &crate::state::ActiveAgent) {
+    let provider = {
+        let config = agent.config.lock().unwrap();
+        config.provider.clone()
+    };
+
+    if provider != "opencode" {
+        return;
+    }
+
+    let mut config = agent.config.lock().unwrap();
+    if config
+        .resume_session
+        .as_deref()
+        .map(|s| !s.starts_with("ses_"))
+        .unwrap_or(true)
+    {
+        let log_path_snap = agent.log_path.lock().ok().and_then(|guard| guard.clone());
+        if let Some(log_path) = log_path_snap {
+            if let Some(ses_id) = manager::opencode_extract_created_session_id(&log_path) {
+                config.resume_session = Some(ses_id);
+            }
+        }
+    }
+}
+
+fn mark_agent_paused_off(agent: &mut crate::state::ActiveAgent) {
+    agent.pty_master = None;
+    agent.stdin_tx = None;
+    {
+        let mut config = agent.config.lock().unwrap();
+        config.is_off = true;
+    }
+    if let Ok(mut status) = agent.current_status.lock() {
+        *status = "Off".to_string();
+    }
+}
+
 fn is_valid_name(name: &str) -> bool {
     let re = regex::Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap();
     re.is_match(name)
@@ -999,38 +1088,10 @@ pub async fn pause_agent(
 
         // For opencode: capture the real ses_xxx session ID from the log so
         // resume can pass --session ses_xxx rather than the internal UUID.
-        let provider = {
-            let config = agent.config.lock().unwrap();
-            config.provider.clone()
-        };
+        capture_opencode_pause_resume_session(agent);
+        mark_agent_paused_off(agent);
 
-        if provider == "opencode" {
-            let mut config = agent.config.lock().unwrap();
-            if config
-                .resume_session
-                .as_deref()
-                .map(|s| !s.starts_with("ses_"))
-                .unwrap_or(true)
-            {
-                let log_path_snap = agent.log_path.lock().ok().and_then(|guard| guard.clone());
-                if let Some(log_path) = log_path_snap {
-                    if let Some(ses_id) = manager::opencode_extract_created_session_id(&log_path) {
-                        config.resume_session = Some(ses_id);
-                    }
-                }
-            }
-        }
-
-        agent.pty_master = None;
-        agent.stdin_tx = None;
-        {
-            let mut config = agent.config.lock().unwrap();
-            config.is_off = true;
-        }
         // Remove from input_senders
-        if let Ok(mut status) = agent.current_status.lock() {
-            *status = "Off".to_string();
-        }
         if let Ok(mut senders) = state.input_senders.write() {
             senders.remove(&session_id);
         }
@@ -1038,10 +1099,7 @@ pub async fn pause_agent(
         let _ = app.emit("agents-updated", ());
         let _ = app.emit(
             "agent-status-updated",
-            serde_json::json!({
-                "session_id": session_id,
-                "current_status": "Off",
-            }),
+            agent_status_update_payload(&session_id, "Off"),
         );
         Ok(())
     } else {
@@ -1059,31 +1117,30 @@ pub async fn resume_agent(
         "[WARDIAN] resume_agent called for session: {}",
         session_id
     ));
-    let (mut config, born, query_count, log_path) = {
+    let snapshot = {
         let agents = state.agents.lock().await;
         let agent = agents
             .get(&session_id)
             .ok_or_else(|| format!("Agent {} not found", session_id))?;
-        let config = agent.config.lock().unwrap().clone();
-        let born = agent.init_timestamp.lock().unwrap().clone();
-        let query_count = agent.query_count.lock().map(|count| *count).unwrap_or(0);
-        let log_path = agent.log_path.lock().ok().and_then(|path| path.clone());
-        (config, born, query_count, log_path)
+        capture_resume_runtime_snapshot(agent)
     };
 
+    let mut config = snapshot.config;
     prepare_resume_config(&mut config)?;
-    let mut new_active =
-        manager::spawn_agent(app.clone(), config.clone(), true, born.clone()).await?;
-    restore_runtime_state_snapshot_after_resume(&mut new_active, query_count, born, log_path);
-
-    {
-        let mut new_config = new_active.config.lock().unwrap();
-        if config.provider == "claude" {
-            if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take() {
-                new_config.resume_session = Some(fresh_provider_session_id);
-            }
-        }
-    }
+    let mut new_active = manager::spawn_agent(
+        app.clone(),
+        config.clone(),
+        true,
+        snapshot.init_timestamp.clone(),
+    )
+    .await?;
+    restore_runtime_state_snapshot_after_resume(
+        &mut new_active,
+        snapshot.query_count,
+        snapshot.init_timestamp,
+        snapshot.log_path,
+    );
+    promote_fresh_provider_session_after_resume(&config.provider, &mut new_active);
 
     let stdin_tx = new_active.stdin_tx.clone();
     let mut old_agent = {
@@ -1098,21 +1155,12 @@ pub async fn resume_agent(
         old_agent
     };
 
-    if let Ok(mut senders) = state.input_senders.write() {
-        if let Some(tx) = stdin_tx {
-            senders.insert(session_id.clone(), tx);
-        } else {
-            senders.remove(&session_id);
-        }
-    }
+    sync_resumed_input_sender(&state, &session_id, stdin_tx);
 
     let _ = app.emit("agents-updated", ());
     let _ = app.emit(
         "agent-status-updated",
-        serde_json::json!({
-            "session_id": session_id,
-            "current_status": "Idle",
-        }),
+        agent_status_update_payload(&session_id, "Idle"),
     );
     manager::terminate_active_agent_process(&mut old_agent);
     Ok(())
@@ -1407,13 +1455,16 @@ pub async fn reorder_agents(
 #[cfg(test)]
 mod tests {
     use super::{
-        clone_copy_agent_profile_files, clone_ensure_profile_destination_available,
-        clone_sanitize_config, clone_unique_name, codex_provider_session_is_new,
-        generated_agent_name, insert_new_agent_order, normalize_spawn_folder,
-        persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
+        agent_status_update_payload, capture_opencode_pause_resume_session,
+        capture_resume_runtime_snapshot, clone_copy_agent_profile_files,
+        clone_ensure_profile_destination_available, clone_sanitize_config, clone_unique_name,
+        codex_provider_session_is_new, generated_agent_name, insert_new_agent_order,
+        mark_agent_paused_off, normalize_spawn_folder, persisted_resume_session_for_provider,
+        prepare_clear_config, prepare_resume_config, promote_fresh_provider_session_after_resume,
         provider_needs_obtain_session_id_on_clear, provider_uses_generated_session_id,
         reserve_spawn_session_name, resolve_requested_spawn_session_name,
-        restore_runtime_state_snapshot_after_resume, AgentOrderPlacement,
+        restore_runtime_state_snapshot_after_resume, sync_resumed_input_sender,
+        AgentOrderPlacement,
     };
     use crate::state::{ActiveAgent, AppState};
     use crate::utils::fs::create_directory_link;
@@ -1861,6 +1912,154 @@ mod tests {
         assert_eq!(
             new_active.log_path.lock().unwrap().as_deref(),
             Some(std::path::Path::new("C:/tmp/session.json"))
+        );
+    }
+
+    #[test]
+    fn claude_resume_promotes_fresh_provider_session_to_resume_session() {
+        let mut new_active = make_test_agent();
+        {
+            let mut config = new_active.config.lock().unwrap();
+            config.fresh_provider_session_id = Some("claude-fresh-session".to_string());
+            config.resume_session = None;
+        }
+
+        promote_fresh_provider_session_after_resume("claude", &mut new_active);
+
+        let config = new_active.config.lock().unwrap();
+        assert_eq!(
+            config.resume_session.as_deref(),
+            Some("claude-fresh-session")
+        );
+        assert_eq!(config.fresh_provider_session_id, None);
+    }
+
+    #[test]
+    fn non_claude_resume_keeps_fresh_provider_session_field() {
+        let mut new_active = make_test_agent();
+        {
+            let mut config = new_active.config.lock().unwrap();
+            config.fresh_provider_session_id = Some("provider-session".to_string());
+            config.resume_session = None;
+        }
+
+        promote_fresh_provider_session_after_resume("codex", &mut new_active);
+
+        let config = new_active.config.lock().unwrap();
+        assert_eq!(config.resume_session, None);
+        assert_eq!(
+            config.fresh_provider_session_id.as_deref(),
+            Some("provider-session")
+        );
+    }
+
+    #[test]
+    fn sync_resumed_input_sender_inserts_or_removes_sender() {
+        let state = AppState::new();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+
+        sync_resumed_input_sender(&state, "agent-1", Some(tx));
+        assert!(state.input_senders.read().unwrap().contains_key("agent-1"));
+
+        sync_resumed_input_sender(&state, "agent-1", None);
+        assert!(!state.input_senders.read().unwrap().contains_key("agent-1"));
+    }
+
+    #[test]
+    fn agent_status_update_payload_uses_frontend_status_contract() {
+        assert_eq!(
+            agent_status_update_payload("agent-1", "Idle"),
+            serde_json::json!({
+                "session_id": "agent-1",
+                "current_status": "Idle",
+            })
+        );
+    }
+
+    #[test]
+    fn capture_resume_runtime_snapshot_reads_resume_fields_without_holding_state_locks() {
+        let active = make_test_agent();
+        {
+            let mut config = active.config.lock().unwrap();
+            config.session_id = "agent-1".to_string();
+            config.provider = "codex".to_string();
+        }
+        *active.init_timestamp.lock().unwrap() = Some("2026-05-07T00:00:00Z".to_string());
+        *active.query_count.lock().unwrap() = 7;
+        *active.log_path.lock().unwrap() = Some(std::path::PathBuf::from("D:/tmp/agent.log"));
+
+        let snapshot = capture_resume_runtime_snapshot(&active);
+
+        assert_eq!(snapshot.config.session_id, "agent-1");
+        assert_eq!(snapshot.config.provider, "codex");
+        assert_eq!(
+            snapshot.init_timestamp.as_deref(),
+            Some("2026-05-07T00:00:00Z")
+        );
+        assert_eq!(snapshot.query_count, 7);
+        assert_eq!(
+            snapshot.log_path.as_deref(),
+            Some(std::path::Path::new("D:/tmp/agent.log"))
+        );
+    }
+
+    #[test]
+    fn mark_agent_paused_off_clears_runtime_channels_and_status() {
+        let mut active = make_test_agent();
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        active.stdin_tx = Some(tx);
+        {
+            let mut config = active.config.lock().unwrap();
+            config.is_off = false;
+        }
+
+        mark_agent_paused_off(&mut active);
+
+        assert!(active.stdin_tx.is_none());
+        assert!(active.pty_master.is_none());
+        assert!(active.config.lock().unwrap().is_off);
+        assert_eq!(active.current_status.lock().unwrap().as_str(), "Off");
+    }
+
+    #[test]
+    fn opencode_pause_captures_real_session_id_from_log() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let log_path = temp.path().join("opencode.log");
+        std::fs::write(
+            &log_path,
+            "INFO service=session id=ses_old created\nINFO service=session id=ses_new created\n",
+        )
+        .expect("write opencode log");
+        let active = make_test_agent();
+        {
+            let mut config = active.config.lock().unwrap();
+            config.provider = "opencode".to_string();
+            config.resume_session = Some("stale-uuid".to_string());
+        }
+        *active.log_path.lock().unwrap() = Some(log_path);
+
+        capture_opencode_pause_resume_session(&active);
+
+        assert_eq!(
+            active.config.lock().unwrap().resume_session.as_deref(),
+            Some("ses_new")
+        );
+    }
+
+    #[test]
+    fn opencode_pause_keeps_existing_real_session_id() {
+        let active = make_test_agent();
+        {
+            let mut config = active.config.lock().unwrap();
+            config.provider = "opencode".to_string();
+            config.resume_session = Some("ses_existing".to_string());
+        }
+
+        capture_opencode_pause_resume_session(&active);
+
+        assert_eq!(
+            active.config.lock().unwrap().resume_session.as_deref(),
+            Some("ses_existing")
         );
     }
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -283,32 +283,27 @@ fn persisted_resume_session_for_provider(
 }
 
 fn provider_uses_generated_session_id(provider_name: &str) -> bool {
-    matches!(provider_name, "claude" | "codex")
+    matches!(provider_name, "claude" | "codex" | "mock")
 }
 
 fn provider_needs_obtain_session_id_on_clear(provider_name: &str) -> bool {
     matches!(provider_name, "gemini")
 }
 
-fn restore_runtime_state_after_resume(
+fn restore_runtime_state_snapshot_after_resume(
     new_active: &mut crate::state::ActiveAgent,
-    old_active: &crate::state::ActiveAgent,
+    query_count: usize,
+    init_timestamp: Option<String>,
+    log_path: Option<std::path::PathBuf>,
 ) {
-    if let (Ok(old_count), Ok(mut new_count)) =
-        (old_active.query_count.lock(), new_active.query_count.lock())
-    {
-        *new_count = *old_count;
+    if let Ok(mut new_count) = new_active.query_count.lock() {
+        *new_count = query_count;
     }
-    if let (Ok(old_ts), Ok(mut new_ts)) = (
-        old_active.init_timestamp.lock(),
-        new_active.init_timestamp.lock(),
-    ) {
-        *new_ts = old_ts.clone();
+    if let Ok(mut new_ts) = new_active.init_timestamp.lock() {
+        *new_ts = init_timestamp;
     }
-    if let (Ok(old_path), Ok(mut new_path)) =
-        (old_active.log_path.lock(), new_active.log_path.lock())
-    {
-        *new_path = old_path.clone();
+    if let Ok(mut new_path) = new_active.log_path.lock() {
+        *new_path = log_path;
     }
 }
 
@@ -958,6 +953,7 @@ pub async fn kill_agent(
 
         // Phase 2: Remove from SQLite
         let _ = wardian_core::db::delete_agent(&session_id);
+        let _ = app.emit("agents-updated", ());
 
         // Cleanup: remove the agent's private directory
         if let Some(home) = crate::utils::fs::get_wardian_home() {
@@ -1039,6 +1035,14 @@ pub async fn pause_agent(
             senders.remove(&session_id);
         }
         manager::save_state(&app, &agents, &order);
+        let _ = app.emit("agents-updated", ());
+        let _ = app.emit(
+            "agent-status-updated",
+            serde_json::json!({
+                "session_id": session_id,
+                "current_status": "Off",
+            }),
+        );
         Ok(())
     } else {
         Err(format!("Agent {} not found", session_id))
@@ -1055,52 +1059,63 @@ pub async fn resume_agent(
         "[WARDIAN] resume_agent called for session: {}",
         session_id
     ));
-    let mut agents = state.agents.lock().await;
-    let order = state.agent_order.lock().await;
+    let (mut config, born, query_count, log_path) = {
+        let agents = state.agents.lock().await;
+        let agent = agents
+            .get(&session_id)
+            .ok_or_else(|| format!("Agent {} not found", session_id))?;
+        let config = agent.config.lock().unwrap().clone();
+        let born = agent.init_timestamp.lock().unwrap().clone();
+        let query_count = agent.query_count.lock().map(|count| *count).unwrap_or(0);
+        let log_path = agent.log_path.lock().ok().and_then(|path| path.clone());
+        (config, born, query_count, log_path)
+    };
 
-    if let Some(agent) = agents.get_mut(&session_id) {
-        let (mut config, born) = {
-            let config_lock = agent.config.lock().unwrap();
-            (
-                config_lock.clone(),
-                agent.init_timestamp.lock().unwrap().clone(),
-            )
-        };
-        prepare_resume_config(&mut config)?;
-        let mut new_active = manager::spawn_agent(app.clone(), config, true, born).await?;
-        restore_runtime_state_after_resume(&mut new_active, agent);
+    prepare_resume_config(&mut config)?;
+    let mut new_active =
+        manager::spawn_agent(app.clone(), config.clone(), true, born.clone()).await?;
+    restore_runtime_state_snapshot_after_resume(&mut new_active, query_count, born, log_path);
 
-        {
-            let mut new_config = new_active.config.lock().unwrap();
-            let mut old_config = agent.config.lock().unwrap();
-            if old_config.provider == "claude" {
-                if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take()
-                {
-                    new_config.resume_session = Some(fresh_provider_session_id);
-                }
-            }
-            *old_config = new_config.clone();
-        }
-
-        // Register new input sender
-        if let Some(ref tx) = new_active.stdin_tx {
-            if let Ok(mut senders) = state.input_senders.write() {
-                senders.insert(session_id.clone(), tx.clone());
+    {
+        let mut new_config = new_active.config.lock().unwrap();
+        if config.provider == "claude" {
+            if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take() {
+                new_config.resume_session = Some(fresh_provider_session_id);
             }
         }
-
-        // Terminate the old agent's process tree before replacing it.
-        manager::terminate_active_agent_process(agent);
-
-        // Preserve the updated config on the new agent, then swap the entire struct.
-        // The old ActiveAgent is dropped here; its Drop impl is a no-op because
-        // terminate_active_agent_process already cleared process_id and child_process.
-        let _ = std::mem::replace(agent, new_active);
-        manager::save_state(&app, &agents, &order);
-        Ok(())
-    } else {
-        Err(format!("Agent {} not found", session_id))
     }
+
+    let stdin_tx = new_active.stdin_tx.clone();
+    let mut old_agent = {
+        let mut agents = state.agents.lock().await;
+        let order = state.agent_order.lock().await;
+        let Some(old_agent) = agents.remove(&session_id) else {
+            manager::terminate_active_agent_process(&mut new_active);
+            return Err(format!("Agent {} not found", session_id));
+        };
+        agents.insert(session_id.clone(), new_active);
+        manager::save_state(&app, &agents, &order);
+        old_agent
+    };
+
+    if let Ok(mut senders) = state.input_senders.write() {
+        if let Some(tx) = stdin_tx {
+            senders.insert(session_id.clone(), tx);
+        } else {
+            senders.remove(&session_id);
+        }
+    }
+
+    let _ = app.emit("agents-updated", ());
+    let _ = app.emit(
+        "agent-status-updated",
+        serde_json::json!({
+            "session_id": session_id,
+            "current_status": "Idle",
+        }),
+    );
+    manager::terminate_active_agent_process(&mut old_agent);
+    Ok(())
 }
 
 #[tauri::command]
@@ -1398,7 +1413,7 @@ mod tests {
         persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
         provider_needs_obtain_session_id_on_clear, provider_uses_generated_session_id,
         reserve_spawn_session_name, resolve_requested_spawn_session_name,
-        restore_runtime_state_after_resume, AgentOrderPlacement,
+        restore_runtime_state_snapshot_after_resume, AgentOrderPlacement,
     };
     use crate::state::{ActiveAgent, AppState};
     use crate::utils::fs::create_directory_link;
@@ -1816,6 +1831,11 @@ mod tests {
     }
 
     #[test]
+    fn mock_uses_generated_session_id() {
+        assert!(provider_uses_generated_session_id("mock"));
+    }
+
+    #[test]
     fn gemini_needs_obtain_session_id_on_clear() {
         assert!(provider_needs_obtain_session_id_on_clear("gemini"));
         assert!(!provider_needs_obtain_session_id_on_clear("claude"));
@@ -1824,15 +1844,14 @@ mod tests {
     }
 
     #[test]
-    fn resume_restores_query_count_and_log_path() {
-        let old_active = make_test_agent();
-        *old_active.query_count.lock().unwrap() = 3;
-        *old_active.init_timestamp.lock().unwrap() = Some("2026-04-12T17:00:00.000Z".to_string());
-        *old_active.log_path.lock().unwrap() =
-            Some(std::path::PathBuf::from("C:/tmp/session.json"));
-
+    fn resume_snapshot_restores_query_count_and_log_path() {
         let mut new_active = make_test_agent();
-        restore_runtime_state_after_resume(&mut new_active, &old_active);
+        restore_runtime_state_snapshot_after_resume(
+            &mut new_active,
+            3,
+            Some("2026-04-12T17:00:00.000Z".to_string()),
+            Some(std::path::PathBuf::from("C:/tmp/session.json")),
+        );
 
         assert_eq!(*new_active.query_count.lock().unwrap(), 3);
         assert_eq!(

--- a/src-tauri/src/commands/class.rs
+++ b/src-tauri/src/commands/class.rs
@@ -54,7 +54,7 @@ pub async fn create_agent_class(
             let _ = std::fs::write(agents_md_path, content);
         }
 
-        // Create provider stubs for providers that do not read AGENTS.md directly
+        // Create thin compatibility stubs that point providers back to AGENTS.md.
         for stub_name in &["GEMINI.md", "CLAUDE.md"] {
             let stub_path = role_dir.join(stub_name);
             if !stub_path.exists() {

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1,9 +1,10 @@
 use crate::state::AppState;
+use std::fmt;
 use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
     AgentListResponse, AgentResponse, ControlRequest, OkResponse, WorkflowListResponse,
-    WorkflowSummary,
+    WorkflowResponse, WorkflowSummary,
 };
 use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
 
@@ -85,14 +86,7 @@ where
             stream.flush().await?;
         }
         Err(error) => {
-            let payload = serde_json::json!({
-                "schema": wardian_core::control::CONTROL_SCHEMA,
-                "error": {
-                    "code": "request_failed",
-                    "message": error.to_string(),
-                }
-            })
-            .to_string();
+            let payload = error_payload(&error)?;
             stream.write_all(payload.as_bytes()).await?;
             stream.write_all(b"\n").await?;
             stream.flush().await?;
@@ -102,10 +96,9 @@ where
     Ok(())
 }
 
-async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, std::io::Error> {
-    let req = serde_json::from_str::<ControlRequest>(line).map_err(|e| {
-        std::io::Error::other(format!("bad_request: {e}"))
-    })?;
+async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, ControlError> {
+    let req = serde_json::from_str::<ControlRequest>(line)
+        .map_err(|e| ControlError::bad_request(format!("malformed control request JSON: {e}")))?;
 
     match req {
         ControlRequest::AgentList => {
@@ -114,49 +107,62 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, std::io
         }
 
         ControlRequest::AgentKill { target } => {
-            let uuid = resolve_target_uuid(app, &target).await
-                .ok_or_else(|| std::io::Error::other(format!("agent not found: {target}")))?;
+            let uuid = resolve_target_uuid(app, &target)
+                .await
+                .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
             handle_agent_kill(app, uuid).await?;
             ok_json(&OkResponse::new())
         }
 
         ControlRequest::AgentPause { target } => {
-            let uuid = resolve_target_uuid(app, &target).await
-                .ok_or_else(|| std::io::Error::other(format!("agent not found: {target}")))?;
+            let uuid = resolve_target_uuid(app, &target)
+                .await
+                .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
             handle_agent_pause(app, &uuid).await?;
             ok_json(&OkResponse::new())
         }
 
         ControlRequest::AgentResume { target } => {
-            let uuid = resolve_target_uuid(app, &target).await
-                .ok_or_else(|| std::io::Error::other(format!("agent not found: {target}")))?;
+            let uuid = resolve_target_uuid(app, &target)
+                .await
+                .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
             crate::commands::agent::resume_agent(uuid, app.state::<AppState>(), app.clone())
                 .await
-                .map_err(std::io::Error::other)?;
+                .map_err(ControlError::request_failed)?;
             ok_json(&OkResponse::new())
         }
 
-        ControlRequest::AgentSpawn { class, name, workspace } => {
+        ControlRequest::AgentSpawn {
+            provider,
+            class,
+            name,
+            workspace,
+        } => {
             use crate::commands::agent::{spawn_agent, SpawnAgentRequest};
+            let config_override = wardian_core::models::AgentConfig {
+                provider,
+                ..Default::default()
+            };
             let req = SpawnAgentRequest {
                 session_name: name.unwrap_or_default(),
                 agent_class: class,
                 folder: workspace.unwrap_or_default(),
                 resume_session: None,
                 is_off: None,
-                config_override: None,
+                config_override: Some(config_override),
             };
             let config = spawn_agent(req, app.state::<AppState>(), app.clone())
                 .await
-                .map_err(std::io::Error::other)?;
+                .map_err(ControlError::request_failed)?;
             let identity = agent_config_to_identity(&config, app).await;
             ok_json(&AgentResponse::new(identity))
         }
 
         ControlRequest::AgentClone { target, name } => {
             use crate::commands::agent::{clone_agent, CloneAgentMode, CloneAgentRequest};
-            let uuid = resolve_target_uuid(app, &target).await
-                .ok_or_else(|| std::io::Error::other(format!("agent not found: {target}")))?;
+            let uuid = resolve_target_uuid(app, &target)
+                .await
+                .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
             let req = CloneAgentRequest {
                 source_session_id: uuid,
                 mode: CloneAgentMode::Fresh,
@@ -168,7 +174,7 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, std::io
             };
             let config = clone_agent(req, app.state::<AppState>(), app.clone())
                 .await
-                .map_err(std::io::Error::other)?;
+                .map_err(ControlError::request_failed)?;
             let identity = agent_config_to_identity(&config, app).await;
             ok_json(&AgentResponse::new(identity))
         }
@@ -186,10 +192,19 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, std::io
             ok_json(&WorkflowListResponse::new(summaries))
         }
 
+        ControlRequest::WorkflowShow { target } => {
+            let workflow = crate::workflow_engine::list_workflows()
+                .unwrap_or_default()
+                .into_iter()
+                .find(|w| w.id == target || w.name == target)
+                .ok_or_else(|| ControlError::not_found(format!("workflow not found: {target}")))?;
+            ok_json(&WorkflowResponse::new(workflow))
+        }
+
         ControlRequest::WorkflowRun { id } => {
             crate::workflow_engine::run_workflow(app.clone(), id, None)
                 .await
-                .map_err(std::io::Error::other)?;
+                .map_err(ControlError::request_failed)?;
             ok_json(&OkResponse::new())
         }
 
@@ -198,10 +213,15 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, std::io
             ok_json(&OkResponse::new())
         }
 
-        ControlRequest::SendMessage { target, message, thread: _ } => {
+        ControlRequest::SendMessage {
+            target,
+            message,
+            thread,
+        } => {
+            let bytes = send_message_bytes(&message, thread.as_deref())?;
             let session_ids = resolve_send_targets(app, &target).await;
             if session_ids.is_empty() {
-                return Err(std::io::Error::other(format!(
+                return Err(ControlError::not_found(format!(
                     "no agents matched target: {target}"
                 )));
             }
@@ -209,12 +229,31 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, std::io
             let senders = state
                 .input_senders
                 .read()
-                .map_err(|_| std::io::Error::other("input_senders lock poisoned"))?;
-            let bytes = format!("{message}\n").into_bytes();
+                .map_err(|_| ControlError::request_failed("input_senders lock poisoned"))?;
+            let mut delivered = 0usize;
+            let mut failures = Vec::new();
             for session_id in &session_ids {
-                if let Some(tx) = senders.get(session_id) {
-                    let _ = tx.try_send(bytes.clone());
+                match senders.get(session_id) {
+                    Some(tx) => match tx.try_send(bytes.clone()) {
+                        Ok(()) => delivered += 1,
+                        Err(error) => failures.push(format!("{session_id}: {error}")),
+                    },
+                    None => failures.push(format!("{session_id}: no input channel")),
                 }
+            }
+            if delivered == 0 {
+                return Err(ControlError::request_failed(format!(
+                    "message was not delivered to any matched agents: {}",
+                    failures.join("; ")
+                )));
+            }
+            if !failures.is_empty() {
+                return Err(ControlError::request_failed(format!(
+                    "message delivery failed for {} of {} matched agents: {}",
+                    failures.len(),
+                    session_ids.len(),
+                    failures.join("; ")
+                )));
             }
             ok_json(&OkResponse::new())
         }
@@ -227,40 +266,16 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, std::io
 
 async fn handle_agent_kill(app: &AppHandle, session_id: String) -> std::io::Result<()> {
     let state = app.state::<AppState>();
-    let mut agents = state.agents.lock().await;
-    let mut order = state.agent_order.lock().await;
-
-    if let Some(mut agent) = agents.remove(&session_id) {
-        if let Ok(mut senders) = state.input_senders.write() {
-            senders.remove(&session_id);
-        }
-        order.retain(|id| id != &session_id);
-        crate::manager::save_state(app, &agents, &order);
-        crate::manager::terminate_active_agent_process(&mut agent);
-        let _ = wardian_core::db::delete_agent(&session_id);
-        if let Some(home) = crate::utils::fs::get_wardian_home() {
-            let agent_dir = home.join("agents").join(&session_id);
-            if agent_dir.exists() {
-                let _ = std::fs::remove_dir_all(&agent_dir);
-            }
-        }
-        Ok(())
-    } else {
-        Err(std::io::Error::other(format!(
-            "agent not found: {session_id}"
-        )))
-    }
+    crate::commands::agent::kill_agent(session_id, state, app.clone())
+        .await
+        .map_err(std::io::Error::other)
 }
 
 async fn handle_agent_pause(app: &AppHandle, session_id: &str) -> std::io::Result<()> {
     let state = app.state::<AppState>();
-    crate::commands::agent::pause_agent(
-        session_id.to_string(),
-        state,
-        app.clone(),
-    )
-    .await
-    .map_err(std::io::Error::other)
+    crate::commands::agent::pause_agent(session_id.to_string(), state, app.clone())
+        .await
+        .map_err(std::io::Error::other)
 }
 
 async fn resolve_target_uuid(app: &AppHandle, target: &str) -> Option<String> {
@@ -341,8 +356,82 @@ async fn agent_config_to_identity(
 // Serialization helpers
 // ---------------------------------------------------------------------------
 
-fn ok_json<T: serde::Serialize>(value: &T) -> Result<String, std::io::Error> {
-    serde_json::to_string(value).map_err(|e| std::io::Error::other(e.to_string()))
+fn ok_json<T: serde::Serialize>(value: &T) -> Result<String, ControlError> {
+    serde_json::to_string(value).map_err(ControlError::request_failed)
+}
+
+fn error_payload(error: &ControlError) -> Result<String, std::io::Error> {
+    serde_json::to_string(&serde_json::json!({
+        "schema": wardian_core::control::CONTROL_SCHEMA,
+        "error": {
+            "code": error.code(),
+            "message": error.to_string(),
+        }
+    }))
+    .map_err(|e| std::io::Error::other(e.to_string()))
+}
+
+fn send_message_bytes(message: &str, thread: Option<&str>) -> Result<Vec<u8>, ControlError> {
+    if thread.is_some() {
+        return Err(ControlError::not_supported(
+            "--thread is not supported by the Wardian control endpoint yet",
+        ));
+    }
+    Ok(format!("{message}\r").into_bytes())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ControlError {
+    code: &'static str,
+    message: String,
+}
+
+impl ControlError {
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            code: "bad_request",
+            message: message.into(),
+        }
+    }
+
+    fn not_supported(message: impl Into<String>) -> Self {
+        Self {
+            code: "not_supported",
+            message: message.into(),
+        }
+    }
+
+    fn not_found(message: impl Into<String>) -> Self {
+        Self {
+            code: "not_found",
+            message: message.into(),
+        }
+    }
+
+    fn request_failed(message: impl ToString) -> Self {
+        Self {
+            code: "request_failed",
+            message: message.to_string(),
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        self.code
+    }
+}
+
+impl fmt::Display for ControlError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ControlError {}
+
+impl From<std::io::Error> for ControlError {
+    fn from(error: std::io::Error) -> Self {
+        Self::request_failed(error)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -351,8 +440,8 @@ fn ok_json<T: serde::Serialize>(value: &T) -> Result<String, std::io::Error> {
 
 async fn live_agent_snapshots(app: &AppHandle) -> Vec<AgentIdentity> {
     let state = app.state::<AppState>();
-    let order = state.agent_order.lock().await.clone();
     let agents = state.agents.lock().await;
+    let order = state.agent_order.lock().await.clone();
     let mut snapshots = Vec::new();
     let mut seen = std::collections::HashSet::new();
 
@@ -400,5 +489,46 @@ fn snapshot_agent(agent: &crate::state::ActiveAgent) -> AgentIdentity {
         workspace: (!config.folder.trim().is_empty()).then_some(config.folder),
         last_status_at: None,
         status_source: StatusSource::Live,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_errors_emit_bad_request_code() {
+        let error = ControlError::bad_request("expected value");
+        let payload = error_payload(&error).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+
+        assert_eq!(value["error"]["code"], "bad_request");
+        assert_eq!(value["schema"], wardian_core::control::CONTROL_SCHEMA);
+    }
+
+    #[test]
+    fn send_message_rejects_thread_until_supported() {
+        let error = send_message_bytes("hello", Some("review")).unwrap_err();
+
+        assert_eq!(error.code(), "not_supported");
+        assert!(error.to_string().contains("--thread is not supported"));
+    }
+
+    #[test]
+    fn send_message_submits_with_terminal_enter() {
+        assert_eq!(send_message_bytes("hello", None).unwrap(), b"hello\r");
+    }
+
+    #[test]
+    fn not_found_errors_emit_not_found_code() {
+        let error = ControlError::not_found("agent not found: ghost");
+        let payload = error_payload(&error).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+
+        assert_eq!(value["error"]["code"], "not_found");
+        assert!(value["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("ghost"));
     }
 }

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1,7 +1,10 @@
 use crate::state::AppState;
 use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use wardian_core::control::{AgentListResponse, ControlRequest};
+use wardian_core::control::{
+    AgentListResponse, AgentResponse, ControlRequest, OkResponse, WorkflowListResponse,
+    WorkflowSummary,
+};
 use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
 
 pub fn spawn_control_server(app: AppHandle) {
@@ -72,31 +75,25 @@ where
     let mut line = String::new();
     reader.read_line(&mut line).await?;
 
-    match serde_json::from_str::<ControlRequest>(&line) {
-        Ok(ControlRequest::AgentList) => {
-            let response = AgentListResponse::new(live_agent_snapshots(&app).await);
-            let json = serde_json::to_string(&response)
-                .map_err(|error| std::io::Error::other(error.to_string()))?;
-            let stream = reader.get_mut();
+    let result = dispatch_request(&line, &app).await;
+
+    let stream = reader.get_mut();
+    match result {
+        Ok(json) => {
             stream.write_all(json.as_bytes()).await?;
             stream.write_all(b"\n").await?;
             stream.flush().await?;
         }
         Err(error) => {
-            let stream = reader.get_mut();
-            stream
-                .write_all(
-                    serde_json::json!({
-                        "schema": wardian_core::control::CONTROL_SCHEMA,
-                        "error": {
-                            "code": "bad_request",
-                            "message": error.to_string(),
-                        }
-                    })
-                    .to_string()
-                    .as_bytes(),
-                )
-                .await?;
+            let payload = serde_json::json!({
+                "schema": wardian_core::control::CONTROL_SCHEMA,
+                "error": {
+                    "code": "request_failed",
+                    "message": error.to_string(),
+                }
+            })
+            .to_string();
+            stream.write_all(payload.as_bytes()).await?;
             stream.write_all(b"\n").await?;
             stream.flush().await?;
         }
@@ -104,6 +101,253 @@ where
 
     Ok(())
 }
+
+async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, std::io::Error> {
+    let req = serde_json::from_str::<ControlRequest>(line).map_err(|e| {
+        std::io::Error::other(format!("bad_request: {e}"))
+    })?;
+
+    match req {
+        ControlRequest::AgentList => {
+            let response = AgentListResponse::new(live_agent_snapshots(app).await);
+            ok_json(&response)
+        }
+
+        ControlRequest::AgentKill { target } => {
+            let uuid = resolve_target_uuid(app, &target).await
+                .ok_or_else(|| std::io::Error::other(format!("agent not found: {target}")))?;
+            handle_agent_kill(app, uuid).await?;
+            ok_json(&OkResponse::new())
+        }
+
+        ControlRequest::AgentPause { target } => {
+            let uuid = resolve_target_uuid(app, &target).await
+                .ok_or_else(|| std::io::Error::other(format!("agent not found: {target}")))?;
+            handle_agent_pause(app, &uuid).await?;
+            ok_json(&OkResponse::new())
+        }
+
+        ControlRequest::AgentResume { target } => {
+            let uuid = resolve_target_uuid(app, &target).await
+                .ok_or_else(|| std::io::Error::other(format!("agent not found: {target}")))?;
+            crate::commands::agent::resume_agent(uuid, app.state::<AppState>(), app.clone())
+                .await
+                .map_err(std::io::Error::other)?;
+            ok_json(&OkResponse::new())
+        }
+
+        ControlRequest::AgentSpawn { class, name, workspace } => {
+            use crate::commands::agent::{spawn_agent, SpawnAgentRequest};
+            let req = SpawnAgentRequest {
+                session_name: name.unwrap_or_default(),
+                agent_class: class,
+                folder: workspace.unwrap_or_default(),
+                resume_session: None,
+                is_off: None,
+                config_override: None,
+            };
+            let config = spawn_agent(req, app.state::<AppState>(), app.clone())
+                .await
+                .map_err(std::io::Error::other)?;
+            let identity = agent_config_to_identity(&config, app).await;
+            ok_json(&AgentResponse::new(identity))
+        }
+
+        ControlRequest::AgentClone { target, name } => {
+            use crate::commands::agent::{clone_agent, CloneAgentMode, CloneAgentRequest};
+            let uuid = resolve_target_uuid(app, &target).await
+                .ok_or_else(|| std::io::Error::other(format!("agent not found: {target}")))?;
+            let req = CloneAgentRequest {
+                source_session_id: uuid,
+                mode: CloneAgentMode::Fresh,
+                session_name: name,
+                provider: None,
+                folder: None,
+                agent_class: None,
+                start: Some(true),
+            };
+            let config = clone_agent(req, app.state::<AppState>(), app.clone())
+                .await
+                .map_err(std::io::Error::other)?;
+            let identity = agent_config_to_identity(&config, app).await;
+            ok_json(&AgentResponse::new(identity))
+        }
+
+        ControlRequest::WorkflowList => {
+            let workflows = crate::workflow_engine::list_workflows().unwrap_or_default();
+            let summaries: Vec<WorkflowSummary> = workflows
+                .iter()
+                .map(|w| WorkflowSummary {
+                    id: w.id.clone(),
+                    name: w.name.clone(),
+                    node_count: w.nodes.len(),
+                })
+                .collect();
+            ok_json(&WorkflowListResponse::new(summaries))
+        }
+
+        ControlRequest::WorkflowRun { id } => {
+            crate::workflow_engine::run_workflow(app.clone(), id, None)
+                .await
+                .map_err(std::io::Error::other)?;
+            ok_json(&OkResponse::new())
+        }
+
+        ControlRequest::WorkflowStop { run_instance_id } => {
+            crate::workflow_engine::stop_workflow_run(app.clone(), &run_instance_id).await;
+            ok_json(&OkResponse::new())
+        }
+
+        ControlRequest::SendMessage { target, message, thread: _ } => {
+            let session_ids = resolve_send_targets(app, &target).await;
+            if session_ids.is_empty() {
+                return Err(std::io::Error::other(format!(
+                    "no agents matched target: {target}"
+                )));
+            }
+            let state = app.state::<AppState>();
+            let senders = state
+                .input_senders
+                .read()
+                .map_err(|_| std::io::Error::other("input_senders lock poisoned"))?;
+            let bytes = format!("{message}\n").into_bytes();
+            for session_id in &session_ids {
+                if let Some(tx) = senders.get(session_id) {
+                    let _ = tx.try_send(bytes.clone());
+                }
+            }
+            ok_json(&OkResponse::new())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Agent operation helpers
+// ---------------------------------------------------------------------------
+
+async fn handle_agent_kill(app: &AppHandle, session_id: String) -> std::io::Result<()> {
+    let state = app.state::<AppState>();
+    let mut agents = state.agents.lock().await;
+    let mut order = state.agent_order.lock().await;
+
+    if let Some(mut agent) = agents.remove(&session_id) {
+        if let Ok(mut senders) = state.input_senders.write() {
+            senders.remove(&session_id);
+        }
+        order.retain(|id| id != &session_id);
+        crate::manager::save_state(app, &agents, &order);
+        crate::manager::terminate_active_agent_process(&mut agent);
+        let _ = wardian_core::db::delete_agent(&session_id);
+        if let Some(home) = crate::utils::fs::get_wardian_home() {
+            let agent_dir = home.join("agents").join(&session_id);
+            if agent_dir.exists() {
+                let _ = std::fs::remove_dir_all(&agent_dir);
+            }
+        }
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "agent not found: {session_id}"
+        )))
+    }
+}
+
+async fn handle_agent_pause(app: &AppHandle, session_id: &str) -> std::io::Result<()> {
+    let state = app.state::<AppState>();
+    crate::commands::agent::pause_agent(
+        session_id.to_string(),
+        state,
+        app.clone(),
+    )
+    .await
+    .map_err(std::io::Error::other)
+}
+
+async fn resolve_target_uuid(app: &AppHandle, target: &str) -> Option<String> {
+    let state = app.state::<AppState>();
+    let agents = state.agents.lock().await;
+    agents
+        .iter()
+        .find(|(id, agent)| {
+            id.as_str() == target
+                || agent
+                    .config
+                    .lock()
+                    .map(|c| c.session_name == target)
+                    .unwrap_or(false)
+        })
+        .map(|(id, _)| id.clone())
+}
+
+async fn resolve_send_targets(app: &AppHandle, target: &str) -> Vec<String> {
+    let state = app.state::<AppState>();
+    let agents = state.agents.lock().await;
+
+    if target == "all" {
+        return agents.keys().cloned().collect();
+    }
+
+    if let Some(class) = target.strip_prefix("class:") {
+        return agents
+            .iter()
+            .filter(|(_, a)| {
+                a.config
+                    .lock()
+                    .map(|c| c.agent_class == class)
+                    .unwrap_or(false)
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+    }
+
+    agents
+        .iter()
+        .find(|(id, a)| {
+            id.as_str() == target
+                || a.config
+                    .lock()
+                    .map(|c| c.session_name == target)
+                    .unwrap_or(false)
+        })
+        .map(|(id, _)| vec![id.clone()])
+        .unwrap_or_default()
+}
+
+async fn agent_config_to_identity(
+    config: &wardian_core::models::AgentConfig,
+    app: &AppHandle,
+) -> AgentIdentity {
+    let state = app.state::<AppState>();
+    let agents = state.agents.lock().await;
+    if let Some(agent) = agents.get(&config.session_id) {
+        snapshot_agent(agent)
+    } else {
+        AgentIdentity {
+            name: config.session_name.clone(),
+            uuid: config.session_id.clone(),
+            class: config.agent_class.clone(),
+            provider: config.provider.clone(),
+            status: "idle".to_string(),
+            pid: None,
+            started_at: None,
+            workspace: (!config.folder.trim().is_empty()).then_some(config.folder.clone()),
+            last_status_at: None,
+            status_source: StatusSource::Live,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Serialization helpers
+// ---------------------------------------------------------------------------
+
+fn ok_json<T: serde::Serialize>(value: &T) -> Result<String, std::io::Error> {
+    serde_json::to_string(value).map_err(|e| std::io::Error::other(e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Agent snapshot (unchanged)
+// ---------------------------------------------------------------------------
 
 async fn live_agent_snapshots(app: &AppHandle) -> Vec<AgentIdentity> {
     let state = app.state::<AppState>();

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -138,19 +138,8 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             name,
             workspace,
         } => {
-            use crate::commands::agent::{spawn_agent, SpawnAgentRequest};
-            let config_override = wardian_core::models::AgentConfig {
-                provider,
-                ..Default::default()
-            };
-            let req = SpawnAgentRequest {
-                session_name: name.unwrap_or_default(),
-                agent_class: class,
-                folder: workspace.unwrap_or_default(),
-                resume_session: None,
-                is_off: None,
-                config_override: Some(config_override),
-            };
+            use crate::commands::agent::spawn_agent;
+            let req = build_spawn_agent_request(provider, class, name, workspace);
             let config = spawn_agent(req, app.state::<AppState>(), app.clone())
                 .await
                 .map_err(ControlError::request_failed)?;
@@ -159,19 +148,11 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
         }
 
         ControlRequest::AgentClone { target, name } => {
-            use crate::commands::agent::{clone_agent, CloneAgentMode, CloneAgentRequest};
+            use crate::commands::agent::clone_agent;
             let uuid = resolve_target_uuid(app, &target)
                 .await
                 .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
-            let req = CloneAgentRequest {
-                source_session_id: uuid,
-                mode: CloneAgentMode::Fresh,
-                session_name: name,
-                provider: None,
-                folder: None,
-                agent_class: None,
-                start: Some(true),
-            };
+            let req = build_clone_agent_request(uuid, name);
             let config = clone_agent(req, app.state::<AppState>(), app.clone())
                 .await
                 .map_err(ControlError::request_failed)?;
@@ -181,15 +162,7 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
 
         ControlRequest::WorkflowList => {
             let workflows = crate::workflow_engine::list_workflows().unwrap_or_default();
-            let summaries: Vec<WorkflowSummary> = workflows
-                .iter()
-                .map(|w| WorkflowSummary {
-                    id: w.id.clone(),
-                    name: w.name.clone(),
-                    node_count: w.nodes.len(),
-                })
-                .collect();
-            ok_json(&WorkflowListResponse::new(summaries))
+            ok_json(&WorkflowListResponse::new(workflow_summaries(&workflows)))
         }
 
         ControlRequest::WorkflowShow { target } => {
@@ -218,46 +191,59 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             message,
             thread,
         } => {
-            let bytes = send_message_bytes(&message, thread.as_deref())?;
-            let session_ids = resolve_send_targets(app, &target).await;
-            if session_ids.is_empty() {
-                return Err(ControlError::not_found(format!(
-                    "no agents matched target: {target}"
-                )));
-            }
             let state = app.state::<AppState>();
-            let senders = state
-                .input_senders
-                .read()
-                .map_err(|_| ControlError::request_failed("input_senders lock poisoned"))?;
-            let mut delivered = 0usize;
-            let mut failures = Vec::new();
-            for session_id in &session_ids {
-                match senders.get(session_id) {
-                    Some(tx) => match tx.try_send(bytes.clone()) {
-                        Ok(()) => delivered += 1,
-                        Err(error) => failures.push(format!("{session_id}: {error}")),
-                    },
-                    None => failures.push(format!("{session_id}: no input channel")),
-                }
-            }
-            if delivered == 0 {
-                return Err(ControlError::request_failed(format!(
-                    "message was not delivered to any matched agents: {}",
-                    failures.join("; ")
-                )));
-            }
-            if !failures.is_empty() {
-                return Err(ControlError::request_failed(format!(
-                    "message delivery failed for {} of {} matched agents: {}",
-                    failures.len(),
-                    session_ids.len(),
-                    failures.join("; ")
-                )));
-            }
+            deliver_message_to_target(&state, &target, &message, thread.as_deref()).await?;
             ok_json(&OkResponse::new())
         }
     }
+}
+
+fn build_spawn_agent_request(
+    provider: String,
+    class: String,
+    name: Option<String>,
+    workspace: Option<String>,
+) -> crate::commands::agent::SpawnAgentRequest {
+    let config_override = wardian_core::models::AgentConfig {
+        provider,
+        ..Default::default()
+    };
+    crate::commands::agent::SpawnAgentRequest {
+        session_name: name.unwrap_or_default(),
+        agent_class: class,
+        folder: workspace.unwrap_or_default(),
+        resume_session: None,
+        is_off: None,
+        config_override: Some(config_override),
+    }
+}
+
+fn build_clone_agent_request(
+    source_session_id: String,
+    name: Option<String>,
+) -> crate::commands::agent::CloneAgentRequest {
+    crate::commands::agent::CloneAgentRequest {
+        source_session_id,
+        mode: crate::commands::agent::CloneAgentMode::Fresh,
+        session_name: name,
+        provider: None,
+        folder: None,
+        agent_class: None,
+        start: Some(true),
+    }
+}
+
+fn workflow_summaries(
+    workflows: &[wardian_core::models::WorkflowDefinition],
+) -> Vec<WorkflowSummary> {
+    workflows
+        .iter()
+        .map(|w| WorkflowSummary {
+            id: w.id.clone(),
+            name: w.name.clone(),
+            node_count: w.nodes.len(),
+        })
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -280,6 +266,10 @@ async fn handle_agent_pause(app: &AppHandle, session_id: &str) -> std::io::Resul
 
 async fn resolve_target_uuid(app: &AppHandle, target: &str) -> Option<String> {
     let state = app.state::<AppState>();
+    resolve_target_uuid_in_state(&state, target).await
+}
+
+async fn resolve_target_uuid_in_state(state: &AppState, target: &str) -> Option<String> {
     let agents = state.agents.lock().await;
     agents
         .iter()
@@ -294,8 +284,7 @@ async fn resolve_target_uuid(app: &AppHandle, target: &str) -> Option<String> {
         .map(|(id, _)| id.clone())
 }
 
-async fn resolve_send_targets(app: &AppHandle, target: &str) -> Vec<String> {
-    let state = app.state::<AppState>();
+async fn resolve_send_targets_in_state(state: &AppState, target: &str) -> Vec<String> {
     let agents = state.agents.lock().await;
 
     if target == "all" {
@@ -326,6 +315,51 @@ async fn resolve_send_targets(app: &AppHandle, target: &str) -> Vec<String> {
         })
         .map(|(id, _)| vec![id.clone()])
         .unwrap_or_default()
+}
+
+async fn deliver_message_to_target(
+    state: &AppState,
+    target: &str,
+    message: &str,
+    thread: Option<&str>,
+) -> Result<(), ControlError> {
+    let bytes = send_message_bytes(message, thread)?;
+    let session_ids = resolve_send_targets_in_state(state, target).await;
+    if session_ids.is_empty() {
+        return Err(ControlError::not_found(format!(
+            "no agents matched target: {target}"
+        )));
+    }
+    let senders = state
+        .input_senders
+        .read()
+        .map_err(|_| ControlError::request_failed("input_senders lock poisoned"))?;
+    let mut delivered = 0usize;
+    let mut failures = Vec::new();
+    for session_id in &session_ids {
+        match senders.get(session_id) {
+            Some(tx) => match tx.try_send(bytes.clone()) {
+                Ok(()) => delivered += 1,
+                Err(error) => failures.push(format!("{session_id}: {error}")),
+            },
+            None => failures.push(format!("{session_id}: no input channel")),
+        }
+    }
+    if delivered == 0 {
+        return Err(ControlError::request_failed(format!(
+            "message was not delivered to any matched agents: {}",
+            failures.join("; ")
+        )));
+    }
+    if !failures.is_empty() {
+        return Err(ControlError::request_failed(format!(
+            "message delivery failed for {} of {} matched agents: {}",
+            failures.len(),
+            session_ids.len(),
+            failures.join("; ")
+        )));
+    }
+    Ok(())
 }
 
 async fn agent_config_to_identity(
@@ -495,6 +529,62 @@ fn snapshot_agent(agent: &crate::state::ActiveAgent) -> AgentIdentity {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::ActiveAgent;
+    use std::sync::{Arc, Mutex};
+    use wardian_core::models::{AgentConfig, WorkflowDefinition, WorkflowNode, WorkflowSettings};
+
+    fn test_agent(session_id: &str, session_name: &str, agent_class: &str) -> ActiveAgent {
+        ActiveAgent {
+            config: Arc::new(Mutex::new(AgentConfig {
+                session_id: session_id.to_string(),
+                session_name: session_name.to_string(),
+                agent_class: agent_class.to_string(),
+                provider: "mock".to_string(),
+                folder: "D:/work".to_string(),
+                ..Default::default()
+            })),
+            child_process: None,
+            background_processes: Vec::new(),
+            pty_master: None,
+            stdin_tx: None,
+            output_buffer: Arc::new(Mutex::new(String::new())),
+            process_id: Some(1234),
+            query_count: Arc::new(Mutex::new(0)),
+            init_timestamp: Arc::new(Mutex::new(Some("2026-05-07T00:00:00.000Z".to_string()))),
+            current_status: Arc::new(Mutex::new("Processing".to_string())),
+            terminal_title: Arc::new(Mutex::new(String::new())),
+            last_output_at: Arc::new(Mutex::new(None)),
+            log_path: Arc::new(Mutex::new(None)),
+            log_last_modified: Arc::new(Mutex::new(None)),
+            #[cfg(windows)]
+            job_object: None,
+        }
+    }
+
+    async fn insert_test_agent(
+        state: &AppState,
+        session_id: &str,
+        session_name: &str,
+        agent_class: &str,
+    ) {
+        state.agents.lock().await.insert(
+            session_id.to_string(),
+            test_agent(session_id, session_name, agent_class),
+        );
+    }
+
+    fn sample_workflow(id: &str, name: &str, nodes: Vec<WorkflowNode>) -> WorkflowDefinition {
+        WorkflowDefinition {
+            id: id.to_string(),
+            name: name.to_string(),
+            settings: WorkflowSettings {
+                max_iterations: 10,
+                on_limit_reached: "stop".to_string(),
+            },
+            nodes,
+            role_mappings: std::collections::HashMap::new(),
+        }
+    }
 
     #[test]
     fn parse_errors_emit_bad_request_code() {
@@ -530,5 +620,200 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("ghost"));
+    }
+
+    #[test]
+    fn spawn_request_preserves_provider_and_defaults_optional_fields() {
+        let req =
+            build_spawn_agent_request("codex".to_string(), "Reviewer".to_string(), None, None);
+
+        assert_eq!(req.session_name, "");
+        assert_eq!(req.agent_class, "Reviewer");
+        assert_eq!(req.folder, "");
+        assert_eq!(req.resume_session, None);
+        assert_eq!(
+            req.config_override
+                .as_ref()
+                .map(|config| config.provider.as_str()),
+            Some("codex")
+        );
+    }
+
+    #[test]
+    fn clone_request_uses_fresh_started_clone_by_default() {
+        let req = build_clone_agent_request("source-1".to_string(), Some("reviewer-2".into()));
+
+        assert_eq!(req.source_session_id, "source-1");
+        assert_eq!(req.mode, crate::commands::agent::CloneAgentMode::Fresh);
+        assert_eq!(req.session_name.as_deref(), Some("reviewer-2"));
+        assert_eq!(req.provider, None);
+        assert_eq!(req.folder, None);
+        assert_eq!(req.agent_class, None);
+        assert_eq!(req.start, Some(true));
+    }
+
+    #[test]
+    fn workflow_summaries_count_nodes_without_serializing_full_workflows() {
+        let summaries = workflow_summaries(&[
+            sample_workflow(
+                "wf-a",
+                "Daily review",
+                vec![WorkflowNode {
+                    id: "n1".to_string(),
+                    r#type: "agent".to_string(),
+                    name: Some("Reviewer".to_string()),
+                    config: serde_json::json!({}),
+                    parameter_schema: None,
+                    dependencies: None,
+                    position: None,
+                }],
+            ),
+            sample_workflow("wf-b", "Empty", Vec::new()),
+        ]);
+
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].id, "wf-a");
+        assert_eq!(summaries[0].node_count, 1);
+        assert_eq!(summaries[1].node_count, 0);
+    }
+
+    #[tokio::test]
+    async fn target_resolution_matches_uuid_or_session_name() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+
+        assert_eq!(
+            resolve_target_uuid_in_state(&state, "agent-1")
+                .await
+                .as_deref(),
+            Some("agent-1")
+        );
+        assert_eq!(
+            resolve_target_uuid_in_state(&state, "CoderOne")
+                .await
+                .as_deref(),
+            Some("agent-1")
+        );
+        assert_eq!(resolve_target_uuid_in_state(&state, "missing").await, None);
+    }
+
+    #[tokio::test]
+    async fn send_target_resolution_supports_all_class_uuid_and_name() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        insert_test_agent(&state, "agent-2", "ReviewerOne", "Reviewer").await;
+
+        let mut all = resolve_send_targets_in_state(&state, "all").await;
+        all.sort();
+        assert_eq!(all, vec!["agent-1".to_string(), "agent-2".to_string()]);
+
+        assert_eq!(
+            resolve_send_targets_in_state(&state, "class:Reviewer").await,
+            vec!["agent-2".to_string()]
+        );
+        assert_eq!(
+            resolve_send_targets_in_state(&state, "CoderOne").await,
+            vec!["agent-1".to_string()]
+        );
+        assert_eq!(
+            resolve_send_targets_in_state(&state, "agent-2").await,
+            vec!["agent-2".to_string()]
+        );
+        assert!(resolve_send_targets_in_state(&state, "class:Missing")
+            .await
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn message_delivery_writes_terminal_bytes_to_matched_agent() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        deliver_message_to_target(&state, "CoderOne", "hello", None)
+            .await
+            .unwrap();
+
+        assert_eq!(rx.try_recv().unwrap(), b"hello\r");
+    }
+
+    #[tokio::test]
+    async fn message_delivery_reports_missing_target_as_not_found() {
+        let state = AppState::new();
+
+        let error = deliver_message_to_target(&state, "ghost", "hello", None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), "not_found");
+        assert!(error
+            .to_string()
+            .contains("no agents matched target: ghost"));
+    }
+
+    #[tokio::test]
+    async fn message_delivery_reports_agent_without_input_channel() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+
+        let error = deliver_message_to_target(&state, "agent-1", "hello", None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), "request_failed");
+        assert!(error.to_string().contains("agent-1: no input channel"));
+    }
+
+    #[tokio::test]
+    async fn message_delivery_reports_partial_failures_after_successful_delivery() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        insert_test_agent(&state, "agent-2", "CoderTwo", "Coder").await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let error = deliver_message_to_target(&state, "class:Coder", "hello", None)
+            .await
+            .unwrap_err();
+
+        assert_eq!(rx.try_recv().unwrap(), b"hello\r");
+        assert_eq!(error.code(), "request_failed");
+        assert!(error
+            .to_string()
+            .contains("message delivery failed for 1 of 2 matched agents"));
+        assert!(error.to_string().contains("agent-2: no input channel"));
+    }
+
+    #[test]
+    fn snapshot_agent_normalizes_status_and_omits_blank_workspace() {
+        let agent = test_agent("agent-1", "CoderOne", "Coder");
+        {
+            let mut config = agent.config.lock().unwrap();
+            config.folder.clear();
+        }
+
+        let snapshot = snapshot_agent(&agent);
+
+        assert_eq!(snapshot.uuid, "agent-1");
+        assert_eq!(snapshot.name, "CoderOne");
+        assert_eq!(snapshot.class, "Coder");
+        assert_eq!(snapshot.provider, "mock");
+        assert_eq!(snapshot.status, "processing");
+        assert_eq!(snapshot.pid, Some(1234));
+        assert_eq!(
+            snapshot.started_at.as_deref(),
+            Some("2026-05-07T00:00:00.000Z")
+        );
+        assert_eq!(snapshot.workspace, None);
+        assert_eq!(snapshot.status_source, StatusSource::Live);
     }
 }

--- a/src-tauri/src/default_classes.json
+++ b/src-tauri/src/default_classes.json
@@ -21,11 +21,11 @@
     },
     {
         "name":  "Orchestrator",
-        "description":  "Meta-agent responsible for delegating tasks and managing multi-agent workflows."
+        "description":  "Meta-agent responsible for coordinating Wardian agents through the CLI and aggressively delegating multi-agent work."
     },
     {
         "name":  "Evolver",
-        "description":  "Iteratively analyzes and optimizes existing systems, workflows, or codebases."
+        "description":  "Iteratively analyzes Wardian agent failures and improves shared prompts, skills, workflows, and system resources."
     },
     {
         "name":  "Researcher",

--- a/src-tauri/src/manager/classes.rs
+++ b/src-tauri/src/manager/classes.rs
@@ -29,7 +29,7 @@ pub fn init_agent_classes(app: &AppHandle) {
         let _ = std::fs::create_dir_all(app_dir.join("common/desk"));
         let _ = std::fs::create_dir_all(app_dir.join("common/lineages"));
 
-        // Ensure Claude can discover skills from the canonical .agents/skills/ location
+        // Keep `.agents/skills` canonical while exposing provider-specific discovery shims.
         ensure_claude_skills_link(&app_dir.join("common"));
         init_bundled_common_skills(app, &app_dir);
 
@@ -83,10 +83,10 @@ pub fn init_agent_classes(app: &AppHandle) {
                 let _ = std::fs::write(agents_md_path, content);
             }
 
-            // 2. Symlink .claude/skills/ → .agents/skills/ for Claude discovery
+            // 2. Expose canonical skills through provider-specific discovery shims.
             ensure_claude_skills_link(&role_dir);
 
-            // 3. Create provider stub files for providers that do not read AGENTS.md directly
+            // 3. Create thin compatibility stubs that point providers back to AGENTS.md.
             for stub_name in &["GEMINI.md", "CLAUDE.md"] {
                 let stub_path = role_dir.join(stub_name);
                 if !stub_path.exists() {

--- a/src-tauri/src/providers/factory.rs
+++ b/src-tauri/src/providers/factory.rs
@@ -24,7 +24,7 @@ impl ProviderFactory {
             "opencode" => Ok(Arc::new(OpenCodeProvider::new())),
             "mock" => Ok(Arc::new(MockProvider::new())),
             other => Err(format!(
-                "Unknown provider '{}'. Supported providers: gemini, claude, codex, opencode",
+                "Unknown provider '{}'. Supported providers: gemini, claude, codex, opencode, mock",
                 other
             )),
         }

--- a/src-tauri/src/providers/gemini.rs
+++ b/src-tauri/src/providers/gemini.rs
@@ -234,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn instruction_filename_is_gemini_md() {
+    fn instruction_filename_is_provider_specific_stub() {
         let p = make_provider();
         assert_eq!(p.get_instruction_filename(), "GEMINI.md");
     }

--- a/src-tauri/src/providers/mock.rs
+++ b/src-tauri/src/providers/mock.rs
@@ -19,6 +19,19 @@ impl MockProvider {
         MockProvider
     }
 
+    fn existing_script_path(path: std::path::PathBuf) -> Option<String> {
+        if !path.exists() {
+            return None;
+        }
+
+        Some(
+            std::fs::canonicalize(&path)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .to_string(),
+        )
+    }
+
     /// Resolves the path to `scripts/mock-agent.cjs`.
     ///
     /// Priority:
@@ -27,8 +40,10 @@ impl MockProvider {
     /// 3. Fallback to repo-relative path (development mode)
     fn resolve_mock_script_path() -> String {
         if let Ok(path) = std::env::var("WARDIAN_MOCK_SCRIPT") {
-            if !path.is_empty() && std::path::Path::new(&path).exists() {
-                return path;
+            if !path.is_empty() {
+                if let Some(path) = Self::existing_script_path(std::path::PathBuf::from(path)) {
+                    return path;
+                }
             }
         }
 
@@ -36,17 +51,34 @@ impl MockProvider {
         if let Ok(exe) = std::env::current_exe() {
             if let Some(exe_dir) = exe.parent() {
                 // Tauri bundles resources alongside the binary
-                let bundled = exe_dir.join("scripts").join("mock-agent.cjs");
-                if bundled.exists() {
-                    return bundled.to_string_lossy().to_string();
+                if let Some(path) =
+                    Self::existing_script_path(exe_dir.join("scripts").join("mock-agent.cjs"))
+                {
+                    return path;
+                }
+
+                if let Some(path) = Self::existing_script_path(
+                    exe_dir
+                        .join("..")
+                        .join("..")
+                        .join("scripts")
+                        .join("mock-agent.cjs"),
+                ) {
+                    return path;
                 }
             }
         }
 
-        // Development fallback: repo-relative path from src-tauri/
-        let dev_path = std::path::Path::new("../scripts/mock-agent.cjs");
-        if dev_path.exists() {
-            return dev_path.to_string_lossy().to_string();
+        // Development fallback: repo-relative paths from the Tauri app cwd or src-tauri/.
+        for dev_path in [
+            std::path::PathBuf::from("scripts").join("mock-agent.cjs"),
+            std::path::PathBuf::from("..")
+                .join("scripts")
+                .join("mock-agent.cjs"),
+        ] {
+            if let Some(path) = Self::existing_script_path(dev_path) {
+                return path;
+            }
         }
 
         // Ultimate fallback
@@ -162,6 +194,17 @@ mod tests {
         assert!(
             args[0].contains("mock-agent"),
             "First arg should be mock-agent script path, got: {}",
+            args[0]
+        );
+    }
+
+    #[test]
+    fn get_executable_returns_absolute_script_path() {
+        let (_bin, args) = make_provider().get_executable();
+
+        assert!(
+            std::path::Path::new(&args[0]).is_absolute(),
+            "mock script path should survive provider cwd changes, got: {}",
             args[0]
         );
     }

--- a/src-tauri/src/providers/mock.rs
+++ b/src-tauri/src/providers/mock.rs
@@ -210,6 +210,44 @@ mod tests {
     }
 
     #[test]
+    fn existing_script_path_returns_canonical_existing_path() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let script = temp.path().join("mock-agent.cjs");
+        std::fs::write(&script, "console.log('mock');").expect("write script");
+
+        let resolved = MockProvider::existing_script_path(script.clone()).unwrap();
+
+        assert_eq!(
+            std::path::PathBuf::from(resolved),
+            std::fs::canonicalize(script).expect("canonical script path")
+        );
+    }
+
+    #[test]
+    fn existing_script_path_rejects_missing_path() {
+        let temp = tempfile::tempdir().expect("temp dir");
+
+        assert!(MockProvider::existing_script_path(temp.path().join("missing.cjs")).is_none());
+    }
+
+    #[test]
+    fn resolve_mock_script_path_prefers_existing_env_override() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        let script = temp.path().join("custom-mock-agent.cjs");
+        std::fs::write(&script, "console.log('custom mock');").expect("write script");
+        std::env::set_var("WARDIAN_MOCK_SCRIPT", &script);
+
+        let resolved = MockProvider::resolve_mock_script_path();
+
+        assert_eq!(
+            std::path::PathBuf::from(resolved),
+            std::fs::canonicalize(&script).expect("canonical script path")
+        );
+        std::env::remove_var("WARDIAN_MOCK_SCRIPT");
+    }
+
+    #[test]
     fn spawn_args_empty_for_fresh_session() {
         let config = AgentConfig::default();
         let args = make_provider().get_spawn_args(&config, false);

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -134,7 +134,7 @@ pub fn resolve_system_include_directories(class_name: &str, session_id: &str) ->
         if !agent_path.exists() {
             let _ = std::fs::create_dir_all(&agent_path);
         }
-        // Ensure Claude can discover skills from agent's .agents/skills/
+        // Expose canonical agent skills through provider-specific discovery shims.
         ensure_claude_skills_link(&agent_path);
 
         if common_path.exists() {
@@ -643,8 +643,9 @@ fn project_file(source: &std::path::Path, target: &std::path::Path) -> Result<()
 }
 
 /// Ensures `.claude/skills` is a symlink (or junction on Windows) pointing to
-/// `.agents/skills` within the given base directory. This lets Claude Code
-/// natively discover skills from the provider-agnostic canonical location.
+/// `.agents/skills` within the given base directory. `.agents/skills` remains
+/// the provider-agnostic canonical location; this is only a compatibility shim
+/// for providers that require their own discovery path.
 /// No-ops if the link already exists and points to the right target.
 pub fn ensure_claude_skills_link(base_dir: &std::path::Path) {
     let canonical = base_dir.join(".agents").join("skills");

--- a/src/features/agents/ClassManagerPanel.test.tsx
+++ b/src/features/agents/ClassManagerPanel.test.tsx
@@ -33,6 +33,7 @@ describe('ClassManagerPanel', () => {
     expect(screen.getByText('Available Classes')).toBeInTheDocument();
     expect(screen.getByText('Coder')).toBeInTheDocument();
     expect(screen.getByText('CustomAgent')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reset all default prompts' })).toBeInTheDocument();
   });
 
   it('renders the Default badge only for default classes', () => {

--- a/src/features/agents/ClassManagerPanel.tsx
+++ b/src/features/agents/ClassManagerPanel.tsx
@@ -52,7 +52,7 @@ export const ClassManagerPanel: React.FC<ClassManagerPanelProps> = ({
   };
   
   const resetAllPrompts = async () => {
-    if (!confirm("Reset ALL default agent prompts to system defaults? This will overwrite your current AGENTS.md instructions for all default classes.")) return;
+    if (!confirm("Reset all default agent prompts to system defaults? This will overwrite your current AGENTS.md instructions for all default classes.")) return;
     try {
       await invoke("reset_all_class_prompts");
       alert("All default agent prompts have been reset to system defaults.");
@@ -148,9 +148,9 @@ export const ClassManagerPanel: React.FC<ClassManagerPanelProps> = ({
         <div className="px-1 mt-4">
             <button
                 onClick={resetAllPrompts}
-                className="w-full text-[9px] font-bold text-muted hover:text-[var(--color-wardian-accent)] uppercase tracking-[0.2em] py-3 border border-dashed border-wardian-light/20 rounded-lg transition-all hover:border-[var(--color-wardian-accent)]/30 group/reset"
+                className="w-full text-[11px] font-bold text-muted hover:text-[var(--color-wardian-accent)] tracking-wide py-3 border border-dashed border-wardian-light/20 rounded-lg transition-all hover:border-[var(--color-wardian-accent)]/30 group/reset"
             >
-                Reset All Default Prompts
+                Reset all default prompts
             </button>
             <p className="text-[9px] text-muted-neutral text-center mt-2 opacity-50 italic">
                 This will overwrite AGENTS.md for all default roles.

--- a/src/features/commands/CommandPanel.test.tsx
+++ b/src/features/commands/CommandPanel.test.tsx
@@ -134,6 +134,7 @@ describe("CommandPanel", () => {
 
     renderCommandPanel({ selectedAgentIds: new Set() });
     await user.click(screen.getByRole("button", { name: /Review Notes/i }));
+    expect(screen.getByText(/broadcast the prompt to all agents/i)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Confirm" }));
 
     await waitFor(() => {
@@ -170,6 +171,7 @@ describe("CommandPanel", () => {
     });
     await user.click(screen.getByTestId("broadcast-submit"));
     expect(onBroadcast).not.toHaveBeenCalled();
+    expect(screen.getByText(/broadcast to all agents/i)).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Confirm" }));
     expect(onBroadcast).toHaveBeenCalledTimes(1);

--- a/src/features/commands/CommandPanel.tsx
+++ b/src/features/commands/CommandPanel.tsx
@@ -56,7 +56,7 @@ export const CommandPanel: React.FC<CommandPanelProps> = ({
       if (selectedAgentIds.size > 0) {
         await submitInputToAgents(selectedAgentIds, flattenedPrompt);
       } else {
-        if (await confirm("No agents selected. This will broadcast the prompt to ALL agents. Are you sure?")) {
+        if (await confirm("No agents selected. This will broadcast the prompt to all agents. Are you sure?")) {
           const agents = await invoke<AgentConfig[]>("list_agents");
           await submitInputToAgents(
             agents.map((agent) => agent.session_id),
@@ -83,7 +83,7 @@ export const CommandPanel: React.FC<CommandPanelProps> = ({
   const handleBroadcastSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (selectedAgentIds.size === 0) {
-      if (!await confirm("No agents selected. This will broadcast to ALL agents. Are you sure?")) {
+      if (!await confirm("No agents selected. This will broadcast to all agents. Are you sure?")) {
         return;
       }
     }

--- a/src/features/git/GitPanel.test.tsx
+++ b/src/features/git/GitPanel.test.tsx
@@ -118,6 +118,8 @@ describe("GitPanel", () => {
     renderGitPanel();
 
     expect(await screen.findByText("main")).toBeInTheDocument();
+    expect(screen.getByText("Staged changes")).toBeInTheDocument();
+    expect(screen.getByText("Changes")).toBeInTheDocument();
     expect(screen.getByText("changed.ts")).toBeInTheDocument();
     expect(screen.getByText("README.md")).toBeInTheDocument();
     expect(screen.getByText("Initial commit")).toBeInTheDocument();

--- a/src/features/git/GitPanel.tsx
+++ b/src/features/git/GitPanel.tsx
@@ -424,7 +424,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
                 <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${stagedOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
                 </svg>
-                <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Staged Changes</span>
+                <span className="text-[11px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide">Staged changes</span>
               </button>
               <div className="flex-1" />
               <button
@@ -461,7 +461,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
                 <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${changesOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
                 </svg>
-                <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Changes</span>
+                <span className="text-[11px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide">Changes</span>
               </button>
               <div className="flex-1" />
               <button
@@ -499,7 +499,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
                 <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${untrackedOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
                 </svg>
-                <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">Untracked</span>
+                <span className="text-[11px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide">Untracked</span>
               </button>
               <div className="flex-1" />
               <button
@@ -545,7 +545,7 @@ export const GitPanel: React.FC<GitPanelProps> = ({ selectedAgentIds, agents, on
               <svg className={`w-3 h-3 text-[var(--color-wardian-text-muted)] transition-transform ${historyOpen ? "rotate-90" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
               </svg>
-              <span className="text-[10px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide uppercase">History</span>
+              <span className="text-[11px] font-bold text-[var(--color-wardian-text-muted)] tracking-wide">History</span>
               <span className="min-w-[18px] h-[18px] px-1 rounded bg-wardian-card-bg-muted text-[var(--color-wardian-text-muted)] text-[10px] font-mono flex items-center justify-center ml-1">
                 {historyError ? "!" : history.length}
               </span>

--- a/src/features/library/AssignPromptModal.tsx
+++ b/src/features/library/AssignPromptModal.tsx
@@ -61,7 +61,7 @@ export const AssignPromptModal: React.FC<AssignPromptModalProps> = ({ prompt, is
                 
                 <div className="p-5 flex flex-col gap-4">
                     <div className="flex flex-col gap-2">
-                        <label htmlFor={agentSelectId} className="text-xs font-bold text-muted uppercase tracking-widest">Select Agent</label>
+                        <label htmlFor={agentSelectId} className="text-xs font-bold text-muted tracking-wide">Select agent</label>
                         <select 
                             id={agentSelectId}
                             value={selectedTargetId}

--- a/src/features/library/AssignSkillModal.test.tsx
+++ b/src/features/library/AssignSkillModal.test.tsx
@@ -62,8 +62,8 @@ describe('AssignSkillModal', () => {
 
     expect(await screen.findByText('Coder One')).toBeInTheDocument();
     await user.selectOptions(screen.getByLabelText('Target Scope'), 'class');
-    expect(screen.getByLabelText('Select Class')).toHaveValue('Coder');
-    await user.selectOptions(screen.getByLabelText('Select Class'), 'Reviewer');
+    expect(screen.getByLabelText('Select class')).toHaveValue('Coder');
+    await user.selectOptions(screen.getByLabelText('Select class'), 'Reviewer');
     await user.click(screen.getByRole('button', { name: 'Deploy Skill' }));
 
     expect(mockInvoke).toHaveBeenCalledWith('deploy_skill', {
@@ -80,7 +80,7 @@ describe('AssignSkillModal', () => {
 
     expect(await screen.findByText('Coder One')).toBeInTheDocument();
     await user.selectOptions(screen.getByLabelText('Target Scope'), 'agent');
-    expect(screen.getByLabelText('Select Agent')).toHaveValue('agent-1');
+    expect(screen.getByLabelText('Select agent')).toHaveValue('agent-1');
     await user.click(screen.getByRole('button', { name: 'Deploy Skill' }));
 
     expect(mockInvoke).toHaveBeenCalledWith('deploy_skill', {

--- a/src/features/library/AssignSkillModal.tsx
+++ b/src/features/library/AssignSkillModal.tsx
@@ -104,7 +104,7 @@ export const AssignSkillModal: React.FC<AssignSkillModalProps> = ({ skill, isOpe
                     
                     {/* Existing Deployments */}
                     <div className="flex flex-col gap-2">
-                        <h3 className="text-xs font-bold text-muted uppercase tracking-widest">Active Deployments</h3>
+                        <h3 className="text-xs font-bold text-muted tracking-wide">Active deployments</h3>
                         <div className="flex flex-col gap-2 bg-[var(--color-wardian-input-bg)] border border-wardian-light rounded-lg p-3">
                             {deployments.length === 0 ? (
                                 <p className="text-[10px] text-muted-neutral italic">Skill is not deployed anywhere.</p>
@@ -131,7 +131,7 @@ export const AssignSkillModal: React.FC<AssignSkillModalProps> = ({ skill, isOpe
 
                     {/* New Deployment */}
                     <div className="flex flex-col gap-3">
-                        <h3 className="text-xs font-bold text-muted uppercase tracking-widest">New Deployment</h3>
+                        <h3 className="text-xs font-bold text-muted tracking-wide">New deployment</h3>
                         <div className="flex flex-col gap-2">
                             <label htmlFor={targetScopeId} className="text-xs font-bold text-muted-neutral">Target Scope</label>
                             <select 
@@ -149,7 +149,7 @@ export const AssignSkillModal: React.FC<AssignSkillModalProps> = ({ skill, isOpe
 
                         {targetType === 'class' && (
                             <div className="flex flex-col gap-2 animate-in slide-in-from-top-2 duration-200">
-                                <label htmlFor={classSelectId} className="text-xs font-bold text-muted-neutral">Select Class</label>
+                                <label htmlFor={classSelectId} className="text-xs font-bold text-muted-neutral">Select class</label>
                                 <select 
                                     id={classSelectId}
                                     value={selectedTargetId}
@@ -167,7 +167,7 @@ export const AssignSkillModal: React.FC<AssignSkillModalProps> = ({ skill, isOpe
 
                         {targetType === 'agent' && (
                             <div className="flex flex-col gap-2 animate-in slide-in-from-top-2 duration-200">
-                                <label htmlFor={agentSelectId} className="text-xs font-bold text-muted-neutral">Select Agent</label>
+                                <label htmlFor={agentSelectId} className="text-xs font-bold text-muted-neutral">Select agent</label>
                                 <select 
                                     id={agentSelectId}
                                     value={selectedTargetId}

--- a/src/features/settings/SettingsPanel.test.tsx
+++ b/src/features/settings/SettingsPanel.test.tsx
@@ -108,6 +108,18 @@ describe('SettingsPanel', () => {
     expect(await screen.findByText('Shell settings updated.')).toBeInTheDocument();
   });
 
+  it('shows the Gemini patch success message after running the patch', async () => {
+    const user = userEvent.setup();
+    render(<SettingsPanel />);
+
+    await user.click(await screen.findByText('Run Patch Now'));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('run_gemini_patch');
+    });
+    expect(await screen.findByText('Gemini CLI patch applied successfully.')).toBeInTheDocument();
+  });
+
   it('shows the auto-selected shell when default shell is auto', async () => {
     mockInvoke.mockImplementation(async (command, args) => {
       switch (command) {

--- a/src/features/settings/SettingsPanel.tsx
+++ b/src/features/settings/SettingsPanel.tsx
@@ -107,7 +107,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = () => {
     try {
       await invoke<string>("run_gemini_patch");
       setPatchStatus("success");
-      setPatchMessage("Gemini CLI Patch Applied Successfully.");
+      setPatchMessage("Gemini CLI patch applied successfully.");
       setTimeout(() => {
         setPatchStatus("idle");
         setPatchMessage("");

--- a/src/features/terminal/UserTerminalPanel.tsx
+++ b/src/features/terminal/UserTerminalPanel.tsx
@@ -284,7 +284,7 @@ export function UserTerminalPanel({
         onPointerUp={handlePointerUp}
       />
       <div className="h-9 px-3 flex items-center gap-2 border-b border-wardian-border bg-[var(--color-wardian-sidebar-secondary)]/30">
-        <h2 className="text-xs font-bold text-primary uppercase tracking-[0.08em]">Terminal</h2>
+        <h2 className="text-xs font-bold text-primary tracking-tight">Terminal</h2>
         {statusMessage && (
           <span className="text-xs text-muted truncate" title={statusMessage}>
             {statusMessage}

--- a/src/features/workflows/ActiveMonitoring.tsx
+++ b/src/features/workflows/ActiveMonitoring.tsx
@@ -269,7 +269,7 @@ export const ActiveMonitoring: React.FC<ActiveMonitoringProps> = ({
                         <span className="opacity-30">•</span>
                         <span className="truncate">{targetSummary}</span>
                       </div>
-                      <div className="mt-1 flex items-center gap-1.5 text-[9px] font-bold uppercase tracking-[0.12em] text-[var(--color-wardian-accent)]/80">
+                      <div className="mt-1 flex items-center gap-1.5 text-[10px] font-bold tracking-wide text-[var(--color-wardian-accent)]/80">
                         <span>
                           {lastFailure
                             ? `Last failed: ${lastFailure}`
@@ -303,19 +303,19 @@ export const ActiveMonitoring: React.FC<ActiveMonitoringProps> = ({
                   {isExpanded && (
                     <div className="border-t border-wardian-border/20 px-2.5 py-2.5">
                       <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-[9px] text-muted-neutral">
-                        <span className="font-bold uppercase tracking-[0.12em]">Schedule</span>
+                        <span className="font-bold tracking-wide">Schedule</span>
                         <span className="truncate">{formatScheduleSummary(schedule.schedule)}</span>
-                        <span className="font-bold uppercase tracking-[0.12em]">Status</span>
+                        <span className="font-bold tracking-wide">Status</span>
                         <span className="truncate">{status}</span>
-                        <span className="font-bold uppercase tracking-[0.12em]">Next</span>
+                        <span className="font-bold tracking-wide">Next</span>
                         <span className="truncate">{formatNextRun(schedule.next_run_epoch_ms)}</span>
-                        <span className="font-bold uppercase tracking-[0.12em]">Target</span>
+                        <span className="font-bold tracking-wide">Target</span>
                         <span className="truncate">{targetSummary}</span>
                         {roleMappings.map(([role, agentId]) => {
                           const agentName = agents.find(agent => agent.session_id === agentId)?.session_name || agentId;
                           return (
                             <React.Fragment key={role}>
-                              <span className="font-mono uppercase tracking-[0.08em]">{role}</span>
+                              <span className="font-mono tracking-wide">{role}</span>
                               <span className="truncate">{agentName}</span>
                             </React.Fragment>
                           );

--- a/src/features/workflows/RunPayloadModal.test.tsx
+++ b/src/features/workflows/RunPayloadModal.test.tsx
@@ -9,6 +9,15 @@ const workflow: WorkflowDefinition = {
   settings: { max_iterations: 10, on_limit_reached: "pause" },
   role_mappings: {},
   nodes: [
+    {
+      id: "trigger-1",
+      type: "trigger",
+      name: "Manual Trigger",
+      config: {},
+      parameter_schema: {
+        topic: { type: "string", title: "Topic", default: "Coverage" },
+      },
+    },
     { id: "agent-1", type: "agent", name: "Planner", config: { role: "planner" } },
   ],
 };
@@ -19,12 +28,17 @@ describe("RunPayloadModal", () => {
       <RunPayloadModal
         workflow={workflow}
         isOpen={true}
-        agents={[]}
+        agents={[{ session_id: "agent-1", session_name: "Planner One" }]}
         onRun={vi.fn()}
         onCancel={vi.fn()}
       />,
     );
 
     expect(screen.getByRole("heading", { name: "Agent Handoff" })).toBeInTheDocument();
+    expect(screen.getByText("Configure Agents & Inputs")).toBeInTheDocument();
+    expect(screen.getByText("Agent assignments")).toBeInTheDocument();
+    expect(screen.getByText("Input parameters")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Select agent" })).toBeInTheDocument();
+    expect(screen.getByText("Topic")).toBeInTheDocument();
   });
 });

--- a/src/features/workflows/RunPayloadModal.tsx
+++ b/src/features/workflows/RunPayloadModal.tsx
@@ -199,7 +199,7 @@ export const RunPayloadModal: React.FC<RunPayloadModalProps> = ({
         <div className="p-6 border-b border-wardian-border flex items-center justify-between">
           <div className="flex flex-col">
             <h3 className="text-xl font-bold text-[var(--color-wardian-text)] tracking-tight">{workflow.name}</h3>
-            <span className="text-[10px] font-bold text-muted-neutral uppercase tracking-widest">
+            <span className="text-[11px] font-bold text-muted-neutral tracking-wide">
               Configure {subtitleParts.join(' & ')}
             </span>
           </div>
@@ -217,7 +217,7 @@ export const RunPayloadModal: React.FC<RunPayloadModalProps> = ({
             <div className="space-y-3">
               <div className="flex items-center gap-2 mb-1">
                 <svg className="w-3.5 h-3.5 text-[var(--color-wardian-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                <span className="text-[11px] font-bold text-[var(--color-wardian-accent)] uppercase tracking-[0.15em]">Schedule</span>
+                <span className="text-[12px] font-bold text-[var(--color-wardian-accent)] tracking-wide">Schedule</span>
               </div>
               <ScheduleEditor
                 value={scheduleConfig}
@@ -236,12 +236,12 @@ export const RunPayloadModal: React.FC<RunPayloadModalProps> = ({
             <div className="space-y-3">
               <div className="flex items-center gap-2 mb-1">
                 <svg className="w-3.5 h-3.5 text-[var(--color-wardian-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
-                <span className="text-[11px] font-bold text-[var(--color-wardian-accent)] uppercase tracking-[0.15em]">Agent Assignments</span>
+                <span className="text-[12px] font-bold text-[var(--color-wardian-accent)] tracking-wide">Agent assignments</span>
               </div>
               {roles.map(({ role, nodeName }) => (
                 <div key={role} className="flex flex-col gap-1.5">
                   <div className="flex items-center justify-between">
-                    <label className="text-[10px] font-bold text-muted-neutral uppercase tracking-wider">{nodeName}</label>
+                    <label className="text-[11px] font-bold text-muted-neutral tracking-wide">{nodeName}</label>
                     <span className="text-[8px] font-mono text-muted-neutral/50 bg-white/5 px-1.5 py-0.5 rounded border border-white/5">{role}</span>
                   </div>
                   <select
@@ -249,7 +249,7 @@ export const RunPayloadModal: React.FC<RunPayloadModalProps> = ({
                     onChange={(e) => handleRoleChange(role, e.target.value)}
                     className="w-full bg-[var(--color-wardian-input-bg)] border border-wardian-border rounded-xl px-3 py-2 text-[11px] text-[var(--color-wardian-text)] outline-none focus:border-[var(--color-wardian-accent)]/50 transition-colors cursor-pointer"
                   >
-                    <option value="">-- Select Agent --</option>
+                    <option value="">Select agent</option>
                     {agents.map((a) => (
                       <option key={a.session_id} value={a.session_id}>
                         {a.session_name || a.session_id}
@@ -272,7 +272,7 @@ export const RunPayloadModal: React.FC<RunPayloadModalProps> = ({
               {(hasRoles || hasSchedule) && (
                 <div className="flex items-center gap-2 mb-1">
                   <svg className="w-3.5 h-3.5 text-[var(--color-wardian-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
-                  <span className="text-[11px] font-bold text-[var(--color-wardian-accent)] uppercase tracking-[0.15em]">Input Parameters</span>
+                  <span className="text-[12px] font-bold text-[var(--color-wardian-accent)] tracking-wide">Input parameters</span>
                 </div>
               )}
               {Object.entries(properties).map(([key, prop]: [string, any]) => {
@@ -281,7 +281,7 @@ export const RunPayloadModal: React.FC<RunPayloadModalProps> = ({
                 <div key={key} className="flex flex-col gap-2">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-1">
-                      <label className="text-[11px] font-bold text-[var(--color-wardian-accent)] uppercase tracking-[0.2em]">{prop.title || key}</label>
+                      <label className="text-[11px] font-bold text-[var(--color-wardian-accent)] tracking-wide">{prop.title || key}</label>
                       {isRequired && <span className="text-[11px] text-[var(--color-wardian-error)] font-bold">*</span>}
                     </div>
                     <div className="flex items-center gap-1.5 opacity-60">
@@ -314,7 +314,7 @@ export const RunPayloadModal: React.FC<RunPayloadModalProps> = ({
           </button>
           <button
             onClick={handleSubmit}
-            className="px-8 py-2 bg-[var(--color-wardian-accent)] text-[var(--color-wardian-bg)] rounded-xl text-[10px] font-bold uppercase tracking-widest hover:scale-105 active:scale-95 transition-all cursor-pointer"
+            className="px-8 py-2 bg-[var(--color-wardian-accent)] text-[var(--color-wardian-bg)] rounded-xl text-xs font-bold tracking-wide hover:scale-105 active:scale-95 transition-all cursor-pointer"
           >
             {hasSchedule ? 'Schedule Workflow' : 'Run Workflow'}
           </button>

--- a/src/features/workflows/ScheduleEditor.tsx
+++ b/src/features/workflows/ScheduleEditor.tsx
@@ -34,7 +34,7 @@ interface ScheduleEditorProps {
 
 const inputClass = "w-full bg-[var(--color-wardian-input-bg)] border border-wardian-border rounded-lg px-3 py-1.5 text-[11px] text-[var(--color-wardian-text)] outline-none focus:border-[var(--color-wardian-accent)]/50 transition-colors";
 const selectClass = inputClass + " cursor-pointer";
-const labelClass = "text-[10px] font-bold text-muted-neutral uppercase tracking-wider";
+const labelClass = "text-[11px] font-bold text-muted-neutral tracking-wide";
 
 export const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ value, onChange, compact }) => {
   const schedType = value.schedule_type || 'interval';

--- a/src/features/workflows/WorkflowNode.tsx
+++ b/src/features/workflows/WorkflowNode.tsx
@@ -69,11 +69,11 @@ function describeScheduleConfig(config: any): string {
 }
 
 const CATEGORY_COLORS: Record<string, string> = {
-  'TRIGGER': 'border-[var(--color-workflow-agent)] bg-[color-mix(in_srgb,var(--color-workflow-agent),transparent_95%)]',
-  'EXECUTION': 'border-[var(--color-workflow-command)] bg-[color-mix(in_srgb,var(--color-workflow-command),transparent_95%)]',
-  'FLOW CONTROL': 'border-[var(--color-workflow-logic)] bg-[color-mix(in_srgb,var(--color-workflow-logic),transparent_95%)]',
-  'PERSISTENCE': 'border-[var(--color-workflow-comm)] bg-[color-mix(in_srgb,var(--color-workflow-comm),transparent_95%)]',
-  'COMMUNICATION': 'border-[var(--color-workflow-comm)] bg-[color-mix(in_srgb,var(--color-workflow-comm),transparent_95%)]',
+  'Trigger': 'border-[var(--color-workflow-agent)] bg-[color-mix(in_srgb,var(--color-workflow-agent),transparent_95%)]',
+  'Execution': 'border-[var(--color-workflow-command)] bg-[color-mix(in_srgb,var(--color-workflow-command),transparent_95%)]',
+  'Flow control': 'border-[var(--color-workflow-logic)] bg-[color-mix(in_srgb,var(--color-workflow-logic),transparent_95%)]',
+  'Persistence': 'border-[var(--color-workflow-comm)] bg-[color-mix(in_srgb,var(--color-workflow-comm),transparent_95%)]',
+  'Communication': 'border-[var(--color-workflow-comm)] bg-[color-mix(in_srgb,var(--color-workflow-comm),transparent_95%)]',
 };
 
 const STATUS_COLORS: Record<NodeStatus, string> = {
@@ -90,8 +90,8 @@ export const WorkflowNode = memo(({ id, data, selected }: NodeProps<Node<{ label
   
   // Lookup block definition by type and name to get category
   const blockDef = BLOCK_LIBRARY.find(b => b.type === type && (data.blockName ? b.name === data.blockName : true));
-  const category = blockDef?.category || 'EXECUTION';
-  const colorClass = CATEGORY_COLORS[category] || CATEGORY_COLORS['EXECUTION'];
+  const category = blockDef?.category || 'Execution';
+  const colorClass = CATEGORY_COLORS[category] || CATEGORY_COLORS['Execution'];
   const statusColorClass = STATUS_COLORS[status];
   
   const { 
@@ -214,7 +214,7 @@ export const WorkflowNode = memo(({ id, data, selected }: NodeProps<Node<{ label
                 const summary = describeScheduleConfig(data.config);
                 return (
                   <div key={field.name} className="flex flex-col gap-1 p-2 mt-1 bg-[color-mix(in_srgb,var(--color-wardian-accent),transparent_95%)] rounded border border-[var(--color-wardian-accent)]/10">
-                    <span className="text-[8px] font-mono uppercase text-[var(--color-wardian-accent)] font-bold tracking-wide">{field.label}</span>
+                    <span className="text-[9px] font-mono text-[var(--color-wardian-accent)] font-bold tracking-wide">{field.label}</span>
                     <span className="text-[10px] text-[var(--color-wardian-text)] font-medium opacity-90 truncate">{summary}</span>
                   </div>
                 );
@@ -231,7 +231,7 @@ export const WorkflowNode = memo(({ id, data, selected }: NodeProps<Node<{ label
               if (field.name === 'agent_id') {
                 return (
                   <div key={field.name} className="flex flex-col gap-1">
-                    <span className="text-[8px] font-mono uppercase text-[var(--color-wardian-text-muted)]">{field.label}</span>
+                    <span className="text-[9px] font-mono text-[var(--color-wardian-text-muted)]">{field.label}</span>
                     <select
                       className="nodrag nowheel p-1.5 rounded bg-[color-mix(in_srgb,var(--color-wardian-bg),black_10%)] border border-[var(--color-wardian-border)] text-xs text-[var(--color-wardian-text)] w-full outline-none focus:border-[var(--color-wardian-accent)] cursor-pointer"
                       value={val}

--- a/src/features/workflows/WorkflowSidebar.test.tsx
+++ b/src/features/workflows/WorkflowSidebar.test.tsx
@@ -112,7 +112,7 @@ describe('WorkflowSidebar', () => {
     renderWithProvider(<WorkflowSidebar />);
 
     fireEvent.click(screen.getByTitle('Stop All (Panic)'));
-    await waitFor(() => expect(screen.getByText(/STOP ALL/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Stop all active runs/)).toBeInTheDocument());
     fireEvent.click(screen.getByText('Confirm'));
     await waitFor(() => expect(mockStopAllTriggers).toHaveBeenCalled());
     await waitFor(() => expect(mockFetchWorkflows).toHaveBeenCalled());

--- a/src/features/workflows/WorkflowSidebar.tsx
+++ b/src/features/workflows/WorkflowSidebar.tsx
@@ -156,7 +156,7 @@ export const WorkflowSidebar: React.FC<WorkflowSidebarProps> = ({
   [availableWorkflows]);
 
   const handleStopAll = async () => {
-    if (await confirm('STOP ALL: Immediately terminate all active runs and triggers?')) {
+    if (await confirm('Stop all active runs and triggers?')) {
       await stopAllTriggers();
       fetchWorkflows();
     }

--- a/src/features/workflows/blockLibrary.ts
+++ b/src/features/workflows/blockLibrary.ts
@@ -42,7 +42,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'trigger', 
     name: 'Manual Trigger', 
-    category: 'TRIGGER', 
+    category: 'Trigger',
     description: 'Fires the initial sequence pulse.', 
     inputs: 'Provided Payload', 
     outputs: 'Trigger Context', 
@@ -52,7 +52,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'trigger', 
     name: 'File Watcher', 
-    category: 'TRIGGER', 
+    category: 'Trigger',
     description: 'Fires on file system events.', 
     inputs: 'Glob Pattern', 
     outputs: 'Trigger Context', 
@@ -66,7 +66,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   {
     type: 'trigger',
     name: 'Scheduled Trigger',
-    category: 'TRIGGER',
+    category: 'Trigger',
     description: 'Runs on a scheduled interval or at a specific time.',
     inputs: 'Schedule Config',
     outputs: 'Trigger Context',
@@ -76,17 +76,17 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     ]
   },
   
-  // EXECUTION
+  // Execution
   { 
     type: 'agent', 
     name: 'Agent', 
-    category: 'EXECUTION', 
+    category: 'Execution',
     description: 'Structured prompt execution via LLM.', 
     inputs: 'Registry Context', 
     outputs: 'Agent Result', 
     ports: DEFAULT_PORTS,
     fields: [
-      { name: 'agent_id', label: 'Target Agent', type: 'select', placeholder: 'Select Agent' },
+      { name: 'agent_id', label: 'Target agent', type: 'select', placeholder: 'Select agent' },
       { name: 'agent_class', label: 'Agent Class', type: 'select', placeholder: 'Select Class' },
       { name: 'prompt', label: 'Prompt Template', type: 'textarea', placeholder: 'Analyze {{nodes.step1.output}}', required: true },
       { name: 'mode', label: 'Run Mode', type: 'select', options: ['ephemeral', 'inherit_fresh', 'inherit_resume'], default: 'ephemeral' },
@@ -102,7 +102,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'command', 
     name: 'Shell Command', 
-    category: 'EXECUTION', 
+    category: 'Execution',
     description: 'Native PTY execution.', 
     inputs: 'Registry Context', 
     outputs: 'Cmd Result', 
@@ -120,7 +120,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'script', 
     name: 'Script', 
-    category: 'EXECUTION', 
+    category: 'Execution',
     description: 'Isolated local file execution.', 
     inputs: 'Registry Context', 
     outputs: 'Script Result', 
@@ -137,7 +137,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'tool', 
     name: 'Tool Call', 
-    category: 'EXECUTION', 
+    category: 'Execution',
     description: 'Direct MCP tool invocation.', 
     inputs: 'Registry Context', 
     outputs: 'Tool Result', 
@@ -146,11 +146,11 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     advancedFields: SIMPLE_ADVANCED
   },
 
-  // FLOW CONTROL
+  // Flow control
   { 
     type: 'logic', 
     name: 'Branch', 
-    category: 'FLOW CONTROL', 
+    category: 'Flow control',
     description: 'Branching based on conditions.', 
     inputs: 'Registry Context', 
     outputs: 'True/False Path',
@@ -160,7 +160,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'loop', 
     name: 'Loop', 
-    category: 'FLOW CONTROL', 
+    category: 'Flow control',
     description: 'Iterative execution pulse.', 
     inputs: 'Registry Context', 
     outputs: 'Body / Done', 
@@ -175,7 +175,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'wait', 
     name: 'Wait', 
-    category: 'FLOW CONTROL', 
+    category: 'Flow control',
     description: 'Synchronization barrier.', 
     inputs: 'Multiple Temporal signals', 
     outputs: 'Sync Stamp', 
@@ -185,7 +185,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'subflow', 
     name: 'Sub-Flow', 
-    category: 'FLOW CONTROL', 
+    category: 'Flow control',
     description: 'Invoke an existing workflow.', 
     inputs: 'Explicit Args', 
     outputs: 'Final Registry State', 
@@ -196,11 +196,11 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     ]
   },
 
-  // PERSISTENCE
+  // Persistence
   { 
     type: 'memory', 
     name: 'KV Storage', 
-    category: 'PERSISTENCE', 
+    category: 'Persistence',
     description: 'Read/Write to shared storage.', 
     inputs: 'Registry Context', 
     outputs: 'Result/Status', 
@@ -213,11 +213,11 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
     ]
   },
   
-  // COMMUNICATION
+  // Communication
   { 
     type: 'communication', 
     name: 'Notify', 
-    category: 'COMMUNICATION', 
+    category: 'Communication',
     description: 'Send UI toast or message.', 
     inputs: 'Registry Context', 
     outputs: 'Delivery Status', 
@@ -227,7 +227,7 @@ export const BLOCK_LIBRARY: BlockDefinition[] = [
   { 
     type: 'communication', 
     name: 'Broadcast', 
-    category: 'COMMUNICATION', 
+    category: 'Communication',
     description: 'Unified message to all agents.', 
     inputs: 'Registry Context', 
     outputs: 'Status', 

--- a/src/views/WorkflowBuilderView.tsx
+++ b/src/views/WorkflowBuilderView.tsx
@@ -96,7 +96,7 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
   const confirm = useConfirm();
   const [selectedNodeId, setSelectedNodeId] = React.useState<string | null>(null);
   const [isLibraryOpen, setIsBlockLibraryOpen] = React.useState(false);
-  const [activeCategory, setActiveCategory] = React.useState("ALL");
+  const [activeCategory, setActiveCategory] = React.useState("All");
   const [searchQuery, setSearchQuery] = React.useState("");
   
   const [isRenamingWf, setIsRenamingWf] = React.useState(false);
@@ -398,9 +398,9 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
     [nodes, nodeStatuses]
   );
 
-  const categories = ["ALL", ...Array.from(new Set(BLOCK_LIBRARY.map(b => b.category)))];
+  const categories = ["All", ...Array.from(new Set(BLOCK_LIBRARY.map(b => b.category)))];
   const filteredBlocks = BLOCK_LIBRARY.filter(b => 
-    (activeCategory === "ALL" || b.category === activeCategory) &&
+    (activeCategory === "All" || b.category === activeCategory) &&
     (b.name.toLowerCase().includes(searchQuery.toLowerCase()) || b.description.toLowerCase().includes(searchQuery.toLowerCase()))
   );
 
@@ -541,14 +541,14 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
                 }
               }
             }}
-            className={`px-4 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-widest transition-all ${activeWorkflowId ? 'bg-[var(--color-wardian-card-bg-muted)] text-[var(--color-wardian-text-muted)] hover:bg-[color-mix(in_srgb,var(--color-wardian-card-bg-muted),var(--color-wardian-text)_10%)] hover:text-[var(--color-wardian-text)] border border-wardian-border cursor-pointer' : 'hidden'}`}
+            className={`px-4 py-1.5 rounded-md text-[11px] font-bold tracking-wide transition-all ${activeWorkflowId ? 'bg-[var(--color-wardian-card-bg-muted)] text-[var(--color-wardian-text-muted)] hover:bg-[color-mix(in_srgb,var(--color-wardian-card-bg-muted),var(--color-wardian-text)_10%)] hover:text-[var(--color-wardian-text)] border border-wardian-border cursor-pointer' : 'hidden'}`}
           >
             Reset
           </button>
           <button 
             disabled={!activeWorkflowId}
             onClick={handleSave}
-            className={`px-4 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-widest transition-all ${activeWorkflowId ? 'bg-[var(--color-wardian-card-bg-muted)] text-[var(--color-wardian-text-muted)] hover:bg-[color-mix(in_srgb,var(--color-wardian-card-bg-muted),var(--color-wardian-text)_10%)] hover:text-[var(--color-wardian-text)] border border-wardian-border cursor-pointer' : 'bg-[var(--color-wardian-card-bg-muted)] text-[var(--color-wardian-text-muted-neutral)] cursor-not-allowed hidden'}`}
+            className={`px-4 py-1.5 rounded-md text-[11px] font-bold tracking-wide transition-all ${activeWorkflowId ? 'bg-[var(--color-wardian-card-bg-muted)] text-[var(--color-wardian-text-muted)] hover:bg-[color-mix(in_srgb,var(--color-wardian-card-bg-muted),var(--color-wardian-text)_10%)] hover:text-[var(--color-wardian-text)] border border-wardian-border cursor-pointer' : 'bg-[var(--color-wardian-card-bg-muted)] text-[var(--color-wardian-text-muted-neutral)] cursor-not-allowed hidden'}`}
           >
             {isSaving ? 'Saving...' : 'Save Changes'}
           </button>
@@ -556,7 +556,7 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
             data-testid="run-workflow-button"
             onClick={handleRun}
             disabled={!activeWorkflowId || hasGraphErrors}
-            className={`px-6 py-1.5 rounded-md text-[10px] font-bold uppercase tracking-widest transition-all ${activeWorkflowId && !hasGraphErrors ? 'bg-[var(--color-wardian-accent)] text-[var(--color-wardian-bg)] hover:bg-[var(--color-wardian-accent-hover)] hover:scale-105 active:scale-95 cursor-pointer shadow-wardian-accent' : 'bg-wardian-error/10 text-wardian-error/50 cursor-not-allowed border border-wardian-error/20 shadow-none scale-100'}`}
+            className={`px-6 py-1.5 rounded-md text-[11px] font-bold tracking-wide transition-all ${activeWorkflowId && !hasGraphErrors ? 'bg-[var(--color-wardian-accent)] text-[var(--color-wardian-bg)] hover:bg-[var(--color-wardian-accent-hover)] hover:scale-105 active:scale-95 cursor-pointer shadow-wardian-accent' : 'bg-wardian-error/10 text-wardian-error/50 cursor-not-allowed border border-wardian-error/20 shadow-none scale-100'}`}
             title={hasGraphErrors ? "Cannot run: Fix node errors first" : undefined}
           >
             {hasGraphErrors ? 'Graph Error' : 'Run Workflow'}
@@ -679,7 +679,7 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
                       onClick={() => setActiveCategory(cat)}
                       className={`w-full text-left px-4 py-3 rounded-xl text-xs font-bold tracking-wide transition-all cursor-pointer ${activeCategory === cat ? 'bg-[var(--color-wardian-accent)]/10 text-[var(--color-wardian-accent)] shadow-sm' : 'text-muted-neutral hover:bg-[var(--color-wardian-card-bg-muted)] hover:text-[var(--color-wardian-text)]'}`}
                     >
-                      {cat === "ALL" ? "✦ All Blocks" : cat.charAt(0).toUpperCase() + cat.slice(1).toLowerCase()}
+                      {cat === "All" ? "✦ All blocks" : cat}
                     </button>
                   ))}
                 </nav>
@@ -688,7 +688,7 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
               {/* Main Content */}
               <div className="flex-1 flex flex-col min-w-0">
                 <div className="h-16 border-b border-wardian-border flex items-center justify-between px-8 bg-[var(--color-wardian-card)]">
-                  <span className="text-sm font-mono font-bold text-muted-neutral tracking-wide">{activeCategory.charAt(0).toUpperCase() + activeCategory.slice(1).toLowerCase()} Blocks ({filteredBlocks.length})</span>
+                  <span className="text-sm font-mono font-bold text-muted-neutral tracking-wide">{activeCategory} blocks ({filteredBlocks.length})</span>
                   <button 
                     onClick={() => setIsBlockLibraryOpen(false)}
                     className="p-2 hover:bg-[var(--color-wardian-card-bg-muted)] rounded-full text-muted-neutral hover:text-[var(--color-wardian-text)] transition-all cursor-pointer"
@@ -713,11 +713,11 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
                         
                         <div className="space-y-3 mt-auto pt-2 border-t border-white/5">
                           <div className="flex flex-col gap-1">
-                            <span className="text-[10px] font-mono font-bold uppercase tracking-wider text-[var(--color-wardian-text-muted)] opacity-80">Input</span>
+                            <span className="text-[11px] font-mono font-bold tracking-wide text-[var(--color-wardian-text-muted)] opacity-80">Input</span>
                             <span className="text-sm font-mono text-[var(--color-wardian-text)]/80 break-all leading-tight">{block.inputs}</span>
                           </div>
                           <div className="flex flex-col gap-1">
-                            <span className="text-[10px] font-mono font-bold uppercase tracking-wider text-[var(--color-wardian-text-muted)] opacity-80">Output</span>
+                            <span className="text-[11px] font-mono font-bold tracking-wide text-[var(--color-wardian-text-muted)] opacity-80">Output</span>
                             <span className="text-sm font-mono text-[var(--color-wardian-processing)] break-all leading-tight">{block.outputs}</span>
                           </div>
                         </div>
@@ -809,7 +809,7 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
                   if (field.name === 'agent_id') {
                     return (
                       <div key={field.name} className="flex flex-col gap-2">
-                        <label className="text-[10px] font-bold text-[var(--color-wardian-accent)] uppercase tracking-[0.2em]">{field.label}</label>
+                        <label className="text-[11px] font-bold text-[var(--color-wardian-accent)] tracking-wide">{field.label}</label>
                         <select
                           className="p-3 rounded-xl bg-[var(--color-wardian-bg)] border border-wardian-border text-sm text-[var(--color-wardian-text)] w-full outline-none focus:ring-2 focus:ring-[var(--color-wardian-accent)] cursor-pointer"
                           value={val}
@@ -861,7 +861,7 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
                     
                     {blockDef.advancedFields && blockDef.advancedFields.length > 0 && (
                       <div className="pt-8 border-t border-wardian-border space-y-6">
-                        <h4 className="text-[10px] font-bold text-muted-neutral uppercase tracking-[0.3em]">Advanced Configuration</h4>
+                        <h4 className="text-[11px] font-bold text-muted-neutral tracking-wide">Advanced configuration</h4>
                         {blockDef.advancedFields.map(f => renderField(f))}
                       </div>
                     )}
@@ -871,7 +871,7 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
 
               <div className="pt-8 border-t border-wardian-border space-y-6">
                 <div className="flex items-center justify-between">
-                  <h4 className="text-[10px] font-bold text-muted-neutral uppercase tracking-[0.3em]">Parameter Schema</h4>
+                  <h4 className="text-[11px] font-bold text-muted-neutral tracking-wide">Parameter schema</h4>
                 </div>
                 <p className="text-[10px] text-muted-neutral">Define required parameters and default values for this node.</p>
                 <SchemaEditor 
@@ -912,8 +912,6 @@ export const WorkflowBuilderView: React.FC<WorkflowBuilderViewProps> = ({ theme 
     </div>
   );
 };
-
-
 
 
 


### PR DESCRIPTION
## Description
Adds the live Wardian CLI control surface for agent lifecycle, workflow control, inter-agent send/wait, and Wardian-native orchestration guidance. The CLI now talks to the running desktop app for mutating commands, falls back to disk for workflow list/show when appropriate, and preserves clearer error semantics for bad requests, unsupported threading, wait timeouts, and app-not-running cases.

## Related Issues
Fixes #208

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `cargo test -p wardian-cli --no-fail-fast` (34 unit + 14 agent CLI + 5 send CLI + 10 workflow CLI tests passed)
- [x] `cargo test -p wardian-core --no-fail-fast` (34 tests passed)
- [x] `cargo check -p wardian-cli`
- [x] `cargo clippy -p wardian-cli --no-deps`
- [x] `cargo test --manifest-path src-tauri\Cargo.toml --no-fail-fast` (305 backend tests + 4 mock provider E2E tests passed)
- [x] `cargo check --manifest-path src-tauri\Cargo.toml`
- [x] `cargo clippy --manifest-path src-tauri\Cargo.toml --no-deps`
- [x] `npm run lint`
- [x] `npm run test` (455 tests passed; existing React act warnings remain in watchlist/app tests)
- [x] `npm run build` / `npm run tauri -- build --debug --no-bundle`
- [x] `npm run test:e2e:native:fast -- e2e-native/tests/cli-shared-state-native.test.mjs` (3 passed, 1 real-provider Codex test skipped)
- [x] `git diff --check` (clean; only line-ending warnings)
- [x] Secret scan with `rg` for API keys, passwords, tokens, and private keys returned no hits

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable