### PR TITLE
Implement Queue v1

### DIFF
--- a/e2e-native/tests/git-panel-native.test.mjs
+++ b/e2e-native/tests/git-panel-native.test.mjs
@@ -18,6 +18,10 @@ const RUN_ID = `${process.pid}-${Date.now()}`;
 const SESSION_ID = `e2e-git-${RUN_ID}`;
 const SESSION_NAME = `E2E-Git-${RUN_ID}`;
 
+function normalizeForWardianRecords(workspacePath) {
+  return workspacePath.split(path.sep).join("/");
+}
+
 function runGit(repoPath, args) {
   const result = spawnSync("git", args, {
     cwd: repoPath,
@@ -142,7 +146,7 @@ test("source control panel renders git files and history for a seeded repo", { t
   await waitForAppShell(driver, 20000);
   await createOffMockAgent(driver, repoPath);
   const rootPath = await invokeTauri(driver, "get_explorer_root", { sessionId: SESSION_ID });
-  assert.equal(rootPath, repoPath);
+  assert.equal(rootPath, normalizeForWardianRecords(repoPath));
   const status = await invokeTauri(driver, "git_status", { cwd: rootPath });
   assert.equal(status.branch, "main");
   assert.ok(status.files.some((file) => file.path === "tracked.txt"));

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,6 +6,7 @@ const testHome = path.join(os.tmpdir(), "wardian-e2e-test-home");
 
 export default defineConfig({
   testDir: "./tests",
+  workers: 1,
   timeout: 60_000,
   retries: 1,
   reporter: [["html", { open: "never" }]],
@@ -18,7 +19,7 @@ export default defineConfig({
   },
 
   webServer: {
-    command: "npm run tauri dev",
+    command: "npm run vite",
     url: "http://localhost:1420",
     timeout: 180_000,
     reuseExistingServer: true,

--- a/e2e/tests/agent-lifecycle.spec.ts
+++ b/e2e/tests/agent-lifecycle.spec.ts
@@ -12,29 +12,38 @@
  * See e2e/fixtures/mockAgent.ts for the unlock path.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.describe("Agent Spawn Form", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+  test.describe.configure({ mode: "serial" });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
     await page.locator('[data-testid="sidebar-tab-agent-config"]').click();
     await page.locator('[data-testid="spawn-agent-name"]').waitFor();
   });
 
-  test("spawn form renders all required fields", async ({ page }) => {
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("spawn form renders all required fields", async () => {
     await expect(page.locator('[data-testid="spawn-agent-name"]')).toBeVisible();
     await expect(page.locator('[data-testid="spawn-workspace-path"]')).toBeVisible();
     await expect(page.locator('[data-testid="spawn-provider"]')).toBeVisible();
     await expect(page.locator('[data-testid="spawn-submit"]')).toBeVisible();
   });
 
-  test("submit button is present when name is filled", async ({ page }) => {
+  test("submit button is present when name is filled", async () => {
     await page.locator('[data-testid="spawn-agent-name"]').fill("test-agent");
     await expect(page.locator('[data-testid="spawn-submit"]')).toBeVisible();
   });
 
-  test("provider dropdown has expected options", async ({ page }) => {
+  test("provider dropdown has expected options", async () => {
     const select = page.locator('[data-testid="spawn-provider"]');
     await expect(select).toBeVisible();
     const options = await select.locator("option").allTextContents();
@@ -42,19 +51,19 @@ test.describe("Agent Spawn Form", () => {
     expect(options.length).toBeGreaterThanOrEqual(3);
   });
 
-  test("workspace path field accepts input", async ({ page }) => {
+  test("workspace path field accepts input", async () => {
     const input = page.locator('[data-testid="spawn-workspace-path"]');
     await input.fill("C:/projects/test");
     await expect(input).toHaveValue("C:/projects/test");
   });
 
-  test("grid is empty before any agent is spawned", async ({ page }) => {
+  test("grid is empty before any agent is spawned", async () => {
     await page.getByRole("button", { name: "Grid" }).click();
     const cards = page.locator('[data-testid="agent-card"]');
     await expect(cards).toHaveCount(0);
   });
 
-  test("watchlist is empty before any agent is spawned", async ({ page }) => {
+  test("watchlist is empty before any agent is spawned", async () => {
     const watchlist = page.locator('[data-testid="agent-watchlist"]');
     await expect(watchlist).toBeVisible();
     // No agent rows expected in empty state.

--- a/e2e/tests/boot.spec.ts
+++ b/e2e/tests/boot.spec.ts
@@ -1,28 +1,36 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.describe("App Boot", () => {
-  test("renders the app shell", async ({ page }) => {
-    await page.goto("/");
+  test.describe.configure({ mode: "serial" });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("renders the app shell", async () => {
     const shell = page.locator('[data-testid="app-shell"]');
     await expect(shell).toBeVisible({ timeout: 15_000 });
   });
 
-  test("renders the sidebar icon rail", async ({ page }) => {
-    await page.goto("/");
+  test("renders the sidebar icon rail", async () => {
     const rail = page.locator('[data-testid="sidebar-icon-rail"]');
     await expect(rail).toBeVisible({ timeout: 15_000 });
   });
 
-  test("renders the agent watchlist panel", async ({ page }) => {
-    await page.goto("/");
+  test("renders the agent watchlist panel", async () => {
     const watchlist = page.locator('[data-testid="agent-watchlist"]');
     await expect(watchlist).toBeVisible({ timeout: 15_000 });
   });
 
-  test("shows empty grid when no agents are configured", async ({ page }) => {
-    await page.goto("/");
-    // Wait for app to fully load
-    await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
+  test("shows empty grid when no agents are configured", async () => {
     // With an empty WARDIAN_HOME there should be no agent cards
     const cards = page.locator('[data-testid="agent-card"]');
     await expect(cards).toHaveCount(0);

--- a/e2e/tests/critical-flows.spec.ts
+++ b/e2e/tests/critical-flows.spec.ts
@@ -1,12 +1,21 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 test.describe("Critical browser flows", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+  test.describe.configure({ mode: "serial" });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
   });
 
-  test("command broadcast asks for confirmation when no agents are selected", async ({ page }) => {
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("command broadcast asks for confirmation when no agents are selected", async () => {
     await page.locator('[data-testid="sidebar-tab-command"]').click();
     await expect(page.locator('[data-testid="command-panel"]')).toBeVisible();
 
@@ -25,7 +34,7 @@ test.describe("Critical browser flows", () => {
     await expect(textarea).toHaveValue("status check");
   });
 
-  test("workflow builder can add a manual trigger block from the library", async ({ page }) => {
+  test("workflow builder can add a manual trigger block from the library", async () => {
     await page
       .locator(".titlebar-center")
       .getByRole("button", { name: "Workflows" })

--- a/e2e/tests/features.spec.ts
+++ b/e2e/tests/features.spec.ts
@@ -1,56 +1,69 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.describe("Wardian Core Feature Tests", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+  test.describe.configure({ mode: "serial" });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
   });
 
-  test("1. App renders with main layout", async ({ page }) => {
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test.beforeEach(async () => {
+    await expect(page.locator('[data-testid="app-shell"]')).toBeVisible();
+  });
+
+  test("1. App renders with main layout", async () => {
     await expect(page.locator('[data-testid="app-shell"]')).toBeVisible();
     await expect(page.locator('[data-testid="sidebar-icon-rail"]')).toBeVisible();
     await expect(page.locator('[data-testid="agent-watchlist"]')).toBeVisible();
   });
 
-  test("2. Sidebar navigation - Agent Config tab", async ({ page }) => {
+  test("2. Sidebar navigation - Agent Config tab", async () => {
     await page.locator('[data-testid="sidebar-tab-agent-config"]').click();
     await page.waitForTimeout(500);
     await expect(page.locator('[data-testid="spawn-agent-name"]')).toBeVisible();
     await expect(page.locator('[data-testid="spawn-submit"]')).toBeVisible();
   });
 
-  test("3. Sidebar navigation - Command tab", async ({ page }) => {
+  test("3. Sidebar navigation - Command tab", async () => {
     await page.locator('[data-testid="sidebar-tab-command"]').click();
     await page.waitForTimeout(500);
     await expect(page.locator('[data-testid="command-panel"]')).toBeVisible();
     await expect(page.locator('[data-testid="broadcast-textarea"]')).toBeVisible();
   });
 
-  test("4. Sidebar navigation - Workflows tab", async ({ page }) => {
+  test("4. Sidebar navigation - Workflows tab", async () => {
     await page.locator('[data-testid="sidebar-tab-workflows"]').click();
     await page.waitForTimeout(500);
     await expect(page.locator('[data-testid="workflow-sidebar"]')).toBeVisible();
   });
 
-  test("5. Sidebar navigation - Settings tab", async ({ page }) => {
+  test("5. Sidebar navigation - Settings tab", async () => {
     await page.locator('[data-testid="sidebar-tab-settings"]').click();
     await page.waitForTimeout(500);
     await expect(page.locator('[data-testid="settings-panel"]')).toBeVisible();
   });
 
-  test("6. Sidebar navigation - Classes tab", async ({ page }) => {
+  test("6. Sidebar navigation - Classes tab", async () => {
     await page.locator('[data-testid="sidebar-tab-classes"]').click();
     await page.waitForTimeout(500);
     await expect(page.locator('[data-testid="class-manager-panel"]')).toBeVisible();
   });
 
-  test("7. Sidebar navigation - Explorer tab", async ({ page }) => {
+  test("7. Sidebar navigation - Explorer tab", async () => {
     await page.locator('[data-testid="sidebar-tab-explorer"]').click();
     await page.waitForTimeout(500);
     await expect(page.locator('[data-testid="explorer-panel"]')).toBeVisible();
   });
 
-  test("8. Settings - Theme switching", async ({ page }) => {
+  test("8. Settings - Theme switching", async () => {
     await page.locator('[data-testid="sidebar-tab-settings"]').click();
     await page.waitForTimeout(500);
     
@@ -64,7 +77,7 @@ test.describe("Wardian Core Feature Tests", () => {
     await page.waitForTimeout(300);
   });
 
-  test("9. Settings - Shell selection", async ({ page }) => {
+  test("9. Settings - Shell selection", async () => {
     await page.locator('[data-testid="sidebar-tab-settings"]').click();
     await page.waitForTimeout(500);
     
@@ -75,7 +88,7 @@ test.describe("Wardian Core Feature Tests", () => {
     expect(options).toBeGreaterThan(0);
   });
 
-  test("10. Class Manager - Create class form", async ({ page }) => {
+  test("10. Class Manager - Create class form", async () => {
     await page.locator('[data-testid="sidebar-tab-classes"]').click();
     await page.waitForTimeout(500);
     
@@ -86,7 +99,7 @@ test.describe("Wardian Core Feature Tests", () => {
     await expect(page.locator('[data-testid="class-create-button"]')).toBeVisible();
   });
 
-  test("11. Spawn Agent form validation", async ({ page }) => {
+  test("11. Spawn Agent form validation", async () => {
     await page.locator('[data-testid="sidebar-tab-agent-config"]').click();
     await page.waitForTimeout(500);
     
@@ -99,7 +112,7 @@ test.describe("Wardian Core Feature Tests", () => {
     await expect(workspaceInput).toHaveValue("C:/temp");
   });
 
-  test("12. Broadcast input functionality", async ({ page }) => {
+  test("12. Broadcast input functionality", async () => {
     await page.locator('[data-testid="sidebar-tab-command"]').click();
     await page.waitForTimeout(500);
     
@@ -110,17 +123,17 @@ test.describe("Wardian Core Feature Tests", () => {
     await expect(page.locator('[data-testid="broadcast-submit"]')).toBeVisible();
   });
 
-  test("13. Empty state - no agent cards", async ({ page }) => {
+  test("13. Empty state - no agent cards", async () => {
     const cards = page.locator('[data-testid="agent-card"]');
     await expect(cards).toHaveCount(0);
   });
 
-  test("14. Grid view container exists", async ({ page }) => {
+  test("14. Grid view container exists", async () => {
     await page.getByRole("button", { name: "Grid" }).click();
     await expect(page.getByText("No Active Instances")).toBeVisible();
   });
 
-  test("15. Watchlist shows empty state message", async ({ page }) => {
+  test("15. Watchlist shows empty state message", async () => {
     // Verify watchlist shows empty state
     const watchlist = page.locator('[data-testid="agent-watchlist"]');
     await expect(watchlist).toBeVisible();

--- a/e2e/tests/opencode-debug.spec.ts
+++ b/e2e/tests/opencode-debug.spec.ts
@@ -13,7 +13,7 @@ test.describe("OpenCode Debug Provider", () => {
       await dialog.dismiss();
     });
 
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
 
     const hasTauriBridge = await page.evaluate(() => {

--- a/e2e/tests/responsive-layout.spec.ts
+++ b/e2e/tests/responsive-layout.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('responsive layout', () => {
   test('left sidebar width persists across reload', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: "domcontentloaded" });
     // First aside is the fixed-width SidebarIconRail; the resize handle's parent aside is the resizable pane.
     const handle = page.getByTestId('sidebar-resize-handle').first();
     const sidebar = handle.locator('xpath=ancestor::aside[1]');
@@ -25,7 +25,7 @@ test.describe('responsive layout', () => {
   });
 
   test('grid drag past 2/3 enters stacked mode; stack-exit drag restores multi-column', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: "domcontentloaded" });
     // Pre-condition: at least 2 mock agents present in fixtures.
     const agentCards = page.locator('[data-testid="agent-card"]');
     test.skip(await agentCards.count() < 2, 'requires at least two visible agent cards');

--- a/e2e/tests/sidebar.spec.ts
+++ b/e2e/tests/sidebar.spec.ts
@@ -1,12 +1,21 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.describe("Sidebar Navigation", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+  test.describe.configure({ mode: "serial" });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
   });
 
-  test("sidebar icon rail has navigation buttons", async ({ page }) => {
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("sidebar icon rail has navigation buttons", async () => {
     const rail = page.locator('[data-testid="sidebar-icon-rail"]');
     const buttons = rail.locator("button");
     // Should have at least explorer, workflows, settings tabs
@@ -15,7 +24,7 @@ test.describe("Sidebar Navigation", () => {
     expect(count).toBeGreaterThanOrEqual(3);
   });
 
-  test("clicking sidebar tabs switches content pane", async ({ page }) => {
+  test("clicking sidebar tabs switches content pane", async () => {
     const rail = page.locator('[data-testid="sidebar-icon-rail"]');
     const buttons = rail.locator("button");
     // Click the second tab (workflows)

--- a/e2e/tests/watchlist.spec.ts
+++ b/e2e/tests/watchlist.spec.ts
@@ -8,19 +8,28 @@
  *      Run via: npm run test:e2e:native
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.describe("Watchlist Panel", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+  test.describe.configure({ mode: "serial" });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
   });
 
-  test("watchlist panel is visible by default", async ({ page }) => {
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("watchlist panel is visible by default", async () => {
     await expect(page.locator('[data-testid="agent-watchlist"]')).toBeVisible();
   });
 
-  test("collapse toggle hides the watchlist", async ({ page }) => {
+  test("collapse toggle hides the watchlist", async () => {
     const watchlist = page.locator('[data-testid="agent-watchlist"]');
     await expect(watchlist).toBeVisible();
 
@@ -33,11 +42,12 @@ test.describe("Watchlist Panel", () => {
     await expect(watchlist).toHaveClass(/w-0/);
   });
 
-  test("expand toggle restores the watchlist", async ({ page }) => {
-    // Collapse first.
+  test("expand toggle restores the watchlist", async () => {
     const watchlist = page.locator('[data-testid="agent-watchlist"]');
-    await page.getByTitle("Hide Agent Roster").click();
-    await expect(watchlist).toHaveClass(/w-0/);
+    if (!(await watchlist.evaluate((el) => el.className.includes("w-0")))) {
+      await page.getByTitle("Hide Agent Roster").click();
+      await expect(watchlist).toHaveClass(/w-0/);
+    }
 
     // Expand.
     await page.getByTitle("Show Agent Roster").click();
@@ -45,18 +55,18 @@ test.describe("Watchlist Panel", () => {
     await expect(watchlist).toBeVisible();
   });
 
-  test("search input is visible inside watchlist", async ({ page }) => {
+  test("search input is visible inside watchlist", async () => {
     const searchInput = page.locator('[data-testid="agent-watchlist"] input[placeholder="Search agents..."]');
     await expect(searchInput).toBeVisible();
   });
 
-  test("search input accepts text", async ({ page }) => {
+  test("search input accepts text", async () => {
     const searchInput = page.locator('[data-testid="agent-watchlist"] input[placeholder="Search agents..."]');
     await searchInput.fill("test-query");
     await expect(searchInput).toHaveValue("test-query");
   });
 
-  test("search input can be cleared", async ({ page }) => {
+  test("search input can be cleared", async () => {
     const searchInput = page.locator('[data-testid="agent-watchlist"] input[placeholder="Search agents..."]');
     await searchInput.fill("some-text");
     await searchInput.fill("");

--- a/e2e/tests/workflow.spec.ts
+++ b/e2e/tests/workflow.spec.ts
@@ -8,27 +8,36 @@
  *      Run via: npm run test:e2e:native
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 test.describe("Workflow Builder UI", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+  test.describe.configure({ mode: "serial" });
+
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto("/", { waitUntil: "domcontentloaded" });
     await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
     await page.locator('[data-testid="sidebar-tab-workflows"]').click();
     await page.locator('[data-testid="workflow-sidebar"]').waitFor();
   });
 
-  test("workflow sidebar renders", async ({ page }) => {
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("workflow sidebar renders", async () => {
     await expect(page.locator('[data-testid="workflow-sidebar"]')).toBeVisible();
   });
 
-  test("switching to workflow builder view renders canvas", async ({ page }) => {
+  test("switching to workflow builder view renders canvas", async () => {
     // The builder canvas is shown when a workflow is open/selected.
     // With empty state the sidebar is visible; builder may not be visible yet.
     await expect(page.locator('[data-testid="workflow-sidebar"]')).toBeVisible();
   });
 
-  test("workflow builder renders when navigated to directly", async ({ page }) => {
+  test("workflow builder renders when navigated to directly", async () => {
     // If the builder view is accessible via a nav button, verify it loads.
     const builder = page.locator('[data-testid="workflow-builder"]');
     const builderVisible = await builder.isVisible().catch(() => false);
@@ -40,7 +49,7 @@ test.describe("Workflow Builder UI", () => {
     }
   });
 
-  test("add-block button is visible when builder is open", async ({ page }) => {
+  test("add-block button is visible when builder is open", async () => {
     const builder = page.locator('[data-testid="workflow-builder"]');
     const builderVisible = await builder.isVisible().catch(() => false);
     if (builderVisible) {
@@ -50,7 +59,7 @@ test.describe("Workflow Builder UI", () => {
     }
   });
 
-  test("run-workflow button is visible when builder is open", async ({ page }) => {
+  test("run-workflow button is visible when builder is open", async () => {
     const builder = page.locator('[data-testid="workflow-builder"]');
     const builderVisible = await builder.isVisible().catch(() => false);
     if (builderVisible) {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -76,39 +76,16 @@ pub async fn send_input_to_agent(
                         if let Ok(mut status) = agent.current_status.lock() {
                             *status = "Idle".to_string();
                         }
-                        let _ = app.emit(
-                            "agent-status-updated",
-                            serde_json::json!({
-                                "session_id": session_id,
-                                "current_status": "Idle",
-                            }),
-                        );
+                        manager::emit_agent_status(&app, &session_id, "Idle");
                     }
                 } else if is_submit {
                     let agents = state.agents.lock().await;
                     if let Some(agent) = agents.get(&session_id) {
                         let provider = agent.config.lock().unwrap().provider.clone();
-                        if provider == "opencode" || provider == "gemini" {
-                            let current_status = agent
-                                .current_status
-                                .lock()
-                                .map(|status| status.clone())
-                                .unwrap_or_default();
-                            if current_status != "Action Needed" && current_status != "Off" {
-                                if let Ok(mut count) = agent.query_count.lock() {
-                                    *count += 1;
-                                }
-                                if let Ok(mut status) = agent.current_status.lock() {
-                                    *status = "Processing...".to_string();
-                                }
-                                let _ = app.emit(
-                                    "agent-status-updated",
-                                    serde_json::json!({
-                                        "session_id": session_id,
-                                        "current_status": "Processing...",
-                                    }),
-                                );
-                            }
+                        if (provider == "opencode" || provider == "gemini")
+                            && manager::mark_agent_prompt_started(agent)
+                        {
+                            manager::emit_agent_status(&app, &session_id, "Processing...");
                         }
                     }
                 }
@@ -199,22 +176,11 @@ pub async fn submit_prompt_to_agent(
         {
             let agents = state.agents.lock().await;
             if let Some(agent) = agents.get(&session_id) {
-                if let Ok(mut count) = agent.query_count.lock() {
-                    *count += 1;
-                }
-                if let Ok(mut status) = agent.current_status.lock() {
-                    *status = "Processing...".to_string();
+                if manager::mark_agent_prompt_started(agent) {
+                    manager::emit_agent_status(&_app, &session_id, "Processing...");
                 }
             }
         }
-
-        let _ = _app.emit(
-            "agent-status-updated",
-            serde_json::json!({
-                "session_id": session_id,
-                "current_status": "Processing...",
-            }),
-        );
 
         let habitat_cwd = crate::utils::fs::get_wardian_home()
             .map(|home| home.join("agents").join(&session_id).join("habitat"))
@@ -242,13 +208,7 @@ pub async fn submit_prompt_to_agent(
                     }
                 }
 
-                let _ = _app.emit(
-                    "agent-status-updated",
-                    serde_json::json!({
-                        "session_id": session_id,
-                        "current_status": "Error",
-                    }),
-                );
+                manager::emit_agent_status(&_app, &session_id, "Error");
 
                 return Err(error);
             }
@@ -297,15 +257,18 @@ pub async fn submit_prompt_to_agent(
             }
         }
 
-        let _ = _app.emit(
-            "agent-status-updated",
-            serde_json::json!({
-                "session_id": session_id,
-                "current_status": "Idle",
-            }),
-        );
+        manager::emit_agent_status(&_app, &session_id, "Idle");
 
         return Ok(());
+    }
+
+    {
+        let agents = state.agents.lock().await;
+        if let Some(agent) = agents.get(&session_id) {
+            if manager::mark_agent_prompt_started(agent) {
+                manager::emit_agent_status(&_app, &session_id, "Processing...");
+            }
+        }
     }
 
     submit_prompt_via_sender(&tx, &prompt, &provider_name).await

--- a/src-tauri/src/commands/watchlist.rs
+++ b/src-tauri/src/commands/watchlist.rs
@@ -75,3 +75,30 @@ pub async fn save_agent_interactions(
     std::fs::write(path, json).map_err(|e| e.to_string())?;
     Ok(())
 }
+
+#[tauri::command]
+pub async fn load_queue_items(_app: tauri::AppHandle) -> Result<serde_json::Value, String> {
+    if let Some(home) = crate::utils::fs::get_wardian_home() {
+        let path = home.join("queue/items.json");
+        if let Ok(data) = std::fs::read_to_string(&path) {
+            let parsed: serde_json::Value =
+                serde_json::from_str(&data).unwrap_or_else(|_| serde_json::json!([]));
+            return Ok(parsed);
+        }
+    }
+    Ok(serde_json::json!([]))
+}
+
+#[tauri::command]
+pub async fn save_queue_items(
+    items: serde_json::Value,
+    _app: tauri::AppHandle,
+) -> Result<(), String> {
+    let home = crate::utils::fs::get_wardian_home()
+        .ok_or_else(|| "Could not find home directory".to_string())?;
+    let _ = std::fs::create_dir_all(home.join("queue"));
+    let path = home.join("queue/items.json");
+    let json = serde_json::to_string_pretty(&items).map_err(|e| e.to_string())?;
+    std::fs::write(path, json).map_err(|e| e.to_string())?;
+    Ok(())
+}

--- a/src-tauri/src/commands/watchlist.rs
+++ b/src-tauri/src/commands/watchlist.rs
@@ -102,3 +102,11 @@ pub async fn save_queue_items(
     std::fs::write(path, json).map_err(|e| e.to_string())?;
     Ok(())
 }
+
+#[tauri::command]
+pub async fn load_opencode_last_assistant_text(
+    session_id: String,
+    _app: tauri::AppHandle,
+) -> Result<Option<String>, String> {
+    crate::manager::opencode_last_assistant_text(&session_id)
+}

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1,4 +1,5 @@
 use crate::state::AppState;
+use crate::utils::terminal_input::submit_prompt_via_sender;
 use std::fmt;
 use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -192,7 +193,8 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             thread,
         } => {
             let state = app.state::<AppState>();
-            deliver_message_to_target(&state, &target, &message, thread.as_deref()).await?;
+            deliver_message_to_target(Some(app), &state, &target, &message, thread.as_deref())
+                .await?;
             ok_json(&OkResponse::new())
         }
     }
@@ -318,34 +320,69 @@ async fn resolve_send_targets_in_state(state: &AppState, target: &str) -> Vec<St
 }
 
 async fn deliver_message_to_target(
+    app: Option<&AppHandle>,
     state: &AppState,
     target: &str,
     message: &str,
     thread: Option<&str>,
 ) -> Result<(), ControlError> {
-    let bytes = send_message_bytes(message, thread)?;
+    validate_send_thread(thread)?;
     let session_ids = resolve_send_targets_in_state(state, target).await;
     if session_ids.is_empty() {
         return Err(ControlError::not_found(format!(
             "no agents matched target: {target}"
         )));
     }
-    let senders = state
-        .input_senders
-        .read()
-        .map_err(|_| ControlError::request_failed("input_senders lock poisoned"))?;
-    let mut delivered = 0usize;
-    let mut failures = Vec::new();
-    for session_id in &session_ids {
-        match senders.get(session_id) {
-            Some(tx) => match tx.try_send(bytes.clone()) {
-                Ok(()) => delivered += 1,
-                Err(error) => failures.push(format!("{session_id}: {error}")),
-            },
-            None => failures.push(format!("{session_id}: no input channel")),
+    let (delivery_targets, mut failures) = {
+        let agents = state.agents.lock().await;
+        let senders = state
+            .input_senders
+            .read()
+            .map_err(|_| ControlError::request_failed("input_senders lock poisoned"))?;
+        let mut delivery_targets = Vec::new();
+        let mut failures = Vec::new();
+        for session_id in &session_ids {
+            let provider = agents
+                .get(session_id)
+                .and_then(|agent| agent.config.lock().ok().map(|config| config.provider.clone()))
+                .unwrap_or_default();
+            match senders.get(session_id).cloned() {
+                Some(tx) => delivery_targets.push((session_id.clone(), provider, tx)),
+                None => failures.push(format!("{session_id}: no input channel")),
+            }
+        }
+        (delivery_targets, failures)
+    };
+
+    let mut delivered_session_ids = Vec::new();
+    for (session_id, provider, tx) in delivery_targets {
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            submit_prompt_via_sender(&tx, message, &provider),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(())) => delivered_session_ids.push(session_id),
+            Ok(Err(error)) => failures.push(format!("{session_id}: {error}")),
+            Err(_) => failures.push(format!("{session_id}: input delivery timed out")),
         }
     }
-    if delivered == 0 {
+
+    if !delivered_session_ids.is_empty() {
+        let agents = state.agents.lock().await;
+        for session_id in &delivered_session_ids {
+            if let Some(agent) = agents.get(session_id) {
+                if crate::manager::mark_agent_prompt_started(agent) {
+                    if let Some(app) = app {
+                        crate::manager::emit_agent_status(app, session_id, "Processing...");
+                    }
+                }
+            }
+        }
+    }
+
+    if delivered_session_ids.is_empty() {
         return Err(ControlError::request_failed(format!(
             "message was not delivered to any matched agents: {}",
             failures.join("; ")
@@ -405,13 +442,13 @@ fn error_payload(error: &ControlError) -> Result<String, std::io::Error> {
     .map_err(|e| std::io::Error::other(e.to_string()))
 }
 
-fn send_message_bytes(message: &str, thread: Option<&str>) -> Result<Vec<u8>, ControlError> {
+fn validate_send_thread(thread: Option<&str>) -> Result<(), ControlError> {
     if thread.is_some() {
         return Err(ControlError::not_supported(
             "--thread is not supported by the Wardian control endpoint yet",
         ));
     }
-    Ok(format!("{message}\r").into_bytes())
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -534,12 +571,21 @@ mod tests {
     use wardian_core::models::{AgentConfig, WorkflowDefinition, WorkflowNode, WorkflowSettings};
 
     fn test_agent(session_id: &str, session_name: &str, agent_class: &str) -> ActiveAgent {
+        test_agent_with_provider(session_id, session_name, agent_class, "mock")
+    }
+
+    fn test_agent_with_provider(
+        session_id: &str,
+        session_name: &str,
+        agent_class: &str,
+        provider: &str,
+    ) -> ActiveAgent {
         ActiveAgent {
             config: Arc::new(Mutex::new(AgentConfig {
                 session_id: session_id.to_string(),
                 session_name: session_name.to_string(),
                 agent_class: agent_class.to_string(),
-                provider: "mock".to_string(),
+                provider: provider.to_string(),
                 folder: "D:/work".to_string(),
                 ..Default::default()
             })),
@@ -573,6 +619,19 @@ mod tests {
         );
     }
 
+    async fn insert_test_agent_with_provider(
+        state: &AppState,
+        session_id: &str,
+        session_name: &str,
+        agent_class: &str,
+        provider: &str,
+    ) {
+        state.agents.lock().await.insert(
+            session_id.to_string(),
+            test_agent_with_provider(session_id, session_name, agent_class, provider),
+        );
+    }
+
     fn sample_workflow(id: &str, name: &str, nodes: Vec<WorkflowNode>) -> WorkflowDefinition {
         WorkflowDefinition {
             id: id.to_string(),
@@ -598,15 +657,15 @@ mod tests {
 
     #[test]
     fn send_message_rejects_thread_until_supported() {
-        let error = send_message_bytes("hello", Some("review")).unwrap_err();
+        let error = validate_send_thread(Some("review")).unwrap_err();
 
         assert_eq!(error.code(), "not_supported");
         assert!(error.to_string().contains("--thread is not supported"));
     }
 
     #[test]
-    fn send_message_submits_with_terminal_enter() {
-        assert_eq!(send_message_bytes("hello", None).unwrap(), b"hello\r");
+    fn send_message_accepts_unthreaded_delivery() {
+        validate_send_thread(None).unwrap();
     }
 
     #[test]
@@ -728,25 +787,66 @@ mod tests {
     async fn message_delivery_writes_terminal_bytes_to_matched_agent() {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
-        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").expect("agent");
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+            *agent.query_count.lock().unwrap() = 0;
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(2);
         state
             .input_senders
             .write()
             .unwrap()
             .insert("agent-1".to_string(), tx);
 
-        deliver_message_to_target(&state, "CoderOne", "hello", None)
+        deliver_message_to_target(None, &state, "CoderOne", "hello", None)
             .await
             .unwrap();
 
-        assert_eq!(rx.try_recv().unwrap(), b"hello\r");
+        assert_eq!(rx.try_recv().unwrap(), b"hello");
+        assert_eq!(rx.try_recv().unwrap(), b"\r");
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").expect("agent");
+            assert_eq!(
+                agent.current_status.lock().unwrap().as_str(),
+                "Processing..."
+            );
+            assert_eq!(*agent.query_count.lock().unwrap(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn message_delivery_uses_provider_specific_submit_sequence_for_codex() {
+        let state = AppState::new();
+        insert_test_agent_with_provider(&state, "agent-1", "CoderOne", "Coder", "codex").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").expect("agent");
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+            *agent.query_count.lock().unwrap() = 0;
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(2);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        deliver_message_to_target(None, &state, "CoderOne", "hello", None)
+            .await
+            .unwrap();
+
+        assert_eq!(rx.try_recv().unwrap(), b"hello");
+        assert_eq!(rx.try_recv().unwrap(), b"\x1b\r");
     }
 
     #[tokio::test]
     async fn message_delivery_reports_missing_target_as_not_found() {
         let state = AppState::new();
 
-        let error = deliver_message_to_target(&state, "ghost", "hello", None)
+        let error = deliver_message_to_target(None, &state, "ghost", "hello", None)
             .await
             .unwrap_err();
 
@@ -761,7 +861,7 @@ mod tests {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
 
-        let error = deliver_message_to_target(&state, "agent-1", "hello", None)
+        let error = deliver_message_to_target(None, &state, "agent-1", "hello", None)
             .await
             .unwrap_err();
 
@@ -774,18 +874,19 @@ mod tests {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         insert_test_agent(&state, "agent-2", "CoderTwo", "Coder").await;
-        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(2);
         state
             .input_senders
             .write()
             .unwrap()
             .insert("agent-1".to_string(), tx);
 
-        let error = deliver_message_to_target(&state, "class:Coder", "hello", None)
+        let error = deliver_message_to_target(None, &state, "class:Coder", "hello", None)
             .await
             .unwrap_err();
 
-        assert_eq!(rx.try_recv().unwrap(), b"hello\r");
+        assert_eq!(rx.try_recv().unwrap(), b"hello");
+        assert_eq!(rx.try_recv().unwrap(), b"\r");
         assert_eq!(error.code(), "request_failed");
         assert!(error
             .to_string()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -296,6 +296,7 @@ pub fn run() {
             commands::watchlist::save_watchlist_prefs,
             commands::watchlist::load_queue_items,
             commands::watchlist::save_queue_items,
+            commands::watchlist::load_opencode_last_assistant_text,
             commands::watchlist::load_agent_interactions,
             commands::watchlist::save_agent_interactions,
             commands::workflow::list_workflows,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -294,6 +294,8 @@ pub fn run() {
             commands::watchlist::save_watchlists,
             commands::watchlist::load_watchlist_prefs,
             commands::watchlist::save_watchlist_prefs,
+            commands::watchlist::load_queue_items,
+            commands::watchlist::save_queue_items,
             commands::watchlist::load_agent_interactions,
             commands::watchlist::save_agent_interactions,
             commands::workflow::list_workflows,

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -19,6 +19,7 @@ pub use headless::{
     HeadlessRunOptions,
 };
 pub use opencode::opencode_extract_created_session_id;
+pub(crate) use opencode::opencode_last_assistant_text;
 pub use spawn::{resize_pty, spawn_agent};
 pub use telemetry::{get_all_metrics, get_app_metrics};
 

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -163,6 +163,42 @@ pub(crate) fn set_agent_status(
     }
 }
 
+pub(crate) fn emit_agent_status(app: &AppHandle, session_id: &str, current_status: &str) {
+    let _ = wardian_core::db::update_agent_status(session_id, current_status, None);
+
+    let _ = app.emit(
+        "agent-status-updated",
+        serde_json::json!({
+            "session_id": session_id,
+            "current_status": current_status,
+        }),
+    );
+}
+
+pub(crate) fn mark_agent_prompt_started(agent: &crate::state::ActiveAgent) -> bool {
+    let current_status = agent
+        .current_status
+        .lock()
+        .map(|status| status.clone())
+        .unwrap_or_default();
+    if current_status == "Action Needed" || current_status == "Off" {
+        return false;
+    }
+
+    if let Ok(mut count) = agent.query_count.lock() {
+        *count += 1;
+    }
+
+    if let Ok(mut status) = agent.current_status.lock() {
+        if *status != "Processing..." {
+            *status = "Processing...".to_string();
+            return true;
+        }
+    }
+
+    false
+}
+
 pub(crate) fn debug_preview_bytes(bytes: &[u8], limit: usize) -> String {
     let mut out = String::new();
     for &byte in bytes.iter().take(limit) {
@@ -683,5 +719,52 @@ mod tests {
                 "claude-session".to_string(),
             ]
         );
+    }
+
+    fn test_active_agent(status: &str) -> crate::state::ActiveAgent {
+        crate::state::ActiveAgent {
+            config: std::sync::Arc::new(std::sync::Mutex::new(AgentConfig::default())),
+            child_process: None,
+            background_processes: Vec::new(),
+            pty_master: None,
+            stdin_tx: None,
+            output_buffer: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
+            process_id: None,
+            query_count: std::sync::Arc::new(std::sync::Mutex::new(0)),
+            init_timestamp: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            current_status: std::sync::Arc::new(std::sync::Mutex::new(status.to_string())),
+            terminal_title: std::sync::Arc::new(std::sync::Mutex::new(String::new())),
+            last_output_at: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            log_path: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            log_last_modified: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            #[cfg(windows)]
+            job_object: None,
+        }
+    }
+
+    #[test]
+    fn mark_agent_prompt_started_sets_processing_and_counts_query() {
+        let agent = test_active_agent("Idle");
+
+        assert!(mark_agent_prompt_started(&agent));
+
+        assert_eq!(
+            agent.current_status.lock().unwrap().as_str(),
+            "Processing..."
+        );
+        assert_eq!(*agent.query_count.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn mark_agent_prompt_started_preserves_action_needed() {
+        let agent = test_active_agent("Action Needed");
+
+        assert!(!mark_agent_prompt_started(&agent));
+
+        assert_eq!(
+            agent.current_status.lock().unwrap().as_str(),
+            "Action Needed"
+        );
+        assert_eq!(*agent.query_count.lock().unwrap(), 0);
     }
 }

--- a/src-tauri/src/manager/opencode.rs
+++ b/src-tauri/src/manager/opencode.rs
@@ -29,6 +29,92 @@ pub(crate) fn opencode_session_diff_path(session_id: &str) -> std::path::PathBuf
         .join(format!("{session_id}.json"))
 }
 
+fn opencode_data_dirs() -> Vec<std::path::PathBuf> {
+    let mut dirs = Vec::new();
+    if let Some(d) = dirs::data_local_dir() {
+        dirs.push(d.join("opencode"));
+    }
+    if let Some(d) = dirs::data_dir() {
+        let p = d.join("opencode");
+        if !dirs.contains(&p) {
+            dirs.push(p);
+        }
+    }
+    if let Some(h) = dirs::home_dir() {
+        let p = h.join(".local").join("share").join("opencode");
+        if !dirs.contains(&p) {
+            dirs.push(p);
+        }
+    }
+    dirs
+}
+
+pub(crate) fn opencode_database_path() -> Option<std::path::PathBuf> {
+    opencode_data_dirs()
+        .into_iter()
+        .map(|dir| dir.join("opencode.db"))
+        .find(|path| path.exists())
+}
+
+pub(crate) fn opencode_last_assistant_text(session_id: &str) -> Result<Option<String>, String> {
+    let Some(db_path) = opencode_database_path() else {
+        return Ok(None);
+    };
+    opencode_last_assistant_text_from_db(&db_path, session_id)
+}
+
+pub(crate) fn opencode_last_assistant_text_from_db(
+    db_path: &std::path::Path,
+    session_id: &str,
+) -> Result<Option<String>, String> {
+    let conn =
+        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|err| err.to_string())?;
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT p.data, m.data
+             FROM part p
+             JOIN message m ON m.id = p.message_id
+             WHERE p.session_id = ?1 AND m.session_id = ?1
+             ORDER BY p.time_created DESC
+             LIMIT 100",
+        )
+        .map_err(|err| err.to_string())?;
+
+    let rows = stmt
+        .query_map([session_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .map_err(|err| err.to_string())?;
+
+    for row in rows {
+        let (part_data, message_data) = row.map_err(|err| err.to_string())?;
+        let message: serde_json::Value =
+            serde_json::from_str(&message_data).map_err(|err| err.to_string())?;
+        if message.get("role").and_then(|value| value.as_str()) != Some("assistant") {
+            continue;
+        }
+
+        let part: serde_json::Value =
+            serde_json::from_str(&part_data).map_err(|err| err.to_string())?;
+        if part.get("type").and_then(|value| value.as_str()) != Some("text") {
+            continue;
+        }
+
+        if let Some(text) = part
+            .get("text")
+            .and_then(|value| value.as_str())
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+        {
+            return Ok(Some(text.to_string()));
+        }
+    }
+
+    Ok(None)
+}
+
 pub(crate) fn opencode_should_fallback_to_idle(
     current_status: &str,
     last_output_at: Option<std::time::SystemTime>,
@@ -427,6 +513,121 @@ mod tests {
         let found = opencode_log_path_in(&log_dir, "ses_target").expect("matching log path");
 
         assert_eq!(found, newer);
+    }
+
+    #[test]
+    fn opencode_last_assistant_text_from_db_returns_newest_assistant_text() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let db_path = temp.path().join("opencode.db");
+        let conn = rusqlite::Connection::open(&db_path).expect("open db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE message (
+                id text PRIMARY KEY,
+                session_id text NOT NULL,
+                time_created integer NOT NULL,
+                time_updated integer NOT NULL,
+                data text NOT NULL
+            );
+            CREATE TABLE part (
+                id text PRIMARY KEY,
+                message_id text NOT NULL,
+                session_id text NOT NULL,
+                time_created integer NOT NULL,
+                time_updated integer NOT NULL,
+                data text NOT NULL
+            );
+            "#,
+        )
+        .expect("create schema");
+
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params!["user-1", "ses_test", 1, 1, r#"{"role":"user"}"#],
+        )
+        .expect("insert user message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                "user-part",
+                "user-1",
+                "ses_test",
+                2,
+                2,
+                r#"{"type":"text","text":"Prompt text"}"#,
+            ],
+        )
+        .expect("insert user part");
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params!["assistant-1", "ses_test", 3, 3, r#"{"role":"assistant"}"#],
+        )
+        .expect("insert assistant message");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                "assistant-finish",
+                "assistant-1",
+                "ses_test",
+                5,
+                5,
+                r#"{"type":"step-finish","reason":"stop"}"#,
+            ],
+        )
+        .expect("insert finish part");
+        conn.execute(
+            "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                "assistant-text",
+                "assistant-1",
+                "ses_test",
+                4,
+                4,
+                r#"{"type":"text","text":"Actual assistant text"}"#,
+            ],
+        )
+        .expect("insert assistant text");
+        drop(conn);
+
+        let text = opencode_last_assistant_text_from_db(&db_path, "ses_test")
+            .expect("read assistant text");
+
+        assert_eq!(text, Some("Actual assistant text".to_string()));
+    }
+
+    #[test]
+    fn opencode_last_assistant_text_from_db_skips_empty_text() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let db_path = temp.path().join("opencode.db");
+        let conn = rusqlite::Connection::open(&db_path).expect("open db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE message (
+                id text PRIMARY KEY,
+                session_id text NOT NULL,
+                time_created integer NOT NULL,
+                time_updated integer NOT NULL,
+                data text NOT NULL
+            );
+            CREATE TABLE part (
+                id text PRIMARY KEY,
+                message_id text NOT NULL,
+                session_id text NOT NULL,
+                time_created integer NOT NULL,
+                time_updated integer NOT NULL,
+                data text NOT NULL
+            );
+            INSERT INTO message VALUES ('assistant-1', 'ses_test', 1, 1, '{"role":"assistant"}');
+            INSERT INTO part VALUES ('blank', 'assistant-1', 'ses_test', 2, 2, '{"type":"text","text":"   "}');
+            "#,
+        )
+        .expect("create db");
+        drop(conn);
+
+        let text = opencode_last_assistant_text_from_db(&db_path, "ses_test")
+            .expect("read assistant text");
+
+        assert_eq!(text, None);
     }
 
     #[test]

--- a/src-tauri/src/utils/terminal_input.rs
+++ b/src-tauri/src/utils/terminal_input.rs
@@ -16,16 +16,27 @@ pub async fn submit_prompt_via_sender(
     prompt: &str,
     provider_name: &str,
 ) -> Result<(), String> {
-    let normalized = normalize_prompt_for_terminal_submit(prompt);
-    if normalized.is_empty() {
-        return Ok(());
+    for (index, chunk) in terminal_submit_chunks(prompt, provider_name)
+        .into_iter()
+        .enumerate()
+    {
+        if index > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(TERMINAL_SUBMIT_DELAY_MS)).await;
+        }
+
+        tx.send(chunk)
+            .await
+            .map_err(|e| format!("Failed to send prompt input: {}", e))?;
     }
 
-    tx.send(normalized.into_bytes())
-        .await
-        .map_err(|e| format!("Failed to send prompt text: {}", e))?;
+    Ok(())
+}
 
-    tokio::time::sleep(std::time::Duration::from_millis(TERMINAL_SUBMIT_DELAY_MS)).await;
+pub fn terminal_submit_chunks(prompt: &str, provider_name: &str) -> Vec<Vec<u8>> {
+    let normalized = normalize_prompt_for_terminal_submit(prompt);
+    if normalized.is_empty() {
+        return Vec::new();
+    }
 
     let submit_key = if provider_name == "codex" {
         b"\x1b\r".as_slice()
@@ -33,16 +44,14 @@ pub async fn submit_prompt_via_sender(
         TERMINAL_SUBMIT_KEY
     };
 
-    tx.send(submit_key.to_vec())
-        .await
-        .map_err(|e| format!("Failed to send prompt submit key: {}", e))?;
-
-    Ok(())
+    vec![normalized.into_bytes(), submit_key.to_vec()]
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_prompt_for_terminal_submit, submit_prompt_via_sender};
+    use super::{
+        normalize_prompt_for_terminal_submit, submit_prompt_via_sender, terminal_submit_chunks,
+    };
 
     #[test]
     fn normalize_prompt_flattens_newlines_and_trims() {
@@ -65,5 +74,13 @@ mod tests {
 
         assert_eq!(String::from_utf8(first).expect("utf8"), "hello world");
         assert_eq!(second, b"\r".to_vec());
+    }
+
+    #[test]
+    fn terminal_submit_chunks_uses_codex_escape_enter_submit_key() {
+        assert_eq!(
+            terminal_submit_chunks("hello", "codex"),
+            vec![b"hello".to_vec(), b"\x1b\r".to_vec()]
+        );
     }
 }

--- a/src/features/commands/CommandPanel.test.tsx
+++ b/src/features/commands/CommandPanel.test.tsx
@@ -171,7 +171,7 @@ describe("CommandPanel", () => {
     });
     await user.click(screen.getByTestId("broadcast-submit"));
     expect(onBroadcast).not.toHaveBeenCalled();
-    expect(screen.getByText(/broadcast to all agents/i)).toBeInTheDocument();
+    expect(screen.getByText("No agents selected. This will broadcast to ALL agents. Are you sure?")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Confirm" }));
     expect(onBroadcast).toHaveBeenCalledTimes(1);

--- a/src/features/commands/CommandPanel.tsx
+++ b/src/features/commands/CommandPanel.tsx
@@ -83,7 +83,7 @@ export const CommandPanel: React.FC<CommandPanelProps> = ({
   const handleBroadcastSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (selectedAgentIds.size === 0) {
-      if (!await confirm("No agents selected. This will broadcast to all agents. Are you sure?")) {
+      if (!await confirm("No agents selected. This will broadcast to ALL agents. Are you sure?")) {
         return;
       }
     }

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, cleanup, act, screen } from "@testing-library/react";
+import { render, waitFor, cleanup, act, screen, fireEvent } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Terminal } from "@xterm/xterm";
@@ -208,6 +208,26 @@ describe("AgentTerminal scrollback", () => {
     expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
       sessionId: "codex-text",
       input: "abc",
+    });
+  });
+
+  it("captures terminal host Tab keydown and forwards a tab byte", async () => {
+    render(<AgentTerminal sessionId="codex-tab" theme="dark" />);
+
+    await waitFor(() => {
+      expect(mockTerminal).toHaveBeenCalled();
+    });
+
+    const host = screen.getByTestId("agent-terminal-host");
+    host.focus();
+    mockInvoke.mockClear();
+
+    const prevented = !fireEvent.keyDown(host, { key: "Tab", code: "Tab" });
+
+    expect(prevented).toBe(true);
+    expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-tab",
+      input: "\t",
     });
   });
 

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, cleanup, act, screen, fireEvent } from "@testing-library/react";
+import { render, waitFor, cleanup, act, screen } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Terminal } from "@xterm/xterm";
@@ -208,26 +208,6 @@ describe("AgentTerminal scrollback", () => {
     expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
       sessionId: "codex-text",
       input: "abc",
-    });
-  });
-
-  it("captures terminal host Tab keydown and forwards a tab byte", async () => {
-    render(<AgentTerminal sessionId="codex-tab" theme="dark" />);
-
-    await waitFor(() => {
-      expect(mockTerminal).toHaveBeenCalled();
-    });
-
-    const host = screen.getByTestId("agent-terminal-host");
-    host.focus();
-    mockInvoke.mockClear();
-
-    const prevented = !fireEvent.keyDown(host, { key: "Tab", code: "Tab" });
-
-    expect(prevented).toBe(true);
-    expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
-      sessionId: "codex-tab",
-      input: "\t",
     });
   });
 

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -175,6 +175,34 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
+  it("does not capture Gemini terminal redraws for queue summaries", async () => {
+    let readCount = 0;
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      switch (cmd) {
+        case "read_agent_pty":
+          return readCount++ === 0
+            ? "⁝ Thinking... (esc to cancel, 8s) press tab twice for more"
+            : null;
+        case "resize_agent_terminal":
+          return null;
+        default:
+          return null;
+      }
+    });
+
+    render(<AgentTerminal sessionId="gemini-summary" provider="gemini" theme="dark" />);
+
+    await waitFor(() => {
+      const instance = getLatestTerminalInstance();
+      expect(instance.write).toHaveBeenCalledWith(
+        "⁝ Thinking... (esc to cancel, 8s) press tab twice for more",
+        expect.any(Function),
+      );
+    });
+
+    expect(useQueueStore.getState()._agentBuffers["gemini-summary"]).toBeUndefined();
+  });
+
   it("forwards xterm binary input through the byte-preserving PTY path", async () => {
     render(<AgentTerminal sessionId="codex-2" theme="dark" />);
 

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -7,6 +7,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { AgentTerminal } from "./AgentTerminal";
 import { defaultTerminalFontFamily, useSettingsStore } from "../../store/useSettingsStore";
+import { useQueueStore } from "../../store/useQueueStore";
 
 const mockInvoke = vi.mocked(invoke);
 const mockListen = vi.mocked(listen);
@@ -26,6 +27,7 @@ describe("AgentTerminal scrollback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useSettingsStore.setState({ terminalFontSize: 14, terminalFontFamily: "" });
+    useQueueStore.setState({ items: [], _agentBuffers: {}, _workflowLastOutput: {} });
     rectSpy = vi
       .spyOn(HTMLElement.prototype, "getBoundingClientRect")
       .mockReturnValue({
@@ -149,6 +151,28 @@ describe("AgentTerminal scrollback", () => {
       expect(secondInstance.write).toHaveBeenCalledWith("hello from codex\n", expect.any(Function));
     });
 
+  });
+
+  it("captures readable terminal output for queue summaries", async () => {
+    let readCount = 0;
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      switch (cmd) {
+        case "read_agent_pty":
+          return readCount++ === 0
+            ? "\u001b[10;6HTest received.\u001b[15;6H"
+            : null;
+        case "resize_agent_terminal":
+          return null;
+        default:
+          return null;
+      }
+    });
+
+    render(<AgentTerminal sessionId="opencode-summary" provider="opencode" theme="dark" />);
+
+    await waitFor(() => {
+      expect(useQueueStore.getState()._agentBuffers["opencode-summary"]).toBe("Test received.");
+    });
   });
 
   it("forwards xterm binary input through the byte-preserving PTY path", async () => {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -363,7 +363,7 @@ async function drainPty(sessionId: string) {
         const batchedWrite = rawChunks
           .map((data) => normalizeOpenCodeOutput(data, entry.provider, entry))
           .join("");
-        useQueueStore.getState().appendAgentTerminalOutput(sessionId, batchedWrite);
+        useQueueStore.getState().appendAgentTerminalOutput(sessionId, batchedWrite, entry.provider);
         entry.existingScrollbackLines = undefined;
         entry.parser.write(batchedWrite);
         if (entry.renderer) {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -695,6 +695,15 @@ export const AgentTerminal = memo(function AgentTerminal({
     xtermRef.current?.focus();
   }, []);
 
+  const handleTerminalKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Tab" || event.altKey || event.ctrlKey || event.metaKey) {
+      return;
+    }
+
+    event.preventDefault();
+    queueAgentInput(sessionId, "\t");
+  }, [sessionId]);
+
   useEffect(() => {
     if (!sessionId || !terminalRef.current) {
       return;
@@ -838,6 +847,7 @@ export const AgentTerminal = memo(function AgentTerminal({
         data-testid="agent-terminal-host"
         tabIndex={-1}
         onFocusCapture={onTerminalFocus}
+        onKeyDownCapture={handleTerminalKeyDown}
         onClick={focusTerminal}
         className={`w-full h-full overflow-hidden ${
           provider === "opencode" ? "wardian-terminal--tui-owned-scroll" : ""

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -16,6 +16,7 @@ import {
   type TerminalOutputState,
 } from "./terminalCapabilities";
 import { effectiveTerminalFontFamily, useSettingsStore } from "../../store/useSettingsStore";
+import { useQueueStore } from "../../store/useQueueStore";
 
 const DARK_TERM_THEME = {
   background: "#020402",
@@ -362,6 +363,7 @@ async function drainPty(sessionId: string) {
         const batchedWrite = rawChunks
           .map((data) => normalizeOpenCodeOutput(data, entry.provider, entry))
           .join("");
+        useQueueStore.getState().appendAgentTerminalOutput(sessionId, batchedWrite);
         entry.existingScrollbackLines = undefined;
         entry.parser.write(batchedWrite);
         if (entry.renderer) {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -695,15 +695,6 @@ export const AgentTerminal = memo(function AgentTerminal({
     xtermRef.current?.focus();
   }, []);
 
-  const handleTerminalKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "Tab" || event.altKey || event.ctrlKey || event.metaKey) {
-      return;
-    }
-
-    event.preventDefault();
-    queueAgentInput(sessionId, "\t");
-  }, [sessionId]);
-
   useEffect(() => {
     if (!sessionId || !terminalRef.current) {
       return;
@@ -847,7 +838,6 @@ export const AgentTerminal = memo(function AgentTerminal({
         data-testid="agent-terminal-host"
         tabIndex={-1}
         onFocusCapture={onTerminalFocus}
-        onKeyDownCapture={handleTerminalKeyDown}
         onClick={focusTerminal}
         className={`w-full h-full overflow-hidden ${
           provider === "opencode" ? "wardian-terminal--tui-owned-scroll" : ""

--- a/src/layout/titlebar/WorkspaceTabs.test.tsx
+++ b/src/layout/titlebar/WorkspaceTabs.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { WorkspaceTabs } from "./WorkspaceTabs";
+import { useQueueStore } from "../../store/useQueueStore";
+
+vi.mocked(invoke).mockResolvedValue([]);
+
+function resetStore() {
+  useQueueStore.setState({ items: [], _agentBuffers: {}, _workflowLastOutput: {} });
+}
+
+describe("WorkspaceTabs queue badge", () => {
+  beforeEach(resetStore);
+
+  it("does not show a badge when there are no unread items", () => {
+    render(<WorkspaceTabs viewMode="grid" setViewMode={() => {}} />);
+    expect(screen.queryByTestId("queue-unread-badge")).not.toBeInTheDocument();
+  });
+
+  it("shows a badge with unread count when there are unread items", () => {
+    useQueueStore.setState({
+      items: [
+        { id: "1", type: "agent_completed", timestamp: Date.now(), read: false, agent_name: "A", summary: "s" },
+        { id: "2", type: "agent_completed", timestamp: Date.now(), read: true, agent_name: "B", summary: "s" },
+      ],
+    });
+    render(<WorkspaceTabs viewMode="grid" setViewMode={() => {}} />);
+    expect(screen.getByTestId("queue-unread-badge")).toHaveTextContent("1");
+  });
+
+  it("shows 9+ when unread count exceeds 9", () => {
+    useQueueStore.setState({
+      items: Array.from({ length: 11 }, (_, i) => ({
+        id: String(i),
+        type: "agent_completed" as const,
+        timestamp: Date.now(),
+        read: false,
+        agent_name: "A",
+        summary: "s",
+      })),
+    });
+    render(<WorkspaceTabs viewMode="grid" setViewMode={() => {}} />);
+    expect(screen.getByTestId("queue-unread-badge")).toHaveTextContent("9+");
+  });
+});

--- a/src/layout/titlebar/WorkspaceTabs.tsx
+++ b/src/layout/titlebar/WorkspaceTabs.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useQueueStore } from "../../store/useQueueStore";
 
 export type ViewMode = "grid" | "dashboard" | "library" | "queue" | "workflow-builder" | "graph" | "garden";
 
@@ -20,16 +21,29 @@ interface WorkspaceTabsProps {
 export const WorkspaceTabs: React.FC<WorkspaceTabsProps> = ({
   viewMode,
   setViewMode,
-}) => (
-  <div className="titlebar-zone titlebar-center">
-    {VIEW_TABS.map(({ label, mode }) => (
-      <button
-        key={mode}
-        onClick={() => setViewMode(mode)}
-        className={`titlebar-tab ${viewMode === mode ? "active" : ""}`}
-      >
-        {label}
-      </button>
-    ))}
-  </div>
-);
+}) => {
+  const unreadCount = useQueueStore((s) => s.items.filter((i) => !i.read).length);
+  const badgeLabel = unreadCount > 9 ? "9+" : String(unreadCount);
+
+  return (
+    <div className="titlebar-zone titlebar-center">
+      {VIEW_TABS.map(({ label, mode }) => (
+        <button
+          key={mode}
+          onClick={() => setViewMode(mode)}
+          className={`titlebar-tab ${viewMode === mode ? "active" : ""}`}
+        >
+          {label}
+          {mode === "queue" && unreadCount > 0 && (
+            <span
+              data-testid="queue-unread-badge"
+              className="ml-1.5 inline-flex items-center justify-center min-w-[16px] h-[16px] px-1 rounded-full bg-[var(--color-wardian-accent)] text-[9px] font-bold text-black leading-none"
+            >
+              {badgeLabel}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/store/useQueueStore.test.ts
+++ b/src/store/useQueueStore.test.ts
@@ -55,6 +55,7 @@ describe("useQueueStore - agent completion", () => {
     useQueueStore.getState().appendAgentTerminalOutput(
       "agent-1",
       "\u001b[10;6HTest received.\u001b[15;6H",
+      "opencode",
     );
     useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
     expect(useQueueStore.getState().items[0].summary).toBe("Test received.");
@@ -67,16 +68,34 @@ describe("useQueueStore - agent completion", () => {
     useQueueStore.getState().appendAgentTerminalOutput(
       "agent-1",
       "\u001b[10;6HDelayed final text.\u001b[15;6H",
+      "opencode",
     );
 
     expect(useQueueStore.getState().items).toHaveLength(1);
     expect(useQueueStore.getState().items[0].summary).toBe("Delayed final text.");
   });
 
+  it("does not use Gemini terminal redraws as queue completion summaries", () => {
+    useQueueStore.getState().appendAgentTerminalOutput(
+      "agent-1",
+      "⁝ Thinking... (esc to cancel, 8s) press tab twice for more",
+      "gemini",
+    );
+    expect(useQueueStore.getState().hasAgentBufferedContent("agent-1")).toBe(false);
+
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+    expect(useQueueStore.getState().items[0].summary).toBe("Completed");
+
+    useQueueStore.getState().appendAgentTerminalOutput("agent-1", "> What", "gemini");
+    expect(useQueueStore.getState().items).toHaveLength(1);
+    expect(useQueueStore.getState().items[0].summary).toBe("Completed");
+  });
+
   it("does not use terminal prompt chrome as a completion summary", () => {
     useQueueStore.getState().appendAgentTerminalOutput(
       "agent-1",
       "\u001b[24;2H> Type your message or @path/to/file",
+      "opencode",
     );
     useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
     expect(useQueueStore.getState().items[0].summary).toBe("Completed");
@@ -86,6 +105,7 @@ describe("useQueueStore - agent completion", () => {
     useQueueStore.getState().appendAgentTerminalOutput(
       "agent-1",
       "\u001b[1;1H▣ Build · GPT-5.5 · 1.6s┃ List 50 rows of numbers.┃▣ Build · GPT-5.5 ■⬝⬝⬝⬝⬝⬝⬝esc interrupt",
+      "opencode",
     );
     useQueueStore.getState().flushAgentCompletion(
       "agent-1",

--- a/src/store/useQueueStore.test.ts
+++ b/src/store/useQueueStore.test.ts
@@ -42,6 +42,15 @@ describe("useQueueStore - agent completion", () => {
     expect(useQueueStore.getState()._agentBuffers["agent-1"]).toBe("");
   });
 
+  it("reports whether an agent has buffered completion content", () => {
+    expect(useQueueStore.getState().hasAgentBufferedContent("agent-1")).toBe(false);
+    useQueueStore.getState().appendAgentEvent("agent-1", {
+      type: "result",
+      result: "Final answer here",
+    });
+    expect(useQueueStore.getState().hasAgentBufferedContent("agent-1")).toBe(true);
+  });
+
   it("flushAgentCompletion creates an item with the buffered summary", () => {
     useQueueStore.getState().appendAgentEvent("agent-1", {
       type: "result",

--- a/src/store/useQueueStore.test.ts
+++ b/src/store/useQueueStore.test.ts
@@ -51,6 +51,28 @@ describe("useQueueStore - agent completion", () => {
     expect(useQueueStore.getState().hasAgentBufferedContent("agent-1")).toBe(true);
   });
 
+  it("uses terminal output as the completion summary when no JSON result is available", () => {
+    useQueueStore.getState().appendAgentTerminalOutput(
+      "agent-1",
+      "\u001b[10;6HTest received.\u001b[15;6H",
+    );
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+    expect(useQueueStore.getState().items[0].summary).toBe("Test received.");
+  });
+
+  it("replaces a recent fallback Completed summary when terminal output arrives after flush", () => {
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+    expect(useQueueStore.getState().items[0].summary).toBe("Completed");
+
+    useQueueStore.getState().appendAgentTerminalOutput(
+      "agent-1",
+      "\u001b[10;6HDelayed final text.\u001b[15;6H",
+    );
+
+    expect(useQueueStore.getState().items).toHaveLength(1);
+    expect(useQueueStore.getState().items[0].summary).toBe("Delayed final text.");
+  });
+
   it("flushAgentCompletion creates an item with the buffered summary", () => {
     useQueueStore.getState().appendAgentEvent("agent-1", {
       type: "result",

--- a/src/store/useQueueStore.test.ts
+++ b/src/store/useQueueStore.test.ts
@@ -359,4 +359,20 @@ describe("useQueueStore - item management", () => {
     expect(useQueueStore.getState().items).toHaveLength(0);
     expect(mockInvoke).toHaveBeenCalledWith("save_queue_items", expect.anything());
   });
+
+  it("clearRead removes only read items and persists", () => {
+    useQueueStore.getState().markAllRead();
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-unread", run_instance_id: "run-unread", status: "completed" },
+      "Unread",
+    );
+
+    useQueueStore.getState().clearRead();
+
+    const { items } = useQueueStore.getState();
+    expect(items).toHaveLength(1);
+    expect(items[0].workflow_name).toBe("Unread");
+    expect(items[0].read).toBe(false);
+    expect(mockInvoke).toHaveBeenCalledWith("save_queue_items", expect.anything());
+  });
 });

--- a/src/store/useQueueStore.test.ts
+++ b/src/store/useQueueStore.test.ts
@@ -290,6 +290,49 @@ describe("useQueueStore - item management", () => {
     expect(useQueueStore.getState().items.every((i) => i.read)).toBe(true);
   });
 
+  it("serializes queue persistence so markAllRead cannot be overwritten by an older save", async () => {
+    resetStore();
+    const saves: Array<{
+      items: Array<{ read: boolean }>;
+      resolve: () => void;
+      promise: Promise<void>;
+    }> = [];
+    let persisted: Array<{ read: boolean }> = [];
+
+    mockInvoke.mockImplementation((cmd, args) => {
+      if (cmd !== "save_queue_items") return Promise.resolve([]);
+      const payload = args as { items?: unknown } | undefined;
+      const items = JSON.parse(JSON.stringify(payload?.items ?? [])) as Array<{ read: boolean }>;
+      let resolve!: () => void;
+      const promise = new Promise<void>((res) => {
+        resolve = () => {
+          persisted = items;
+          res();
+        };
+      });
+      saves.push({ items, resolve, promise });
+      return promise;
+    });
+
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-1", run_instance_id: "run-1", status: "completed" },
+      "Test",
+    );
+    await vi.waitFor(() => expect(saves).toHaveLength(1));
+
+    useQueueStore.getState().markAllRead();
+    expect(useQueueStore.getState().items.every((i) => i.read)).toBe(true);
+    expect(saves).toHaveLength(1);
+
+    saves[0].resolve();
+    await saves[0].promise;
+    await vi.waitFor(() => expect(saves).toHaveLength(2));
+    saves[1].resolve();
+    await saves[1].promise;
+
+    expect(persisted.every((i) => i.read)).toBe(true);
+  });
+
   it("dismissItem removes the item and persists", () => {
     const id = useQueueStore.getState().items[0].id;
     useQueueStore.getState().dismissItem(id);

--- a/src/store/useQueueStore.test.ts
+++ b/src/store/useQueueStore.test.ts
@@ -73,6 +73,28 @@ describe("useQueueStore - agent completion", () => {
     expect(useQueueStore.getState().items[0].summary).toBe("Delayed final text.");
   });
 
+  it("does not use terminal prompt chrome as a completion summary", () => {
+    useQueueStore.getState().appendAgentTerminalOutput(
+      "agent-1",
+      "\u001b[24;2H> Type your message or @path/to/file",
+    );
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+    expect(useQueueStore.getState().items[0].summary).toBe("Completed");
+  });
+
+  it("uses an explicit completion summary instead of terminal fallback text", () => {
+    useQueueStore.getState().appendAgentTerminalOutput(
+      "agent-1",
+      "\u001b[1;1H▣ Build · GPT-5.5 · 1.6s┃ List 50 rows of numbers.┃▣ Build · GPT-5.5 ■⬝⬝⬝⬝⬝⬝⬝esc interrupt",
+    );
+    useQueueStore.getState().flushAgentCompletion(
+      "agent-1",
+      "My Agent",
+      "1\n2\n3\n4\n5",
+    );
+    expect(useQueueStore.getState().items[0].summary).toBe("1\n2\n3\n4\n5");
+  });
+
   it("flushAgentCompletion creates an item with the buffered summary", () => {
     useQueueStore.getState().appendAgentEvent("agent-1", {
       type: "result",

--- a/src/store/useQueueStore.test.ts
+++ b/src/store/useQueueStore.test.ts
@@ -131,6 +131,26 @@ describe("useQueueStore - agent completion", () => {
     expect(items[0].read).toBe(false);
   });
 
+  it("keeps the beginning visible when bounding long completion summaries", () => {
+    const longResult = [
+      "useQueueStore.test.ts:293 failed before the fix",
+      "x".repeat(700),
+      "serialize persistence writes",
+    ].join("\n");
+
+    useQueueStore.getState().appendAgentEvent("agent-1", {
+      type: "result",
+      result: longResult,
+    });
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+
+    const summary = useQueueStore.getState().items[0].summary ?? "";
+    expect(summary.length).toBeLessThanOrEqual(500);
+    expect(summary.startsWith("useQueueStore.test.ts:293 failed before the fix")).toBe(true);
+    expect(summary).toContain("...");
+    expect(summary).toContain("serialize persistence writes");
+  });
+
   it("flushAgentCompletion falls back to 'Completed' when buffer is empty", () => {
     useQueueStore.getState().flushAgentCompletion("agent-2", "Agent B");
     expect(useQueueStore.getState().items[0].summary).toBe("Completed");

--- a/src/store/useQueueStore.test.ts
+++ b/src/store/useQueueStore.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { useQueueStore } from "./useQueueStore";
+
+const mockInvoke = vi.mocked(invoke);
+
+function resetStore() {
+  useQueueStore.setState({
+    items: [],
+    _agentBuffers: {},
+    _workflowLastOutput: {},
+  });
+}
+
+describe("useQueueStore - agent completion", () => {
+  beforeEach(() => {
+    resetStore();
+    mockInvoke.mockResolvedValue([]);
+  });
+
+  it("accumulates text events in the buffer", () => {
+    useQueueStore.getState().appendAgentEvent("agent-1", {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hello" }] },
+    });
+    useQueueStore.getState().appendAgentEvent("agent-1", {
+      type: "assistant",
+      message: { content: [{ type: "text", text: " World" }] },
+    });
+    expect(useQueueStore.getState()._agentBuffers["agent-1"]).toBe("Hello World");
+  });
+
+  it("resets buffer on tool call event", () => {
+    useQueueStore.getState().appendAgentEvent("agent-1", {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Some text" }] },
+    });
+    useQueueStore.getState().appendAgentEvent("agent-1", {
+      type: "assistant",
+      message: { content: [{ type: "tool_use", name: "Bash" }] },
+    });
+    expect(useQueueStore.getState()._agentBuffers["agent-1"]).toBe("");
+  });
+
+  it("flushAgentCompletion creates an item with the buffered summary", () => {
+    useQueueStore.getState().appendAgentEvent("agent-1", {
+      type: "result",
+      result: "Final answer here",
+    });
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+
+    const { items } = useQueueStore.getState();
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe("agent_completed");
+    expect(items[0].agent_name).toBe("My Agent");
+    expect(items[0].agent_session_id).toBe("agent-1");
+    expect(items[0].summary).toBe("Final answer here");
+    expect(items[0].read).toBe(false);
+  });
+
+  it("flushAgentCompletion falls back to 'Completed' when buffer is empty", () => {
+    useQueueStore.getState().flushAgentCompletion("agent-2", "Agent B");
+    expect(useQueueStore.getState().items[0].summary).toBe("Completed");
+  });
+
+  it("flushAgentCompletion clears the buffer after flushing", () => {
+    useQueueStore.getState().appendAgentEvent("agent-1", {
+      type: "result",
+      result: "Some output",
+    });
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+    expect(useQueueStore.getState()._agentBuffers["agent-1"]).toBe("");
+  });
+
+  it("deduplicates a second flush for the same agent within 1 second (guards against double status-updated emissions)", () => {
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+    useQueueStore.setState((s) => ({
+      items: s.items.map((i) => ({ ...i, timestamp: Date.now() - 500 })),
+    }));
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+    expect(useQueueStore.getState().items).toHaveLength(1);
+  });
+
+  it("calls save_queue_items after flushAgentCompletion", () => {
+    useQueueStore.getState().flushAgentCompletion("agent-1", "My Agent");
+    expect(mockInvoke).toHaveBeenCalledWith("save_queue_items", expect.objectContaining({ items: expect.any(Array) }));
+  });
+});
+
+describe("useQueueStore - workflow completion", () => {
+  beforeEach(() => {
+    resetStore();
+    mockInvoke.mockResolvedValue([]);
+  });
+
+  it("addWorkflowCompletion creates a completed item", () => {
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-1", run_instance_id: "run-1", status: "completed" },
+      "My Workflow",
+    );
+    const { items } = useQueueStore.getState();
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe("workflow_completed");
+    expect(items[0].workflow_name).toBe("My Workflow");
+    expect(items[0].status).toBe("completed");
+    expect(items[0].read).toBe(false);
+  });
+
+  it("addWorkflowCompletion falls back to workflow_id when name is undefined", () => {
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-unknown", run_instance_id: "run-1", status: "completed" },
+    );
+    expect(useQueueStore.getState().items[0].workflow_name).toBe("wf-unknown");
+  });
+
+  it("addWorkflowCompletion includes error for failed workflows", () => {
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-2", run_instance_id: "run-2", status: "failed", error: "Timeout" },
+      "Failing Workflow",
+    );
+    const { items } = useQueueStore.getState();
+    expect(items[0].status).toBe("failed");
+    expect(items[0].error).toBe("Timeout");
+  });
+
+  it("trackWorkflowNodeOutput stores last completed-node output", () => {
+    useQueueStore.getState().trackWorkflowNodeOutput({
+      workflow_id: "wf-1",
+      node_id: "node-a",
+      status: "completed",
+      output: { text: "Node result" },
+    });
+    expect(useQueueStore.getState()._workflowLastOutput["wf-1"]).toBe("Node result");
+  });
+
+  it("addWorkflowCompletion attaches tracked node output as summary", () => {
+    useQueueStore.getState().trackWorkflowNodeOutput({
+      workflow_id: "wf-1",
+      node_id: "node-a",
+      status: "completed",
+      output: { text: "Workflow output" },
+    });
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-1", run_instance_id: "run-1", status: "completed" },
+      "My Workflow",
+    );
+    expect(useQueueStore.getState().items[0].summary).toBe("Workflow output");
+  });
+
+  it("addWorkflowCompletion omits summary when no node output was tracked", () => {
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-empty", run_instance_id: "run-1", status: "completed" },
+      "Logic-only Workflow",
+    );
+    expect(useQueueStore.getState().items[0].summary).toBeUndefined();
+  });
+});
+
+describe("useQueueStore - persistence", () => {
+  beforeEach(() => {
+    resetStore();
+    mockInvoke.mockResolvedValue([]);
+  });
+
+  it("loadItems populates state from persisted data", async () => {
+    const persisted = [
+      {
+        id: "p-1",
+        type: "agent_completed",
+        timestamp: Date.now(),
+        read: false,
+        agent_name: "Persisted Agent",
+        summary: "From disk",
+      },
+    ];
+    mockInvoke.mockResolvedValueOnce(persisted);
+    await useQueueStore.getState().loadItems();
+    expect(useQueueStore.getState().items).toHaveLength(1);
+    expect(useQueueStore.getState().items[0].agent_name).toBe("Persisted Agent");
+  });
+
+  it("loadItems filters out items older than 7 days", async () => {
+    const old = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const persisted = [
+      { id: "old", type: "agent_completed", timestamp: old, read: false, agent_name: "Stale", summary: "" },
+      { id: "new", type: "agent_completed", timestamp: Date.now(), read: false, agent_name: "Fresh", summary: "" },
+    ];
+    mockInvoke.mockResolvedValueOnce(persisted);
+    await useQueueStore.getState().loadItems();
+    expect(useQueueStore.getState().items).toHaveLength(1);
+    expect(useQueueStore.getState().items[0].id).toBe("new");
+  });
+});
+
+describe("useQueueStore - item management", () => {
+  beforeEach(() => {
+    resetStore();
+    mockInvoke.mockResolvedValue([]);
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-1", run_instance_id: "run-1", status: "completed" },
+      "Test",
+    );
+  });
+
+  it("markRead sets read=true for one item", () => {
+    const id = useQueueStore.getState().items[0].id;
+    useQueueStore.getState().markRead(id);
+    expect(useQueueStore.getState().items[0].read).toBe(true);
+  });
+
+  it("markAllRead marks all items read", () => {
+    useQueueStore.getState().addWorkflowCompletion(
+      { workflow_id: "wf-2", run_instance_id: "run-2", status: "completed" },
+      "Test2",
+    );
+    useQueueStore.getState().markAllRead();
+    expect(useQueueStore.getState().items.every((i) => i.read)).toBe(true);
+  });
+
+  it("dismissItem removes the item and persists", () => {
+    const id = useQueueStore.getState().items[0].id;
+    useQueueStore.getState().dismissItem(id);
+    expect(useQueueStore.getState().items).toHaveLength(0);
+    expect(mockInvoke).toHaveBeenCalledWith("save_queue_items", expect.anything());
+  });
+});

--- a/src/store/useQueueStore.ts
+++ b/src/store/useQueueStore.ts
@@ -15,6 +15,7 @@ interface QueueState {
 
   loadItems: () => Promise<void>;
   appendAgentEvent: (sessionId: string, data: Record<string, unknown>) => void;
+  hasAgentBufferedContent: (sessionId: string) => boolean;
   flushAgentCompletion: (sessionId: string, agentName: string) => void;
   trackWorkflowNodeOutput: (event: WorkflowTelemetryEvent) => void;
   addWorkflowCompletion: (
@@ -58,6 +59,10 @@ export const useQueueStore = create<QueueState>((set, get) => ({
         },
       }));
     }
+  },
+
+  hasAgentBufferedContent(sessionId) {
+    return (get()._agentBuffers[sessionId] ?? "").trim().length > 0;
   },
 
   flushAgentCompletion(sessionId, agentName) {

--- a/src/store/useQueueStore.ts
+++ b/src/store/useQueueStore.ts
@@ -7,6 +7,7 @@ import { WorkflowTelemetryEvent } from "../types/workflow";
 export const QUEUE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days - future settings hook-in point
 const SUMMARY_MAX_CHARS = 500;
 const DEDUP_WINDOW_MS = 1_000;
+let persistQueue: Promise<void> = Promise.resolve();
 
 interface QueueState {
   items: QueueItem[];
@@ -29,7 +30,9 @@ interface QueueState {
 }
 
 function persist(items: QueueItem[]) {
-  invoke("save_queue_items", { items }).catch(() => {});
+  persistQueue = persistQueue
+    .catch(() => undefined)
+    .then(() => invoke("save_queue_items", { items }).then(() => undefined, () => undefined));
 }
 
 export const useQueueStore = create<QueueState>((set, get) => ({

--- a/src/store/useQueueStore.ts
+++ b/src/store/useQueueStore.ts
@@ -35,6 +35,15 @@ function persist(items: QueueItem[]) {
     .then(() => invoke("save_queue_items", { items }).then(() => undefined, () => undefined));
 }
 
+function boundSummary(text: string): string {
+  if (text.length <= SUMMARY_MAX_CHARS) return text;
+  const marker = "\n...\n";
+  const available = SUMMARY_MAX_CHARS - marker.length;
+  const headLength = Math.ceil(available * 0.72);
+  const tailLength = available - headLength;
+  return `${text.slice(0, headLength)}${marker}${text.slice(-tailLength)}`;
+}
+
 export const useQueueStore = create<QueueState>((set, get) => ({
   items: [],
   _agentBuffers: {},
@@ -59,7 +68,7 @@ export const useQueueStore = create<QueueState>((set, get) => ({
       set((s) => ({
         _agentBuffers: {
           ...s._agentBuffers,
-          [sessionId]: ((s._agentBuffers[sessionId] ?? "") + text).slice(-SUMMARY_MAX_CHARS),
+          [sessionId]: boundSummary((s._agentBuffers[sessionId] ?? "") + text),
         },
       }));
     }
@@ -70,6 +79,7 @@ export const useQueueStore = create<QueueState>((set, get) => ({
 
     const text = extractTerminalQueueContent(data);
     if (!text) return;
+    const boundedText = boundSummary(text);
     const now = Date.now();
     set((s) => ({
       items: s.items.map((item) =>
@@ -77,19 +87,19 @@ export const useQueueStore = create<QueueState>((set, get) => ({
         item.agent_session_id === sessionId &&
         item.summary === "Completed" &&
         now - item.timestamp < DEDUP_WINDOW_MS
-          ? { ...item, summary: text.slice(-SUMMARY_MAX_CHARS) }
+          ? { ...item, summary: boundedText }
           : item,
       ),
       _agentBuffers: {
         ...s._agentBuffers,
-        [sessionId]: text.slice(-SUMMARY_MAX_CHARS),
+        [sessionId]: boundedText,
       },
     }));
     const nextItems = get().items;
     if (nextItems.some((item) =>
       item.type === "agent_completed" &&
       item.agent_session_id === sessionId &&
-      item.summary === text.slice(-SUMMARY_MAX_CHARS) &&
+      item.summary === boundedText &&
       now - item.timestamp < DEDUP_WINDOW_MS
     )) {
       persist(nextItems);
@@ -109,7 +119,7 @@ export const useQueueStore = create<QueueState>((set, get) => ({
 
     const override = summaryOverride?.trim();
     const raw = override || (_agentBuffers[sessionId] ?? "").trim();
-    const summary = raw || "Completed";
+    const summary = raw ? boundSummary(raw) : "Completed";
     const item: QueueItem = {
       id: crypto.randomUUID(),
       type: "agent_completed",
@@ -139,7 +149,7 @@ export const useQueueStore = create<QueueState>((set, get) => ({
   addWorkflowCompletion(payload, workflowName) {
     const { workflow_id, run_instance_id, status, error } = payload;
     const trackedOutput = get()._workflowLastOutput[workflow_id];
-    const summary = trackedOutput ? trackedOutput.slice(0, SUMMARY_MAX_CHARS) : undefined;
+    const summary = trackedOutput ? boundSummary(trackedOutput) : undefined;
     const item: QueueItem = {
       id: crypto.randomUUID(),
       type: "workflow_completed",

--- a/src/store/useQueueStore.ts
+++ b/src/store/useQueueStore.ts
@@ -15,7 +15,7 @@ interface QueueState {
 
   loadItems: () => Promise<void>;
   appendAgentEvent: (sessionId: string, data: Record<string, unknown>) => void;
-  appendAgentTerminalOutput: (sessionId: string, data: string) => void;
+  appendAgentTerminalOutput: (sessionId: string, data: string, provider?: string) => void;
   hasAgentBufferedContent: (sessionId: string) => boolean;
   flushAgentCompletion: (sessionId: string, agentName: string, summaryOverride?: string | null) => void;
   trackWorkflowNodeOutput: (event: WorkflowTelemetryEvent) => void;
@@ -62,7 +62,9 @@ export const useQueueStore = create<QueueState>((set, get) => ({
     }
   },
 
-  appendAgentTerminalOutput(sessionId, data) {
+  appendAgentTerminalOutput(sessionId, data, provider) {
+    if (provider && provider !== "opencode") return;
+
     const text = extractTerminalQueueContent(data);
     if (!text) return;
     const now = Date.now();

--- a/src/store/useQueueStore.ts
+++ b/src/store/useQueueStore.ts
@@ -27,6 +27,7 @@ interface QueueState {
   dismissItem: (id: string) => void;
   markRead: (id: string) => void;
   markAllRead: () => void;
+  clearRead: () => void;
 }
 
 function persist(items: QueueItem[]) {
@@ -192,6 +193,14 @@ export const useQueueStore = create<QueueState>((set, get) => ({
   markAllRead() {
     set((s) => {
       const next = s.items.map((i) => ({ ...i, read: true }));
+      persist(next);
+      return { items: next };
+    });
+  },
+
+  clearRead() {
+    set((s) => {
+      const next = s.items.filter((i) => !i.read);
       persist(next);
       return { items: next };
     });

--- a/src/store/useQueueStore.ts
+++ b/src/store/useQueueStore.ts
@@ -1,0 +1,148 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+import { QueueItem } from "../types";
+import { extractQueueContent } from "../utils/statusUtils";
+import { WorkflowTelemetryEvent } from "../types/workflow";
+
+export const QUEUE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days - future settings hook-in point
+const SUMMARY_MAX_CHARS = 500;
+const DEDUP_WINDOW_MS = 1_000;
+
+interface QueueState {
+  items: QueueItem[];
+  _agentBuffers: Record<string, string>;
+  _workflowLastOutput: Record<string, string>;
+
+  loadItems: () => Promise<void>;
+  appendAgentEvent: (sessionId: string, data: Record<string, unknown>) => void;
+  flushAgentCompletion: (sessionId: string, agentName: string) => void;
+  trackWorkflowNodeOutput: (event: WorkflowTelemetryEvent) => void;
+  addWorkflowCompletion: (
+    payload: { workflow_id: string; run_instance_id?: string; status: "completed" | "failed"; error?: string },
+    workflowName?: string,
+  ) => void;
+  dismissItem: (id: string) => void;
+  markRead: (id: string) => void;
+  markAllRead: () => void;
+}
+
+function persist(items: QueueItem[]) {
+  invoke("save_queue_items", { items }).catch(() => {});
+}
+
+export const useQueueStore = create<QueueState>((set, get) => ({
+  items: [],
+  _agentBuffers: {},
+  _workflowLastOutput: {},
+
+  async loadItems() {
+    try {
+      const raw = await invoke<QueueItem[]>("load_queue_items");
+      const cutoff = Date.now() - QUEUE_MAX_AGE_MS;
+      const items = (Array.isArray(raw) ? raw : []).filter((i) => i.timestamp > cutoff);
+      set({ items });
+    } catch {
+      // First run or unavailable: leave items empty.
+    }
+  },
+
+  appendAgentEvent(sessionId, data) {
+    const { text, isToolCall } = extractQueueContent(data);
+    if (isToolCall) {
+      set((s) => ({ _agentBuffers: { ...s._agentBuffers, [sessionId]: "" } }));
+    } else if (text) {
+      set((s) => ({
+        _agentBuffers: {
+          ...s._agentBuffers,
+          [sessionId]: ((s._agentBuffers[sessionId] ?? "") + text).slice(-SUMMARY_MAX_CHARS),
+        },
+      }));
+    }
+  },
+
+  flushAgentCompletion(sessionId, agentName) {
+    const { items, _agentBuffers } = get();
+    const recent = items.find(
+      (i) => i.type === "agent_completed" && i.agent_session_id === sessionId && Date.now() - i.timestamp < DEDUP_WINDOW_MS,
+    );
+    if (recent) return;
+
+    const raw = (_agentBuffers[sessionId] ?? "").trim();
+    const summary = raw || "Completed";
+    const item: QueueItem = {
+      id: crypto.randomUUID(),
+      type: "agent_completed",
+      timestamp: Date.now(),
+      read: false,
+      agent_session_id: sessionId,
+      agent_name: agentName,
+      summary,
+    };
+
+    set((s) => {
+      const next = [item, ...s.items];
+      persist(next);
+      return { items: next, _agentBuffers: { ...s._agentBuffers, [sessionId]: "" } };
+    });
+  },
+
+  trackWorkflowNodeOutput(event) {
+    if (event.status !== "completed") return;
+    const output = event.output as Record<string, unknown> | undefined;
+    const text = typeof output?.text === "string" ? output.text : undefined;
+    if (text) {
+      set((s) => ({ _workflowLastOutput: { ...s._workflowLastOutput, [event.workflow_id]: text } }));
+    }
+  },
+
+  addWorkflowCompletion(payload, workflowName) {
+    const { workflow_id, run_instance_id, status, error } = payload;
+    const trackedOutput = get()._workflowLastOutput[workflow_id];
+    const summary = trackedOutput ? trackedOutput.slice(0, SUMMARY_MAX_CHARS) : undefined;
+    const item: QueueItem = {
+      id: crypto.randomUUID(),
+      type: "workflow_completed",
+      timestamp: Date.now(),
+      read: false,
+      workflow_id,
+      workflow_run_id: run_instance_id,
+      workflow_name: workflowName ?? workflow_id,
+      status,
+      error,
+      summary,
+    };
+
+    set((s) => {
+      const next = [item, ...s.items];
+      persist(next);
+      return {
+        items: next,
+        _workflowLastOutput: { ...s._workflowLastOutput, [workflow_id]: "" },
+      };
+    });
+  },
+
+  dismissItem(id) {
+    set((s) => {
+      const next = s.items.filter((i) => i.id !== id);
+      persist(next);
+      return { items: next };
+    });
+  },
+
+  markRead(id) {
+    set((s) => {
+      const next = s.items.map((i) => (i.id === id ? { ...i, read: true } : i));
+      persist(next);
+      return { items: next };
+    });
+  },
+
+  markAllRead() {
+    set((s) => {
+      const next = s.items.map((i) => ({ ...i, read: true }));
+      persist(next);
+      return { items: next };
+    });
+  },
+}));

--- a/src/store/useQueueStore.ts
+++ b/src/store/useQueueStore.ts
@@ -17,7 +17,7 @@ interface QueueState {
   appendAgentEvent: (sessionId: string, data: Record<string, unknown>) => void;
   appendAgentTerminalOutput: (sessionId: string, data: string) => void;
   hasAgentBufferedContent: (sessionId: string) => boolean;
-  flushAgentCompletion: (sessionId: string, agentName: string) => void;
+  flushAgentCompletion: (sessionId: string, agentName: string, summaryOverride?: string | null) => void;
   trackWorkflowNodeOutput: (event: WorkflowTelemetryEvent) => void;
   addWorkflowCompletion: (
     payload: { workflow_id: string; run_instance_id?: string; status: "completed" | "failed"; error?: string },
@@ -95,14 +95,15 @@ export const useQueueStore = create<QueueState>((set, get) => ({
     return (get()._agentBuffers[sessionId] ?? "").trim().length > 0;
   },
 
-  flushAgentCompletion(sessionId, agentName) {
+  flushAgentCompletion(sessionId, agentName, summaryOverride) {
     const { items, _agentBuffers } = get();
     const recent = items.find(
       (i) => i.type === "agent_completed" && i.agent_session_id === sessionId && Date.now() - i.timestamp < DEDUP_WINDOW_MS,
     );
     if (recent) return;
 
-    const raw = (_agentBuffers[sessionId] ?? "").trim();
+    const override = summaryOverride?.trim();
+    const raw = override || (_agentBuffers[sessionId] ?? "").trim();
     const summary = raw || "Completed";
     const item: QueueItem = {
       id: crypto.randomUUID(),

--- a/src/store/useQueueStore.ts
+++ b/src/store/useQueueStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
 import { QueueItem } from "../types";
-import { extractQueueContent } from "../utils/statusUtils";
+import { extractQueueContent, extractTerminalQueueContent } from "../utils/statusUtils";
 import { WorkflowTelemetryEvent } from "../types/workflow";
 
 export const QUEUE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days - future settings hook-in point
@@ -15,6 +15,7 @@ interface QueueState {
 
   loadItems: () => Promise<void>;
   appendAgentEvent: (sessionId: string, data: Record<string, unknown>) => void;
+  appendAgentTerminalOutput: (sessionId: string, data: string) => void;
   hasAgentBufferedContent: (sessionId: string) => boolean;
   flushAgentCompletion: (sessionId: string, agentName: string) => void;
   trackWorkflowNodeOutput: (event: WorkflowTelemetryEvent) => void;
@@ -58,6 +59,35 @@ export const useQueueStore = create<QueueState>((set, get) => ({
           [sessionId]: ((s._agentBuffers[sessionId] ?? "") + text).slice(-SUMMARY_MAX_CHARS),
         },
       }));
+    }
+  },
+
+  appendAgentTerminalOutput(sessionId, data) {
+    const text = extractTerminalQueueContent(data);
+    if (!text) return;
+    const now = Date.now();
+    set((s) => ({
+      items: s.items.map((item) =>
+        item.type === "agent_completed" &&
+        item.agent_session_id === sessionId &&
+        item.summary === "Completed" &&
+        now - item.timestamp < DEDUP_WINDOW_MS
+          ? { ...item, summary: text.slice(-SUMMARY_MAX_CHARS) }
+          : item,
+      ),
+      _agentBuffers: {
+        ...s._agentBuffers,
+        [sessionId]: text.slice(-SUMMARY_MAX_CHARS),
+      },
+    }));
+    const nextItems = get().items;
+    if (nextItems.some((item) =>
+      item.type === "agent_completed" &&
+      item.agent_session_id === sessionId &&
+      item.summary === text.slice(-SUMMARY_MAX_CHARS) &&
+      now - item.timestamp < DEDUP_WINDOW_MS
+    )) {
+      persist(nextItems);
     }
   },
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,24 @@ export interface AgentStatusUpdate {
     current_status: string;
 }
 
+export interface QueueItem {
+    id: string;
+    type: "agent_completed" | "workflow_completed";
+    timestamp: number;
+    read: boolean;
+    // agent fields
+    agent_session_id?: string;
+    agent_name?: string;
+    // workflow fields
+    workflow_id?: string;
+    workflow_run_id?: string;
+    workflow_name?: string;
+    status?: "completed" | "failed";
+    error?: string;
+    // shared
+    summary?: string;
+}
+
 export interface GridLayout {
     column_tracks: number[]; // Relative weights (e.g. [1, 1] for 50/50)
     row_height: number;      // Fixed height for all rows in pixels

--- a/src/utils/statusUtils.test.ts
+++ b/src/utils/statusUtils.test.ts
@@ -5,6 +5,7 @@ import {
   deriveCurrentThought,
   classifyJsonEvent,
   extractQueueContent,
+  extractTerminalQueueContent,
   getStatusColorClass,
   getStatusLabel,
 } from "./statusUtils";
@@ -493,5 +494,16 @@ describe("extractQueueContent", () => {
   it("returns empty result for unknown event type", () => {
     expect(extractQueueContent({ type: "unknown_event" }))
       .toEqual({ isToolCall: false });
+  });
+});
+
+describe("extractTerminalQueueContent", () => {
+  it("extracts readable text from ANSI terminal output", () => {
+    const chunk = "\u001b[?25l\u001b[38;2;26;26;26m\u001b[48;2;255;255;255m\u001b[10;6HTest received.\u001b[15;6H\u001b[?25h";
+    expect(extractTerminalQueueContent(chunk)).toBe("Test received.");
+  });
+
+  it("ignores control-only terminal output", () => {
+    expect(extractTerminalQueueContent("\u001b[?2026h\u001b[?2026l\u001b[H")).toBeUndefined();
   });
 });

--- a/src/utils/statusUtils.test.ts
+++ b/src/utils/statusUtils.test.ts
@@ -4,6 +4,7 @@ import {
   cleanThought,
   deriveCurrentThought,
   classifyJsonEvent,
+  extractQueueContent,
   getStatusColorClass,
   getStatusLabel,
 } from "./statusUtils";
@@ -414,5 +415,83 @@ describe("getStatusLabel", () => {
 
   it("maps unknown values to Pending", () => {
     expect(getStatusLabel("Something Else")).toBe("Pending");
+  });
+});
+
+describe("extractQueueContent", () => {
+  it("returns text from Claude assistant event with text block", () => {
+    const data = {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hello world" }] },
+    };
+    expect(extractQueueContent(data)).toEqual({ text: "Hello world", isToolCall: false });
+  });
+
+  it("returns isToolCall for Claude assistant event with only tool_use block", () => {
+    const data = {
+      type: "assistant",
+      message: { content: [{ type: "tool_use", name: "Bash" }] },
+    };
+    expect(extractQueueContent(data)).toEqual({ isToolCall: true });
+  });
+
+  it("returns text AND isToolCall for Claude assistant event with both text and tool_use", () => {
+    const data = {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Let me run that." },
+          { type: "tool_use", name: "Bash" },
+        ],
+      },
+    };
+    const result = extractQueueContent(data);
+    expect(result.text).toBe("Let me run that.");
+    expect(result.isToolCall).toBe(true);
+  });
+
+  it("returns isToolCall for Claude system permission_request", () => {
+    expect(extractQueueContent({ type: "system", subtype: "permission_request" }))
+      .toEqual({ isToolCall: true });
+  });
+
+  it("returns text from Gemini text event", () => {
+    expect(extractQueueContent({ type: "text", part: { text: "Gemini response" } }))
+      .toEqual({ text: "Gemini response", isToolCall: false });
+  });
+
+  it("returns isToolCall for Gemini tool_use event", () => {
+    expect(extractQueueContent({ type: "tool_use", part: { tool: "bash" } }))
+      .toEqual({ isToolCall: true });
+  });
+
+  it("returns text from Codex item.completed agent_message", () => {
+    expect(extractQueueContent({ type: "item.completed", item: { type: "agent_message", text: "Done!" } }))
+      .toEqual({ text: "Done!", isToolCall: false });
+  });
+
+  it("returns isToolCall for Codex item.completed exec_command", () => {
+    expect(extractQueueContent({ type: "item.completed", item: { type: "exec_command", command: "ls" } }))
+      .toEqual({ isToolCall: true });
+  });
+
+  it("returns text from Codex event_msg agent_message", () => {
+    const data = { type: "event_msg", payload: { type: "agent_message", message: "Codex says hi" } };
+    expect(extractQueueContent(data)).toEqual({ text: "Codex says hi", isToolCall: false });
+  });
+
+  it("returns isToolCall for Codex event_msg exec_command", () => {
+    const data = { type: "event_msg", payload: { type: "exec_command", command: "ls" } };
+    expect(extractQueueContent(data)).toEqual({ isToolCall: true });
+  });
+
+  it("returns text from Claude result event", () => {
+    expect(extractQueueContent({ type: "result", result: "Final answer" }))
+      .toEqual({ text: "Final answer", isToolCall: false });
+  });
+
+  it("returns empty result for unknown event type", () => {
+    expect(extractQueueContent({ type: "unknown_event" }))
+      .toEqual({ isToolCall: false });
   });
 });

--- a/src/utils/statusUtils.test.ts
+++ b/src/utils/statusUtils.test.ts
@@ -503,6 +503,16 @@ describe("extractTerminalQueueContent", () => {
     expect(extractTerminalQueueContent(chunk)).toBe("Test received.");
   });
 
+  it("ignores OpenCode input placeholders", () => {
+    expect(extractTerminalQueueContent("\u001b[24;2H> Type your message or @path/to/file"))
+      .toBeUndefined();
+  });
+
+  it("ignores OpenCode status and prompt chrome", () => {
+    const chunk = "\u001b[1;1H▣ Build · GPT-5.5 · 1.6s┃ List 50 rows of numbers.┃▣ Build · GPT-5.5 ■⬝⬝⬝⬝⬝⬝⬝esc interrupt";
+    expect(extractTerminalQueueContent(chunk)).toBeUndefined();
+  });
+
   it("ignores control-only terminal output", () => {
     expect(extractTerminalQueueContent("\u001b[?2026h\u001b[?2026l\u001b[H")).toBeUndefined();
   });

--- a/src/utils/statusUtils.test.ts
+++ b/src/utils/statusUtils.test.ts
@@ -513,6 +513,12 @@ describe("extractTerminalQueueContent", () => {
     expect(extractTerminalQueueContent(chunk)).toBeUndefined();
   });
 
+  it("ignores Gemini thinking and overflow hint chrome", () => {
+    expect(extractTerminalQueueContent("⁝ Thinking... (esc to cancel, 8s) press tab twice for more"))
+      .toBeUndefined();
+    expect(extractTerminalQueueContent("press tab twice for more")).toBeUndefined();
+  });
+
   it("ignores control-only terminal output", () => {
     expect(extractTerminalQueueContent("\u001b[?2026h\u001b[?2026l\u001b[H")).toBeUndefined();
   });

--- a/src/utils/statusUtils.ts
+++ b/src/utils/statusUtils.ts
@@ -388,3 +388,28 @@ export function extractQueueContent(data: Record<string, unknown>): {
 
   return { isToolCall: false };
 }
+
+const TERMINAL_OSC_SEQUENCE = /\u001b\][\s\S]*?(?:\u0007|\u001b\\)/g;
+const TERMINAL_DCS_SEQUENCE = /\u001bP[\s\S]*?\u001b\\/g;
+const TERMINAL_CSI_SEQUENCE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
+const TERMINAL_ESC_SEQUENCE = /\u001b[@-_]/g;
+const TERMINAL_CONTROL_CHARS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
+
+export function extractTerminalQueueContent(data: string): string | undefined {
+  const plain = data
+    .replace(TERMINAL_OSC_SEQUENCE, "")
+    .replace(TERMINAL_DCS_SEQUENCE, "")
+    .replace(TERMINAL_CSI_SEQUENCE, "")
+    .replace(TERMINAL_ESC_SEQUENCE, "")
+    .replace(/\r/g, "\n")
+    .replace(TERMINAL_CONTROL_CHARS, "");
+
+  const candidates = plain
+    .split(/\n+/)
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => /[A-Za-z0-9]/.test(line))
+    .filter((line) => !/^[0-9?;$<>= ]+$/.test(line));
+
+  return candidates[candidates.length - 1];
+}

--- a/src/utils/statusUtils.ts
+++ b/src/utils/statusUtils.ts
@@ -395,6 +395,15 @@ const TERMINAL_CSI_SEQUENCE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
 const TERMINAL_ESC_SEQUENCE = /\u001b[@-_]/g;
 const TERMINAL_CONTROL_CHARS = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g;
 
+function isTerminalQueueChrome(line: string): boolean {
+  const lower = line.toLowerCase();
+  if (lower.includes("type your message") || lower.includes("@path/to/file")) return true;
+  if (lower.includes("esc interrupt")) return true;
+  if (line.includes("▣") && line.includes("GPT-")) return true;
+  if (/^·\s*\d+(?:\.\d+)?s\s+\d+$/.test(line)) return true;
+  return false;
+}
+
 export function extractTerminalQueueContent(data: string): string | undefined {
   const plain = data
     .replace(TERMINAL_OSC_SEQUENCE, "")
@@ -409,7 +418,8 @@ export function extractTerminalQueueContent(data: string): string | undefined {
     .map((line) => line.replace(/\s+/g, " ").trim())
     .filter((line) => line.length > 0)
     .filter((line) => /[A-Za-z0-9]/.test(line))
-    .filter((line) => !/^[0-9?;$<>= ]+$/.test(line));
+    .filter((line) => !/^[0-9?;$<>= ]+$/.test(line))
+    .filter((line) => !isTerminalQueueChrome(line));
 
   return candidates[candidates.length - 1];
 }

--- a/src/utils/statusUtils.ts
+++ b/src/utils/statusUtils.ts
@@ -399,6 +399,8 @@ function isTerminalQueueChrome(line: string): boolean {
   const lower = line.toLowerCase();
   if (lower.includes("type your message") || lower.includes("@path/to/file")) return true;
   if (lower.includes("esc interrupt")) return true;
+  if (lower.includes("press tab twice for more")) return true;
+  if (lower.includes("thinking...") && lower.includes("esc to cancel")) return true;
   if (line.includes("▣") && line.includes("GPT-")) return true;
   if (/^·\s*\d+(?:\.\d+)?s\s+\d+$/.test(line)) return true;
   return false;

--- a/src/utils/statusUtils.ts
+++ b/src/utils/statusUtils.ts
@@ -323,3 +323,68 @@ export function getStatusColorClass(effectiveStatus: string): string {
   }
   return "bg-wardian-off flex-shrink-0";
 }
+
+export function extractQueueContent(data: Record<string, unknown>): {
+  text?: string;
+  isToolCall: boolean;
+} {
+  // Claude: assistant message — may carry text, tool_use, or both
+  if (data.type === "assistant") {
+    const msg = data.message as Record<string, unknown> | undefined;
+    const content = msg?.content as Array<Record<string, unknown>> | undefined;
+    const textBlock = content?.find((c) => c.type === "text");
+    const hasToolUse = content?.some((c) => c.type === "tool_use") ?? false;
+    if (textBlock?.text) {
+      return { text: textBlock.text as string, isToolCall: hasToolUse };
+    }
+    if (hasToolUse) return { isToolCall: true };
+  }
+
+  // Claude: system permission request = tool call boundary
+  if (data.type === "system" && (data.subtype as string | undefined) === "permission_request") {
+    return { isToolCall: true };
+  }
+
+  // Claude: result event carries the final agent output
+  if (data.type === "result") {
+    const result = data.result as string | undefined;
+    if (result) return { text: result, isToolCall: false };
+  }
+
+  // Gemini: text part
+  if (data.type === "text") {
+    const part = data.part as Record<string, unknown> | undefined;
+    const text = part?.text as string | undefined;
+    if (text) return { text, isToolCall: false };
+  }
+
+  // Gemini: tool_use
+  if (data.type === "tool_use") {
+    return { isToolCall: true };
+  }
+
+  // Codex: completed item
+  if (data.type === "item.completed") {
+    const item = data.item as Record<string, unknown> | undefined;
+    const itemType = item?.type as string | undefined;
+    if (itemType === "agent_message") {
+      return { text: (item?.text as string) || "", isToolCall: false };
+    }
+    if (itemType === "exec_command") return { isToolCall: true };
+  }
+
+  // Codex: nested event_msg
+  if (data.type === "event_msg") {
+    const payload = data.payload as Record<string, unknown> | undefined;
+    const payloadType = payload?.type as string | undefined;
+    if (payloadType === "agent_message") {
+      const text = (payload?.message as string) || (payload?.text as string) || "";
+      if (text) return { text, isToolCall: false };
+    }
+    if (payloadType === "exec_command" || payloadType === "exec_started") {
+      return { isToolCall: true };
+    }
+  }
+
+  return { isToolCall: false };
+}

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -214,6 +214,17 @@ const sampleAgents: AgentConfig[] = [
   { session_id: "agent-3", session_name: "Gamma", agent_class: "DevOps", folder: "/tmp", is_off: false },
 ];
 
+const opencodeAgents: AgentConfig[] = [
+  {
+    session_id: "ses_opencode",
+    session_name: "OpenCode Agent",
+    agent_class: "Coder",
+    folder: "C:/project",
+    is_off: false,
+    provider: "opencode",
+  },
+];
+
 beforeEach(() => {
   vi.clearAllMocks();
   useLayoutStore.getState().resetLayout();
@@ -538,6 +549,89 @@ describe("Agent Watchlist Sidebar", () => {
               agent_session_id: "agent-1",
               agent_name: "Alpha",
               summary: "Completed",
+              read: false,
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
+  it("uses OpenCode assistant database text when an OpenCode agent completes", async () => {
+    setupDefaultMocks(opencodeAgents, defaultClasses);
+    mockInvoke.mockImplementation(async (cmd: any, args?: any) => {
+      if (cmd === "load_opencode_last_assistant_text" && args?.sessionId === "ses_opencode") {
+        return "1\n2\n3\n4\n5";
+      }
+      switch (cmd) {
+        case "list_agents":
+          return opencodeAgents;
+        case "list_agent_classes":
+        case "load_watchlists":
+        case "load_queue_items":
+        case "list_workflows":
+        case "list_scheduled_runs":
+        case "list_deployed_skills":
+          return [];
+        case "get_library_tree":
+          return { type: "Folder", path: "", name: "Root", children: [] };
+        case "load_workflow_library":
+          return { folders: [], rootWorkflowIds: [] };
+        default:
+          return null;
+      }
+    });
+    const emitAgentMetrics = captureAgentMetricsListener();
+
+    await act(async () => {
+      render(<App />);
+    });
+    await screen.findByText("All Agents");
+
+    await act(async () => {
+      emitAgentMetrics([
+        {
+          session_id: "ses_opencode",
+          current_status: "Processing...",
+          cpu_usage: 0,
+          memory_mb: 0,
+          uptime_seconds: 1,
+          query_count: 1,
+          init_timestamp: null,
+          log_path: null,
+        },
+      ]);
+    });
+    mockInvoke.mockClear();
+
+    await act(async () => {
+      emitAgentMetrics([
+        {
+          session_id: "ses_opencode",
+          current_status: "Idle",
+          cpu_usage: 0,
+          memory_mb: 0,
+          uptime_seconds: 2,
+          query_count: 1,
+          init_timestamp: null,
+          log_path: null,
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("load_opencode_last_assistant_text", {
+        sessionId: "ses_opencode",
+      });
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "save_queue_items",
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              type: "agent_completed",
+              agent_session_id: "ses_opencode",
+              agent_name: "OpenCode Agent",
+              summary: "1\n2\n3\n4\n5",
               read: false,
             }),
           ],

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -488,6 +488,64 @@ describe("Agent Watchlist Sidebar", () => {
     });
   });
 
+  it("adds an agent completion to the queue when agent metrics transition from active to Idle", async () => {
+    setupDefaultMocks(sampleAgents, defaultClasses);
+    const emitAgentMetrics = captureAgentMetricsListener();
+
+    await act(async () => {
+      render(<App />);
+    });
+    await screen.findByText("All Agents");
+
+    await act(async () => {
+      emitAgentMetrics([
+        {
+          session_id: "agent-1",
+          current_status: "Processing...",
+          cpu_usage: 0,
+          memory_mb: 0,
+          uptime_seconds: 1,
+          query_count: 1,
+          init_timestamp: null,
+          log_path: null,
+        },
+      ]);
+    });
+    mockInvoke.mockClear();
+
+    await act(async () => {
+      emitAgentMetrics([
+        {
+          session_id: "agent-1",
+          current_status: "Idle",
+          cpu_usage: 0,
+          memory_mb: 0,
+          uptime_seconds: 2,
+          query_count: 1,
+          init_timestamp: null,
+          log_path: null,
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "save_queue_items",
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              type: "agent_completed",
+              agent_session_id: "agent-1",
+              agent_name: "Alpha",
+              summary: "Completed",
+              read: false,
+            }),
+          ],
+        }),
+      );
+    });
+  });
+
   it("shows Select All and Clear buttons", async () => {
     setupDefaultMocks(sampleAgents, defaultClasses);
     await act(async () => {

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -7,6 +7,7 @@ import App from "./App";
 import type { AgentConfig, AgentClassDefinition } from "../types";
 import type { AgentTelemetry } from "../types";
 import { useLayoutStore } from "../store/useLayoutStore";
+import { useQueueStore } from "../store/useQueueStore";
 
 // Mock window.matchMedia globally for tests
 Object.defineProperty(window, 'matchMedia', {
@@ -64,10 +65,12 @@ const mockListen = vi.mocked(listen);
 let currentAgents: AgentConfig[] = [];
 let currentWatchlists: unknown = [];
 let currentInteractions: unknown = {};
+let currentQueueItems: unknown = [];
 function setupDefaultMocks(agents: AgentConfig[] = [], classes: AgentClassDefinition[] = []) {
   currentAgents = [...agents];
   currentWatchlists = [];
   currentInteractions = {};
+  currentQueueItems = [];
   mockInvoke.mockImplementation(async (cmd: any, args?: any) => {
     switch (cmd) {
       case "list_agents":
@@ -83,6 +86,11 @@ function setupDefaultMocks(agents: AgentConfig[] = [], classes: AgentClassDefini
         return currentInteractions;
       case "save_agent_interactions":
         currentInteractions = args?.interactions;
+        return null;
+      case "load_queue_items":
+        return currentQueueItems;
+      case "save_queue_items":
+        currentQueueItems = args?.items;
         return null;
       case "pause_agent":
         if (args?.sessionId) {
@@ -169,6 +177,28 @@ function captureAgentMetricsListener() {
   };
 }
 
+function captureQueueAgentListeners() {
+  let jsonListener: EventCallback<{ session_id: string; data: Record<string, unknown> }> | null = null;
+  let statusListener: EventCallback<{ session_id: string; current_status: string }> | null = null;
+  mockListen.mockImplementation((eventName, handler) => {
+    if (eventName === "agent-json-event") {
+      jsonListener = handler as EventCallback<{ session_id: string; data: Record<string, unknown> }>;
+    }
+    if (eventName === "agent-status-updated") {
+      statusListener = handler as EventCallback<{ session_id: string; current_status: string }>;
+    }
+    return Promise.resolve(() => {});
+  });
+  return {
+    emitJson(payload: { session_id: string; data: Record<string, unknown> }) {
+      jsonListener?.({ event: "agent-json-event", id: 0, payload });
+    },
+    emitStatus(payload: { session_id: string; current_status: string }) {
+      statusListener?.({ event: "agent-status-updated", id: 0, payload });
+    },
+  };
+}
+
 const defaultClasses: AgentClassDefinition[] = [
   { name: "Coder", description: "Writes code", is_default: true },
   { name: "Architect", description: "Designs systems", is_default: true },
@@ -187,6 +217,7 @@ const sampleAgents: AgentConfig[] = [
 beforeEach(() => {
   vi.clearAllMocks();
   useLayoutStore.getState().resetLayout();
+  useQueueStore.setState({ items: [], _agentBuffers: {}, _workflowLastOutput: {} });
   // Mock window.confirm
   window.confirm = vi.fn(() => true);
 });
@@ -419,6 +450,42 @@ describe("Agent Watchlist Sidebar", () => {
         interactions: expect.objectContaining({ "agent-1": expect.any(String) }),
       }),
     );
+  });
+
+  it("adds an agent completion to the queue when buffered output is followed by Idle", async () => {
+    setupDefaultMocks(sampleAgents, defaultClasses);
+    const { emitJson, emitStatus } = captureQueueAgentListeners();
+
+    await act(async () => {
+      render(<App />);
+    });
+    await screen.findByText("All Agents");
+    mockInvoke.mockClear();
+
+    await act(async () => {
+      emitJson({
+        session_id: "agent-1",
+        data: { type: "result", result: "Finished the requested update." },
+      });
+      emitStatus({ session_id: "agent-1", current_status: "Idle" });
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "save_queue_items",
+        expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              type: "agent_completed",
+              agent_session_id: "agent-1",
+              agent_name: "Alpha",
+              summary: "Finished the requested update.",
+              read: false,
+            }),
+          ],
+        }),
+      );
+    });
   });
 
   it("shows Select All and Clear buttons", async () => {

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -95,6 +95,13 @@ function AppBody() {
   const trackWorkflowNodeOutput = useQueueStore((s) => s.trackWorkflowNodeOutput);
   const addWorkflowCompletion = useQueueStore((s) => s.addWorkflowCompletion);
   const loadQueueItems = useQueueStore((s) => s.loadItems);
+  const maybeFlushAgentQueueCompletion = useCallback((sessionId: string, currentStatus: string, previousStatus?: string) => {
+    const wasActive = previousStatus ? ACTIVE_STATUSES.has(previousStatus) : false;
+    if (currentStatus === "Idle" && (wasActive || hasAgentBufferedContent(sessionId))) {
+      const agent = agentsRef.current.find((a) => a.session_id === sessionId);
+      flushAgentCompletion(sessionId, agent?.session_name ?? sessionId);
+    }
+  }, [flushAgentCompletion, hasAgentBufferedContent]);
 
   useEffect(() => {
     const unlistenWorkflow = listen<any>("workflow-telemetry", (event) => {
@@ -584,6 +591,7 @@ function AppBody() {
       const mapping: Record<string, AgentTelemetry> = {};
       for (const m of event.payload) mapping[m.session_id] = m;
       for (const [sessionId, metric] of Object.entries(mapping)) {
+        maybeFlushAgentQueueCompletion(sessionId, metric.current_status, agentStatusRef.current[sessionId]);
         agentStatusRef.current[sessionId] = metric.current_status;
       }
       setTelemetry(prev => {
@@ -615,13 +623,8 @@ function AppBody() {
         setCurrentThoughts(prev => ({ ...prev, [session_id]: "" }));
       }
       const previousStatus = agentStatusRef.current[session_id];
-      const wasActive = previousStatus ? ACTIVE_STATUSES.has(previousStatus) : false;
-      const shouldFlush = current_status === "Idle" && (wasActive || hasAgentBufferedContent(session_id));
+      maybeFlushAgentQueueCompletion(session_id, current_status, previousStatus);
       agentStatusRef.current[session_id] = current_status;
-      if (shouldFlush) {
-        const agent = agentsRef.current.find((a) => a.session_id === session_id);
-        flushAgentCompletion(session_id, agent?.session_name ?? session_id);
-      }
       setTelemetry(prev => {
         return {
           ...prev,
@@ -643,7 +646,7 @@ function AppBody() {
       unlistenAppMetrics.then(fn => fn());
       unlistenStatus.then(fn => fn());
     };
-  }, [flushAgentCompletion, hasAgentBufferedContent]);
+  }, [maybeFlushAgentQueueCompletion]);
 
   async function sendCommand(sessionId: string, cmd: string) {
     try {

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -76,6 +76,7 @@ function AppBody() {
   const confirm = useConfirm();
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const agentsRef = React.useRef(agents);
+  const agentStatusRef = React.useRef<Record<string, string>>({});
   useEffect(() => { agentsRef.current = agents; }, [agents]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const handleWorkflowTelemetry = useWorkflowStore(s => s.handleTelemetry);
@@ -89,6 +90,7 @@ function AppBody() {
   const createScheduledRun = useWorkflowStore(s => s.createScheduledRun);
   const fetchLibraryTree = useLibraryStore(s => s.fetchLibraryTree);
   const appendAgentEvent = useQueueStore((s) => s.appendAgentEvent);
+  const hasAgentBufferedContent = useQueueStore((s) => s.hasAgentBufferedContent);
   const flushAgentCompletion = useQueueStore((s) => s.flushAgentCompletion);
   const trackWorkflowNodeOutput = useQueueStore((s) => s.trackWorkflowNodeOutput);
   const addWorkflowCompletion = useQueueStore((s) => s.addWorkflowCompletion);
@@ -581,6 +583,9 @@ function AppBody() {
     const unlistenMetrics = listen<AgentTelemetry[]>('agent-metrics', (event) => {
       const mapping: Record<string, AgentTelemetry> = {};
       for (const m of event.payload) mapping[m.session_id] = m;
+      for (const [sessionId, metric] of Object.entries(mapping)) {
+        agentStatusRef.current[sessionId] = metric.current_status;
+      }
       setTelemetry(prev => {
         const next = { ...prev };
         const interactionUpdates: Record<string, string> = {};
@@ -609,12 +614,15 @@ function AppBody() {
       if (current_status === "Idle" || current_status === "Off" || current_status === "Action Needed") {
         setCurrentThoughts(prev => ({ ...prev, [session_id]: "" }));
       }
+      const previousStatus = agentStatusRef.current[session_id];
+      const wasActive = previousStatus ? ACTIVE_STATUSES.has(previousStatus) : false;
+      const shouldFlush = current_status === "Idle" && (wasActive || hasAgentBufferedContent(session_id));
+      agentStatusRef.current[session_id] = current_status;
+      if (shouldFlush) {
+        const agent = agentsRef.current.find((a) => a.session_id === session_id);
+        flushAgentCompletion(session_id, agent?.session_name ?? session_id);
+      }
       setTelemetry(prev => {
-        const previousStatus = prev[session_id]?.current_status;
-        if (current_status === "Idle" && previousStatus && ACTIVE_STATUSES.has(previousStatus)) {
-          const agent = agentsRef.current.find((a) => a.session_id === session_id);
-          flushAgentCompletion(session_id, agent?.session_name ?? session_id);
-        }
         return {
           ...prev,
           [session_id]: {
@@ -635,7 +643,7 @@ function AppBody() {
       unlistenAppMetrics.then(fn => fn());
       unlistenStatus.then(fn => fn());
     };
-  }, [flushAgentCompletion]);
+  }, [flushAgentCompletion, hasAgentBufferedContent]);
 
   async function sendCommand(sessionId: string, cmd: string) {
     try {

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -77,6 +77,7 @@ function AppBody() {
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const agentsRef = React.useRef(agents);
   const agentStatusRef = React.useRef<Record<string, string>>({});
+  const pendingQueueFlushRef = React.useRef<Set<string>>(new Set());
   useEffect(() => { agentsRef.current = agents; }, [agents]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const handleWorkflowTelemetry = useWorkflowStore(s => s.handleTelemetry);
@@ -98,8 +99,25 @@ function AppBody() {
   const maybeFlushAgentQueueCompletion = useCallback((sessionId: string, currentStatus: string, previousStatus?: string) => {
     const wasActive = previousStatus ? ACTIVE_STATUSES.has(previousStatus) : false;
     if (currentStatus === "Idle" && (wasActive || hasAgentBufferedContent(sessionId))) {
+      if (pendingQueueFlushRef.current.has(sessionId)) return;
+      pendingQueueFlushRef.current.add(sessionId);
       const agent = agentsRef.current.find((a) => a.session_id === sessionId);
-      flushAgentCompletion(sessionId, agent?.session_name ?? sessionId);
+      const agentName = agent?.session_name ?? sessionId;
+      const finishFlush = (summary?: string | null) => {
+        try {
+          flushAgentCompletion(sessionId, agentName, summary);
+        } finally {
+          pendingQueueFlushRef.current.delete(sessionId);
+        }
+      };
+
+      if (agent?.provider === "opencode" && sessionId.startsWith("ses_")) {
+        invoke<string | null>("load_opencode_last_assistant_text", { sessionId })
+          .then(finishFlush)
+          .catch(() => finishFlush());
+      } else {
+        finishFlush();
+      }
     }
   }, [flushAgentCompletion, hasAgentBufferedContent]);
 

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -31,8 +31,10 @@ import { UserTerminalPanel } from "../features/terminal/UserTerminalPanel";
 import { DashboardView } from "./DashboardView";
 import { GridView } from "./GridView";
 import { PlaceholderView } from "./PlaceholderView";
+import { QueueView } from "./QueueView";
 import { WorkflowBuilderView } from "./WorkflowBuilderView";
 import { LibraryView } from "./LibraryView";
+import { useQueueStore } from "../store/useQueueStore";
 import { useWorkflowStore } from "../store/useWorkflowStore";
 import { useLibraryStore } from "../store/useLibraryStore";
 import { useSettingsStore } from "../store/useSettingsStore";
@@ -60,6 +62,8 @@ declare global {
   }
 }
 
+const ACTIVE_STATUSES = new Set(["Processing...", "Headless", "Action Needed"]);
+
 function App() {
   return (
     <ErrorBoundary>
@@ -71,6 +75,8 @@ function App() {
 function AppBody() {
   const confirm = useConfirm();
   const [agents, setAgents] = useState<AgentConfig[]>([]);
+  const agentsRef = React.useRef(agents);
+  useEffect(() => { agentsRef.current = agents; }, [agents]);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const handleWorkflowTelemetry = useWorkflowStore(s => s.handleTelemetry);
   const handleWorkflowProgress = useWorkflowStore(s => s.handleProgress);
@@ -82,17 +88,35 @@ function AppBody() {
   const runWorkflowById = useWorkflowStore(s => s.runWorkflowById);
   const createScheduledRun = useWorkflowStore(s => s.createScheduledRun);
   const fetchLibraryTree = useLibraryStore(s => s.fetchLibraryTree);
+  const appendAgentEvent = useQueueStore((s) => s.appendAgentEvent);
+  const flushAgentCompletion = useQueueStore((s) => s.flushAgentCompletion);
+  const trackWorkflowNodeOutput = useQueueStore((s) => s.trackWorkflowNodeOutput);
+  const addWorkflowCompletion = useQueueStore((s) => s.addWorkflowCompletion);
+  const loadQueueItems = useQueueStore((s) => s.loadItems);
 
   useEffect(() => {
     const unlistenWorkflow = listen<any>("workflow-telemetry", (event) => {
       handleWorkflowTelemetry(event.payload);
+      trackWorkflowNodeOutput(event.payload);
     });
     const unlistenProgress = listen<any>("workflow-progress", (event) => {
       handleWorkflowProgress(event.payload);
     });
-    const unlistenStatus = listen<any>("workflow-status-updated", (event) => {
+    const unlistenWorkflowStatus = listen<any>("workflow-status-updated", (event) => {
+      const status = event.payload?.status as string | undefined;
+      if (status === "completed" || status === "failed") {
+        const { activeRuns, availableWorkflows } = useWorkflowStore.getState();
+        const instanceId = event.payload.run_instance_id || event.payload.workflow_id;
+        const run = activeRuns.find((r) => r.run_instance_id === instanceId);
+        const workflowName =
+          run?.workflow_name ??
+          availableWorkflows.find((w) => w.id === event.payload.workflow_id)?.name;
+        addWorkflowCompletion(
+          event.payload as { workflow_id: string; run_instance_id?: string; status: "completed" | "failed"; error?: string },
+          workflowName,
+        );
+      }
       handleWorkflowStatusUpdate(event.payload);
-      const status = event.payload?.status;
       if (status === "running" || status === "completed" || status === "failed") {
         loadScheduledRuns();
       }
@@ -105,10 +129,10 @@ function AppBody() {
     return () => { 
       unlistenWorkflow.then(fn => fn()); 
       unlistenProgress.then(fn => fn());
-      unlistenStatus.then(fn => fn());
+      unlistenWorkflowStatus.then(fn => fn());
       unlistenScheduledRuns.then(fn => fn());
     };
-  }, [handleWorkflowTelemetry, handleWorkflowProgress, handleWorkflowStatusUpdate, loadScheduledRuns]);
+  }, [addWorkflowCompletion, handleWorkflowTelemetry, handleWorkflowProgress, handleWorkflowStatusUpdate, loadScheduledRuns, trackWorkflowNodeOutput]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -533,10 +557,12 @@ function AppBody() {
     fetchAgentClasses();
     fetchWorkflows();
     loadScheduledRuns();
+    loadQueueItems();
     fetchLibraryTree("prompts");
     fetchLibraryTree("skills");
     const unlistenJson = listen<AgentJsonEvent>("agent-json-event", (event) => {
       const { session_id, data } = event.payload;
+      appendAgentEvent(session_id, data as Record<string, unknown>);
       const effect = classifyJsonEvent(data as Record<string, unknown>);
       if (effect.type === "progress") {
         setCurrentThoughts(prev => ({ ...prev, [session_id]: effect.thought }));
@@ -549,7 +575,7 @@ function AppBody() {
       unlistenJson.then(fn => fn());
       unlistenUpdate.then(fn => fn());
     };
-  }, [fetchLibraryTree, fetchWorkflows, loadScheduledRuns]);
+  }, [appendAgentEvent, fetchLibraryTree, fetchWorkflows, loadQueueItems, loadScheduledRuns]);
 
   useEffect(() => {
     const unlistenMetrics = listen<AgentTelemetry[]>('agent-metrics', (event) => {
@@ -583,26 +609,33 @@ function AppBody() {
       if (current_status === "Idle" || current_status === "Off" || current_status === "Action Needed") {
         setCurrentThoughts(prev => ({ ...prev, [session_id]: "" }));
       }
-      setTelemetry(prev => ({
-        ...prev,
-        [session_id]: {
-          session_id,
-          cpu_usage: prev[session_id]?.cpu_usage ?? 0,
-          memory_mb: prev[session_id]?.memory_mb ?? 0,
-          uptime_seconds: prev[session_id]?.uptime_seconds ?? 0,
-          query_count: prev[session_id]?.query_count ?? 0,
-          init_timestamp: prev[session_id]?.init_timestamp ?? null,
-          current_status,
-          log_path: prev[session_id]?.log_path ?? null,
-        },
-      }));
+      setTelemetry(prev => {
+        const previousStatus = prev[session_id]?.current_status;
+        if (current_status === "Idle" && previousStatus && ACTIVE_STATUSES.has(previousStatus)) {
+          const agent = agentsRef.current.find((a) => a.session_id === session_id);
+          flushAgentCompletion(session_id, agent?.session_name ?? session_id);
+        }
+        return {
+          ...prev,
+          [session_id]: {
+            session_id,
+            cpu_usage: prev[session_id]?.cpu_usage ?? 0,
+            memory_mb: prev[session_id]?.memory_mb ?? 0,
+            uptime_seconds: prev[session_id]?.uptime_seconds ?? 0,
+            query_count: prev[session_id]?.query_count ?? 0,
+            init_timestamp: prev[session_id]?.init_timestamp ?? null,
+            current_status,
+            log_path: prev[session_id]?.log_path ?? null,
+          },
+        };
+      });
     });
     return () => {
       unlistenMetrics.then(fn => fn());
       unlistenAppMetrics.then(fn => fn());
       unlistenStatus.then(fn => fn());
     };
-  }, []);
+  }, [flushAgentCompletion]);
 
   async function sendCommand(sessionId: string, cmd: string) {
     try {
@@ -879,7 +912,13 @@ function AppBody() {
               <LibraryView selectedAgentIds={selectedAgentIds} />
             )}
 
-            {["queue", "graph", "garden"].map(mode => viewMode === mode && (
+            {viewMode === "queue" && (
+              <div className="flex-1 flex flex-col min-h-0">
+                <QueueView />
+              </div>
+            )}
+
+            {["graph", "garden"].map(mode => viewMode === mode && (
               <div key={mode} className="flex-1 flex flex-col min-h-0">
                 <PlaceholderView viewMode={mode as any} />
               </div>

--- a/src/views/PlaceholderView.test.tsx
+++ b/src/views/PlaceholderView.test.tsx
@@ -3,7 +3,6 @@ import { PlaceholderView } from "./PlaceholderView";
 
 describe("PlaceholderView", () => {
   it.each([
-    ["queue", "Queue", "Advanced human-in-the-loop features coming in Phase 3.", "Phase 3"],
     ["workflow-builder", "Workflow Builder", "Advanced workflow-builder features coming in Phase 3.", "Phase 3"],
     ["graph", "Graph", "Advanced graph features coming in Phase 5.", "Phase 5"],
     ["garden", "Garden", "Advanced garden features coming in Phase 5.", "Phase 5"],

--- a/src/views/QueueView.test.tsx
+++ b/src/views/QueueView.test.tsx
@@ -31,9 +31,11 @@ describe("QueueView", () => {
       }],
     });
     render(<QueueView />);
+    expect(document.body.textContent).toContain("My CoderAgent task completed");
+    expect(screen.getByText("Agent task completed")).toBeInTheDocument();
     expect(screen.getByText("My Coder")).toBeInTheDocument();
     expect(screen.getByText("Done writing tests.")).toBeInTheDocument();
-    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.queryByText("Completed")).not.toBeInTheDocument();
   });
 
   it("renders a failed workflow item with error text", () => {
@@ -49,8 +51,10 @@ describe("QueueView", () => {
       }],
     });
     render(<QueueView />);
+    expect(document.body.textContent).toContain("CI PipelineWorkflow failed");
     expect(screen.getByText("CI Pipeline")).toBeInTheDocument();
-    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Workflow failed")).toBeInTheDocument();
+    expect(screen.queryByText("Failed")).not.toBeInTheDocument();
     expect(screen.getByText("Timeout after 30s")).toBeInTheDocument();
   });
 
@@ -67,6 +71,8 @@ describe("QueueView", () => {
       }],
     });
     render(<QueueView />);
+    expect(document.body.textContent).toContain("Data PipelineWorkflow completed");
+    expect(screen.getByText("Workflow completed")).toBeInTheDocument();
     expect(screen.getByText("Processed 42 records.")).toBeInTheDocument();
   });
 
@@ -102,7 +108,7 @@ describe("QueueView", () => {
     expect(screen.getByRole("button", { name: /collapse summary/i })).toBeInTheDocument();
   });
 
-  it("dismiss button removes item", () => {
+  it("clear item button removes item", () => {
     useQueueStore.setState({
       items: [{
         id: "item-1",
@@ -114,7 +120,7 @@ describe("QueueView", () => {
       }],
     });
     render(<QueueView />);
-    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    fireEvent.click(screen.getByRole("button", { name: /clear item/i }));
     expect(screen.queryByText("My Coder")).not.toBeInTheDocument();
     expect(screen.getByText("No completions yet.")).toBeInTheDocument();
   });
@@ -133,5 +139,63 @@ describe("QueueView", () => {
     render(<QueueView />);
     fireEvent.click(screen.getByRole("button", { name: /mark all read/i }));
     expect(useQueueStore.getState().items[0].read).toBe(true);
+  });
+
+  it("uses matching highlighted header button treatment for mark and clear actions", () => {
+    useQueueStore.setState({
+      items: [{
+        id: "item-1",
+        type: "agent_completed",
+        timestamp: Date.now(),
+        read: true,
+        agent_name: "My Coder",
+        summary: "Done.",
+      }],
+    });
+
+    render(<QueueView />);
+
+    expect(screen.getByRole("button", { name: /mark all read/i })).toHaveClass(
+      "rounded-md",
+      "px-2",
+      "py-1",
+      "hover:bg-wardian-card-bg-muted",
+    );
+    expect(screen.getByRole("button", { name: /clear read/i })).toHaveClass(
+      "rounded-md",
+      "px-2",
+      "py-1",
+      "hover:bg-wardian-card-bg-muted",
+    );
+  });
+
+  it("clear read button removes read items and keeps unread items", () => {
+    useQueueStore.setState({
+      items: [
+        {
+          id: "read-item",
+          type: "agent_completed",
+          timestamp: Date.now(),
+          read: true,
+          agent_name: "Read Agent",
+          summary: "Old result.",
+        },
+        {
+          id: "unread-item",
+          type: "workflow_completed",
+          timestamp: Date.now(),
+          read: false,
+          workflow_name: "Unread Workflow",
+          status: "completed",
+          summary: "Fresh result.",
+        },
+      ],
+    });
+
+    render(<QueueView />);
+    fireEvent.click(screen.getByRole("button", { name: /clear read/i }));
+
+    expect(screen.queryByText("Read Agent")).not.toBeInTheDocument();
+    expect(screen.getByText("Unread Workflow")).toBeInTheDocument();
   });
 });

--- a/src/views/QueueView.test.tsx
+++ b/src/views/QueueView.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { QueueView } from "./QueueView";
+import { useQueueStore } from "../store/useQueueStore";
+
+vi.mocked(invoke).mockResolvedValue([]);
+
+function resetStore() {
+  useQueueStore.setState({ items: [], _agentBuffers: {}, _workflowLastOutput: {} });
+}
+
+describe("QueueView", () => {
+  beforeEach(resetStore);
+
+  it("shows empty state when no items", () => {
+    render(<QueueView />);
+    expect(screen.getByText("No completions yet.")).toBeInTheDocument();
+  });
+
+  it("renders an agent completion item", () => {
+    useQueueStore.setState({
+      items: [{
+        id: "item-1",
+        type: "agent_completed",
+        timestamp: Date.now(),
+        read: false,
+        agent_session_id: "sess-1",
+        agent_name: "My Coder",
+        summary: "Done writing tests.",
+      }],
+    });
+    render(<QueueView />);
+    expect(screen.getByText("My Coder")).toBeInTheDocument();
+    expect(screen.getByText("Done writing tests.")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+  });
+
+  it("renders a failed workflow item with error text", () => {
+    useQueueStore.setState({
+      items: [{
+        id: "item-2",
+        type: "workflow_completed",
+        timestamp: Date.now(),
+        read: false,
+        workflow_name: "CI Pipeline",
+        status: "failed",
+        error: "Timeout after 30s",
+      }],
+    });
+    render(<QueueView />);
+    expect(screen.getByText("CI Pipeline")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Timeout after 30s")).toBeInTheDocument();
+  });
+
+  it("renders a completed workflow item with summary when present", () => {
+    useQueueStore.setState({
+      items: [{
+        id: "item-3",
+        type: "workflow_completed",
+        timestamp: Date.now(),
+        read: false,
+        workflow_name: "Data Pipeline",
+        status: "completed",
+        summary: "Processed 42 records.",
+      }],
+    });
+    render(<QueueView />);
+    expect(screen.getByText("Processed 42 records.")).toBeInTheDocument();
+  });
+
+  it("dismiss button removes item", () => {
+    useQueueStore.setState({
+      items: [{
+        id: "item-1",
+        type: "agent_completed",
+        timestamp: Date.now(),
+        read: false,
+        agent_name: "My Coder",
+        summary: "Done.",
+      }],
+    });
+    render(<QueueView />);
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByText("My Coder")).not.toBeInTheDocument();
+    expect(screen.getByText("No completions yet.")).toBeInTheDocument();
+  });
+
+  it("mark all read button appears and calls markAllRead", () => {
+    useQueueStore.setState({
+      items: [{
+        id: "item-1",
+        type: "agent_completed",
+        timestamp: Date.now(),
+        read: false,
+        agent_name: "My Coder",
+        summary: "Done.",
+      }],
+    });
+    render(<QueueView />);
+    fireEvent.click(screen.getByRole("button", { name: /mark all read/i }));
+    expect(useQueueStore.getState().items[0].read).toBe(true);
+  });
+});

--- a/src/views/QueueView.test.tsx
+++ b/src/views/QueueView.test.tsx
@@ -70,6 +70,38 @@ describe("QueueView", () => {
     expect(screen.getByText("Processed 42 records.")).toBeInTheDocument();
   });
 
+  it("collapses and expands long queue summaries", () => {
+    useQueueStore.setState({
+      items: [{
+        id: "item-long",
+        type: "agent_completed",
+        timestamp: Date.now(),
+        read: false,
+        agent_name: "My Coder",
+        summary: [
+          "First line",
+          "Second line",
+          "Third line",
+          "Fourth line",
+          "Fifth line",
+          "Sixth line",
+        ].join("\n"),
+      }],
+    });
+    render(<QueueView />);
+
+    const summary = screen.getByTestId("queue-item-summary-item-long");
+    expect(summary).toHaveClass("line-clamp-4");
+
+    const toggle = screen.getByRole("button", { name: /show full summary/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(toggle);
+
+    expect(summary).not.toHaveClass("line-clamp-4");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /collapse summary/i })).toBeInTheDocument();
+  });
+
   it("dismiss button removes item", () => {
     useQueueStore.setState({
       items: [{

--- a/src/views/QueueView.tsx
+++ b/src/views/QueueView.tsx
@@ -1,4 +1,5 @@
-import { X } from "lucide-react";
+import { useState } from "react";
+import { ChevronDown, ChevronUp, X } from "lucide-react";
 import { useQueueStore } from "../store/useQueueStore";
 import type { QueueItem } from "../types";
 
@@ -31,10 +32,13 @@ function StatusBadge({ status }: { status?: "completed" | "failed" }) {
 function QueueCard({ item }: { item: QueueItem }) {
   const dismissItem = useQueueStore((s) => s.dismissItem);
   const markRead = useQueueStore((s) => s.markRead);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const isAgent = item.type === "agent_completed";
   const title = isAgent ? item.agent_name : item.workflow_name;
   const bodyText = item.status === "failed" && item.error ? item.error : item.summary;
+  const isExpandable = Boolean(bodyText && (bodyText.length > 220 || bodyText.split("\n").length > 4));
+  const summaryId = `queue-item-summary-${item.id}`;
 
   return (
     <div
@@ -57,7 +61,41 @@ function QueueCard({ item }: { item: QueueItem }) {
             <span className="text-[10px] text-muted-neutral ml-auto shrink-0">{relativeTime(item.timestamp)}</span>
           </div>
           {bodyText && (
-            <p className="text-xs text-muted line-clamp-4 whitespace-pre-wrap break-words">{bodyText}</p>
+            <div className="space-y-2">
+              <p
+                id={summaryId}
+                data-testid={summaryId}
+                className={`text-xs text-muted whitespace-pre-wrap break-words ${
+                  isExpandable && !isExpanded
+                    ? "line-clamp-4"
+                    : isExpandable
+                      ? "max-h-80 overflow-y-auto pr-2"
+                      : ""
+                }`}
+              >
+                {bodyText}
+              </p>
+              {isExpandable && (
+                <button
+                  type="button"
+                  aria-controls={summaryId}
+                  aria-expanded={isExpanded}
+                  aria-label={isExpanded ? "Collapse summary" : "Show full summary"}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsExpanded((value) => !value);
+                  }}
+                  className="inline-flex items-center gap-1 text-[11px] text-muted-neutral hover:text-bright-neutral transition-colors"
+                >
+                  {isExpanded ? (
+                    <ChevronUp className="w-3 h-3" aria-hidden="true" />
+                  ) : (
+                    <ChevronDown className="w-3 h-3" aria-hidden="true" />
+                  )}
+                  {isExpanded ? "Show less" : "Show more"}
+                </button>
+              )}
+            </div>
           )}
         </div>
 

--- a/src/views/QueueView.tsx
+++ b/src/views/QueueView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { Bot, ChevronDown, ChevronUp, GitBranch, Trash2 } from "lucide-react";
 import { useQueueStore } from "../store/useQueueStore";
 import type { QueueItem } from "../types";
 
@@ -14,18 +14,50 @@ function relativeTime(ts: number): string {
   return `${Math.floor(hrs / 24)}d ago`;
 }
 
-function StatusBadge({ status }: { status?: "completed" | "failed" }) {
-  const isCompleted = !status || status === "completed";
+function queueItemLabel(item: QueueItem) {
+  if (item.type === "agent_completed") return "Agent task completed";
+  return item.status === "failed" ? "Workflow failed" : "Workflow completed";
+}
+
+function StatusBadge({ item }: { item: QueueItem }) {
+  const isCompleted = item.type === "agent_completed" || item.status === "completed";
   return (
     <span
       className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
         isCompleted
           ? "bg-wardian-success/15 text-wardian-success"
           : "bg-wardian-error/15 text-wardian-error"
-      }`}
+        }`}
     >
-      {isCompleted ? "Completed" : "Failed"}
+      {queueItemLabel(item)}
     </span>
+  );
+}
+
+function queueItemAccent(item: QueueItem) {
+  if (item.type === "workflow_completed" && item.status === "failed") {
+    return "bg-wardian-error";
+  }
+  return item.type === "agent_completed" ? "bg-wardian-processing" : "bg-wardian-headless";
+}
+
+function QueueItemIcon({ item }: { item: QueueItem }) {
+  const isAgent = item.type === "agent_completed";
+  const isFailed = item.type === "workflow_completed" && item.status === "failed";
+  const Icon = isAgent ? Bot : GitBranch;
+  const iconClass = isFailed
+    ? "bg-wardian-error/10 text-wardian-error"
+    : isAgent
+      ? "bg-wardian-processing/10 text-wardian-processing"
+      : "bg-wardian-headless/10 text-wardian-headless";
+
+  return (
+    <div
+      className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${iconClass}`}
+      aria-hidden="true"
+    >
+      <Icon className="h-4 w-4" />
+    </div>
   );
 }
 
@@ -42,30 +74,30 @@ function QueueCard({ item }: { item: QueueItem }) {
 
   return (
     <div
-      className={`relative rounded-xl p-4 border transition-all cursor-pointer ${
+      className={`group relative overflow-hidden rounded-lg border transition-colors cursor-pointer ${
         item.read
           ? "border-wardian-border bg-wardian-card-bg-muted"
           : "border-[var(--color-wardian-accent)]/30 bg-wardian-card-bg"
       }`}
       onClick={() => markRead(item.id)}
     >
-      {!item.read && (
-        <span className="absolute top-3 left-3 w-2 h-2 rounded-full bg-[var(--color-wardian-accent)]" />
-      )}
+      <div className={`absolute left-0 top-0 h-full w-1 ${queueItemAccent(item)}`} />
+      {!item.read && <span className="absolute left-3 top-4 h-2 w-2 rounded-full bg-[var(--color-wardian-accent)]" />}
 
-      <div className="flex items-start justify-between gap-2 pl-4">
+      <div className="flex items-start gap-3 py-3 pl-5 pr-3">
+        <QueueItemIcon item={item} />
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 flex-wrap mb-1">
-            <span className="font-semibold text-sm text-primary truncate">{title ?? "Unknown"}</span>
-            <StatusBadge status={item.type === "workflow_completed" ? item.status : "completed"} />
-            <span className="text-[10px] text-muted-neutral ml-auto shrink-0">{relativeTime(item.timestamp)}</span>
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="truncate text-sm font-semibold text-primary">{title ?? "Unknown"}</span>
+            <StatusBadge item={item} />
+            <span className="text-[10px] text-muted-neutral shrink-0">{relativeTime(item.timestamp)}</span>
           </div>
           {bodyText && (
-            <div className="space-y-2">
+            <div className="mt-2 space-y-2">
               <p
                 id={summaryId}
                 data-testid={summaryId}
-                className={`text-xs text-muted whitespace-pre-wrap break-words ${
+                className={`text-[13px] leading-5 text-muted whitespace-pre-wrap break-words ${
                   isExpandable && !isExpanded
                     ? "line-clamp-4"
                     : isExpandable
@@ -85,14 +117,14 @@ function QueueCard({ item }: { item: QueueItem }) {
                     e.stopPropagation();
                     setIsExpanded((value) => !value);
                   }}
-                  className="inline-flex items-center gap-1 text-[11px] text-muted-neutral hover:text-bright-neutral transition-colors"
+                  className="inline-flex items-center gap-1 rounded-md text-[11px] font-semibold text-muted-neutral hover:text-bright-neutral transition-colors"
                 >
                   {isExpanded ? (
                     <ChevronUp className="w-3 h-3" aria-hidden="true" />
                   ) : (
                     <ChevronDown className="w-3 h-3" aria-hidden="true" />
                   )}
-                  {isExpanded ? "Show less" : "Show more"}
+                  {isExpanded ? "Hide details" : "Show details"}
                 </button>
               )}
             </div>
@@ -100,11 +132,13 @@ function QueueCard({ item }: { item: QueueItem }) {
         </div>
 
         <button
-          aria-label="Dismiss"
+          type="button"
+          aria-label="Clear item"
+          title="Clear item"
           onClick={(e) => { e.stopPropagation(); dismissItem(item.id); }}
           className="shrink-0 p-1 rounded hover:bg-wardian-card-bg-muted text-muted-neutral hover:text-bright-neutral transition-colors"
         >
-          <X className="w-3.5 h-3.5" aria-hidden="true" />
+          <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
         </button>
       </div>
     </div>
@@ -114,18 +148,31 @@ function QueueCard({ item }: { item: QueueItem }) {
 export function QueueView() {
   const items = useQueueStore((s) => s.items);
   const markAllRead = useQueueStore((s) => s.markAllRead);
+  const clearRead = useQueueStore((s) => s.clearRead);
+  const hasReadItems = items.some((item) => item.read);
 
   return (
     <div className="flex flex-col h-full min-h-0 p-4 gap-4">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold text-primary tracking-wide">Queue</h2>
         {items.length > 0 && (
-          <button
-            onClick={markAllRead}
-            className="text-[11px] text-muted-neutral hover:text-bright-neutral transition-colors"
-          >
-            Mark all read
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={markAllRead}
+              className="rounded-md px-2 py-1 text-[11px] text-muted-neutral hover:bg-wardian-card-bg-muted hover:text-bright-neutral transition-colors"
+            >
+              Mark all read
+            </button>
+            <button
+              type="button"
+              onClick={clearRead}
+              disabled={!hasReadItems}
+              className="rounded-md px-2 py-1 text-[11px] text-muted-neutral hover:bg-wardian-card-bg-muted hover:text-bright-neutral disabled:cursor-not-allowed disabled:opacity-40 transition-colors"
+            >
+              Clear read
+            </button>
+          </div>
         )}
       </div>
 

--- a/src/views/QueueView.tsx
+++ b/src/views/QueueView.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { X } from "lucide-react";
 import { useQueueStore } from "../store/useQueueStore";
 import type { QueueItem } from "../types";

--- a/src/views/QueueView.tsx
+++ b/src/views/QueueView.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { X } from "lucide-react";
+import { useQueueStore } from "../store/useQueueStore";
+import type { QueueItem } from "../types";
+
+function relativeTime(ts: number): string {
+  const diffMs = Date.now() - ts;
+  const secs = Math.floor(diffMs / 1000);
+  if (secs < 60) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function StatusBadge({ status }: { status?: "completed" | "failed" }) {
+  const isCompleted = !status || status === "completed";
+  return (
+    <span
+      className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
+        isCompleted
+          ? "bg-wardian-success/15 text-wardian-success"
+          : "bg-wardian-error/15 text-wardian-error"
+      }`}
+    >
+      {isCompleted ? "Completed" : "Failed"}
+    </span>
+  );
+}
+
+function QueueCard({ item }: { item: QueueItem }) {
+  const dismissItem = useQueueStore((s) => s.dismissItem);
+  const markRead = useQueueStore((s) => s.markRead);
+
+  const isAgent = item.type === "agent_completed";
+  const title = isAgent ? item.agent_name : item.workflow_name;
+  const bodyText = item.status === "failed" && item.error ? item.error : item.summary;
+
+  return (
+    <div
+      className={`relative rounded-xl p-4 border transition-all cursor-pointer ${
+        item.read
+          ? "border-wardian-border bg-wardian-card-bg-muted"
+          : "border-[var(--color-wardian-accent)]/30 bg-wardian-card-bg"
+      }`}
+      onClick={() => markRead(item.id)}
+    >
+      {!item.read && (
+        <span className="absolute top-3 left-3 w-2 h-2 rounded-full bg-[var(--color-wardian-accent)]" />
+      )}
+
+      <div className="flex items-start justify-between gap-2 pl-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap mb-1">
+            <span className="font-semibold text-sm text-primary truncate">{title ?? "Unknown"}</span>
+            <StatusBadge status={item.type === "workflow_completed" ? item.status : "completed"} />
+            <span className="text-[10px] text-muted-neutral ml-auto shrink-0">{relativeTime(item.timestamp)}</span>
+          </div>
+          {bodyText && (
+            <p className="text-xs text-muted line-clamp-4 whitespace-pre-wrap break-words">{bodyText}</p>
+          )}
+        </div>
+
+        <button
+          aria-label="Dismiss"
+          onClick={(e) => { e.stopPropagation(); dismissItem(item.id); }}
+          className="shrink-0 p-1 rounded hover:bg-wardian-card-bg-muted text-muted-neutral hover:text-bright-neutral transition-colors"
+        >
+          <X className="w-3.5 h-3.5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function QueueView() {
+  const items = useQueueStore((s) => s.items);
+  const markAllRead = useQueueStore((s) => s.markAllRead);
+
+  return (
+    <div className="flex flex-col h-full min-h-0 p-4 gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-primary tracking-wide">Queue</h2>
+        {items.length > 0 && (
+          <button
+            onClick={markAllRead}
+            className="text-[11px] text-muted-neutral hover:text-bright-neutral transition-colors"
+          >
+            Mark all read
+          </button>
+        )}
+      </div>
+
+      {items.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-sm text-muted-neutral">No completions yet.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3 overflow-y-auto">
+          {items.map((item) => (
+            <QueueCard key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Implements and polishes Queue v1 completion handling:

- Persists queue items and read/clear state, with serialized persistence writes.
- Enqueues workflow and agent completions with provider-specific completion/status handling.
- Updates the Queue UI with clearer source/type labels, expandable summaries, clear-read controls, and cleaner item actions.
- Stabilizes browser/native E2E coverage around queue-adjacent flows and Windows path normalization.

## Related Issues
Related: #17

Duplicate issue #216 was closed in favor of #17.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run test:e2e`
- [x] `npm run setup:e2e:native`
- [x] `npm run test:e2e:native`
- [x] `cargo check` in `src-tauri`
- [x] `cargo clippy` in `src-tauri`
- [x] `cargo test` in `src-tauri`

Notes: frontend unit tests still emit existing unrelated React `act(...)` warnings in watchlist/app tests; build still emits the existing large chunk warning; native build still emits the existing macOS bundle identifier warning.

## Screenshots
Not included. The queue UI was iterated in the running dev app during implementation; final validation is covered by focused QueueView tests and browser/native E2E runs.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable