### PR TITLE
Make agent CLI guidance cross-platform

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,12 @@ Before requesting a commit or finalizing a task, ensure the following steps are 
    - [ ] **Git Status**: Run `git status` to ensure only intended files are staged.
    - [ ] **Commit Message**: Use a clear, semantic commit message (e.g., `feat(workflows): implement parallel execution`).
 
+### Cross-Platform Documentation
+- User-facing docs, bundled skills, examples, and agent instructions must be cross-OS and cross-computer by default.
+- Use placeholders such as `<absolute-workspace-path>` instead of local machine paths, drive-letter paths, or user-home paths.
+- When commands differ by shell, show a POSIX `bash`/`sh` form first and a labeled PowerShell form second. Do not make PowerShell-only syntax the default unless the section is explicitly Windows-only.
+- Keep Windows-specific examples only when documenting Windows behavior, and label them as Windows-specific.
+
 ## 🏛️ Architecture & Naming Standards
 
 ### 1. Naming Conventions (Cross-Cutting)
@@ -120,11 +126,23 @@ Use `e2e/fixtures/mockAgent.ts` to set up an isolated `WARDIAN_HOME` and seed a 
 
 Set `WARDIAN_HOME` to redirect all state to an isolated directory:
 ```bash
-WARDIAN_HOME=/tmp/wardian-test npm run tauri dev
+WARDIAN_HOME="$(mktemp -d)" npm run tauri dev
 ```
 This prevents test runs from interfering with production `~/.wardian` state.
 
 When testing the dev app and CLI together, set the same explicit `WARDIAN_HOME` in both terminals. The CLI defaults to production `~/.wardian`, while the dev app may use debug state unless this is set.
+
+macOS/Linux shell:
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-cli-dev"
+npm run dev
+```
+
+Second terminal:
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-cli-dev"
+cargo run -p wardian-cli -- agent list --scope all
+```
 
 PowerShell:
 ```powershell

--- a/docs/developer/native-e2e.md
+++ b/docs/developer/native-e2e.md
@@ -92,11 +92,11 @@ Real-provider checks are opt-in. Keep them isolated and only use them when the m
 WARDIAN_E2E_REAL_OPENCODE=1 WARDIAN_E2E_REAL_WORKSPACE=/path/to/workspace npm run test:e2e:native
 ```
 
-On PowerShell:
+On PowerShell, use the same placeholder with a Windows absolute path:
 
 ```powershell
 $env:WARDIAN_E2E_REAL_OPENCODE='1'
-$env:WARDIAN_E2E_REAL_WORKSPACE='D:\Development\Wardian'
+$env:WARDIAN_E2E_REAL_WORKSPACE='<absolute-workspace-path>'
 npm run test:e2e:native
 ```
 

--- a/docs/developer/setup.md
+++ b/docs/developer/setup.md
@@ -50,6 +50,22 @@ npm run dev
 
 When testing the CLI against a dev app, set the same explicit `WARDIAN_HOME` in both terminals:
 
+macOS/Linux shell:
+
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-cli-dev"
+npm run dev
+```
+
+Then run CLI commands from another terminal with that same home:
+
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-cli-dev"
+cargo run -p wardian-cli -- agent list --scope all
+```
+
+PowerShell:
+
 ```powershell
 $env:WARDIAN_HOME = "$PWD\.tmp\wardian-cli-dev"
 npm run dev
@@ -64,7 +80,7 @@ cargo run -p wardian-cli -- agent list --scope all
 
 With the app running, CLI output comes from the live desktop endpoint. Request `status_source` explicitly when you need to verify that path:
 
-```powershell
+```bash
 cargo run -p wardian-cli -- agent list --scope all --fields name,status,status_source
 ```
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -44,7 +44,7 @@ wardian agent list --scope all
 wardian agent kill <name-or-uuid>
 wardian agent pause <name-or-uuid>
 wardian agent resume <name-or-uuid>
-wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace D:/Development/Wardian
+wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace <absolute-workspace-path>
 wardian agent clone <name-or-uuid> --name coder-a2
 wardian agent wait reviewer-a1 --until idle --timeout 10m
 wardian agent wait reviewer-a1 --until idle --next --timeout 10m

--- a/docs/specs/024-wardian-cli-and-agent-command.md
+++ b/docs/specs/024-wardian-cli-and-agent-command.md
@@ -135,7 +135,7 @@ The CLI's primary consumer is an agent, not a human. All non-`--pretty` output i
     "uuid": "7f3e…c19d",
     "class": "Coder",
     "provider": "claude-code",
-    "workspace": "D:/Development/Wardian",
+    "workspace": "/path/to/workspace",
     "status": "processing"
   }
 }

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -44,7 +44,7 @@ wardian agent list
 wardian agent list --scope all
 wardian agent list --scope all --status idle
 wardian agent list --scope all --class Coder
-wardian agent list --workspace D:/Development/Wardian
+wardian agent list --workspace <absolute-workspace-path>
 ```
 
 Default list scope is `workspace` when the caller is a Wardian agent with a
@@ -81,7 +81,7 @@ Mutating commands use Wardian's local control endpoint and require the desktop
 app to be running for the same `WARDIAN_HOME`.
 
 ```bash
-wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace D:/Development/Wardian
+wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace <absolute-workspace-path>
 wardian agent clone coder-a1 --name coder-a2
 wardian agent pause reviewer-a1
 wardian agent resume reviewer-a1
@@ -134,6 +134,15 @@ dropping it.
 For substantial prompts, prefer `--stdin` or `--file` so quoting does not damage
 the instruction:
 
+```bash
+cat <<'EOF' | wardian send --stdin --to reviewer-a1 --wait-until idle --timeout 10m
+Review the changes since origin/main.
+Return findings first, then tests run, then any residual risk.
+EOF
+```
+
+On PowerShell, use a here-string instead of a POSIX heredoc:
+
 ```powershell
 @"
 Review the changes since origin/main.
@@ -165,10 +174,10 @@ one terminal:
 
 ```bash
 wardian agent list --scope all --fields name,class,provider,workspace,status
-wardian agent spawn --provider codex --class Reviewer --name review-cli-surface --workspace D:/Development/Wardian
-@"
+wardian agent spawn --provider codex --class Reviewer --name review-cli-surface --workspace <absolute-workspace-path>
+cat <<'EOF' | wardian send --stdin --to review-cli-surface
 Review this patch. End with REVIEW_DONE.
-"@ | wardian send --stdin --to review-cli-surface
+EOF
 wardian agent watch review-cli-surface --until output:REVIEW_DONE --timeout 10m --include status,output
 wardian agent kill review-cli-surface
 ```
@@ -205,6 +214,20 @@ Errors are JSON on stderr. Common cases:
 When testing a dev app and CLI together, set the same `WARDIAN_HOME` in both
 terminals. The live control endpoint is keyed by `WARDIAN_HOME`.
 
+macOS/Linux shell:
+
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-cli-dev"
+npm run dev
+```
+
+Second terminal:
+
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-cli-dev"
+cargo run -p wardian-cli -- agent list --scope all --fields name,status,status_source
+```
+
 PowerShell:
 
 ```powershell
@@ -221,7 +244,12 @@ cargo run -p wardian-cli -- agent list --scope all --fields name,status,status_s
 
 After a release build from this workspace, use repo-root `target` outputs:
 
+```bash
+./target/release/wardian-cli agent list --scope all
+```
+
+On Windows release builds, the binaries use `.exe` names:
+
 ```powershell
-D:\Development\Wardian\target\release\Wardian.exe
-D:\Development\Wardian\target\release\wardian-cli.exe agent list --scope all
+.\target\release\wardian-cli.exe agent list --scope all
 ```


### PR DESCRIPTION
## Description
Removes machine-specific defaults from the bundled agent CLI guidance and related docs:

- Replaces local workspace examples with `<absolute-workspace-path>` or `/path/to/workspace` placeholders.
- Makes POSIX shell examples the default where appropriate and keeps PowerShell examples explicitly labeled.
- Adds root `AGENTS.md` guidance requiring user-facing docs, bundled skills, examples, and agent instructions to stay cross-OS and cross-computer by default.

## Related Issues
Fixes #212

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `git diff --check origin/main...HEAD`
- [x] Audit of user-facing docs/resources with `rg` for local paths such as `D:/Development`, `D:\\Development`, `C:/Users`, `C:\\Users`, `/Users/`, `/home/`, and `WARDIAN_HOME=/tmp` found no matches.

Remaining path-like examples are either placeholders, explicitly labeled PowerShell/Windows command forms, or non-user-facing test fixtures.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable