### PR TITLE
Add agent watch communication diagnostics

### DIFF
--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -128,12 +128,29 @@ pub enum AgentCommand {
         #[arg(long)]
         name: Option<String>,
     },
+    Watch {
+        target: String,
+        #[arg(long)]
+        since: Option<String>,
+        #[arg(long)]
+        until: Option<String>,
+        #[arg(long)]
+        include: Option<String>,
+        #[arg(long = "tail")]
+        tail: Option<usize>,
+        #[arg(long, default_value = "10m")]
+        timeout: String,
+        #[arg(long)]
+        follow: bool,
+    },
     Wait {
         target: String,
         #[arg(long)]
         until: String,
         #[arg(long, default_value = "10m")]
         timeout: String,
+        #[arg(long)]
+        next: bool,
     },
 }
 
@@ -309,8 +326,66 @@ mod tests {
         };
         assert!(matches!(
             args.command,
-            Some(AgentCommand::Wait { ref target, ref until, ref timeout })
+            Some(AgentCommand::Wait { ref target, ref until, ref timeout, next: false })
             if target == "reviewer-a1" && until == "idle" && timeout == "30s"
+        ));
+    }
+
+    #[test]
+    fn parses_agent_watch_options() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "agent",
+            "watch",
+            "Wardian-Codex",
+            "--since",
+            "agent-1:0001",
+            "--until",
+            "output:OK",
+            "--include",
+            "status,output",
+            "--tail",
+            "4096",
+            "--timeout",
+            "30s",
+        ])
+        .unwrap();
+
+        let Command::Agent(args) = cli.command else {
+            panic!("agent")
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Watch { ref target, ref since, ref until, ref include, tail, ref timeout, follow })
+                if target == "Wardian-Codex"
+                    && since.as_deref() == Some("agent-1:0001")
+                    && until.as_deref() == Some("output:OK")
+                    && include.as_deref() == Some("status,output")
+                    && tail == Some(4096)
+                    && timeout == "30s"
+                    && !follow
+        ));
+    }
+
+    #[test]
+    fn parses_agent_wait_next() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "agent",
+            "wait",
+            "Wardian-Codex",
+            "--until",
+            "idle",
+            "--next",
+        ])
+        .unwrap();
+
+        let Command::Agent(args) = cli.command else {
+            panic!("agent")
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Wait { next: true, .. })
         ));
     }
 

--- a/crates/wardian-cli/src/errors.rs
+++ b/crates/wardian-cli/src/errors.rs
@@ -116,6 +116,21 @@ impl CliError {
         }
     }
 
+    pub fn backend_with_details(
+        exit_code: ExitCode,
+        code: &'static str,
+        message: impl Into<String>,
+        details: serde_json::Value,
+    ) -> Self {
+        Self {
+            exit_code,
+            code,
+            message: message.into(),
+            hint: None,
+            details: Some(Box::new(details)),
+        }
+    }
+
     pub fn to_json(&self) -> String {
         serde_json::to_string(&ErrorEnvelope {
             schema: 1,
@@ -156,5 +171,29 @@ mod tests {
         let error = CliError::not_found("ghost");
         assert_eq!(error.code_i32(), 2);
         assert!(error.to_json().contains("ghost"));
+    }
+
+    #[test]
+    fn backend_error_can_emit_details() {
+        let error = CliError::backend_with_details(
+            ExitCode::Generic,
+            "request_failed",
+            "message delivery failed",
+            serde_json::json!({
+                "delivery": [{
+                    "uuid": "agent-2",
+                    "runtime_state": "restored_without_sender",
+                    "delivery_state": "failed"
+                }]
+            }),
+        );
+
+        let value: serde_json::Value = serde_json::from_str(&error.to_json()).unwrap();
+
+        assert_eq!(value["error"]["code"], "request_failed");
+        assert_eq!(
+            value["error"]["details"]["delivery"][0]["runtime_state"],
+            "restored_without_sender"
+        );
     }
 }

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -5,8 +5,8 @@ use std::{
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
-    AgentListResponse, AgentResponse, ControlRequest, WorkflowListResponse, WorkflowResponse,
-    WorkflowSummary,
+    AgentListResponse, AgentResponse, AgentWatchResponse, ControlRequest, SendMessageResponse,
+    WorkflowListResponse, WorkflowResponse, WorkflowSummary,
 };
 use wardian_core::identity::AgentIdentity;
 use wardian_core::models::WorkflowDefinition;
@@ -14,7 +14,7 @@ use wardian_core::models::WorkflowDefinition;
 const CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
 const CONTROL_MUTATION_TIMEOUT: Duration = Duration::from_secs(30);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ControlOperation {
     AgentList,
     AgentKill,
@@ -27,12 +27,18 @@ enum ControlOperation {
     WorkflowRun,
     WorkflowStop,
     SendMessage,
+    AgentWatch {
+        requested: Duration,
+        target: String,
+        until: String,
+    },
 }
 
 #[derive(Debug)]
 pub struct ControlEndpointError {
     code: String,
     message: String,
+    details: Option<serde_json::Value>,
 }
 
 impl ControlEndpointError {
@@ -40,11 +46,28 @@ impl ControlEndpointError {
         Self {
             code: code.into(),
             message: message.into(),
+            details: None,
+        }
+    }
+
+    pub fn with_details(
+        code: impl Into<String>,
+        message: impl Into<String>,
+        details: serde_json::Value,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            details: Some(details),
         }
     }
 
     pub fn code(&self) -> &str {
         &self.code
+    }
+
+    pub fn details(&self) -> Option<&serde_json::Value> {
+        self.details.as_ref()
     }
 }
 
@@ -84,6 +107,35 @@ impl fmt::Display for WaitTimeoutError {
 }
 
 impl std::error::Error for WaitTimeoutError {}
+
+#[derive(Debug)]
+pub struct WatchTimeoutError {
+    target: String,
+    until: String,
+    last_status: String,
+}
+
+impl WatchTimeoutError {
+    pub fn new(target: &str, until: &str, last_status: &str) -> Self {
+        Self {
+            target: target.to_string(),
+            until: until.to_string(),
+            last_status: last_status.to_string(),
+        }
+    }
+}
+
+impl fmt::Display for WatchTimeoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "timed out watching {} for {}; last status: {}",
+            self.target, self.until, self.last_status
+        )
+    }
+}
+
+impl std::error::Error for WatchTimeoutError {}
 
 #[derive(Debug)]
 pub struct WaitTargetNotFoundError {
@@ -243,9 +295,13 @@ pub fn workflow_stop(run_instance_id: &str) -> io::Result<()> {
     .map(|_| ())
 }
 
-pub fn send_message(target: &str, message: &str, thread: Option<&str>) -> io::Result<()> {
+pub fn send_message(
+    target: &str,
+    message: &str,
+    thread: Option<&str>,
+) -> io::Result<SendMessageResponse> {
     let runtime = build_runtime()?;
-    timeout_block(
+    let value = timeout_block(
         &runtime,
         ControlOperation::SendMessage,
         send_request(ControlRequest::SendMessage {
@@ -253,24 +309,103 @@ pub fn send_message(target: &str, message: &str, thread: Option<&str>) -> io::Re
             message: message.to_string(),
             thread: thread.map(str::to_string),
         }),
-    )
-    .map(|_| ())
+    )?;
+    serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
 }
 
-pub fn send_message_and_wait(
+pub fn wait_agent_until(target: &str, until: &str, timeout: Duration) -> io::Result<AgentIdentity> {
+    wait_agent_until_after_snapshot(target, until, timeout, None)
+}
+
+pub fn agent_watch(
+    target: &str,
+    since: Option<&str>,
+    until: Option<&str>,
+    include: Vec<String>,
+    tail_bytes: Option<usize>,
+    follow: bool,
+    timeout: Duration,
+) -> io::Result<AgentWatchResponse> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::AgentWatch {
+            requested: timeout,
+            target: target.to_string(),
+            until: until.unwrap_or("snapshot").to_string(),
+        },
+        send_request(ControlRequest::AgentWatch {
+            target: target.to_string(),
+            since: since.map(str::to_string),
+            until: until.map(str::to_string),
+            include,
+            tail_bytes,
+            follow,
+            timeout_ms: Some(timeout.as_millis().try_into().unwrap_or(u64::MAX)),
+        }),
+    )?;
+    serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
+}
+
+pub fn wait_agent_until_next(
+    target: &str,
+    until: &str,
+    timeout: Duration,
+) -> io::Result<AgentWatchResponse> {
+    let initial = agent_watch(
+        target,
+        None,
+        None,
+        vec!["status".to_string()],
+        Some(4096),
+        false,
+        Duration::from_secs(5),
+    )?;
+    agent_watch(
+        target,
+        Some(&initial.cursor),
+        Some(&format!("status:{until}")),
+        vec!["status".to_string()],
+        Some(4096),
+        false,
+        timeout,
+    )
+}
+
+pub fn send_message_and_watch(
     target: &str,
     message: &str,
     thread: Option<&str>,
     until: &str,
     timeout: Duration,
-) -> io::Result<AgentIdentity> {
-    let initial = wait_target_snapshot(target)?;
+) -> io::Result<AgentWatchResponse> {
+    let initial = agent_watch(
+        target,
+        None,
+        None,
+        vec![
+            "status".to_string(),
+            "output".to_string(),
+            "delivery".to_string(),
+        ],
+        Some(4096),
+        false,
+        Duration::from_secs(5),
+    )?;
     send_message(target, message, thread)?;
-    wait_agent_until_after_snapshot(target, until, timeout, Some(initial))
-}
-
-pub fn wait_agent_until(target: &str, until: &str, timeout: Duration) -> io::Result<AgentIdentity> {
-    wait_agent_until_after_snapshot(target, until, timeout, None)
+    agent_watch(
+        target,
+        Some(&initial.cursor),
+        Some(&format!("status:{until}")),
+        vec![
+            "status".to_string(),
+            "output".to_string(),
+            "delivery".to_string(),
+        ],
+        Some(4096),
+        false,
+        timeout,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -290,17 +425,23 @@ fn timeout_block(
     operation: ControlOperation,
     fut: impl std::future::Future<Output = io::Result<serde_json::Value>>,
 ) -> io::Result<serde_json::Value> {
-    let timeout = operation_timeout(operation);
+    let timeout = operation_timeout(&operation);
     match runtime.block_on(async { tokio::time::timeout(timeout, fut).await }) {
         Ok(result) => result,
-        Err(_) => Err(io::Error::new(
-            io::ErrorKind::TimedOut,
-            "Wardian control endpoint timed out",
-        )),
+        Err(_) => match operation {
+            ControlOperation::AgentWatch { target, until, .. } => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                WatchTimeoutError::new(&target, &until, "unknown"),
+            )),
+            _ => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "Wardian control endpoint timed out",
+            )),
+        },
     }
 }
 
-fn operation_timeout(operation: ControlOperation) -> Duration {
+fn operation_timeout(operation: &ControlOperation) -> Duration {
     match operation {
         ControlOperation::AgentList
         | ControlOperation::WorkflowList
@@ -313,7 +454,12 @@ fn operation_timeout(operation: ControlOperation) -> Duration {
         | ControlOperation::AgentClone
         | ControlOperation::WorkflowRun
         | ControlOperation::WorkflowStop => CONTROL_MUTATION_TIMEOUT,
+        ControlOperation::AgentWatch { requested, .. } => watch_timeout_for(*requested),
     }
+}
+
+fn watch_timeout_for(requested: Duration) -> Duration {
+    requested + Duration::from_secs(5)
 }
 
 fn wait_agent_until_after_snapshot(
@@ -463,7 +609,11 @@ where
             .get("message")
             .and_then(|m| m.as_str())
             .unwrap_or("unknown error");
-        return Err(io::Error::other(ControlEndpointError::new(code, msg)));
+        let endpoint_error = err.get("details").cloned().map_or_else(
+            || ControlEndpointError::new(code, msg),
+            |details| ControlEndpointError::with_details(code, msg, details),
+        );
+        return Err(io::Error::other(endpoint_error));
     }
 
     Ok(value)
@@ -475,16 +625,29 @@ mod tests {
 
     #[test]
     fn spawn_and_clone_use_longer_control_timeout() {
-        assert!(operation_timeout(ControlOperation::AgentSpawn) > CONTROL_TIMEOUT);
-        assert!(operation_timeout(ControlOperation::AgentClone) > CONTROL_TIMEOUT);
+        assert!(operation_timeout(&ControlOperation::AgentSpawn) > CONTROL_TIMEOUT);
+        assert!(operation_timeout(&ControlOperation::AgentClone) > CONTROL_TIMEOUT);
     }
 
     #[test]
     fn agent_list_keeps_short_control_timeout() {
         assert_eq!(
-            operation_timeout(ControlOperation::AgentList),
+            operation_timeout(&ControlOperation::AgentList),
             CONTROL_TIMEOUT
         );
+    }
+
+    #[test]
+    fn agent_watch_operation_timeout_includes_requested_timeout_plus_slack() {
+        let requested = Duration::from_secs(30);
+        let actual = operation_timeout(&ControlOperation::AgentWatch {
+            requested,
+            target: "Wardian-Codex".to_string(),
+            until: "output:OK".to_string(),
+        });
+
+        assert!(actual > requested);
+        assert!(actual < requested + Duration::from_secs(10));
     }
 
     #[test]
@@ -550,5 +713,40 @@ mod tests {
             .get_ref()
             .and_then(|inner| inner.downcast_ref::<WaitTargetNotFoundError>())
             .is_some());
+    }
+
+    #[test]
+    fn exchange_json_preserves_backend_error_details() {
+        let runtime = build_runtime().unwrap();
+        runtime.block_on(async {
+            let (mut client, mut server) = tokio::io::duplex(4096);
+            tokio::spawn(async move {
+            let mut line = String::new();
+            let mut reader = BufReader::new(&mut server);
+            reader.read_line(&mut line).await.unwrap();
+            let stream = reader.get_mut();
+            stream
+                .write_all(
+                    br#"{"schema":1,"error":{"code":"request_failed","message":"message delivery failed","details":{"delivery":[{"uuid":"agent-2","name":"CoderTwo","provider":"claude","runtime_state":"restored_without_sender","delivery_state":"failed","error":{"code":"no_input_channel","message":"missing sender"}}]}}}"#,
+                )
+                .await
+                .unwrap();
+            stream.write_all(b"\n").await.unwrap();
+            });
+
+            let error = exchange_json(&mut client, ControlRequest::AgentList)
+                .await
+                .unwrap_err();
+            let endpoint_error = error
+                .get_ref()
+                .and_then(|inner| inner.downcast_ref::<ControlEndpointError>())
+                .unwrap();
+
+            assert_eq!(endpoint_error.code(), "request_failed");
+            assert_eq!(
+                endpoint_error.details().unwrap()["delivery"][0]["runtime_state"],
+                "restored_without_sender"
+            );
+        });
     }
 }

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -90,11 +90,34 @@ fn handle_agent(args: AgentArgs) -> Result<String, CliError> {
         Some(AgentCommand::Clone { target, name }) => {
             handle_agent_clone(target, name.as_deref(), &args)
         }
+        Some(AgentCommand::Watch { follow, .. }) if *follow => Err(CliError::backend(
+            ExitCode::Generic,
+            "not_supported",
+            "agent watch --follow is reserved for a future streaming implementation",
+        )),
+        Some(AgentCommand::Watch {
+            target,
+            since,
+            until,
+            include,
+            tail,
+            timeout,
+            follow,
+        }) => handle_agent_watch(
+            target,
+            since.as_deref(),
+            until.as_deref(),
+            include.as_deref(),
+            *tail,
+            timeout,
+            *follow,
+        ),
         Some(AgentCommand::Wait {
             target,
             until,
             timeout,
-        }) => handle_agent_wait(target, until, timeout, &args),
+            next,
+        }) => handle_agent_wait(target, until, timeout, *next, &args),
     }
 }
 
@@ -149,11 +172,44 @@ fn handle_agent_wait(
     target: &str,
     until: &str,
     timeout: &str,
+    next: bool,
     args: &AgentArgs,
 ) -> Result<String, CliError> {
     let timeout = parse_timeout(timeout)?;
+    if next {
+        let response =
+            live::wait_agent_until_next(target, until, timeout).map_err(control_error)?;
+        return serde_json::to_string_pretty(&response)
+            .map(|json| format!("{json}\n"))
+            .map_err(|e| CliError::generic(e.to_string()));
+    }
     let agent = live::wait_agent_until(target, until, timeout).map_err(control_error)?;
     render_show(&agent, &render_options(args))
+}
+
+fn handle_agent_watch(
+    target: &str,
+    since: Option<&str>,
+    until: Option<&str>,
+    include: Option<&str>,
+    tail: Option<usize>,
+    timeout: &str,
+    follow: bool,
+) -> Result<String, CliError> {
+    if follow {
+        return Err(CliError::backend(
+            ExitCode::Generic,
+            "not_supported",
+            "agent watch --follow is reserved for a future streaming implementation",
+        ));
+    }
+    let timeout = parse_timeout(timeout)?;
+    let include = parse_include(include);
+    let response = live::agent_watch(target, since, until, include, tail, follow, timeout)
+        .map_err(control_error)?;
+    serde_json::to_string_pretty(&response)
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string()))
 }
 
 // ---------------------------------------------------------------------------
@@ -228,26 +284,61 @@ fn handle_send(args: SendArgs) -> Result<String, CliError> {
             .ok_or_else(|| CliError::generic("Provide a message, --stdin, or --file".to_string()))?
     };
 
-    let waited_agent = if let Some(until) = args.wait_until.as_deref() {
+    let response = if let Some(until) = args.wait_until.as_deref() {
+        validate_single_wait_target(&args.to)?;
         let timeout = parse_timeout(&args.timeout)?;
-        Some(
-            live::send_message_and_wait(&args.to, &message, args.thread.as_deref(), until, timeout)
-                .map_err(control_error)?,
+        let watch = live::send_message_and_watch(
+            &args.to,
+            &message,
+            args.thread.as_deref(),
+            until,
+            timeout,
         )
+        .map_err(control_error)?;
+        serde_json::json!({
+            "schema": 1,
+            "ok": true,
+            "target": args.to,
+            "status": watch.agent.status,
+            "delivery": watch.delivery.delivery,
+            "cursor": watch.cursor,
+        })
     } else {
-        live::send_message(&args.to, &message, args.thread.as_deref()).map_err(control_error)?;
-        None
+        let sent = live::send_message(&args.to, &message, args.thread.as_deref())
+            .map_err(control_error)?;
+        serde_json::json!({
+            "schema": 1,
+            "ok": true,
+            "target": args.to,
+            "delivery": sent.delivery,
+        })
     };
-
-    let mut response = serde_json::json!({"schema":1,"ok":true,"target":args.to});
-    if let Some(agent) = waited_agent {
-        response["status"] = serde_json::Value::String(agent.status);
-    }
 
     Ok(format!(
         "{}\n",
         serde_json::to_string_pretty(&response).unwrap()
     ))
+}
+
+fn validate_single_wait_target(target: &str) -> Result<(), CliError> {
+    if target == "all" || target.starts_with("class:") {
+        return Err(CliError::backend(
+            ExitCode::Generic,
+            "not_supported",
+            "send --wait-until requires a single agent name or uuid",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_include(include: Option<&str>) -> Vec<String> {
+    include
+        .unwrap_or("status,output,delivery")
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
 }
 
 // ---------------------------------------------------------------------------
@@ -260,6 +351,15 @@ fn control_error(e: std::io::Error) -> CliError {
         .and_then(|inner| inner.downcast_ref::<live::WaitTimeoutError>())
     {
         CliError::backend(ExitCode::Generic, "wait_timeout", wait_timeout.to_string())
+    } else if let Some(watch_timeout) = e
+        .get_ref()
+        .and_then(|inner| inner.downcast_ref::<live::WatchTimeoutError>())
+    {
+        CliError::backend(
+            ExitCode::Generic,
+            "watch_timeout",
+            watch_timeout.to_string(),
+        )
     } else if let Some(wait_not_found) = e
         .get_ref()
         .and_then(|inner| inner.downcast_ref::<live::WaitTargetNotFoundError>())
@@ -271,16 +371,38 @@ fn control_error(e: std::io::Error) -> CliError {
         .get_ref()
         .and_then(|inner| inner.downcast_ref::<live::ControlEndpointError>())
     {
+        let backend_error = |exit_code, code: &'static str| {
+            endpoint_error.details().cloned().map_or_else(
+                || CliError::backend(exit_code, code, endpoint_error.to_string()),
+                |details| {
+                    CliError::backend_with_details(
+                        exit_code,
+                        code,
+                        endpoint_error.to_string(),
+                        details,
+                    )
+                },
+            )
+        };
         match endpoint_error.code() {
-            "not_supported" => CliError::backend(
-                ExitCode::Generic,
-                "not_supported",
-                endpoint_error.to_string(),
+            "not_supported" => backend_error(ExitCode::Generic, "not_supported"),
+            "not_found" => backend_error(ExitCode::NotFound, "not_found"),
+            "request_failed" => backend_error(ExitCode::Generic, "request_failed"),
+            "watch_timeout" => backend_error(ExitCode::Generic, "watch_timeout"),
+            "cursor_expired" => backend_error(ExitCode::Generic, "cursor_expired"),
+            "gap_detected" => backend_error(ExitCode::Generic, "gap_detected"),
+            "invalid_cursor" => backend_error(ExitCode::Generic, "invalid_cursor"),
+            _ => endpoint_error.details().cloned().map_or_else(
+                || CliError::generic(endpoint_error.to_string()),
+                |details| {
+                    CliError::backend_with_details(
+                        ExitCode::Generic,
+                        "generic",
+                        endpoint_error.to_string(),
+                        details,
+                    )
+                },
             ),
-            "not_found" => {
-                CliError::backend(ExitCode::NotFound, "not_found", endpoint_error.to_string())
-            }
-            _ => CliError::generic(endpoint_error.to_string()),
         }
     } else {
         CliError::generic(e.to_string())
@@ -518,6 +640,20 @@ mod tests {
         assert_eq!(cli_error.code, "wait_timeout");
         assert_eq!(cli_error.code_i32(), 1);
         assert!(cli_error.message.contains("reviewer-a1"));
+    }
+
+    #[test]
+    fn control_error_does_not_map_watch_timeout_to_app_not_running() {
+        let error = std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            live::WatchTimeoutError::new("Wardian-Codex", "output:OK", "idle"),
+        );
+
+        let cli_error = control_error(error);
+
+        assert_eq!(cli_error.code, "watch_timeout");
+        assert_eq!(cli_error.code_i32(), 1);
+        assert!(cli_error.message.contains("Wardian-Codex"));
     }
 
     #[test]

--- a/crates/wardian-cli/tests/agent_cli.rs
+++ b/crates/wardian-cli/tests/agent_cli.rs
@@ -350,6 +350,20 @@ fn malformed_args_emit_json_error_and_exit_one() {
 }
 
 #[test]
+fn watch_follow_without_app_parses_before_app_lookup() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args(["agent", "watch", "coder-a1", "--follow"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_ne!(output.status.code(), Some(0));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"not_supported""#));
+}
+
+#[test]
 fn list_accepts_output_fields_after_subcommand() {
     let home = seed_home();
     let output = Command::new(bin())

--- a/crates/wardian-cli/tests/send_cli.rs
+++ b/crates/wardian-cli/tests/send_cli.rs
@@ -87,3 +87,24 @@ fn send_no_message_no_stdin_exits_one() {
     // since control pipe check happens before message validation)
     assert_ne!(output.status.code(), Some(0));
 }
+
+#[test]
+fn send_wait_until_rejects_class_selector_before_app_lookup() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args([
+            "send",
+            "hello",
+            "--to",
+            "class:Coder",
+            "--wait-until",
+            "idle",
+        ])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_ne!(output.status.code(), Some(0));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"not_supported""#));
+}

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -43,6 +43,15 @@ pub enum ControlRequest {
         message: String,
         thread: Option<String>,
     },
+    AgentWatch {
+        target: String,
+        since: Option<String>,
+        until: Option<String>,
+        include: Vec<String>,
+        tail_bytes: Option<usize>,
+        follow: bool,
+        timeout_ms: Option<u64>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -79,6 +88,69 @@ impl Default for OkResponse {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeliveryErrorDetail {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeliveryDetail {
+    pub uuid: String,
+    pub name: String,
+    pub provider: String,
+    pub runtime_state: String,
+    pub delivery_state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<DeliveryErrorDetail>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SendMessageResponse {
+    pub schema: u8,
+    pub ok: bool,
+    pub delivery: Vec<DeliveryDetail>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WatchEvent {
+    pub cursor: String,
+    pub kind: String,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WatchOutput {
+    pub cursor: String,
+    pub text: String,
+    pub truncated: bool,
+    pub omitted_bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WatchDeliverySnapshot {
+    pub delivery: Vec<DeliveryDetail>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WatchAgentSnapshot {
+    pub uuid: String,
+    pub name: String,
+    pub provider: String,
+    pub status: String,
+    pub last_status_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentWatchResponse {
+    pub schema: u8,
+    pub agent: WatchAgentSnapshot,
+    pub cursor: String,
+    pub events: Vec<WatchEvent>,
+    pub output: WatchOutput,
+    pub delivery: WatchDeliverySnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -214,6 +286,63 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains(r#""command":"send_message""#));
         assert!(json.contains(r#""target":"all""#));
+    }
+
+    #[test]
+    fn agent_watch_request_serializes_single_target_options() {
+        let req = ControlRequest::AgentWatch {
+            target: "Wardian-Codex".to_string(),
+            since: Some("57244fa9-2b9c-4b45-ba32-6919d2786c29:0000000000000042".to_string()),
+            until: Some("status:idle".to_string()),
+            include: vec!["status".to_string(), "output".to_string()],
+            tail_bytes: Some(4096),
+            follow: false,
+            timeout_ms: Some(30_000),
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+
+        assert!(json.contains(r#""command":"agent_watch""#));
+        assert!(json.contains(r#""target":"Wardian-Codex""#));
+        assert!(json.contains(r#""until":"status:idle""#));
+    }
+
+    #[test]
+    fn delivery_detail_splits_runtime_and_delivery_state() {
+        let detail = DeliveryDetail {
+            uuid: "agent-1".to_string(),
+            name: "CoderOne".to_string(),
+            provider: "codex".to_string(),
+            runtime_state: "live_pty_available".to_string(),
+            delivery_state: "submitted".to_string(),
+            error: None,
+        };
+
+        let json = serde_json::to_string(&detail).unwrap();
+
+        assert!(json.contains(r#""runtime_state":"live_pty_available""#));
+        assert!(json.contains(r#""delivery_state":"submitted""#));
+    }
+
+    #[test]
+    fn send_message_response_serializes_delivery_details() {
+        let response = SendMessageResponse {
+            schema: CONTROL_SCHEMA,
+            ok: true,
+            delivery: vec![DeliveryDetail {
+                uuid: "agent-1".to_string(),
+                name: "CoderOne".to_string(),
+                provider: "codex".to_string(),
+                runtime_state: "live_pty_available".to_string(),
+                delivery_state: "submitted".to_string(),
+                error: None,
+            }],
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+
+        assert!(json.contains(r#""ok":true"#));
+        assert!(json.contains(r#""delivery_state":"submitted""#));
     }
 
     #[test]

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -47,6 +47,8 @@ wardian agent resume <name-or-uuid>
 wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace D:/Development/Wardian
 wardian agent clone <name-or-uuid> --name coder-a2
 wardian agent wait reviewer-a1 --until idle --timeout 10m
+wardian agent wait reviewer-a1 --until idle --next --timeout 10m
+wardian agent watch reviewer-a1 --until output:REVIEW_DONE --include status,output,delivery --timeout 10m
 wardian workflow list
 wardian workflow show <id-or-name>
 wardian workflow run <id>
@@ -63,9 +65,13 @@ Mutating commands use Wardian's local control endpoint and require the desktop a
 
 `agent spawn` requires both `--provider` and `--class` so the created agent's runtime and role are explicit.
 
-`agent wait <target> --until <status>` blocks inside the CLI process until a single agent name or UUID reaches a normalized status such as `idle`, `processing`, `action_required`, `off`, or `error`. Use `--timeout` with `ms`, `s`, or `m` units.
+`agent wait <target> --until <status>` blocks inside the CLI process until a single agent name or UUID reaches a normalized status such as `idle`, `processing`, `action_required`, `off`, or `error`. Plain `wait` returns immediately when the target is already in the requested status. Add `--next` to wait for a newer matching observation. Use `--timeout` with `ms`, `s`, or `m` units.
 
-`send` writes a newline-terminated message into the target agent PTY. Targets can be an agent name, UUID, `class:<ClassName>`, or `all`. `--stdin` reads the message from standard input, and `--file <path>` reads it from a file. `--wait-until <status>` is available for single-agent targets and waits after delivery; when the target already has the requested status, Wardian waits for it to leave that status and return before reporting success. `--thread` is reserved but not implemented yet; when the app is running, using it returns `not_supported`.
+`agent watch <target>` returns a live snapshot with agent status, retained output, recent events, delivery details, and a cursor. Add `--until` to block until `status:<status>`, `output:<substring>`, `event:<kind>`, or `delivery:<state>` is observed. `watch` accepts only one name or UUID in this slice. `--follow` is reserved and returns `not_supported`.
+
+`send` submits a provider-aware message into the target agent runtime. Targets can be an agent name, UUID, `class:<ClassName>`, or `all`. `--stdin` reads the message from standard input, and `--file <path>` reads it from a file. `--wait-until <status>` is available for single-agent targets and waits from a pre-send watch cursor for a newer matching status observation. `--thread` is reserved but not implemented yet; when the app is running, using it returns `not_supported`.
+
+Successful `send` responses include `delivery[]`. Failed or partial delivery returns a nonzero exit with JSON on stderr and `details.delivery[]`, including `runtime_state`, `delivery_state`, and provider-specific input errors.
 
 List filters:
 

--- a/docs/specs/034-agent-watch-and-communication.md
+++ b/docs/specs/034-agent-watch-and-communication.md
@@ -1,0 +1,283 @@
+# Spec 034: Agent Watch and Communication Stabilization
+
+- **Status:** Implemented
+- **Date:** 2026-05-07
+- **Decider:** Wardian Codex
+
+## Context and Problem Statement
+
+Spec 024 gave agents a CLI surface for introspection, and Spec 033 added live control commands such as `wardian send` and `wardian agent wait`. That first control slice is useful, but it is still too narrow for reliable agent-to-agent work.
+
+The current communication path is mostly a one-way PTY injection. A caller can send text and optionally wait for a target status, but it cannot directly observe what the target saw, whether output changed, whether a response was produced, or why a delivery path was unavailable. This makes failures ambiguous. During provider probes on 2026-05-07:
+
+- Codex and Gemini timed out waiting for `idle` even though the last observed status remained `idle`.
+- Claude and OpenCode failed with `no input channel`, without enough detail to distinguish off sessions, restored sessions missing senders, or unsupported runtime states.
+
+This matches a broader limitation: Wardian agents need a way to watch peers, not just send to them. Similar systems such as `hcom` expose messaging plus observation of transcripts, terminal screens, status changes, file edits, and event streams. Wardian should adopt the same principle while preserving its own architecture: the Rust backend remains authoritative for PTY lifecycle, telemetry, and live state, and Markdown / local state stay inspectable on disk.
+
+## Decision
+
+Wardian adds a live observation surface for agents and stabilizes message delivery around that surface.
+
+### Command Surface
+
+Add:
+
+```bash
+wardian agent watch <target>
+```
+
+`watch` is a live-control command. It requires the running desktop app for the same `WARDIAN_HOME` and returns `app_not_running` when no control endpoint is available.
+
+Supported options:
+
+- `--since <cursor>`: return only events and output after a prior cursor.
+- `--until <condition>`: block until a condition is reached or timeout expires.
+- `--timeout <duration>`: maximum wait time, using the existing `ms`, `s`, and `m` syntax.
+- `--include <fields>`: comma-separated data classes. Initial values: `status`, `output`, `events`, `delivery`, `agent`.
+- `--tail <bytes>`: cap returned terminal output. Default should be conservative enough for model context.
+
+`watch` accepts only a single agent name or UUID in the first implementation. Selectors that can resolve to multiple agents, such as `class:<ClassName>` and `all`, return `not_supported` with a hint to choose a single target. This keeps the first response schema unambiguous and avoids hiding partial observation gaps behind a list response.
+
+Initial conditions for `--until`:
+
+- `status:<normalized-status>`, for example `status:idle`.
+- `output:<substring>`, for example `output:WARDIAN_PROBE_CODEX_OK`.
+- `event:<kind>`, for example `event:turn_completed`.
+- `delivery:<state>`, for example `delivery:submitted` or `delivery:failed`.
+
+Keep:
+
+```bash
+wardian agent wait <target> --until <status>
+wardian agent wait <target> --until <status> --next
+wardian send ... --wait-until <status>
+```
+
+`wait` remains the terse condition command. Plain `agent wait` keeps its readiness semantics: if the agent is already in the requested status, it returns immediately. A new `--next` flag waits for a newer matching observation after the initial snapshot. `send --wait-until` uses `--next`-equivalent semantics internally because a send is waiting for the turn triggered by that send, not merely checking current readiness.
+
+`watch` does not replace `wait`; it provides the evidence and output surface that `wait` intentionally hides.
+
+### Streaming Follow Deferral
+
+`watch --follow` is intentionally deferred from the first implementation. The current control transport is one request with one newline-terminated JSON response over a named pipe or Unix socket. Long-lived NDJSON streaming needs separate transport rules for cancellation, heartbeat, backpressure, connection limits, and preventing a follow request from monopolizing control endpoint workers.
+
+For compatibility with future scripts, the first slice reserves the flag shape: `wardian agent watch <target> --follow` parses successfully, then returns `not_supported` with a hint that streaming follow is deferred. It must not silently ignore `--follow`, and it must not start a partial streaming implementation.
+
+When `--follow` is implemented, it must satisfy these rules before being enabled:
+
+- Each follow connection is handled in its own task and must not block unrelated control requests.
+- The server sends a heartbeat event at a documented interval when no agent events occur.
+- The server drops or coalesces events only with an explicit `gap_detected` event.
+- The client closes the connection on timeout, Ctrl-C, or process exit; the server treats disconnect as cancellation.
+- The endpoint enforces a per-agent and global follow connection limit and returns `too_many_watchers` when exceeded.
+
+### Watch Response Schema
+
+Non-following `watch` returns one JSON envelope:
+
+```json
+{
+  "schema": 1,
+  "agent": {
+    "name": "Wardian-Codex",
+    "uuid": "57244fa9-2b9c-4b45-ba32-6919d2786c29",
+    "provider": "codex",
+    "status": "idle",
+    "last_status_at": "2026-05-07T10:14:32.120Z"
+  },
+  "cursor": "0000000000000042",
+  "events": [
+    {
+      "cursor": "0000000000000041",
+      "time": "2026-05-07T10:14:31.870Z",
+      "kind": "status",
+      "status": "processing"
+    }
+  ],
+  "output": {
+    "text": "WARDIAN_PROBE_CODEX_OK\r\n",
+    "truncated": false
+  },
+  "delivery": {
+    "input_available": true,
+    "last_state": "submitted",
+    "last_error": null
+  }
+}
+```
+
+Cursors are opaque strings. Callers must compare them only for equality or pass them back through `--since`.
+
+Cursor semantics:
+
+- Cursors are scoped to one Wardian session ID. Passing a cursor from another agent returns `invalid_cursor`.
+- Events and output batches share one monotonically increasing cursor sequence per agent, so a cursor represents a total order across status, delivery, provider events, and output tap updates.
+- If `--since` is older than the retained event/output ring, the command fails with `cursor_expired` and includes the oldest available cursor in error details. Silent gaps are not allowed.
+- If retention is lost during a blocking `--until`, the command fails with `gap_detected` rather than continuing against incomplete evidence.
+- `--tail <bytes>` truncates on valid UTF-8 character boundaries after ANSI/control bytes are preserved as text. The response includes `truncated: true`, `omitted_bytes`, and `oldest_available_cursor` when output is trimmed.
+
+### Backend State Model
+
+Extend `ActiveAgent` with live observation state:
+
+- `last_status_at`: timestamp updated whenever the normalized status changes.
+- `watch_events`: bounded in-memory event ring for status changes, delivery attempts, and provider parser events.
+- `output_tap`: bounded, non-draining terminal output ring independent from the UI's drain-on-read `output_buffer`.
+- `delivery_state`: latest structured delivery result per target session.
+
+The terminal reader writes to both:
+
+- `output_buffer`, still drained by `read_agent_pty` for the frontend terminal.
+- `output_tap`, retained for CLI observation and not drained by UI reads.
+
+This avoids a race where the frontend consumes the only copy of output before another agent can inspect it.
+
+The control endpoint adds request/response types for:
+
+- `AgentWatch`
+- `AgentWatchFollow` if streaming is implemented as a distinct request
+
+The response schema remains in `wardian-core` so CLI and Tauri serialization cannot drift.
+
+The retained rings must be bounded by both event count and byte count. The exact defaults are implementation details, but the implementation must expose enough metadata for callers to detect loss: `oldest_available_cursor`, `latest_cursor`, `truncated`, and `omitted_bytes`.
+
+### Status and Wait Semantics
+
+`last_status_at` becomes load-bearing in live snapshots and `watch` responses. It updates whenever Wardian records a status transition. When a provider emits a distinct turn completion event that returns to the same normalized status, Wardian records a new watch event even if the status string is unchanged. This lets `--next` and `send --wait-until` detect a completed turn without changing plain readiness checks.
+
+`wardian agent wait <target> --until idle` returns immediately when the target is currently idle. `wardian agent wait <target> --until idle --next` waits for a matching status observation after the initial cursor.
+
+`wardian send --wait-until idle` should internally perform:
+
+1. Capture a watch cursor for the target.
+2. Submit the message.
+3. Watch from that cursor until `status:idle` or a delivery failure is observed.
+
+`send --wait-until` remains valid only for a single name or UUID target. Broadcasts and class selectors may send without waiting, but combining them with `--wait-until` returns `not_supported`.
+
+### Provider-Aware Delivery
+
+`wardian send` should use the same provider-aware submission behavior as the GUI `submit_prompt_to_agent` path. It should not blindly write `message + "\r"` for every provider.
+
+Initial provider rules:
+
+- Codex: send normalized text, delay briefly, then send the Codex submit sequence already used by `submit_prompt_via_sender`.
+- Gemini: send normalized text, delay briefly, then carriage return.
+- Claude: send normalized text, delay briefly, then carriage return unless evidence shows Claude needs a different submit path.
+- OpenCode: preserve the existing headless submit behavior used by the GUI when appropriate, because interactive OpenCode PTY input has separate readiness constraints.
+- Mock: retain deterministic PTY input for tests.
+
+Delivery details split runtime capability from delivery outcome. Callers must not have to infer why delivery failed from one overloaded field.
+
+Runtime states:
+
+- `target_off`: target exists but its normalized status is `off` or it has no running PTY/headless runtime.
+- `live_pty_available`: target has a live PTY input sender.
+- `restored_without_sender`: target is live in the roster but has no registered input sender after restore or runtime reconciliation.
+- `headless_available`: target supports a non-PTY submit path, such as OpenCode headless submit.
+- `queued_not_ready`: target runtime exists but provider-specific readiness has not completed.
+
+Delivery states:
+
+- `pending`: Wardian selected a runtime path but has not submitted yet.
+- `submitted`: Wardian wrote to the PTY sender or accepted the headless submit request.
+- `failed`: provider-aware submit failed after a runtime path was selected.
+
+`no_input_channel` remains the concrete error code for a missing sender, but delivery details must also include `runtime_state` (`target_off`, `restored_without_sender`, or another state) and `delivery_state` so callers can tell whether the failure is capability-related or submit-related.
+
+Delivery responses should report per-target details:
+
+```json
+{
+  "schema": 1,
+  "ok": false,
+  "target": "class:Coder",
+  "delivery": [
+    {
+      "uuid": "agent-1",
+      "name": "CoderOne",
+      "provider": "codex",
+      "runtime_state": "live_pty_available",
+      "delivery_state": "submitted",
+      "error": null
+    },
+    {
+      "uuid": "agent-2",
+      "name": "CoderTwo",
+      "provider": "claude",
+      "runtime_state": "restored_without_sender",
+      "delivery_state": "failed",
+      "error": {
+        "code": "no_input_channel",
+        "message": "Agent is live in the roster but has no PTY input sender"
+      }
+    }
+  ]
+}
+```
+
+CLI output follows the existing Spec 024 error contract. If any matched target fails, the command exits nonzero, stdout is empty, and stderr contains the standard error envelope with `details.delivery[]`. If every matched target is submitted successfully, stdout contains the success envelope with `delivery[]` and stderr is empty.
+
+### Error Semantics
+
+Add or standardize these delivery and watch error codes:
+
+- `no_input_channel`: target exists but has no live input sender.
+- `target_off`: target exists and is currently off.
+- `watch_timeout`: requested watch condition was not observed before timeout.
+- `unsupported_watch_condition`: condition string is syntactically valid but not supported.
+- `invalid_cursor`: cursor is malformed or belongs to a different agent.
+- `cursor_expired`: requested cursor is older than retained observation state.
+- `gap_detected`: observation state was lost while a watch command was waiting.
+- `too_many_watchers`: reserved for the deferred `--follow` implementation.
+- `output_truncated`: warning-style field, not necessarily a command failure.
+
+Existing `not_found`, `not_supported`, and `app_not_running` semantics remain unchanged.
+
+### Persistence Boundary
+
+The first slice is live-only. `watch` does not fall back to SQLite because persisted state cannot prove current PTY output or delivery state. Later work may persist event summaries to `state.db`, but this spec keeps the first implementation bounded and avoids treating stale state as live evidence.
+
+### Testing Plan
+
+Unit tests:
+
+- CLI argument parsing for `agent watch`, `--since`, `--until`, `--include`, and `--tail`.
+- Reserved `--follow` behavior: the flag parses and returns `not_supported` until the streaming transport slice is implemented.
+- Watch response serialization in `wardian-core`.
+- Event ring cursor behavior and truncation behavior.
+- `agent wait` immediate readiness behavior when the target already starts in the requested status.
+- `agent wait --next` and `send --wait-until` behavior when the target begins in the desired status and later produces a newer completion event.
+- Provider-aware send byte sequences for Codex, Gemini, Claude, and mock.
+- Structured delivery error mapping for off agents and missing input channels, including separate `runtime_state` and `delivery_state` fields.
+- Expired cursors, gap detection, output truncation metadata, and UTF-8 boundary handling.
+
+Native E2E tests:
+
+- Mock provider: `send -> watch --until output:<token>` captures the response without relying on frontend terminal reads.
+- Mock provider: `send --wait-until idle` succeeds when the target starts idle and completes a fast turn.
+- Off target: `send` reports `target_off` or `no_input_channel` with per-target details.
+- Multi-target partial delivery: `class:<ClassName>` returns nonzero with stderr `details.delivery[]` when one target cannot receive input.
+- Restored session missing sender: live roster entry without an input sender reports `restored_without_sender` rather than a generic request failure.
+- OpenCode headless and interactive readiness paths are exercised separately.
+- Windows native run verifies provider submit sequences through ConPTY.
+- Browser-visible smoke: UI terminal continues to render while CLI `watch` observes the same output, proving the observation tap is non-draining.
+- Deferred `--follow` tests must cover heartbeat, cancellation, connection limits, and backpressure before the flag is enabled.
+
+Manual provider probes:
+
+- Codex, Claude, Gemini, and OpenCode should each receive a probe prompt and either return the requested token or produce a structured delivery/runtime diagnostic.
+- Use Playwright or Chrome DevTools to inspect the running app only when the CLI observation evidence is insufficient or a UI/runtime state mismatch is suspected.
+
+## Consequences
+
+- **Positive:** agents can observe peers directly instead of relying on status-only waits or human-visible terminal state.
+- **Positive:** `wait` becomes more reliable without becoming verbose; `watch` carries the evidence for debugging and coordination.
+- **Positive:** frontend PTY reads no longer race CLI/agent observation.
+- **Positive:** provider communication failures become diagnosable through structured delivery details.
+- **Positive:** the control plane moves closer to Wardian's transparent Habitat model: status, output, and delivery state are visible to agents through a stable textual surface.
+- **Negative:** maintaining an output tap and event ring duplicates some terminal data in memory. The implementation must bound retained bytes and event count.
+- **Negative:** `watch --follow` is deferred because long-lived control requests are more complex than the current one-request/one-response pipe model.
+- **Negative:** provider-aware send paths increase coupling between CLI control and provider runtime behavior. Keeping the provider rules in the Rust backend mitigates drift with the GUI path.
+- **Negative:** live-only watch means agents cannot inspect historical output after the app closes in the first slice. Persisted event history should be considered separately.

--- a/e2e-native/tests/cli-shared-state-native.test.mjs
+++ b/e2e-native/tests/cli-shared-state-native.test.mjs
@@ -353,6 +353,20 @@ test("native CLI control commands operate through the running app", { timeout: 1
     ]);
     assert.equal(JSON.parse(sendResult.stdout).status, "idle");
 
+    const watchResult = runCliOk(cliPath, harness, [
+      "agent",
+      "watch",
+      CONTROL_SESSION_NAME,
+      "--until",
+      "output:Action approved",
+      "--include",
+      "status,output,delivery",
+      "--timeout",
+      "30s",
+    ]);
+    const watched = JSON.parse(watchResult.stdout);
+    assert.match(watched.output.text, /Action approved/);
+
     await watchStep(harness, `Cloning ${CONTROL_SESSION_NAME} through the CLI`);
     const cloneResult = runCliOk(cliPath, harness, [
       "agent",
@@ -379,6 +393,27 @@ test("native CLI control commands operate through the running app", { timeout: 1
     const killedShow = runCli(cliPath, harness, ["agent", CONTROL_CLONE_NAME]);
     assert.equal(killedShow.status, 2, killedShow.stderr);
     assert.match(killedShow.stderr, /"code":"not_found"/);
+
+    const removed = await session.driver.executeAsyncScript((sessionId, done) => {
+      window.__TAURI_INTERNALS__.invoke("debug_remove_agent_input_sender", { sessionId }).then(
+        () => done({ ok: true }),
+        (error) => done({ ok: false, error: String(error) }),
+      );
+    }, source.uuid);
+    assert.equal(removed.ok, true, `debug_remove_agent_input_sender failed: ${removed.error}`);
+
+    const missingSender = runCli(cliPath, harness, [
+      "send",
+      "hello",
+      "--to",
+      CONTROL_SESSION_NAME,
+    ]);
+    assert.notEqual(missingSender.status, 0);
+    const missingSenderError = JSON.parse(missingSender.stderr);
+    const delivery = missingSenderError.error.details.delivery[0];
+    assert.equal(delivery.runtime_state, "restored_without_sender");
+    assert.equal(delivery.delivery_state, "failed");
+    assert.equal(delivery.error.code, "no_input_channel");
   });
 });
 

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -87,6 +87,8 @@ wardian agent pause reviewer-a1
 wardian agent resume reviewer-a1
 wardian agent kill reviewer-a1
 wardian agent wait reviewer-a1 --until idle --timeout 10m
+wardian agent wait reviewer-a1 --until idle --next --timeout 10m
+wardian agent watch reviewer-a1 --until output:REVIEW_DONE --include status,output --timeout 10m
 ```
 
 `agent spawn` requires both `--provider` and `--class`; do not rely on implicit
@@ -96,7 +98,13 @@ you need.
 
 `agent wait <target> --until <status>` blocks until a single agent name or UUID
 reaches a normalized status such as `idle`, `processing`, `action_required`,
-`off`, or `error`. Use `--timeout` with `ms`, `s`, or `m` units.
+`off`, or `error`. Plain `wait` returns immediately when the agent is already
+in the requested status. Use `--next` to wait for a newer matching observation.
+Use `--timeout` with `ms`, `s`, or `m` units.
+
+`agent watch <target>` returns status, retained output, events, delivery
+details, and a cursor. Use `--until output:<token>` when you need the response
+text itself. `--follow` is reserved and currently returns `not_supported`.
 
 ## Sending Messages
 
@@ -114,6 +122,10 @@ wardian send "review this patch" --to reviewer-a1 --wait-until idle --timeout 10
 Targets can be an agent name, UUID, `class:<ClassName>`, or `all`. Use
 `--wait-until` only with a single-agent target; broadcasts are for messages that
 should not block the current command.
+
+Successful sends include `delivery[]`. Failed delivery emits JSON on stderr with
+`details.delivery[]`, including `runtime_state`, `delivery_state`, and any input
+channel error.
 
 `--thread` is reserved for grouped conversations. Until threading is implemented
 end-to-end, the running app rejects it with `not_supported` instead of silently
@@ -154,7 +166,10 @@ one terminal:
 ```bash
 wardian agent list --scope all --fields name,class,provider,workspace,status
 wardian agent spawn --provider codex --class Reviewer --name review-cli-surface --workspace D:/Development/Wardian
-wardian send --stdin --to review-cli-surface --wait-until idle --timeout 10m
+@"
+Review this patch. End with REVIEW_DONE.
+"@ | wardian send --stdin --to review-cli-surface
+wardian agent watch review-cli-surface --until output:REVIEW_DONE --timeout 10m --include status,output
 wardian agent kill review-cli-surface
 ```
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1484,6 +1484,12 @@ mod tests {
             query_count: Arc::new(Mutex::new(0)),
             init_timestamp: Arc::new(Mutex::new(None)),
             current_status: Arc::new(Mutex::new("Idle".to_string())),
+            last_status_at: Arc::new(Mutex::new(None)),
+            watch_state: Arc::new(Mutex::new(crate::state::AgentWatchState::new(
+                "test-agent".to_string(),
+                4096,
+                262_144,
+            ))),
             terminal_title: Arc::new(Mutex::new(String::new())),
             last_output_at: Arc::new(Mutex::new(None)),
             log_path: Arc::new(Mutex::new(None)),

--- a/src-tauri/src/commands/debug.rs
+++ b/src-tauri/src/commands/debug.rs
@@ -1,0 +1,19 @@
+use crate::state::AppState;
+use tauri::State;
+
+#[tauri::command]
+pub async fn debug_remove_agent_input_sender(
+    session_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    if !cfg!(debug_assertions) {
+        return Err("debug commands are disabled in production builds".to_string());
+    }
+
+    let mut senders = state
+        .input_senders
+        .write()
+        .map_err(|_| "input_senders lock poisoned".to_string())?;
+    senders.remove(&session_id);
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod class;
+pub mod debug;
 pub mod fs;
 pub mod git;
 pub mod library;
@@ -11,6 +12,7 @@ pub mod workflow;
 
 pub use agent::*;
 pub use class::*;
+pub use debug::*;
 pub use fs::*;
 pub use library::*;
 pub use patch::*;

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1,10 +1,15 @@
 use crate::state::AppState;
-use std::fmt;
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
-    AgentListResponse, AgentResponse, ControlRequest, OkResponse, WorkflowListResponse,
-    WorkflowResponse, WorkflowSummary,
+    AgentListResponse, AgentResponse, AgentWatchResponse, ControlRequest, DeliveryDetail,
+    DeliveryErrorDetail, OkResponse, SendMessageResponse, WatchAgentSnapshot,
+    WatchDeliverySnapshot, WorkflowListResponse, WorkflowResponse, WorkflowSummary,
 };
 use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
 
@@ -192,9 +197,24 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             thread,
         } => {
             let state = app.state::<AppState>();
-            deliver_message_to_target(&state, &target, &message, thread.as_deref()).await?;
-            ok_json(&OkResponse::new())
+            let delivery =
+                deliver_message_to_target(&state, &target, &message, thread.as_deref()).await?;
+            ok_json(&SendMessageResponse {
+                schema: wardian_core::control::CONTROL_SCHEMA,
+                ok: true,
+                delivery,
+            })
         }
+
+        ControlRequest::AgentWatch {
+            target,
+            since,
+            until,
+            include: _,
+            tail_bytes,
+            follow,
+            timeout_ms,
+        } => handle_agent_watch(app, &target, since, until, tail_bytes, follow, timeout_ms).await,
     }
 }
 
@@ -322,34 +342,90 @@ async fn deliver_message_to_target(
     target: &str,
     message: &str,
     thread: Option<&str>,
-) -> Result<(), ControlError> {
-    let bytes = send_message_bytes(message, thread)?;
+) -> Result<Vec<DeliveryDetail>, ControlError> {
+    validate_send_message_thread(thread)?;
     let session_ids = resolve_send_targets_in_state(state, target).await;
     if session_ids.is_empty() {
         return Err(ControlError::not_found(format!(
             "no agents matched target: {target}"
         )));
     }
-    let senders = state
-        .input_senders
-        .read()
-        .map_err(|_| ControlError::request_failed("input_senders lock poisoned"))?;
+
+    let target_infos = delivery_target_infos(state, &session_ids).await?;
+    let senders = {
+        let senders = state
+            .input_senders
+            .read()
+            .map_err(|_| ControlError::request_failed("input_senders lock poisoned"))?;
+        session_ids
+            .iter()
+            .map(|session_id| (session_id.clone(), senders.get(session_id).cloned()))
+            .collect::<std::collections::HashMap<_, _>>()
+    };
+
     let mut delivered = 0usize;
     let mut failures = Vec::new();
-    for session_id in &session_ids {
-        match senders.get(session_id) {
-            Some(tx) => match tx.try_send(bytes.clone()) {
-                Ok(()) => delivered += 1,
-                Err(error) => failures.push(format!("{session_id}: {error}")),
-            },
-            None => failures.push(format!("{session_id}: no input channel")),
+    let mut delivery = Vec::with_capacity(session_ids.len());
+    for info in target_infos {
+        match senders.get(&info.uuid).and_then(Clone::clone) {
+            Some(tx) => {
+                match crate::utils::terminal_input::submit_prompt_chunks_via_sender(
+                    &tx,
+                    &info.provider,
+                    message,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        delivered += 1;
+                        let detail = DeliveryDetail {
+                            uuid: info.uuid,
+                            name: info.name,
+                            provider: info.provider,
+                            runtime_state: "live_pty_available".to_string(),
+                            delivery_state: "submitted".to_string(),
+                            error: None,
+                        };
+                        record_delivery_attempt(state, &detail).await;
+                        delivery.push(detail);
+                    }
+                    Err(error) => {
+                        failures.push(format!("{}: {error}", info.uuid));
+                        let detail = failed_delivery_detail(
+                            info,
+                            "live_pty_available",
+                            "send_failed",
+                            error,
+                        );
+                        record_delivery_attempt(state, &detail).await;
+                        delivery.push(detail);
+                    }
+                }
+            }
+            None => {
+                failures.push(format!("{}: no input channel", info.uuid));
+                let runtime_state = if info.status == "off" {
+                    "target_off"
+                } else {
+                    "restored_without_sender"
+                };
+                let detail = failed_delivery_detail(
+                    info,
+                    runtime_state,
+                    "no_input_channel",
+                    "missing sender",
+                );
+                record_delivery_attempt(state, &detail).await;
+                delivery.push(detail);
+            }
         }
     }
     if delivered == 0 {
         return Err(ControlError::request_failed(format!(
             "message was not delivered to any matched agents: {}",
             failures.join("; ")
-        )));
+        ))
+        .with_details(delivery_details_json(&delivery)));
     }
     if !failures.is_empty() {
         return Err(ControlError::request_failed(format!(
@@ -357,9 +433,306 @@ async fn deliver_message_to_target(
             failures.len(),
             session_ids.len(),
             failures.join("; ")
-        )));
+        ))
+        .with_details(delivery_details_json(&delivery)));
+    }
+    Ok(delivery)
+}
+
+async fn handle_agent_watch(
+    app: &AppHandle,
+    target: &str,
+    since: Option<String>,
+    until: Option<String>,
+    tail_bytes: Option<usize>,
+    follow: bool,
+    timeout_ms: Option<u64>,
+) -> Result<String, ControlError> {
+    validate_watch_follow(follow)?;
+    validate_watch_target(target)?;
+    let condition = until.as_deref().map(parse_watch_condition).transpose()?;
+    let state = app.state::<AppState>();
+    let uuid = resolve_target_uuid_in_state(&state, target)
+        .await
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
+    let watch_state = agent_watch_state(&state, &uuid).await?;
+    let snapshot = if let Some(condition) = condition {
+        wait_for_watch_condition(
+            watch_state,
+            since,
+            condition,
+            Duration::from_millis(timeout_ms.unwrap_or(30_000)),
+            tail_bytes,
+        )
+        .await?
+    } else {
+        watch_state
+            .lock()
+            .map_err(|_| ControlError::request_failed("watch state lock poisoned"))?
+            .snapshot_since(since.as_deref(), tail_bytes)
+            .map_err(control_error_from_watch_state)?
+    };
+    let agent = watch_agent_snapshot(&state, &uuid).await?;
+    let delivery = delivery_snapshot_from_events(&snapshot.events);
+
+    ok_json(&AgentWatchResponse {
+        schema: wardian_core::control::CONTROL_SCHEMA,
+        agent,
+        cursor: snapshot.cursor,
+        events: snapshot.events,
+        output: snapshot.output,
+        delivery,
+    })
+}
+
+fn validate_watch_target(target: &str) -> Result<(), ControlError> {
+    if target == "all" || target.starts_with("class:") {
+        return Err(ControlError::not_supported(
+            "agent watch requires a single agent name or uuid",
+        ));
     }
     Ok(())
+}
+
+fn validate_watch_follow(follow: bool) -> Result<(), ControlError> {
+    if follow {
+        return Err(ControlError::not_supported(
+            "agent watch --follow is reserved for a future streaming implementation",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum WatchCondition {
+    Status(String),
+    OutputContains(String),
+    EventKind(String),
+    DeliveryState(String),
+}
+
+fn parse_watch_condition(value: &str) -> Result<WatchCondition, ControlError> {
+    let Some((kind, argument)) = value.split_once(':') else {
+        return Err(ControlError::not_supported(format!(
+            "unsupported watch condition: {value}"
+        )));
+    };
+    match kind {
+        "status" => Ok(WatchCondition::Status(normalize_status(argument))),
+        "output" => Ok(WatchCondition::OutputContains(argument.to_string())),
+        "event" => Ok(WatchCondition::EventKind(argument.to_string())),
+        "delivery" => Ok(WatchCondition::DeliveryState(argument.to_string())),
+        _ => Err(ControlError::not_supported(format!(
+            "unsupported watch condition: {value}"
+        ))),
+    }
+}
+
+async fn wait_for_watch_condition(
+    state: Arc<Mutex<crate::state::AgentWatchState>>,
+    since: Option<String>,
+    condition: WatchCondition,
+    timeout: Duration,
+    tail_bytes: Option<usize>,
+) -> Result<crate::state::agent_watch::WatchSnapshot, ControlError> {
+    let started = std::time::Instant::now();
+    let notify = state
+        .lock()
+        .map_err(|_| ControlError::request_failed("watch state lock poisoned"))?
+        .notifier();
+
+    loop {
+        let notified = notify.notified();
+        let snapshot = {
+            let guard = state
+                .lock()
+                .map_err(|_| ControlError::request_failed("watch state lock poisoned"))?;
+            guard.snapshot_since(since.as_deref(), tail_bytes)
+        };
+
+        match snapshot {
+            Ok(snapshot) if watch_condition_matches(&condition, &snapshot) => return Ok(snapshot),
+            Ok(_) => {}
+            Err(error) if error.code() == "cursor_expired" => {
+                return Err(
+                    ControlError::gap_detected("watch cursor expired while waiting")
+                        .with_details(error.details().clone()),
+                );
+            }
+            Err(error) => return Err(control_error_from_watch_state(error)),
+        }
+
+        let elapsed = started.elapsed();
+        if elapsed >= timeout {
+            return Err(ControlError::watch_timeout("watch condition timed out"));
+        }
+        let remaining = timeout - elapsed;
+        if tokio::time::timeout(remaining, notified).await.is_err() {
+            return Err(ControlError::watch_timeout("watch condition timed out"));
+        }
+    }
+}
+
+fn watch_condition_matches(
+    condition: &WatchCondition,
+    snapshot: &crate::state::agent_watch::WatchSnapshot,
+) -> bool {
+    match condition {
+        WatchCondition::Status(status) => snapshot.events.iter().any(|event| {
+            event.kind == "status"
+                && event
+                    .payload
+                    .get("status")
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|value| normalize_status(value) == *status)
+        }),
+        WatchCondition::OutputContains(token) => snapshot.output.text.contains(token),
+        WatchCondition::EventKind(kind) => snapshot.events.iter().any(|event| &event.kind == kind),
+        WatchCondition::DeliveryState(state) => snapshot.events.iter().any(|event| {
+            event.kind == "delivery"
+                && event
+                    .payload
+                    .get("delivery_state")
+                    .and_then(|value| value.as_str())
+                    == Some(state.as_str())
+        }),
+    }
+}
+
+fn control_error_from_watch_state(
+    error: crate::state::agent_watch::WatchStateError,
+) -> ControlError {
+    ControlError::coded(error.code(), "watch state error").with_details(error.details().clone())
+}
+
+async fn agent_watch_state(
+    state: &AppState,
+    uuid: &str,
+) -> Result<Arc<Mutex<crate::state::AgentWatchState>>, ControlError> {
+    let agents = state.agents.lock().await;
+    agents
+        .get(uuid)
+        .map(|agent| agent.watch_state.clone())
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {uuid}")))
+}
+
+async fn watch_agent_snapshot(
+    state: &AppState,
+    uuid: &str,
+) -> Result<WatchAgentSnapshot, ControlError> {
+    let agents = state.agents.lock().await;
+    let agent = agents
+        .get(uuid)
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {uuid}")))?;
+    let config = agent
+        .config
+        .lock()
+        .map_err(|_| ControlError::request_failed("agent config lock poisoned"))?;
+    let status = agent
+        .current_status
+        .lock()
+        .map_err(|_| ControlError::request_failed("agent status lock poisoned"))?;
+    let last_status_at = agent
+        .last_status_at
+        .lock()
+        .map_err(|_| ControlError::request_failed("agent status timestamp lock poisoned"))?
+        .clone();
+    Ok(WatchAgentSnapshot {
+        uuid: uuid.to_string(),
+        name: config.session_name.clone(),
+        provider: config.provider.clone(),
+        status: normalize_status(&status),
+        last_status_at,
+    })
+}
+
+fn delivery_snapshot_from_events(
+    events: &[wardian_core::control::WatchEvent],
+) -> WatchDeliverySnapshot {
+    let delivery = events
+        .iter()
+        .filter(|event| event.kind == "delivery")
+        .filter_map(|event| serde_json::from_value::<DeliveryDetail>(event.payload.clone()).ok())
+        .collect();
+    WatchDeliverySnapshot { delivery }
+}
+
+fn validate_send_message_thread(thread: Option<&str>) -> Result<(), ControlError> {
+    if thread.is_some() {
+        return Err(ControlError::not_supported(
+            "--thread is not supported by the Wardian control endpoint yet",
+        ));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct DeliveryTargetInfo {
+    uuid: String,
+    name: String,
+    provider: String,
+    status: String,
+}
+
+async fn delivery_target_infos(
+    state: &AppState,
+    session_ids: &[String],
+) -> Result<Vec<DeliveryTargetInfo>, ControlError> {
+    let agents = state.agents.lock().await;
+    session_ids
+        .iter()
+        .map(|session_id| {
+            let agent = agents.get(session_id).ok_or_else(|| {
+                ControlError::not_found(format!("agent not found after resolution: {session_id}"))
+            })?;
+            let config = agent
+                .config
+                .lock()
+                .map_err(|_| ControlError::request_failed("agent config lock poisoned"))?;
+            let status = agent
+                .current_status
+                .lock()
+                .map_err(|_| ControlError::request_failed("agent status lock poisoned"))?;
+            Ok(DeliveryTargetInfo {
+                uuid: session_id.clone(),
+                name: config.session_name.clone(),
+                provider: config.provider.clone(),
+                status: normalize_status(&status),
+            })
+        })
+        .collect()
+}
+
+fn failed_delivery_detail(
+    info: DeliveryTargetInfo,
+    runtime_state: &str,
+    error_code: &str,
+    error_message: impl Into<String>,
+) -> DeliveryDetail {
+    DeliveryDetail {
+        uuid: info.uuid,
+        name: info.name,
+        provider: info.provider,
+        runtime_state: runtime_state.to_string(),
+        delivery_state: "failed".to_string(),
+        error: Some(DeliveryErrorDetail {
+            code: error_code.to_string(),
+            message: error_message.into(),
+        }),
+    }
+}
+
+fn delivery_details_json(delivery: &[DeliveryDetail]) -> serde_json::Value {
+    serde_json::json!({ "delivery": delivery })
+}
+
+async fn record_delivery_attempt(state: &AppState, detail: &DeliveryDetail) {
+    let agents = state.agents.lock().await;
+    if let Some(agent) = agents.get(&detail.uuid) {
+        if let Ok(mut watch_state) = agent.watch_state.lock() {
+            watch_state.push_delivery(serde_json::json!(detail));
+        }
+    }
 }
 
 async fn agent_config_to_identity(
@@ -395,29 +768,26 @@ fn ok_json<T: serde::Serialize>(value: &T) -> Result<String, ControlError> {
 }
 
 fn error_payload(error: &ControlError) -> Result<String, std::io::Error> {
+    let mut error_body = serde_json::json!({
+        "code": error.code(),
+        "message": error.to_string(),
+    });
+    if let Some(details) = error.details() {
+        error_body["details"] = details.clone();
+    }
+
     serde_json::to_string(&serde_json::json!({
         "schema": wardian_core::control::CONTROL_SCHEMA,
-        "error": {
-            "code": error.code(),
-            "message": error.to_string(),
-        }
+        "error": error_body
     }))
     .map_err(|e| std::io::Error::other(e.to_string()))
-}
-
-fn send_message_bytes(message: &str, thread: Option<&str>) -> Result<Vec<u8>, ControlError> {
-    if thread.is_some() {
-        return Err(ControlError::not_supported(
-            "--thread is not supported by the Wardian control endpoint yet",
-        ));
-    }
-    Ok(format!("{message}\r").into_bytes())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ControlError {
     code: &'static str,
     message: String,
+    details: Option<serde_json::Value>,
 }
 
 impl ControlError {
@@ -425,6 +795,7 @@ impl ControlError {
         Self {
             code: "bad_request",
             message: message.into(),
+            details: None,
         }
     }
 
@@ -432,6 +803,7 @@ impl ControlError {
         Self {
             code: "not_supported",
             message: message.into(),
+            details: None,
         }
     }
 
@@ -439,6 +811,7 @@ impl ControlError {
         Self {
             code: "not_found",
             message: message.into(),
+            details: None,
         }
     }
 
@@ -446,11 +819,37 @@ impl ControlError {
         Self {
             code: "request_failed",
             message: message.to_string(),
+            details: None,
         }
+    }
+
+    fn coded(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    fn watch_timeout(message: impl Into<String>) -> Self {
+        Self::coded("watch_timeout", message)
+    }
+
+    fn gap_detected(message: impl Into<String>) -> Self {
+        Self::coded("gap_detected", message)
     }
 
     fn code(&self) -> &'static str {
         self.code
+    }
+
+    fn with_details(mut self, details: serde_json::Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+
+    fn details(&self) -> Option<&serde_json::Value> {
+        self.details.as_ref()
     }
 }
 
@@ -511,6 +910,11 @@ fn snapshot_agent(agent: &crate::state::ActiveAgent) -> AgentIdentity {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone();
+    let last_status_at = agent
+        .last_status_at
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
 
     AgentIdentity {
         name: config.session_name,
@@ -521,7 +925,7 @@ fn snapshot_agent(agent: &crate::state::ActiveAgent) -> AgentIdentity {
         pid: agent.process_id,
         started_at,
         workspace: (!config.folder.trim().is_empty()).then_some(config.folder),
-        last_status_at: None,
+        last_status_at,
         status_source: StatusSource::Live,
     }
 }
@@ -552,6 +956,12 @@ mod tests {
             query_count: Arc::new(Mutex::new(0)),
             init_timestamp: Arc::new(Mutex::new(Some("2026-05-07T00:00:00.000Z".to_string()))),
             current_status: Arc::new(Mutex::new("Processing".to_string())),
+            last_status_at: Arc::new(Mutex::new(None)),
+            watch_state: Arc::new(Mutex::new(crate::state::AgentWatchState::new(
+                session_id.to_string(),
+                4096,
+                262_144,
+            ))),
             terminal_title: Arc::new(Mutex::new(String::new())),
             last_output_at: Arc::new(Mutex::new(None)),
             log_path: Arc::new(Mutex::new(None)),
@@ -598,15 +1008,35 @@ mod tests {
 
     #[test]
     fn send_message_rejects_thread_until_supported() {
-        let error = send_message_bytes("hello", Some("review")).unwrap_err();
+        let error = validate_send_message_thread(Some("review")).unwrap_err();
 
         assert_eq!(error.code(), "not_supported");
         assert!(error.to_string().contains("--thread is not supported"));
     }
 
     #[test]
-    fn send_message_submits_with_terminal_enter() {
-        assert_eq!(send_message_bytes("hello", None).unwrap(), b"hello\r");
+    fn send_message_without_thread_is_valid() {
+        validate_send_message_thread(None).unwrap();
+    }
+
+    #[test]
+    fn control_send_uses_codex_submit_sequence() {
+        let chunks =
+            crate::utils::terminal_input::provider_submit_chunks("codex", "hello\nworld").unwrap();
+
+        assert_eq!(chunks[0], b"hello world".to_vec());
+        assert_eq!(chunks[1], b"\x1b\r".to_vec());
+    }
+
+    #[test]
+    fn control_send_uses_plain_enter_for_gemini_and_claude() {
+        let gemini =
+            crate::utils::terminal_input::provider_submit_chunks("gemini", "hello").unwrap();
+        let claude =
+            crate::utils::terminal_input::provider_submit_chunks("claude", "hello").unwrap();
+
+        assert_eq!(gemini, vec![b"hello".to_vec(), b"\r".to_vec()]);
+        assert_eq!(claude, vec![b"hello".to_vec(), b"\r".to_vec()]);
     }
 
     #[test]
@@ -620,6 +1050,37 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("ghost"));
+    }
+
+    #[test]
+    fn error_payload_serializes_delivery_details() {
+        let error = ControlError::request_failed("message delivery failed").with_details(
+            serde_json::json!({
+                "delivery": [{
+                    "uuid": "agent-2",
+                    "name": "CoderTwo",
+                    "provider": "claude",
+                    "runtime_state": "restored_without_sender",
+                    "delivery_state": "failed",
+                    "error": {
+                        "code": "no_input_channel",
+                        "message": "missing sender"
+                    }
+                }]
+            }),
+        );
+
+        let payload = error_payload(&error).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&payload).unwrap();
+
+        assert_eq!(
+            value["error"]["details"]["delivery"][0]["runtime_state"],
+            "restored_without_sender"
+        );
+        assert_eq!(
+            value["error"]["details"]["delivery"][0]["error"]["code"],
+            "no_input_channel"
+        );
     }
 
     #[test]
@@ -728,7 +1189,12 @@ mod tests {
     async fn message_delivery_writes_terminal_bytes_to_matched_agent() {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
-        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        {
+            let agents = state.agents.lock().await;
+            let mut config = agents.get("agent-1").unwrap().config.lock().unwrap();
+            config.provider = "codex".to_string();
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
         state
             .input_senders
             .write()
@@ -739,7 +1205,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(rx.try_recv().unwrap(), b"hello\r");
+        assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
+        assert_eq!(rx.recv().await.unwrap(), b"\x1b\r".to_vec());
     }
 
     #[tokio::test]
@@ -767,6 +1234,14 @@ mod tests {
 
         assert_eq!(error.code(), "request_failed");
         assert!(error.to_string().contains("agent-1: no input channel"));
+        assert_eq!(
+            error.details().unwrap()["delivery"][0]["runtime_state"],
+            "restored_without_sender"
+        );
+        assert_eq!(
+            error.details().unwrap()["delivery"][0]["error"]["code"],
+            "no_input_channel"
+        );
     }
 
     #[tokio::test]
@@ -774,7 +1249,7 @@ mod tests {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         insert_test_agent(&state, "agent-2", "CoderTwo", "Coder").await;
-        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
         state
             .input_senders
             .write()
@@ -785,12 +1260,124 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_eq!(rx.try_recv().unwrap(), b"hello\r");
+        assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
+        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
         assert_eq!(error.code(), "request_failed");
         assert!(error
             .to_string()
             .contains("message delivery failed for 1 of 2 matched agents"));
         assert!(error.to_string().contains("agent-2: no input channel"));
+        assert_eq!(
+            error.details().unwrap()["delivery"][1]["delivery_state"],
+            "failed"
+        );
+    }
+
+    #[tokio::test]
+    async fn delivery_attempt_records_watch_event() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        deliver_message_to_target(&state, "CoderOne", "hello", None)
+            .await
+            .unwrap();
+
+        assert!(rx.recv().await.is_some());
+        let agents = state.agents.lock().await;
+        let agent = agents.get("agent-1").unwrap();
+        let snapshot = agent
+            .watch_state
+            .lock()
+            .unwrap()
+            .snapshot_since(None, Some(4096))
+            .unwrap();
+        assert!(snapshot.events.iter().any(|event| event.kind == "delivery"));
+    }
+
+    #[test]
+    fn watch_target_rejects_multi_target_selectors() {
+        assert_eq!(
+            validate_watch_target("all").unwrap_err().code(),
+            "not_supported"
+        );
+        assert_eq!(
+            validate_watch_target("class:Coder").unwrap_err().code(),
+            "not_supported"
+        );
+    }
+
+    #[test]
+    fn follow_flag_is_reserved_not_supported() {
+        let error = validate_watch_follow(false).err();
+        assert!(error.is_none());
+
+        let error = validate_watch_follow(true).unwrap_err();
+        assert_eq!(error.code(), "not_supported");
+    }
+
+    #[tokio::test]
+    async fn blocking_watch_wakes_when_output_arrives() {
+        let state = std::sync::Arc::new(std::sync::Mutex::new(crate::state::AgentWatchState::new(
+            "agent-1".to_string(),
+            16,
+            1024,
+        )));
+        let cursor = state.lock().unwrap().latest_cursor();
+        let writer = state.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            writer.lock().unwrap().push_output(b"WARDIAN_OK");
+        });
+
+        let snapshot = wait_for_watch_condition(
+            state,
+            Some(cursor),
+            WatchCondition::OutputContains("WARDIAN_OK".to_string()),
+            std::time::Duration::from_secs(1),
+            Some(1024),
+        )
+        .await
+        .unwrap();
+
+        assert!(snapshot.output.text.contains("WARDIAN_OK"));
+    }
+
+    #[tokio::test]
+    async fn blocking_watch_reports_gap_when_cursor_expires_while_waiting() {
+        let state = std::sync::Arc::new(std::sync::Mutex::new(crate::state::AgentWatchState::new(
+            "agent-1".to_string(),
+            2,
+            1024,
+        )));
+        let cursor = state.lock().unwrap().latest_cursor();
+        let writer = state.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            let mut guard = writer.lock().unwrap();
+            guard.push_event("status", serde_json::json!({"status":"processing"}));
+            guard.push_event("status", serde_json::json!({"status":"idle"}));
+            guard.push_event("status", serde_json::json!({"status":"processing"}));
+        });
+
+        let error = wait_for_watch_condition(
+            state,
+            Some(cursor),
+            WatchCondition::OutputContains("never".to_string()),
+            std::time::Duration::from_secs(1),
+            Some(1024),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.code(), "gap_detected");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -197,6 +197,16 @@ pub fn run() {
                                         current_status: std::sync::Arc::new(std::sync::Mutex::new(
                                             "Headless".to_string(),
                                         )),
+                                        last_status_at: std::sync::Arc::new(std::sync::Mutex::new(
+                                            None,
+                                        )),
+                                        watch_state: std::sync::Arc::new(std::sync::Mutex::new(
+                                            crate::state::AgentWatchState::new(
+                                                config.session_id.clone(),
+                                                4096,
+                                                262_144,
+                                            ),
+                                        )),
                                         terminal_title: std::sync::Arc::new(std::sync::Mutex::new(
                                             String::new(),
                                         )),
@@ -249,6 +259,7 @@ pub fn run() {
             commands::agent::rename_agent,
             commands::agent::reorder_agents,
             commands::agent::update_agent_config,
+            commands::debug::debug_remove_agent_input_sender,
             commands::terminal::send_input_to_agent,
             commands::terminal::submit_prompt_to_agent,
             commands::terminal::send_binary_input_to_agent,

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -32,10 +32,10 @@ pub use crate::utils::process::{
 };
 pub use crate::utils::shell::build_program_launch;
 
-use crate::state::ActiveAgent;
+use crate::state::{ActiveAgent, AppState};
 use portable_pty::CommandBuilder;
 use std::collections::HashMap;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use wardian_core::models::{AgentConfig, AgentEvent};
 pub(crate) fn session_bootstrap_prompt() -> &'static str {
     "Introduce yourself"
@@ -147,9 +147,33 @@ pub(crate) fn set_agent_status(
     if let Ok(mut status) = current_status.lock() {
         if *status != next_status {
             *status = next_status.to_string();
+            let observed_at =
+                chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
             // Phase 2: Persist status change to SQLite
             let _ = wardian_core::db::update_agent_status(session_id, next_status, None);
+
+            let watch_app = app.clone();
+            let watch_session_id = session_id.to_string();
+            let watch_status = next_status.to_string();
+            tauri::async_runtime::spawn(async move {
+                let state = watch_app.state::<AppState>();
+                let agents = state.agents.lock().await;
+                if let Some(agent) = agents.get(&watch_session_id) {
+                    if let Ok(mut last_status_at) = agent.last_status_at.lock() {
+                        *last_status_at = Some(observed_at.clone());
+                    }
+                    if let Ok(mut watch_state) = agent.watch_state.lock() {
+                        watch_state.push_event(
+                            "status",
+                            serde_json::json!({
+                                "status": wardian_core::identity::normalize_status(&watch_status),
+                                "observed_at": observed_at,
+                            }),
+                        );
+                    }
+                }
+            });
 
             let _ = app.emit(
                 "agent-status-updated",

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -1,6 +1,6 @@
 use crate::providers::claude::{classify_claude_user_event, ClaudeUserEventKind};
 use crate::providers::ProviderFactory;
-use crate::state::{ActiveAgent, AppState};
+use crate::state::{ActiveAgent, AgentWatchState, AppState};
 use crate::utils::fs::*;
 use crate::utils::logging::{log_debug, log_terminal_trace_bytes, log_terminal_trace_note};
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
@@ -61,6 +61,7 @@ pub async fn spawn_agent(
 
     if config.is_off {
         let _ = wardian_core::db::update_agent_status(&config.session_id, "Off", None);
+        let session_id = config.session_id.clone();
 
         return Ok(ActiveAgent {
             config: std::sync::Arc::new(std::sync::Mutex::new(config)),
@@ -73,6 +74,10 @@ pub async fn spawn_agent(
             query_count: std::sync::Arc::new(std::sync::Mutex::new(0)),
             init_timestamp: std::sync::Arc::new(std::sync::Mutex::new(Some(born_to_save))),
             current_status: std::sync::Arc::new(std::sync::Mutex::new("Off".to_string())),
+            last_status_at: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            watch_state: std::sync::Arc::new(std::sync::Mutex::new(AgentWatchState::new(
+                session_id, 4096, 262_144,
+            ))),
             terminal_title: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
             last_output_at: std::sync::Arc::new(std::sync::Mutex::new(None)),
             log_path: std::sync::Arc::new(std::sync::Mutex::new(None)),
@@ -253,6 +258,12 @@ pub async fn spawn_agent(
     let init_timestamp_clone = init_timestamp.clone();
     let current_status = std::sync::Arc::new(std::sync::Mutex::new("Idle".to_string()));
     let current_status_clone = current_status.clone();
+    let watch_state = std::sync::Arc::new(std::sync::Mutex::new(AgentWatchState::new(
+        config.session_id.clone(),
+        4096,
+        262_144,
+    )));
+    let watch_state_clone = watch_state.clone();
     let terminal_title = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
     let terminal_title_clone = terminal_title.clone();
     let last_output_at = std::sync::Arc::new(std::sync::Mutex::new(None));
@@ -311,6 +322,9 @@ pub async fn spawn_agent(
                         opencode_chunks_logged += 1;
                     }
                     had_pty_output = true;
+                    if let Ok(mut watch_state) = watch_state_clone.lock() {
+                        watch_state.push_output(&buf[0..n]);
+                    }
                     log_terminal_trace_bytes(
                         &sid_for_pty,
                         &provider_name_for_pty,
@@ -945,6 +959,8 @@ pub async fn spawn_agent(
         query_count,
         init_timestamp,
         current_status,
+        last_status_at: std::sync::Arc::new(std::sync::Mutex::new(None)),
+        watch_state,
         terminal_title,
         last_output_at,
         log_path,

--- a/src-tauri/src/state/active_agent.rs
+++ b/src-tauri/src/state/active_agent.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use wardian_core::models::AgentConfig;
 
+use super::AgentWatchState;
+
 pub struct ActiveAgent {
     pub config: Arc<Mutex<AgentConfig>>,
     pub child_process: Option<Box<dyn portable_pty::Child + Send>>,
@@ -15,6 +17,8 @@ pub struct ActiveAgent {
     pub query_count: Arc<Mutex<usize>>,
     pub init_timestamp: Arc<Mutex<Option<String>>>,
     pub current_status: Arc<Mutex<String>>,
+    pub last_status_at: Arc<Mutex<Option<String>>>,
+    pub watch_state: Arc<Mutex<AgentWatchState>>,
     pub terminal_title: Arc<Mutex<String>>,
     pub last_output_at: Arc<Mutex<Option<std::time::SystemTime>>>,
     pub log_path: Arc<Mutex<Option<PathBuf>>>,

--- a/src-tauri/src/state/agent_watch.rs
+++ b/src-tauri/src/state/agent_watch.rs
@@ -1,0 +1,344 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+use wardian_core::control::{WatchEvent, WatchOutput};
+
+#[derive(Debug)]
+pub struct AgentWatchState {
+    agent_id: String,
+    max_records: usize,
+    max_output_bytes: usize,
+    next_sequence: u64,
+    records: VecDeque<WatchRecord>,
+    notify: Arc<Notify>,
+}
+
+impl AgentWatchState {
+    pub fn new(agent_id: String, max_records: usize, max_output_bytes: usize) -> Self {
+        Self {
+            agent_id,
+            max_records: max_records.max(1),
+            max_output_bytes: max_output_bytes.max(1),
+            next_sequence: 0,
+            records: VecDeque::new(),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    pub fn latest_cursor(&self) -> String {
+        self.cursor_for_sequence(self.next_sequence)
+    }
+
+    pub fn oldest_available_cursor(&self) -> String {
+        self.cursor_for_sequence(self.oldest_available_sequence())
+    }
+
+    pub fn notifier(&self) -> Arc<Notify> {
+        self.notify.clone()
+    }
+
+    pub fn push_event(&mut self, kind: &str, payload: serde_json::Value) -> WatchCursor {
+        self.push_record(WatchRecordKind::Event {
+            kind: kind.to_string(),
+            payload,
+        })
+    }
+
+    pub fn push_output(&mut self, bytes: &[u8]) -> WatchCursor {
+        self.push_record(WatchRecordKind::Output {
+            bytes: bytes.to_vec(),
+        })
+    }
+
+    pub fn push_delivery(&mut self, payload: serde_json::Value) -> WatchCursor {
+        self.push_record(WatchRecordKind::Delivery { payload })
+    }
+
+    pub fn snapshot_since(
+        &self,
+        since: Option<&str>,
+        tail_bytes: Option<usize>,
+    ) -> Result<WatchSnapshot, WatchStateError> {
+        let since_sequence = self.parse_since_sequence(since)?;
+        let oldest = self.oldest_available_sequence();
+        if since_sequence.saturating_add(1) < oldest {
+            return Err(WatchStateError::new(
+                "cursor_expired",
+                serde_json::json!({
+                    "oldest_available_cursor": self.oldest_available_cursor(),
+                    "requested_cursor": since,
+                }),
+            ));
+        }
+
+        let records = self
+            .records
+            .iter()
+            .filter(|record| record.sequence > since_sequence);
+        let mut events = Vec::new();
+        let mut output = Vec::new();
+        for record in records {
+            match &record.kind {
+                WatchRecordKind::Event { kind, payload } => events.push(WatchEvent {
+                    cursor: self.cursor_for_sequence(record.sequence),
+                    kind: kind.clone(),
+                    payload: payload.clone(),
+                }),
+                WatchRecordKind::Delivery { payload } => events.push(WatchEvent {
+                    cursor: self.cursor_for_sequence(record.sequence),
+                    kind: "delivery".to_string(),
+                    payload: payload.clone(),
+                }),
+                WatchRecordKind::Output { bytes } => output.extend(bytes),
+            }
+        }
+
+        let output = self.snapshot_output(output, tail_bytes);
+        Ok(WatchSnapshot {
+            cursor: self.latest_cursor(),
+            events,
+            output,
+        })
+    }
+
+    fn push_record(&mut self, kind: WatchRecordKind) -> WatchCursor {
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        let sequence = self.next_sequence;
+        self.records.push_back(WatchRecord { sequence, kind });
+        while self.records.len() > self.max_records {
+            self.records.pop_front();
+        }
+        self.trim_output_records();
+        self.notify.notify_waiters();
+        WatchCursor {
+            agent_id: self.agent_id.clone(),
+            sequence,
+        }
+    }
+
+    fn trim_output_records(&mut self) {
+        let mut output_bytes = self.retained_output_bytes();
+        while output_bytes > self.max_output_bytes {
+            let Some(index) = self
+                .records
+                .iter()
+                .position(|record| matches!(record.kind, WatchRecordKind::Output { .. }))
+            else {
+                break;
+            };
+            if let Some(record) = self.records.remove(index) {
+                if let WatchRecordKind::Output { bytes } = record.kind {
+                    output_bytes = output_bytes.saturating_sub(bytes.len());
+                }
+            }
+        }
+    }
+
+    fn retained_output_bytes(&self) -> usize {
+        self.records
+            .iter()
+            .filter_map(|record| match &record.kind {
+                WatchRecordKind::Output { bytes } => Some(bytes.len()),
+                _ => None,
+            })
+            .sum()
+    }
+
+    fn snapshot_output(&self, bytes: Vec<u8>, tail_bytes: Option<usize>) -> WatchOutput {
+        let limit = tail_bytes.unwrap_or(bytes.len()).min(bytes.len());
+        let start = utf8_tail_start(&bytes, limit);
+        let omitted_bytes = start;
+        let text = String::from_utf8_lossy(&bytes[start..]).to_string();
+        WatchOutput {
+            cursor: self.latest_cursor(),
+            text,
+            truncated: omitted_bytes > 0,
+            omitted_bytes,
+        }
+    }
+
+    fn parse_since_sequence(&self, since: Option<&str>) -> Result<u64, WatchStateError> {
+        let Some(cursor) = since else {
+            return Ok(self.oldest_available_sequence().saturating_sub(1));
+        };
+        let Some((agent_id, sequence)) = cursor.split_once(':') else {
+            return Err(WatchStateError::new(
+                "invalid_cursor",
+                serde_json::json!({ "cursor": cursor }),
+            ));
+        };
+        if agent_id != self.agent_id {
+            return Err(WatchStateError::new(
+                "invalid_cursor",
+                serde_json::json!({ "cursor": cursor }),
+            ));
+        }
+        u64::from_str_radix(sequence, 16).map_err(|_| {
+            WatchStateError::new("invalid_cursor", serde_json::json!({ "cursor": cursor }))
+        })
+    }
+
+    fn oldest_available_sequence(&self) -> u64 {
+        self.records
+            .front()
+            .map(|record| record.sequence)
+            .unwrap_or(self.next_sequence)
+    }
+
+    fn cursor_for_sequence(&self, sequence: u64) -> String {
+        format!("{}:{sequence:016x}", self.agent_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WatchCursor {
+    agent_id: String,
+    sequence: u64,
+}
+
+impl WatchCursor {
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WatchSnapshot {
+    pub cursor: String,
+    pub events: Vec<WatchEvent>,
+    pub output: WatchOutput,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WatchStateError {
+    code: &'static str,
+    details: serde_json::Value,
+}
+
+impl WatchStateError {
+    fn new(code: &'static str, details: serde_json::Value) -> Self {
+        Self { code, details }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    pub fn details(&self) -> &serde_json::Value {
+        &self.details
+    }
+}
+
+#[derive(Debug, Clone)]
+struct WatchRecord {
+    sequence: u64,
+    kind: WatchRecordKind,
+}
+
+#[derive(Debug, Clone)]
+enum WatchRecordKind {
+    Event {
+        kind: String,
+        payload: serde_json::Value,
+    },
+    Output {
+        bytes: Vec<u8>,
+    },
+    Delivery {
+        payload: serde_json::Value,
+    },
+}
+
+fn utf8_tail_start(bytes: &[u8], limit: usize) -> usize {
+    if limit >= bytes.len() {
+        return 0;
+    }
+
+    let mut start = bytes.len() - limit;
+    while start < bytes.len() && std::str::from_utf8(&bytes[start..]).is_err() {
+        start += 1;
+    }
+    start
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn watch_state_returns_output_since_cursor_without_draining() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 16, 1024);
+        let start = state.latest_cursor();
+
+        state.push_output("hello".as_bytes());
+        let first = state.snapshot_since(Some(&start), Some(1024)).unwrap();
+        let second = state.snapshot_since(Some(&start), Some(1024)).unwrap();
+
+        assert_eq!(first.output.text, "hello");
+        assert_eq!(second.output.text, "hello");
+    }
+
+    #[test]
+    fn watch_state_rejects_expired_cursor() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 2, 1024);
+        let old = state.latest_cursor();
+        state.push_event("status", serde_json::json!({"status":"processing"}));
+        state.push_event("status", serde_json::json!({"status":"idle"}));
+        state.push_event("status", serde_json::json!({"status":"processing"}));
+
+        let error = state.snapshot_since(Some(&old), Some(1024)).unwrap_err();
+
+        assert_eq!(error.code(), "cursor_expired");
+    }
+
+    #[test]
+    fn watch_state_tail_preserves_utf8_boundary_and_reports_omitted_bytes() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 16, 1024);
+        state.push_output("alpha beta".as_bytes());
+
+        let snapshot = state.snapshot_since(None, Some(6)).unwrap();
+
+        assert!(snapshot.output.truncated);
+        assert!(snapshot.output.omitted_bytes > 0);
+        assert!(std::str::from_utf8(snapshot.output.text.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn watch_state_rejects_cursor_from_another_agent() {
+        let state = AgentWatchState::new("agent-1".to_string(), 16, 1024);
+        let error = state
+            .snapshot_since(Some("agent-2:0000000000000000"), Some(1024))
+            .unwrap_err();
+
+        assert_eq!(error.code(), "invalid_cursor");
+    }
+
+    #[test]
+    fn watch_state_orders_status_output_and_delivery_on_one_cursor_sequence() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 16, 1024);
+
+        let status = state.push_event("status", serde_json::json!({"status":"processing"}));
+        let output = state.push_output("hello".as_bytes());
+        let delivery = state.push_delivery(serde_json::json!({"delivery_state":"submitted"}));
+
+        assert!(status.sequence() < output.sequence());
+        assert!(output.sequence() < delivery.sequence());
+    }
+
+    #[test]
+    fn expired_cursor_error_includes_oldest_available_cursor() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 2, 1024);
+        let old = state.latest_cursor();
+        state.push_event("status", serde_json::json!({"status":"processing"}));
+        state.push_event("status", serde_json::json!({"status":"idle"}));
+        state.push_event("status", serde_json::json!({"status":"processing"}));
+
+        let error = state.snapshot_since(Some(&old), Some(1024)).unwrap_err();
+
+        assert_eq!(error.code(), "cursor_expired");
+        assert!(error.details()["oldest_available_cursor"]
+            .as_str()
+            .is_some());
+    }
+}

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -1,7 +1,9 @@
 pub mod active_agent;
+pub mod agent_watch;
 pub mod app_state;
 pub mod user_terminal;
 
 pub use active_agent::ActiveAgent;
+pub use agent_watch::AgentWatchState;
 pub use app_state::{AppState, LibraryWatchRegistration};
 pub use user_terminal::UserTerminalSession;

--- a/src-tauri/src/utils/terminal_input.rs
+++ b/src-tauri/src/utils/terminal_input.rs
@@ -11,33 +11,52 @@ pub fn normalize_prompt_for_terminal_submit(prompt: &str) -> String {
         .to_string()
 }
 
-pub async fn submit_prompt_via_sender(
-    tx: &Sender<Vec<u8>>,
-    prompt: &str,
-    provider_name: &str,
-) -> Result<(), String> {
+pub fn provider_submit_chunks(provider_name: &str, prompt: &str) -> Result<Vec<Vec<u8>>, String> {
     let normalized = normalize_prompt_for_terminal_submit(prompt);
     if normalized.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let submit_key = if provider_name == "codex" {
+        b"\x1b\r".to_vec()
+    } else {
+        TERMINAL_SUBMIT_KEY.to_vec()
+    };
+
+    Ok(vec![normalized.into_bytes(), submit_key])
+}
+
+pub async fn submit_prompt_chunks_via_sender(
+    tx: &Sender<Vec<u8>>,
+    provider_name: &str,
+    prompt: &str,
+) -> Result<(), String> {
+    let chunks = provider_submit_chunks(provider_name, prompt)?;
+    if chunks.is_empty() {
         return Ok(());
     }
 
-    tx.send(normalized.into_bytes())
+    tx.send(chunks[0].clone())
         .await
         .map_err(|e| format!("Failed to send prompt text: {}", e))?;
 
     tokio::time::sleep(std::time::Duration::from_millis(TERMINAL_SUBMIT_DELAY_MS)).await;
 
-    let submit_key = if provider_name == "codex" {
-        b"\x1b\r".as_slice()
-    } else {
-        TERMINAL_SUBMIT_KEY
-    };
-
-    tx.send(submit_key.to_vec())
-        .await
-        .map_err(|e| format!("Failed to send prompt submit key: {}", e))?;
+    if let Some(submit_key) = chunks.get(1) {
+        tx.send(submit_key.clone())
+            .await
+            .map_err(|e| format!("Failed to send prompt submit key: {}", e))?;
+    }
 
     Ok(())
+}
+
+pub async fn submit_prompt_via_sender(
+    tx: &Sender<Vec<u8>>,
+    prompt: &str,
+    provider_name: &str,
+) -> Result<(), String> {
+    submit_prompt_chunks_via_sender(tx, provider_name, prompt).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description
Adds the first implementation slice for agent watch and provider-aware communication diagnostics:

- Adds `wardian agent watch` plus `agent wait --next` for cursor-based observation of status, output, and delivery events while preserving existing plain wait readiness semantics.
- Records provider-aware delivery attempts with split `runtime_state` / `delivery_state` and preserves structured `details.delivery[]` errors through the backend and CLI.
- Adds watch-state cursor/ring-buffer semantics, UTF-8-safe tailing, wakeups for blocking watch conditions, Codex submit timing preservation, and docs/spec updates.

## Related Issues
Fixes #210

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test` - 57 files / 456 tests passed; existing React `act(...)` warnings still appear in watchlist/App tests.
- [x] `npm run build` - passed; existing Vite large chunk warning remains.
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo clippy --all-targets -- -D warnings`
- [x] `cd src-tauri && cargo test -- --test-threads=1` - 340 lib tests and 4 mock provider E2E tests passed.
- [x] `cargo test -p wardian-core -- --test-threads=1` - 37 tests passed.
- [x] `cargo test -p wardian-cli -- --test-threads=1` - CLI unit/integration tests passed.
- [x] `npm run test:e2e:native:fast -- e2e-native/tests/cli-shared-state-native.test.mjs` - exited 0 but skipped because no native WebDriver binary was available.
- [x] `git diff --check` - no whitespace errors; Git reported the existing LF-to-CRLF warning for `e2e-native/tests/cli-shared-state-native.test.mjs`.
- [x] Secrets check - no `.env` files found and no common token/API-key patterns matched.

Real provider probes were not completed in this environment because they require an updated running Wardian desktop app, live provider sessions, and native WebDriver support for runtime validation.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable