### PR TITLE
feat(agent): add custom clone flow

### DIFF
--- a/docs/guide/ui-overview.md
+++ b/docs/guide/ui-overview.md
@@ -37,6 +37,10 @@ The **Agent Watchlist** is your persistent high-fidelity roster for monitoring a
 - **Thought Stream**: A real-time glimpse into the agent's internal monologue and current task progress.
 - **Watchlists**: Organize agents into logical groups (e.g., "Dev Team", "Security Audit") for easier oversight.
 
+### Agent Cloning
+
+Use the single-agent roster context menu to create Fresh, Profile, or Custom clones. Clicking **Clone** directly starts a Fresh Clone immediately. The **Fresh Clone** submenu option keeps visible setup and starts a clean provider session. **Profile Clone** also keeps agent-local profile files and instance skills. **Custom Clone** opens a modal where you can change the clone name, provider engine, agent class, workspace path, and choose which eligible agent-local files and instance skills to keep.
+
 ## 🖱️ Interaction Patterns
 
 ### "Physical-First" Navigation

--- a/docs/specs/035-custom-agent-clone.md
+++ b/docs/specs/035-custom-agent-clone.md
@@ -1,6 +1,6 @@
 # Spec 035: Custom Agent Clone
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-10
 - **Decider:** User
 

--- a/e2e/tests/agent-lifecycle.spec.ts
+++ b/e2e/tests/agent-lifecycle.spec.ts
@@ -14,6 +14,108 @@
 
 import { test, expect, type Page } from "@playwright/test";
 
+async function installCustomCloneIpcMock(page: Page) {
+  await page.addInitScript(() => {
+    type Agent = {
+      session_id: string;
+      session_name: string;
+      agent_class: string;
+      folder: string;
+      provider: string;
+      is_off: boolean;
+    };
+
+    const agents: Agent[] = [
+      {
+        session_id: "mock-session-e2e-001",
+        session_name: "E2E Mock Agent",
+        agent_class: "TestClass",
+        folder: "C:/projects/e2e",
+        provider: "mock",
+        is_off: false,
+      },
+    ];
+    const callbacks = new Map<number, unknown>();
+    let callbackId = 1;
+    const tauriWindow = window as Window & {
+      __TAURI_INTERNALS__?: Record<string, unknown>;
+      __TAURI_EVENT_PLUGIN_INTERNALS__?: Record<string, unknown>;
+    };
+
+    tauriWindow.__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+      unregisterListener: () => undefined,
+    };
+
+    tauriWindow.__TAURI_INTERNALS__ = {
+      metadata: {
+        currentWindow: { label: "main" },
+        currentWebview: { label: "main" },
+      },
+      transformCallback: (callback: unknown) => {
+        const id = callbackId++;
+        callbacks.set(id, callback);
+        return id;
+      },
+      unregisterCallback: (id: number) => {
+        callbacks.delete(id);
+      },
+      convertFileSrc: (filePath: string) => filePath,
+      invoke: async (command: string, args?: Record<string, unknown>) => {
+        if (command === "list_agents") return agents;
+        if (command === "list_agent_classes") {
+          return [{ name: "TestClass", description: "E2E test class", is_default: true }];
+        }
+        if (command === "load_watchlists") return [];
+        if (command === "load_watchlist_prefs") return null;
+        if (command === "load_agent_interactions") return {};
+        if (command === "load_queue_items") return [];
+        if (command === "list_workflows") return [];
+        if (command === "list_scheduled_runs") return [];
+        if (command === "load_workflow_library") return { folders: [], rootWorkflowIds: [] };
+        if (command === "get_library_tree") {
+          return { type: "Folder", path: "", name: "Root", children: [] };
+        }
+        if (command === "list_deployed_skills") return [];
+        if (command === "plugin:event|listen") return callbackId++;
+        if (command === "plugin:event|unlisten") return null;
+        if (command === "sync_provider_theme_settings") return null;
+        if (command === "get_agent_clone_preview") {
+          return {
+            source_session_id: "mock-session-e2e-001",
+            source_session_name: "E2E Mock Agent",
+            suggested_session_name: "E2E Mock Agent-copy",
+            provider: "mock",
+            agent_class: "TestClass",
+            folder: "C:/projects/e2e",
+            files: {
+              name: "mock-session-e2e-001",
+              path: "",
+              kind: "directory",
+              children: [
+                { name: "AGENTS.md", path: "AGENTS.md", kind: "file", children: [] },
+                { name: "notes.md", path: "notes.md", kind: "file", children: [] },
+              ],
+            },
+            default_selected_files: ["AGENTS.md", "notes.md"],
+            skills: [],
+            default_selected_skills: [],
+          };
+        }
+        if (command === "clone_agent") {
+          const request = args?.req as { session_name?: string } | undefined;
+          agents.push({
+            ...agents[0],
+            session_id: "mock-session-e2e-clone",
+            session_name: request?.session_name ?? "E2E Mock Agent-copy",
+          });
+          return agents[agents.length - 1];
+        }
+        return null;
+      },
+    };
+  });
+}
+
 test.describe("Agent Spawn Form", () => {
   test.describe.configure({ mode: "serial" });
 
@@ -69,6 +171,32 @@ test.describe("Agent Spawn Form", () => {
     // No agent rows expected in empty state.
     const cards = page.locator('[data-testid="agent-card"]');
     await expect(cards).toHaveCount(0);
+  });
+});
+
+test.describe("Custom Agent Clone", () => {
+  test("opens the modal, changes file selection, and creates a clone row", async ({ page }) => {
+    await installCustomCloneIpcMock(page);
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await page.locator('[data-testid="app-shell"]').waitFor({ timeout: 15_000 });
+
+    const watchlist = page.locator('[data-testid="agent-watchlist"]');
+    const sourceRow = watchlist.locator(".watchlist-row", { hasText: "E2E Mock Agent" });
+    await expect(sourceRow).toBeVisible();
+
+    await sourceRow.click({ button: "right" });
+    const menu = page.locator('[data-testid="agent-context-menu"]');
+    await menu.getByRole("button", { name: "Clone" }).hover();
+    await page.getByRole("button", { name: "Custom Clone" }).click();
+
+    const modal = page.locator('[data-testid="custom-clone-modal"]');
+    await expect(modal).toBeVisible();
+    await expect(modal.getByLabel("Clone Name")).toHaveValue("E2E Mock Agent-copy");
+
+    await modal.locator('[data-testid="custom-clone-file-notes-md"]').uncheck();
+    await modal.locator('[data-testid="custom-clone-submit"]').click();
+
+    await expect(watchlist.locator(".watchlist-row", { hasText: "E2E Mock Agent-copy" })).toBeVisible();
   });
 });
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -386,9 +386,25 @@ fn clone_collect_eligible_file_children(
 fn clone_path_is_generated_or_runtime(rel_path: &str) -> bool {
     let normalized = rel_path.replace('\\', "/");
     let first = normalized.split('/').next().unwrap_or_default();
-    matches!(first, "habitat" | ".codex" | ".claude" | ".gemini" | ".opencode")
-        || normalized == ".agents/skills"
+    let lower = normalized.to_ascii_lowercase();
+    matches!(
+        first,
+        "habitat"
+            | ".codex"
+            | ".claude"
+            | ".gemini"
+            | ".opencode"
+            | "codex"
+            | "claude"
+            | "gemini"
+            | "opencode"
+            | "logs"
+            | "telemetry"
+            | "provider-bootstrap"
+    ) || normalized == ".agents/skills"
         || normalized.starts_with(".agents/skills/")
+        || lower.ends_with(".jsonl")
+        || lower.ends_with(".log")
 }
 
 #[cfg(windows)]
@@ -431,8 +447,10 @@ fn build_agent_clone_preview(
         .into_iter()
         .filter(|path| path == "AGENTS.md")
         .collect::<Vec<_>>();
-    let skills =
-        crate::commands::library::list_deployed_skill_refs_for_target("agent", source_session_id)?;
+    let skills = crate::commands::library::list_deployed_skill_refs_for_target_strict(
+        "agent",
+        source_session_id,
+    )?;
 
     Ok(AgentClonePreview {
         source_session_id: source_session_id.to_string(),
@@ -455,7 +473,18 @@ fn clone_normalize_selected_profile_file(path: &str) -> Result<String, String> {
     }
     let candidate = std::path::Path::new(&normalized);
     if candidate.is_absolute() {
-        return Err(format!("Selected clone file path is absolute: {normalized}"));
+        return Err(format!(
+            "Selected clone file path is absolute: {normalized}"
+        ));
+    }
+    if normalized.len() >= 3
+        && normalized.as_bytes()[1] == b':'
+        && normalized.as_bytes()[0].is_ascii_alphabetic()
+        && normalized.as_bytes()[2] == b'/'
+    {
+        return Err(format!(
+            "Selected clone file path is absolute: {normalized}"
+        ));
     }
     for component in candidate.components() {
         if matches!(
@@ -497,9 +526,7 @@ fn clone_validate_selected_profile_files(
     for selected_file in selected_files {
         let normalized = clone_normalize_selected_profile_file(selected_file)?;
         if !allowlist.contains(&normalized) {
-            return Err(format!(
-                "Selected clone file is not eligible: {normalized}"
-            ));
+            return Err(format!("Selected clone file is not eligible: {normalized}"));
         }
         let source_path = clone_join_normalized_relative_path(&source_root, &normalized);
         let metadata = std::fs::symlink_metadata(&source_path).map_err(|e| e.to_string())?;
@@ -570,8 +597,10 @@ fn clone_validate_selected_agent_skills(
     source_session_id: &str,
     selected_skills: &[DeployedSkillRef],
 ) -> Result<Vec<DeployedSkillRef>, String> {
-    let deployed_skills =
-        crate::commands::library::list_deployed_skill_refs_for_target("agent", source_session_id)?;
+    let deployed_skills = crate::commands::library::list_deployed_skill_refs_for_target_strict(
+        "agent",
+        source_session_id,
+    )?;
     clone_match_selected_agent_skills(&deployed_skills, selected_skills)
 }
 
@@ -950,10 +979,7 @@ fn normalize_spawn_folder(folder: &str) -> Result<String, String> {
 }
 
 fn normalize_clone_folder_override(folder: Option<String>) -> Result<Option<String>, String> {
-    folder
-        .as_deref()
-        .map(normalize_spawn_folder)
-        .transpose()
+    folder.as_deref().map(normalize_spawn_folder).transpose()
 }
 
 fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
@@ -1482,8 +1508,8 @@ pub async fn get_agent_clone_preview(
             .collect::<std::collections::HashSet<_>>();
         (source, names)
     };
-    let wardian_home =
-        crate::utils::fs::get_wardian_home().ok_or_else(|| "Could not find Wardian home".to_string())?;
+    let wardian_home = crate::utils::fs::get_wardian_home()
+        .ok_or_else(|| "Could not find Wardian home".to_string())?;
 
     build_agent_clone_preview(
         &wardian_home,
@@ -1949,20 +1975,22 @@ pub async fn reorder_agents(
 #[cfg(test)]
 mod tests {
     use super::{
-        agent_status_update_payload, build_agent_clone_preview, capture_opencode_pause_resume_session,
-        capture_resume_runtime_snapshot, clone_collect_eligible_file_tree,
-        clone_copy_agent_profile_files, clone_copy_selected_agent_profile_files,
-        clone_copy_profile_plan, clone_copy_selected_agent_skills,
+        agent_status_update_payload, build_agent_clone_preview,
+        capture_opencode_pause_resume_session, capture_resume_runtime_snapshot,
+        clone_cleanup_created_profile_dirs, clone_collect_eligible_file_tree,
+        clone_copy_agent_profile_files, clone_copy_profile_plan,
+        clone_copy_selected_agent_profile_files, clone_copy_selected_agent_skills,
         clone_ensure_profile_destination_available, clone_match_selected_agent_skills,
-        clone_sanitize_config, clone_unique_name, clone_validate_selected_agent_skills,
-        clone_validate_selected_profile_files, codex_provider_session_is_new,
-        flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
-        mark_agent_paused_off, normalize_clone_folder_override, normalize_spawn_folder,
-        persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
-        promote_fresh_provider_session_after_resume, provider_needs_obtain_session_id_on_clear,
-        provider_uses_generated_session_id, reserve_spawn_session_name,
-        resolve_requested_spawn_session_name, restore_runtime_state_snapshot_after_resume,
-        sync_resumed_input_sender, AgentOrderPlacement, CloneProfileCopyPlan, CloneProfileSelection,
+        clone_remove_existing_path, clone_sanitize_config, clone_unique_name,
+        clone_validate_selected_agent_skills, clone_validate_selected_profile_files,
+        codex_provider_session_is_new, flatten_clone_file_paths, generated_agent_name,
+        insert_new_agent_order, mark_agent_paused_off, normalize_clone_folder_override,
+        normalize_spawn_folder, persisted_resume_session_for_provider, prepare_clear_config,
+        prepare_resume_config, promote_fresh_provider_session_after_resume,
+        provider_needs_obtain_session_id_on_clear, provider_uses_generated_session_id,
+        reserve_spawn_session_name, resolve_requested_spawn_session_name,
+        restore_runtime_state_snapshot_after_resume, sync_resumed_input_sender,
+        AgentOrderPlacement, CloneProfileCopyPlan, CloneProfileSelection,
     };
     use crate::state::{ActiveAgent, AppState};
     use crate::utils::fs::create_directory_link;
@@ -2047,7 +2075,10 @@ mod tests {
         .expect("preview");
 
         assert_eq!(preview.suggested_session_name, "Alpha-copy");
-        assert_eq!(preview.default_selected_files, vec!["AGENTS.md".to_string()]);
+        assert_eq!(
+            preview.default_selected_files,
+            vec!["AGENTS.md".to_string()]
+        );
         assert!(preview
             .files
             .children
@@ -2110,6 +2141,8 @@ mod tests {
         let source_root = home.join("agents").join("source-agent");
         std::fs::create_dir_all(source_root.join("nested")).expect("nested");
         std::fs::create_dir_all(source_root.join("habitat")).expect("habitat");
+        std::fs::create_dir_all(source_root.join("claude")).expect("claude");
+        std::fs::create_dir_all(source_root.join("logs")).expect("logs");
         std::fs::create_dir_all(source_root.join(".agents").join("skills").join("planner"))
             .expect("skills");
         std::fs::create_dir_all(source_root.join(".codex")).expect("codex");
@@ -2127,6 +2160,13 @@ mod tests {
         )
         .expect("skill");
         std::fs::write(source_root.join(".codex").join("history.jsonl"), "{}").expect("history");
+        std::fs::write(
+            source_root.join("claude").join("permission-requests.jsonl"),
+            "{}\n",
+        )
+        .expect("permission log");
+        std::fs::write(source_root.join("logs").join("agent.log"), "log").expect("log");
+        std::fs::write(source_root.join("transcript.jsonl"), "{}").expect("transcript");
 
         let files = clone_collect_eligible_file_tree(home, "source-agent").expect("files");
         let paths = flatten_clone_file_paths(&files);
@@ -2134,10 +2174,33 @@ mod tests {
         assert!(paths.contains(&"AGENTS.md".to_string()));
         assert!(paths.contains(&"nested/keep.md".to_string()));
         assert!(!paths.iter().any(|path| path.starts_with("habitat/")));
-        assert!(!paths
-            .iter()
-            .any(|path| path.starts_with(".agents/skills/")));
+        assert!(!paths.iter().any(|path| path.starts_with(".agents/skills/")));
         assert!(!paths.iter().any(|path| path.starts_with(".codex/")));
+        assert!(!paths.iter().any(|path| path.starts_with("claude/")));
+        assert!(!paths.iter().any(|path| path.starts_with("logs/")));
+        assert!(!paths.iter().any(|path| path.ends_with(".jsonl")));
+        assert!(!paths.iter().any(|path| path.ends_with(".log")));
+    }
+
+    #[test]
+    fn clone_selected_profile_file_rejects_runtime_artifacts() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source = home.join("agents").join("source-agent");
+        std::fs::create_dir_all(source.join("claude")).expect("claude");
+        std::fs::write(source.join("AGENTS.md"), "# Agent\n").expect("agents");
+        std::fs::write(
+            source.join("claude").join("permission-requests.jsonl"),
+            "{}\n",
+        )
+        .expect("permission log");
+
+        assert!(clone_validate_selected_profile_files(
+            home,
+            "source-agent",
+            &["claude/permission-requests.jsonl".to_string()]
+        )
+        .is_err());
     }
 
     #[test]
@@ -2315,6 +2378,43 @@ mod tests {
     }
 
     #[test]
+    fn clone_custom_profile_copy_preserves_unmarked_legacy_skill_with_same_named_library_skill() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _guard = WardianHomeGuard;
+
+        let library = temp.path().join("library/skills/group-a/planner");
+        std::fs::create_dir_all(&library).expect("library skill");
+        std::fs::write(library.join("SKILL.md"), "library planner").expect("library skill file");
+        let legacy = temp
+            .path()
+            .join("agents/source-agent/.agents/skills/planner");
+        std::fs::create_dir_all(&legacy).expect("legacy skill");
+        std::fs::write(legacy.join("SKILL.md"), "customized planner").expect("legacy skill file");
+
+        clone_copy_selected_agent_skills(
+            temp.path(),
+            "source-agent",
+            "dest-agent",
+            &[DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: None,
+            }],
+        )
+        .expect("copy legacy skill");
+
+        assert_eq!(
+            std::fs::read_to_string(
+                temp.path()
+                    .join("agents/dest-agent/.agents/skills/planner/SKILL.md")
+            )
+            .expect("legacy copied"),
+            "customized planner"
+        );
+    }
+
+    #[test]
     fn clone_custom_skill_selection_matches_duplicate_names_by_source_path() {
         let matched = clone_match_selected_agent_skills(
             &[
@@ -2404,8 +2504,7 @@ mod tests {
             .join("agents/source-agent/.agents/skills/planner");
         std::fs::create_dir_all(&deployed).expect("deployed skill");
         std::fs::write(deployed.join("SKILL.md"), "stale").expect("skill");
-        std::fs::write(deployed.join(".wardian-skill-source"), "group-a/planner")
-            .expect("marker");
+        std::fs::write(deployed.join(".wardian-skill-source"), "group-a/planner").expect("marker");
 
         let err = clone_validate_selected_agent_skills(
             "source-agent",
@@ -2457,12 +2556,81 @@ mod tests {
     }
 
     #[test]
+    fn clone_cleanup_created_profile_dirs_removes_only_tracked_clone_dirs() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let provisional = home.join("agents").join("provisional-agent");
+        let final_dir = home.join("agents").join("final-agent");
+        let unrelated = home.join("agents").join("unrelated-agent");
+        std::fs::create_dir_all(&provisional).expect("provisional");
+        std::fs::create_dir_all(&final_dir).expect("final");
+        std::fs::create_dir_all(&unrelated).expect("unrelated");
+        std::fs::write(provisional.join("AGENTS.md"), "provisional").expect("provisional file");
+        std::fs::write(final_dir.join("AGENTS.md"), "final").expect("final file");
+        std::fs::write(unrelated.join("AGENTS.md"), "unrelated").expect("unrelated file");
+
+        clone_cleanup_created_profile_dirs(&[provisional.clone(), final_dir.clone()]);
+
+        assert!(!provisional.exists());
+        assert!(!final_dir.exists());
+        assert!(unrelated.join("AGENTS.md").is_file());
+    }
+
+    #[test]
+    fn clone_custom_discovered_session_final_profile_is_copied_from_source_not_provisional() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source = home.join("agents").join("source-agent");
+        let provisional = home.join("agents").join("provisional-agent");
+        let final_dir = home.join("agents").join("real-provider-session");
+        std::fs::create_dir_all(&source).expect("source");
+        std::fs::write(source.join("AGENTS.md"), "source profile").expect("source profile");
+
+        let selection = CloneProfileSelection {
+            files: vec!["AGENTS.md".to_string()],
+            skills: Vec::new(),
+        };
+
+        clone_copy_profile_plan(
+            home,
+            "source-agent",
+            "provisional-agent",
+            CloneProfileCopyPlan::Custom(&selection),
+        )
+        .expect("copy provisional");
+        std::fs::write(
+            provisional.join("AGENTS.md"),
+            "provider mutated provisional",
+        )
+        .expect("mutate provisional");
+
+        clone_copy_profile_plan(
+            home,
+            "source-agent",
+            "real-provider-session",
+            CloneProfileCopyPlan::Custom(&selection),
+        )
+        .expect("copy final");
+        clone_remove_existing_path(&provisional);
+
+        assert!(!provisional.exists());
+        assert_eq!(
+            std::fs::read_to_string(final_dir.join("AGENTS.md")).expect("final profile"),
+            "source profile"
+        );
+    }
+
+    #[test]
     fn clone_folder_override_uses_spawn_workspace_validation() {
         let temp = tempfile::tempdir().expect("temp dir");
-        let valid = normalize_clone_folder_override(Some(temp.path().to_string_lossy().to_string()))
-            .expect("valid folder")
-            .expect("folder override");
-        assert_eq!(valid, normalize_spawn_folder(&temp.path().to_string_lossy()).unwrap());
+        let valid =
+            normalize_clone_folder_override(Some(temp.path().to_string_lossy().to_string()))
+                .expect("valid folder")
+                .expect("folder override");
+        assert_eq!(
+            valid,
+            normalize_spawn_folder(&temp.path().to_string_lossy()).unwrap()
+        );
 
         let missing = temp.path().join("missing");
         let err = normalize_clone_folder_override(Some(missing.to_string_lossy().to_string()))

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -674,6 +674,18 @@ fn clone_cleanup_created_profile_dirs(created_profile_dirs: &[std::path::PathBuf
     }
 }
 
+fn clone_refresh_profile_system_include_directories(
+    config: &mut AgentConfig,
+    session_id: &str,
+    should_copy_profile: bool,
+) {
+    if should_copy_profile {
+        config.system_include_directories = Some(
+            crate::utils::fs::resolve_system_include_directories(&config.agent_class, session_id),
+        );
+    }
+}
+
 fn clone_ensure_profile_destination_available(
     wardian_home: &std::path::Path,
     destination_session_id: &str,
@@ -1465,6 +1477,7 @@ pub async fn clone_agent(
             clone_remove_existing_path(&provisional_root);
             created_profile_dirs.retain(|dir| dir != &provisional_root);
         }
+        clone_refresh_profile_system_include_directories(&mut config, &session_id, true);
     }
 
     let registered = register_new_agent(
@@ -1981,16 +1994,17 @@ mod tests {
         clone_copy_agent_profile_files, clone_copy_profile_plan,
         clone_copy_selected_agent_profile_files, clone_copy_selected_agent_skills,
         clone_ensure_profile_destination_available, clone_match_selected_agent_skills,
-        clone_remove_existing_path, clone_sanitize_config, clone_unique_name,
-        clone_validate_selected_agent_skills, clone_validate_selected_profile_files,
-        codex_provider_session_is_new, flatten_clone_file_paths, generated_agent_name,
-        insert_new_agent_order, mark_agent_paused_off, normalize_clone_folder_override,
-        normalize_spawn_folder, persisted_resume_session_for_provider, prepare_clear_config,
-        prepare_resume_config, promote_fresh_provider_session_after_resume,
-        provider_needs_obtain_session_id_on_clear, provider_uses_generated_session_id,
-        reserve_spawn_session_name, resolve_requested_spawn_session_name,
-        restore_runtime_state_snapshot_after_resume, sync_resumed_input_sender,
-        AgentOrderPlacement, CloneProfileCopyPlan, CloneProfileSelection,
+        clone_refresh_profile_system_include_directories, clone_remove_existing_path,
+        clone_sanitize_config, clone_unique_name, clone_validate_selected_agent_skills,
+        clone_validate_selected_profile_files, codex_provider_session_is_new,
+        flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
+        mark_agent_paused_off, normalize_clone_folder_override, normalize_spawn_folder,
+        persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
+        promote_fresh_provider_session_after_resume, provider_needs_obtain_session_id_on_clear,
+        provider_uses_generated_session_id, reserve_spawn_session_name,
+        resolve_requested_spawn_session_name, restore_runtime_state_snapshot_after_resume,
+        sync_resumed_input_sender, AgentOrderPlacement, CloneProfileCopyPlan,
+        CloneProfileSelection,
     };
     use crate::state::{ActiveAgent, AppState};
     use crate::utils::fs::create_directory_link;
@@ -2618,6 +2632,36 @@ mod tests {
             std::fs::read_to_string(final_dir.join("AGENTS.md")).expect("final profile"),
             "source profile"
         );
+    }
+
+    #[test]
+    fn clone_custom_discovered_session_refreshes_system_includes_to_final_session_id() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _guard = WardianHomeGuard;
+        let mut config = AgentConfig {
+            agent_class: "Coder".to_string(),
+            system_include_directories: Some(crate::utils::fs::resolve_system_include_directories(
+                "Coder",
+                "provisional-agent",
+            )),
+            ..Default::default()
+        };
+
+        clone_refresh_profile_system_include_directories(
+            &mut config,
+            "real-provider-session",
+            true,
+        );
+
+        let joined = config
+            .system_include_directories
+            .expect("include dirs")
+            .join("|")
+            .replace('\\', "/");
+        assert!(joined.contains("/agents/real-provider-session"));
+        assert!(!joined.contains("/agents/provisional-agent"));
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1458,6 +1458,42 @@ pub async fn clone_agent(
 }
 
 #[tauri::command]
+pub async fn get_agent_clone_preview(
+    source_session_id: String,
+    state: State<'_, AppState>,
+) -> Result<AgentClonePreview, String> {
+    let source_session_id = source_session_id.trim().to_string();
+    if source_session_id.is_empty() {
+        return Err("Source agent is required.".to_string());
+    }
+
+    let (source_config, existing_names) = {
+        let agents = state.agents.lock().await;
+        let source = agents
+            .get(&source_session_id)
+            .ok_or_else(|| format!("Agent {} not found", source_session_id))?
+            .config
+            .lock()
+            .unwrap()
+            .clone();
+        let names = agents
+            .values()
+            .map(|agent| agent.config.lock().unwrap().session_name.clone())
+            .collect::<std::collections::HashSet<_>>();
+        (source, names)
+    };
+    let wardian_home =
+        crate::utils::fs::get_wardian_home().ok_or_else(|| "Could not find Wardian home".to_string())?;
+
+    build_agent_clone_preview(
+        &wardian_home,
+        &source_session_id,
+        &source_config,
+        &existing_names,
+    )
+}
+
+#[tauri::command]
 pub async fn list_agents(state: State<'_, AppState>) -> Result<Vec<AgentConfig>, String> {
     manager::log_debug("[WARDIAN] list_agents called");
     let agents = state.agents.lock().await;

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -3,6 +3,7 @@ use crate::state::AppState;
 use tauri::{AppHandle, Emitter, State};
 use wardian_core::models::{
     AgentConfig, AgentSessionPersistence, AgentSessionPersistenceOverride, AgentTelemetry,
+    DeployedSkillRef,
 };
 
 #[derive(serde::Deserialize)]
@@ -33,6 +34,52 @@ pub struct CloneAgentRequest {
     pub folder: Option<String>,
     pub agent_class: Option<String>,
     pub start: Option<bool>,
+    pub profile_selection: Option<CloneProfileSelection>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CloneFileTreeNode {
+    pub name: String,
+    pub path: String,
+    pub kind: CloneFileTreeNodeKind,
+    pub children: Vec<CloneFileTreeNode>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloneFileTreeNodeKind {
+    File,
+    Directory,
+}
+
+impl CloneFileTreeNode {
+    #[cfg(test)]
+    fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentClonePreview {
+    pub source_session_id: String,
+    pub source_session_name: String,
+    pub suggested_session_name: String,
+    pub provider: String,
+    pub agent_class: String,
+    pub folder: String,
+    pub files: CloneFileTreeNode,
+    pub default_selected_files: Vec<String>,
+    pub skills: Vec<DeployedSkillRef>,
+    pub default_selected_skills: Vec<DeployedSkillRef>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CloneProfileSelection {
+    pub files: Vec<String>,
+    pub skills: Vec<DeployedSkillRef>,
 }
 
 fn clone_unique_name(
@@ -248,6 +295,84 @@ fn clone_copy_agent_profile_files(
         &source_root.join(".agents").join("skills"),
         &destination_root.join(".agents").join("skills"),
     )
+}
+
+fn clone_collect_eligible_file_tree(
+    wardian_home: &std::path::Path,
+    source_session_id: &str,
+) -> Result<CloneFileTreeNode, String> {
+    let source_root = wardian_home.join("agents").join(source_session_id);
+    let mut children = Vec::new();
+
+    for entry in std::fs::read_dir(&source_root).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name == ".agents" {
+            continue;
+        }
+        let metadata = std::fs::symlink_metadata(&path).map_err(|e| e.to_string())?;
+        if metadata.is_file() {
+            children.push(CloneFileTreeNode {
+                name: name.clone(),
+                path: name,
+                kind: CloneFileTreeNodeKind::File,
+                children: Vec::new(),
+            });
+        }
+    }
+
+    children.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(CloneFileTreeNode {
+        name: source_session_id.to_string(),
+        path: String::new(),
+        kind: CloneFileTreeNodeKind::Directory,
+        children,
+    })
+}
+
+fn flatten_clone_file_paths(root: &CloneFileTreeNode) -> Vec<String> {
+    fn walk(node: &CloneFileTreeNode, output: &mut Vec<String>) {
+        if node.kind == CloneFileTreeNodeKind::File {
+            output.push(node.path.clone());
+        }
+        for child in &node.children {
+            walk(child, output);
+        }
+    }
+
+    let mut paths = Vec::new();
+    walk(root, &mut paths);
+    paths
+}
+
+fn build_agent_clone_preview(
+    wardian_home: &std::path::Path,
+    source_session_id: &str,
+    source_config: &AgentConfig,
+    existing_names: &std::collections::HashSet<String>,
+) -> Result<AgentClonePreview, String> {
+    let files = clone_collect_eligible_file_tree(wardian_home, source_session_id)?;
+    let default_selected_files = flatten_clone_file_paths(&files)
+        .into_iter()
+        .filter(|path| path == "AGENTS.md")
+        .collect::<Vec<_>>();
+    let skills =
+        crate::commands::library::list_deployed_skill_refs_for_target("agent", source_session_id)?;
+
+    Ok(AgentClonePreview {
+        source_session_id: source_session_id.to_string(),
+        source_session_name: source_config.session_name.clone(),
+        suggested_session_name: clone_unique_name(&source_config.session_name, existing_names),
+        provider: source_config.provider.clone(),
+        agent_class: source_config.agent_class.clone(),
+        folder: source_config.folder.clone(),
+        files,
+        default_selected_files,
+        default_selected_skills: skills.clone(),
+        skills,
+    })
 }
 
 fn clone_ensure_profile_destination_available(
@@ -1455,7 +1580,7 @@ pub async fn reorder_agents(
 #[cfg(test)]
 mod tests {
     use super::{
-        agent_status_update_payload, capture_opencode_pause_resume_session,
+        agent_status_update_payload, build_agent_clone_preview, capture_opencode_pause_resume_session,
         capture_resume_runtime_snapshot, clone_copy_agent_profile_files,
         clone_ensure_profile_destination_available, clone_sanitize_config, clone_unique_name,
         codex_provider_session_is_new, generated_agent_name, insert_new_agent_order,
@@ -1470,7 +1595,15 @@ mod tests {
     use crate::utils::fs::create_directory_link;
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
-    use wardian_core::models::{AgentConfig, AgentSessionPersistenceOverride};
+    use wardian_core::models::{AgentConfig, AgentSessionPersistenceOverride, DeployedSkillRef};
+
+    struct WardianHomeGuard;
+
+    impl Drop for WardianHomeGuard {
+        fn drop(&mut self) {
+            unsafe { std::env::remove_var("WARDIAN_HOME") };
+        }
+    }
 
     fn make_test_agent() -> ActiveAgent {
         ActiveAgent {
@@ -1513,6 +1646,88 @@ mod tests {
 
     fn clone_name_set(names: &[&str]) -> HashSet<String> {
         names.iter().map(|name| name.to_string()).collect()
+    }
+
+    #[test]
+    fn clone_preview_defaults_to_profile_selection() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source_root = home.join("agents").join("source-agent");
+        std::fs::create_dir_all(&source_root).expect("source root");
+        std::fs::write(source_root.join("AGENTS.md"), "# Agent\n").expect("agents");
+        std::fs::write(source_root.join("notes.md"), "notes").expect("notes");
+
+        let existing_names = HashSet::new();
+        let preview = build_agent_clone_preview(
+            home,
+            "source-agent",
+            &AgentConfig {
+                session_id: "source-agent".to_string(),
+                session_name: "Alpha".to_string(),
+                agent_class: "Coder".to_string(),
+                folder: "D:/Development/Wardian".to_string(),
+                provider: "codex".to_string(),
+                ..Default::default()
+            },
+            &existing_names,
+        )
+        .expect("preview");
+
+        assert_eq!(preview.suggested_session_name, "Alpha-copy");
+        assert_eq!(preview.default_selected_files, vec!["AGENTS.md".to_string()]);
+        assert!(preview
+            .files
+            .children
+            .iter()
+            .any(|node| node.path() == "notes.md"));
+    }
+
+    #[test]
+    fn clone_preview_includes_agent_specific_skills_as_default_selected() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _guard = WardianHomeGuard;
+
+        let source_root = temp.path().join("agents").join("source-agent");
+        std::fs::create_dir_all(&source_root).expect("source root");
+        std::fs::write(source_root.join("AGENTS.md"), "# Agent\n").expect("agents");
+        let library_skill = temp
+            .path()
+            .join("library")
+            .join("skills")
+            .join("group-a")
+            .join("planner");
+        std::fs::create_dir_all(&library_skill).expect("library skill");
+        std::fs::write(library_skill.join("SKILL.md"), "planner").expect("skill");
+        crate::commands::library::deploy_skill_from_library(
+            "group-a/planner",
+            "agent",
+            "source-agent",
+        )
+        .expect("deploy");
+
+        let preview = build_agent_clone_preview(
+            temp.path(),
+            "source-agent",
+            &AgentConfig {
+                session_id: "source-agent".to_string(),
+                session_name: "Alpha".to_string(),
+                agent_class: "Coder".to_string(),
+                folder: "D:/Development/Wardian".to_string(),
+                provider: "codex".to_string(),
+                ..Default::default()
+            },
+            &HashSet::new(),
+        )
+        .expect("preview");
+
+        let expected = DeployedSkillRef {
+            name: "planner".to_string(),
+            source_path: Some("group-a/planner".to_string()),
+        };
+        assert_eq!(preview.skills, vec![expected.clone()]);
+        assert_eq!(preview.default_selected_skills, vec![expected]);
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -537,6 +537,74 @@ fn clone_copy_selected_agent_profile_files(
     Ok(())
 }
 
+fn clone_match_selected_agent_skills(
+    deployed_skills: &[DeployedSkillRef],
+    selected_skills: &[DeployedSkillRef],
+) -> Result<Vec<DeployedSkillRef>, String> {
+    let mut matched = Vec::with_capacity(selected_skills.len());
+    for selected_skill in selected_skills {
+        let deployed = deployed_skills
+            .iter()
+            .find(|deployed| {
+                deployed.name == selected_skill.name
+                    && deployed.source_path == selected_skill.source_path
+            })
+            .ok_or_else(|| {
+                format!(
+                    "Selected skill '{}' is not deployed on the source agent.",
+                    selected_skill.name
+                )
+            })?;
+        matched.push(deployed.clone());
+    }
+    Ok(matched)
+}
+
+fn clone_validate_selected_agent_skills(
+    source_session_id: &str,
+    selected_skills: &[DeployedSkillRef],
+) -> Result<Vec<DeployedSkillRef>, String> {
+    let deployed_skills =
+        crate::commands::library::list_deployed_skill_refs_for_target("agent", source_session_id)?;
+    clone_match_selected_agent_skills(&deployed_skills, selected_skills)
+}
+
+fn clone_copy_selected_agent_skills(
+    wardian_home: &std::path::Path,
+    source_session_id: &str,
+    destination_session_id: &str,
+    selected_skills: &[DeployedSkillRef],
+) -> Result<(), String> {
+    let selected_skills = clone_validate_selected_agent_skills(source_session_id, selected_skills)?;
+
+    for selected_skill in selected_skills {
+        if let Some(source_path) = selected_skill.source_path {
+            crate::commands::library::deploy_skill_from_library(
+                &source_path,
+                "agent",
+                destination_session_id,
+            )?;
+        } else {
+            clone_copy_directory_recursive(
+                &wardian_home
+                    .join("agents")
+                    .join(source_session_id)
+                    .join(".agents")
+                    .join("skills")
+                    .join(&selected_skill.name),
+                &wardian_home
+                    .join("agents")
+                    .join(destination_session_id)
+                    .join(".agents")
+                    .join("skills")
+                    .join(&selected_skill.name),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
 fn clone_ensure_profile_destination_available(
     wardian_home: &std::path::Path,
     destination_session_id: &str,
@@ -1745,14 +1813,16 @@ mod tests {
         agent_status_update_payload, build_agent_clone_preview, capture_opencode_pause_resume_session,
         capture_resume_runtime_snapshot, clone_collect_eligible_file_tree,
         clone_copy_agent_profile_files, clone_copy_selected_agent_profile_files,
-        clone_ensure_profile_destination_available, clone_sanitize_config, clone_unique_name,
-        clone_validate_selected_profile_files, codex_provider_session_is_new,
-        flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
-        mark_agent_paused_off, normalize_spawn_folder, persisted_resume_session_for_provider,
-        prepare_clear_config, prepare_resume_config, promote_fresh_provider_session_after_resume,
-        provider_needs_obtain_session_id_on_clear, provider_uses_generated_session_id,
-        reserve_spawn_session_name, resolve_requested_spawn_session_name,
-        restore_runtime_state_snapshot_after_resume, sync_resumed_input_sender, AgentOrderPlacement,
+        clone_copy_selected_agent_skills, clone_ensure_profile_destination_available,
+        clone_match_selected_agent_skills, clone_sanitize_config, clone_unique_name,
+        clone_validate_selected_agent_skills, clone_validate_selected_profile_files,
+        codex_provider_session_is_new, flatten_clone_file_paths, generated_agent_name,
+        insert_new_agent_order, mark_agent_paused_off, normalize_spawn_folder,
+        persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
+        promote_fresh_provider_session_after_resume, provider_needs_obtain_session_id_on_clear,
+        provider_uses_generated_session_id, reserve_spawn_session_name,
+        resolve_requested_spawn_session_name, restore_runtime_state_snapshot_after_resume,
+        sync_resumed_input_sender, AgentOrderPlacement,
     };
     use crate::state::{ActiveAgent, AppState};
     use crate::utils::fs::create_directory_link;
@@ -2020,6 +2090,193 @@ mod tests {
             &["linked/secret.md".to_string()]
         )
         .is_err());
+    }
+
+    #[test]
+    fn clone_custom_profile_copy_recreates_only_selected_skills() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _guard = WardianHomeGuard;
+
+        let library_skill = temp
+            .path()
+            .join("library")
+            .join("skills")
+            .join("group-a")
+            .join("planner");
+        std::fs::create_dir_all(&library_skill).expect("library skill");
+        std::fs::write(library_skill.join("SKILL.md"), "planner").expect("skill");
+        crate::commands::library::deploy_skill_from_library(
+            "group-a/planner",
+            "agent",
+            "source-agent",
+        )
+        .expect("deploy selected");
+
+        let ignored_skill = temp.path().join("library").join("skills").join("ignored");
+        std::fs::create_dir_all(&ignored_skill).expect("ignored");
+        std::fs::write(ignored_skill.join("SKILL.md"), "ignored").expect("ignored skill");
+        crate::commands::library::deploy_skill_from_library("ignored", "agent", "source-agent")
+            .expect("deploy ignored");
+
+        clone_copy_selected_agent_skills(
+            temp.path(),
+            "source-agent",
+            "dest-agent",
+            &[DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: Some("group-a/planner".to_string()),
+            }],
+        )
+        .expect("copy selected skills");
+
+        assert!(temp
+            .path()
+            .join("agents/dest-agent/.agents/skills/planner/SKILL.md")
+            .is_file());
+        assert!(!temp
+            .path()
+            .join("agents/dest-agent/.agents/skills/ignored")
+            .exists());
+    }
+
+    #[test]
+    fn clone_custom_profile_copy_supports_legacy_copied_skills() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _guard = WardianHomeGuard;
+        let legacy = temp
+            .path()
+            .join("agents/source-agent/.agents/skills/legacy");
+        std::fs::create_dir_all(&legacy).expect("legacy skill");
+        std::fs::write(legacy.join("SKILL.md"), "legacy").expect("legacy skill file");
+
+        clone_copy_selected_agent_skills(
+            temp.path(),
+            "source-agent",
+            "dest-agent",
+            &[DeployedSkillRef {
+                name: "legacy".to_string(),
+                source_path: None,
+            }],
+        )
+        .expect("copy legacy skill");
+
+        assert_eq!(
+            std::fs::read_to_string(
+                temp.path()
+                    .join("agents/dest-agent/.agents/skills/legacy/SKILL.md")
+            )
+            .expect("legacy copied"),
+            "legacy"
+        );
+    }
+
+    #[test]
+    fn clone_custom_skill_selection_matches_duplicate_names_by_source_path() {
+        let matched = clone_match_selected_agent_skills(
+            &[
+                DeployedSkillRef {
+                    name: "planner".to_string(),
+                    source_path: Some("group-a/planner".to_string()),
+                },
+                DeployedSkillRef {
+                    name: "planner".to_string(),
+                    source_path: Some("group-b/planner".to_string()),
+                },
+                DeployedSkillRef {
+                    name: "planner".to_string(),
+                    source_path: None,
+                },
+            ],
+            &[DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: Some("group-b/planner".to_string()),
+            }],
+        )
+        .expect("match duplicate");
+
+        assert_eq!(
+            matched,
+            vec![DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: Some("group-b/planner".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn clone_custom_skill_selection_rejects_mismatched_duplicate_refs() {
+        let err = clone_match_selected_agent_skills(
+            &[DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: Some("group-a/planner".to_string()),
+            }],
+            &[DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: Some("group-b/planner".to_string()),
+            }],
+        )
+        .expect_err("mismatched source_path must fail");
+
+        assert!(err.contains("not deployed"));
+    }
+
+    #[test]
+    fn clone_custom_skill_selection_none_source_path_matches_only_legacy_ref() {
+        let matched = clone_match_selected_agent_skills(
+            &[
+                DeployedSkillRef {
+                    name: "planner".to_string(),
+                    source_path: Some("group-a/planner".to_string()),
+                },
+                DeployedSkillRef {
+                    name: "planner".to_string(),
+                    source_path: None,
+                },
+            ],
+            &[DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: None,
+            }],
+        )
+        .expect("match legacy");
+
+        assert_eq!(
+            matched,
+            vec![DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn clone_custom_skill_selection_rejects_missing_source_backed_library_skill() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _guard = WardianHomeGuard;
+        let deployed = temp
+            .path()
+            .join("agents/source-agent/.agents/skills/planner");
+        std::fs::create_dir_all(&deployed).expect("deployed skill");
+        std::fs::write(deployed.join("SKILL.md"), "stale").expect("skill");
+        std::fs::write(deployed.join(".wardian-skill-source"), "group-a/planner")
+            .expect("marker");
+
+        let err = clone_validate_selected_agent_skills(
+            "source-agent",
+            &[DeployedSkillRef {
+                name: "planner".to_string(),
+                source_path: Some("group-a/planner".to_string()),
+            }],
+        )
+        .expect_err("missing library source fails");
+
+        assert!(err.contains("not deployed") || err.contains("Skill source not found"));
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -442,6 +442,101 @@ fn build_agent_clone_preview(
     })
 }
 
+fn clone_normalize_selected_profile_file(path: &str) -> Result<String, String> {
+    let normalized = path.trim().replace('\\', "/");
+    if normalized.is_empty() {
+        return Err("Selected clone file path cannot be empty.".to_string());
+    }
+    let candidate = std::path::Path::new(&normalized);
+    if candidate.is_absolute() {
+        return Err(format!("Selected clone file path is absolute: {normalized}"));
+    }
+    for component in candidate.components() {
+        if matches!(
+            component,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        ) {
+            return Err(format!("Selected clone file path is invalid: {normalized}"));
+        }
+    }
+    Ok(normalized)
+}
+
+fn clone_join_normalized_relative_path(
+    root: &std::path::Path,
+    normalized: &str,
+) -> std::path::PathBuf {
+    normalized
+        .split('/')
+        .fold(root.to_path_buf(), |path, segment| path.join(segment))
+}
+
+fn clone_validate_selected_profile_files(
+    wardian_home: &std::path::Path,
+    source_session_id: &str,
+    selected_files: &[String],
+) -> Result<Vec<String>, String> {
+    let source_root = wardian_home.join("agents").join(source_session_id);
+    let canonical_root = source_root.canonicalize().map_err(|e| e.to_string())?;
+    let allowlist = flatten_clone_file_paths(&clone_collect_eligible_file_tree(
+        wardian_home,
+        source_session_id,
+    )?)
+    .into_iter()
+    .collect::<std::collections::HashSet<_>>();
+    let mut validated = Vec::with_capacity(selected_files.len());
+
+    for selected_file in selected_files {
+        let normalized = clone_normalize_selected_profile_file(selected_file)?;
+        if !allowlist.contains(&normalized) {
+            return Err(format!(
+                "Selected clone file is not eligible: {normalized}"
+            ));
+        }
+        let source_path = clone_join_normalized_relative_path(&source_root, &normalized);
+        let metadata = std::fs::symlink_metadata(&source_path).map_err(|e| e.to_string())?;
+        if clone_path_is_link_or_reparse(&metadata) || std::fs::read_link(&source_path).is_ok() {
+            return Err(format!("Selected clone file is a link: {normalized}"));
+        }
+        if !metadata.is_file() {
+            return Err(format!("Selected clone path is not a file: {normalized}"));
+        }
+        let canonical = source_path.canonicalize().map_err(|e| e.to_string())?;
+        if !canonical.starts_with(&canonical_root) {
+            return Err(format!(
+                "Selected clone file escapes the source agent: {normalized}"
+            ));
+        }
+        validated.push(normalized);
+    }
+
+    Ok(validated)
+}
+
+fn clone_copy_selected_agent_profile_files(
+    wardian_home: &std::path::Path,
+    source_session_id: &str,
+    destination_session_id: &str,
+    selected_files: &[String],
+) -> Result<(), String> {
+    let selected_files =
+        clone_validate_selected_profile_files(wardian_home, source_session_id, selected_files)?;
+    let source_root = wardian_home.join("agents").join(source_session_id);
+    let destination_root = wardian_home.join("agents").join(destination_session_id);
+    std::fs::create_dir_all(&destination_root).map_err(|e| e.to_string())?;
+
+    for selected_file in selected_files {
+        clone_copy_file(
+            &clone_join_normalized_relative_path(&source_root, &selected_file),
+            &clone_join_normalized_relative_path(&destination_root, &selected_file),
+        )?;
+    }
+
+    Ok(())
+}
+
 fn clone_ensure_profile_destination_available(
     wardian_home: &std::path::Path,
     destination_session_id: &str,
@@ -1649,8 +1744,9 @@ mod tests {
     use super::{
         agent_status_update_payload, build_agent_clone_preview, capture_opencode_pause_resume_session,
         capture_resume_runtime_snapshot, clone_collect_eligible_file_tree,
-        clone_copy_agent_profile_files, clone_ensure_profile_destination_available,
-        clone_sanitize_config, clone_unique_name, codex_provider_session_is_new,
+        clone_copy_agent_profile_files, clone_copy_selected_agent_profile_files,
+        clone_ensure_profile_destination_available, clone_sanitize_config, clone_unique_name,
+        clone_validate_selected_profile_files, codex_provider_session_is_new,
         flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
         mark_agent_paused_off, normalize_spawn_folder, persisted_resume_session_for_provider,
         prepare_clear_config, prepare_resume_config, promote_fresh_provider_session_after_resume,
@@ -1854,6 +1950,76 @@ mod tests {
         let paths = flatten_clone_file_paths(&files);
 
         assert!(!paths.iter().any(|path| path.starts_with("linked/")));
+    }
+
+    #[test]
+    fn clone_custom_profile_copy_copies_only_selected_files() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source = home.join("agents").join("source-agent");
+        let dest = home.join("agents").join("dest-agent");
+        std::fs::create_dir_all(source.join("nested")).expect("nested");
+        std::fs::write(source.join("AGENTS.md"), "# Agent\n").expect("agents");
+        std::fs::write(source.join("notes.md"), "notes").expect("notes");
+        std::fs::write(source.join("nested").join("keep.md"), "keep").expect("keep");
+
+        clone_copy_selected_agent_profile_files(
+            home,
+            "source-agent",
+            "dest-agent",
+            &["AGENTS.md".to_string(), "nested/keep.md".to_string()],
+        )
+        .expect("copy selected");
+
+        assert!(dest.join("AGENTS.md").is_file());
+        assert!(dest.join("nested").join("keep.md").is_file());
+        assert!(!dest.join("notes.md").exists());
+    }
+
+    #[test]
+    fn clone_selected_profile_file_rejects_traversal_and_absolute_paths() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source = home.join("agents").join("source-agent");
+        std::fs::create_dir_all(&source).expect("source");
+        std::fs::write(source.join("AGENTS.md"), "# Agent\n").expect("agents");
+
+        assert!(clone_validate_selected_profile_files(
+            home,
+            "source-agent",
+            &["../secret.md".to_string()]
+        )
+        .is_err());
+        assert!(clone_validate_selected_profile_files(
+            home,
+            "source-agent",
+            &["C:/secret.md".to_string()]
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn clone_selected_profile_file_rejects_links_and_escaped_canonical_targets() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source = home.join("agents").join("source-agent");
+        let external = home.join("external");
+        std::fs::create_dir_all(&source).expect("source");
+        std::fs::create_dir_all(&external).expect("external");
+        std::fs::write(source.join("AGENTS.md"), "# Agent\n").expect("agents");
+        std::fs::write(external.join("secret.md"), "secret").expect("secret");
+
+        let linked = source.join("linked");
+        if create_directory_link(&external, &linked).is_err() {
+            return;
+        }
+
+        assert!(clone_validate_selected_profile_files(
+            home,
+            "source-agent",
+            &["linked/secret.md".to_string()]
+        )
+        .is_err());
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -82,6 +82,12 @@ pub struct CloneProfileSelection {
     pub skills: Vec<DeployedSkillRef>,
 }
 
+enum CloneProfileCopyPlan<'a> {
+    None,
+    Profile,
+    Custom(&'a CloneProfileSelection),
+}
+
 fn clone_unique_name(
     source_name: &str,
     existing_names: &std::collections::HashSet<String>,
@@ -605,6 +611,40 @@ fn clone_copy_selected_agent_skills(
     Ok(())
 }
 
+fn clone_copy_profile_plan(
+    wardian_home: &std::path::Path,
+    source_session_id: &str,
+    destination_session_id: &str,
+    plan: CloneProfileCopyPlan<'_>,
+) -> Result<(), String> {
+    match plan {
+        CloneProfileCopyPlan::None => Ok(()),
+        CloneProfileCopyPlan::Profile => {
+            clone_copy_agent_profile_files(wardian_home, source_session_id, destination_session_id)
+        }
+        CloneProfileCopyPlan::Custom(selection) => {
+            clone_copy_selected_agent_profile_files(
+                wardian_home,
+                source_session_id,
+                destination_session_id,
+                &selection.files,
+            )?;
+            clone_copy_selected_agent_skills(
+                wardian_home,
+                source_session_id,
+                destination_session_id,
+                &selection.skills,
+            )
+        }
+    }
+}
+
+fn clone_cleanup_created_profile_dirs(created_profile_dirs: &[std::path::PathBuf]) {
+    for profile_dir in created_profile_dirs.iter().rev() {
+        clone_remove_existing_path(profile_dir);
+    }
+}
+
 fn clone_ensure_profile_destination_available(
     wardian_home: &std::path::Path,
     destination_session_id: &str,
@@ -907,6 +947,13 @@ fn normalize_spawn_folder(folder: &str) -> Result<String, String> {
 
     crate::utils::fs::validate_workspace_path(std::path::Path::new(folder))
         .map(|path| normalize_workspace_record_path(&path))
+}
+
+fn normalize_clone_folder_override(folder: Option<String>) -> Result<Option<String>, String> {
+    folder
+        .as_deref()
+        .map(normalize_spawn_folder)
+        .transpose()
 }
 
 fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
@@ -1248,17 +1295,26 @@ pub async fn clone_agent(
         source_session_id, req.mode
     ));
 
+    let folder_override = normalize_clone_folder_override(req.folder)?;
+    let profile_selection = req.profile_selection;
+    let profile_copy_plan = match profile_selection.as_ref() {
+        Some(selection) => CloneProfileCopyPlan::Custom(selection),
+        None if req.mode == CloneAgentMode::Profile => CloneProfileCopyPlan::Profile,
+        None => CloneProfileCopyPlan::None,
+    };
+    let should_copy_profile = !matches!(profile_copy_plan, CloneProfileCopyPlan::None);
+
     let mut config = clone_sanitize_config(
         &source_config,
         session_name,
         req.provider,
-        req.folder,
+        folder_override,
         req.agent_class,
         req.start.unwrap_or(true),
     );
     let provider_name = config.provider.clone();
     let mut actual_resume = None;
-    let profile_home = if req.mode == CloneAgentMode::Profile {
+    let profile_home = if should_copy_profile {
         Some(
             crate::utils::fs::get_wardian_home()
                 .ok_or_else(|| "Could not find Wardian home".to_string())?,
@@ -1269,13 +1325,26 @@ pub async fn clone_agent(
     let provisional_profile_session_id = (profile_home.is_some()
         && !provider_uses_generated_session_id(&provider_name))
     .then(|| uuid::Uuid::new_v4().to_string());
+    let mut created_profile_dirs = Vec::new();
 
     let session_id = if provider_uses_generated_session_id(&provider_name) {
         let generated_session_id = uuid::Uuid::new_v4().to_string();
         config.session_id = generated_session_id.clone();
         if let Some(home) = profile_home.as_ref() {
             clone_ensure_profile_destination_available(home, &generated_session_id, None)?;
-            clone_copy_agent_profile_files(home, &source_session_id, &generated_session_id)?;
+            created_profile_dirs.push(home.join("agents").join(&generated_session_id));
+            if let Err(error) = clone_copy_profile_plan(
+                home,
+                &source_session_id,
+                &generated_session_id,
+                match profile_selection.as_ref() {
+                    Some(selection) => CloneProfileCopyPlan::Custom(selection),
+                    None => CloneProfileCopyPlan::Profile,
+                },
+            ) {
+                clone_cleanup_created_profile_dirs(&created_profile_dirs);
+                return Err(error);
+            }
         }
         generated_session_id
     } else {
@@ -1285,7 +1354,19 @@ pub async fn clone_agent(
         ) {
             config.session_id = provisional_session_id.clone();
             clone_ensure_profile_destination_available(home, provisional_session_id, None)?;
-            clone_copy_agent_profile_files(home, &source_session_id, provisional_session_id)?;
+            created_profile_dirs.push(home.join("agents").join(provisional_session_id));
+            if let Err(error) = clone_copy_profile_plan(
+                home,
+                &source_session_id,
+                provisional_session_id,
+                match profile_selection.as_ref() {
+                    Some(selection) => CloneProfileCopyPlan::Custom(selection),
+                    None => CloneProfileCopyPlan::Profile,
+                },
+            ) {
+                clone_cleanup_created_profile_dirs(&created_profile_dirs);
+                return Err(error);
+            }
             config.system_include_directories =
                 Some(crate::utils::fs::resolve_system_include_directories(
                     &config.agent_class,
@@ -1295,7 +1376,10 @@ pub async fn clone_agent(
         let cwd = crate::utils::fs::resolve_cwd(&config.folder, "");
         let real_sid = manager::obtain_session_id(&cwd, Some(&config.agent_class), Some(&config))
             .await
-            .map_err(|e| format!("Failed to initialize the provider session: {}", e))?;
+            .map_err(|e| {
+                clone_cleanup_created_profile_dirs(&created_profile_dirs);
+                format!("Failed to initialize the provider session: {}", e)
+            })?;
         manager::log_debug(&format!(
             "[WARDIAN] Intercepted stream-json clone session ID for {}: {}",
             provider_name, real_sid
@@ -1308,12 +1392,7 @@ pub async fn clone_agent(
     config.resume_session = actual_resume.clone();
 
     if !is_session_id_available(&state, &session_id).await {
-        if let Some(home) = profile_home.as_ref() {
-            if let Some(provisional_session_id) = provisional_profile_session_id.as_deref() {
-                let provisional_root = home.join("agents").join(provisional_session_id);
-                clone_remove_existing_path(&provisional_root);
-            }
-        }
+        clone_cleanup_created_profile_dirs(&created_profile_dirs);
         return Err(format!(
             "An agent with session ID '{}' already exists.",
             session_id
@@ -1331,18 +1410,38 @@ pub async fn clone_agent(
             home,
             &session_id,
             allowed_existing_profile_session_id,
-        )?;
-        clone_copy_agent_profile_files(home, &source_session_id, &session_id)?;
+        )
+        .inspect_err(|_| clone_cleanup_created_profile_dirs(&created_profile_dirs))?;
+        let final_profile_dir = home.join("agents").join(&session_id);
+        if !created_profile_dirs
+            .iter()
+            .any(|existing| existing == &final_profile_dir)
+        {
+            created_profile_dirs.push(final_profile_dir);
+        }
+        if let Err(error) = clone_copy_profile_plan(
+            home,
+            &source_session_id,
+            &session_id,
+            match profile_selection.as_ref() {
+                Some(selection) => CloneProfileCopyPlan::Custom(selection),
+                None => CloneProfileCopyPlan::Profile,
+            },
+        ) {
+            clone_cleanup_created_profile_dirs(&created_profile_dirs);
+            return Err(error);
+        }
         if let Some(provisional_session_id) = provisional_profile_session_id
             .as_deref()
             .filter(|id| *id != session_id)
         {
             let provisional_root = home.join("agents").join(provisional_session_id);
             clone_remove_existing_path(&provisional_root);
+            created_profile_dirs.retain(|dir| dir != &provisional_root);
         }
     }
 
-    register_new_agent(
+    let registered = register_new_agent(
         config,
         actual_resume,
         &state,
@@ -1351,7 +1450,11 @@ pub async fn clone_agent(
         None,
         AgentOrderPlacement::After(&source_session_id),
     )
-    .await
+    .await;
+    if registered.is_err() {
+        clone_cleanup_created_profile_dirs(&created_profile_dirs);
+    }
+    registered
 }
 
 #[tauri::command]
@@ -1813,16 +1916,17 @@ mod tests {
         agent_status_update_payload, build_agent_clone_preview, capture_opencode_pause_resume_session,
         capture_resume_runtime_snapshot, clone_collect_eligible_file_tree,
         clone_copy_agent_profile_files, clone_copy_selected_agent_profile_files,
-        clone_copy_selected_agent_skills, clone_ensure_profile_destination_available,
-        clone_match_selected_agent_skills, clone_sanitize_config, clone_unique_name,
-        clone_validate_selected_agent_skills, clone_validate_selected_profile_files,
-        codex_provider_session_is_new, flatten_clone_file_paths, generated_agent_name,
-        insert_new_agent_order, mark_agent_paused_off, normalize_spawn_folder,
+        clone_copy_profile_plan, clone_copy_selected_agent_skills,
+        clone_ensure_profile_destination_available, clone_match_selected_agent_skills,
+        clone_sanitize_config, clone_unique_name, clone_validate_selected_agent_skills,
+        clone_validate_selected_profile_files, codex_provider_session_is_new,
+        flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
+        mark_agent_paused_off, normalize_clone_folder_override, normalize_spawn_folder,
         persisted_resume_session_for_provider, prepare_clear_config, prepare_resume_config,
         promote_fresh_provider_session_after_resume, provider_needs_obtain_session_id_on_clear,
         provider_uses_generated_session_id, reserve_spawn_session_name,
         resolve_requested_spawn_session_name, restore_runtime_state_snapshot_after_resume,
-        sync_resumed_input_sender, AgentOrderPlacement,
+        sync_resumed_input_sender, AgentOrderPlacement, CloneProfileCopyPlan, CloneProfileSelection,
     };
     use crate::state::{ActiveAgent, AppState};
     use crate::utils::fs::create_directory_link;
@@ -2280,6 +2384,57 @@ mod tests {
     }
 
     #[test]
+    fn clone_profile_copy_plan_custom_copies_selected_files_and_skills() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _guard = WardianHomeGuard;
+        let source = temp.path().join("agents").join("source-agent");
+        std::fs::create_dir_all(source.join("nested")).expect("nested");
+        std::fs::write(source.join("AGENTS.md"), "# Agent\n").expect("agents");
+        std::fs::write(source.join("notes.md"), "notes").expect("notes");
+        std::fs::write(source.join("nested").join("keep.md"), "keep").expect("keep");
+        let legacy = source.join(".agents/skills/legacy");
+        std::fs::create_dir_all(&legacy).expect("legacy");
+        std::fs::write(legacy.join("SKILL.md"), "legacy").expect("legacy skill");
+
+        let selection = CloneProfileSelection {
+            files: vec!["nested/keep.md".to_string()],
+            skills: vec![DeployedSkillRef {
+                name: "legacy".to_string(),
+                source_path: None,
+            }],
+        };
+
+        clone_copy_profile_plan(
+            temp.path(),
+            "source-agent",
+            "dest-agent",
+            CloneProfileCopyPlan::Custom(&selection),
+        )
+        .expect("copy custom profile");
+
+        let dest = temp.path().join("agents").join("dest-agent");
+        assert!(dest.join("nested/keep.md").is_file());
+        assert!(!dest.join("AGENTS.md").exists());
+        assert!(dest.join(".agents/skills/legacy/SKILL.md").is_file());
+    }
+
+    #[test]
+    fn clone_folder_override_uses_spawn_workspace_validation() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let valid = normalize_clone_folder_override(Some(temp.path().to_string_lossy().to_string()))
+            .expect("valid folder")
+            .expect("folder override");
+        assert_eq!(valid, normalize_spawn_folder(&temp.path().to_string_lossy()).unwrap());
+
+        let missing = temp.path().join("missing");
+        let err = normalize_clone_folder_override(Some(missing.to_string_lossy().to_string()))
+            .expect_err("missing workspace should fail");
+        assert!(err.contains("Path does not exist or is invalid"));
+    }
+
+    #[test]
     fn fresh_spawn_order_inserts_new_agent_at_top() {
         let mut order = vec!["alpha".to_string(), "beta".to_string()];
 
@@ -2434,6 +2589,7 @@ mod tests {
             git_worktree: Some(true),
             fresh_provider_session_id: Some("fresh-provider-session".to_string()),
             codex_cleared_provider_sessions: vec!["old-provider-session".to_string()],
+            opencode_port: Some(41313),
             is_off: true,
             custom_args: Some("--verbose".to_string()),
             ..Default::default()
@@ -2453,6 +2609,7 @@ mod tests {
         assert_eq!(clone.resume_session, None);
         assert_eq!(clone.fresh_provider_session_id, None);
         assert!(clone.codex_cleared_provider_sessions.is_empty());
+        assert_eq!(clone.opencode_port, None);
         assert!(!clone.is_off);
     }
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -302,27 +302,8 @@ fn clone_collect_eligible_file_tree(
     source_session_id: &str,
 ) -> Result<CloneFileTreeNode, String> {
     let source_root = wardian_home.join("agents").join(source_session_id);
-    let mut children = Vec::new();
-
-    for entry in std::fs::read_dir(&source_root).map_err(|e| e.to_string())? {
-        let entry = entry.map_err(|e| e.to_string())?;
-        let path = entry.path();
-        let name = entry.file_name().to_string_lossy().to_string();
-        if name == ".agents" {
-            continue;
-        }
-        let metadata = std::fs::symlink_metadata(&path).map_err(|e| e.to_string())?;
-        if metadata.is_file() {
-            children.push(CloneFileTreeNode {
-                name: name.clone(),
-                path: name,
-                kind: CloneFileTreeNodeKind::File,
-                children: Vec::new(),
-            });
-        }
-    }
-
-    children.sort_by(|a, b| a.name.cmp(&b.name));
+    let canonical_root = source_root.canonicalize().map_err(|e| e.to_string())?;
+    let children = clone_collect_eligible_file_children(&source_root, &canonical_root, "")?;
 
     Ok(CloneFileTreeNode {
         name: source_session_id.to_string(),
@@ -330,6 +311,92 @@ fn clone_collect_eligible_file_tree(
         kind: CloneFileTreeNodeKind::Directory,
         children,
     })
+}
+
+fn clone_collect_eligible_file_children(
+    directory: &std::path::Path,
+    canonical_root: &std::path::Path,
+    rel_dir: &str,
+) -> Result<Vec<CloneFileTreeNode>, String> {
+    let mut children = Vec::new();
+
+    for entry in std::fs::read_dir(directory).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        let rel_path = if rel_dir.is_empty() {
+            name.clone()
+        } else {
+            format!("{rel_dir}/{name}")
+        };
+        if clone_path_is_generated_or_runtime(&rel_path) {
+            continue;
+        }
+
+        let metadata = std::fs::symlink_metadata(&path).map_err(|e| e.to_string())?;
+        if clone_path_is_link_or_reparse(&metadata) || std::fs::read_link(&path).is_ok() {
+            continue;
+        }
+        let canonical_path = match path.canonicalize() {
+            Ok(canonical_path) => canonical_path,
+            Err(_) => continue,
+        };
+        if !canonical_path.starts_with(canonical_root) {
+            continue;
+        }
+
+        if metadata.is_dir() {
+            let nested = clone_collect_eligible_file_children(&path, canonical_root, &rel_path)?;
+            if !nested.is_empty() {
+                children.push(CloneFileTreeNode {
+                    name,
+                    path: rel_path,
+                    kind: CloneFileTreeNodeKind::Directory,
+                    children: nested,
+                });
+            }
+        } else if metadata.is_file() {
+            children.push(CloneFileTreeNode {
+                name,
+                path: rel_path,
+                kind: CloneFileTreeNodeKind::File,
+                children: Vec::new(),
+            });
+        }
+    }
+
+    children.sort_by(|a, b| {
+        let kind_order = |kind: CloneFileTreeNodeKind| match kind {
+            CloneFileTreeNodeKind::Directory => 0,
+            CloneFileTreeNodeKind::File => 1,
+        };
+        kind_order(a.kind)
+            .cmp(&kind_order(b.kind))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    Ok(children)
+}
+
+fn clone_path_is_generated_or_runtime(rel_path: &str) -> bool {
+    let normalized = rel_path.replace('\\', "/");
+    let first = normalized.split('/').next().unwrap_or_default();
+    matches!(first, "habitat" | ".codex" | ".claude" | ".gemini" | ".opencode")
+        || normalized == ".agents/skills"
+        || normalized.starts_with(".agents/skills/")
+}
+
+#[cfg(windows)]
+fn clone_path_is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    metadata.file_type().is_symlink()
+        || metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn clone_path_is_link_or_reparse(metadata: &std::fs::Metadata) -> bool {
+    metadata.file_type().is_symlink()
 }
 
 fn flatten_clone_file_paths(root: &CloneFileTreeNode) -> Vec<String> {
@@ -1581,15 +1648,15 @@ pub async fn reorder_agents(
 mod tests {
     use super::{
         agent_status_update_payload, build_agent_clone_preview, capture_opencode_pause_resume_session,
-        capture_resume_runtime_snapshot, clone_copy_agent_profile_files,
-        clone_ensure_profile_destination_available, clone_sanitize_config, clone_unique_name,
-        codex_provider_session_is_new, generated_agent_name, insert_new_agent_order,
+        capture_resume_runtime_snapshot, clone_collect_eligible_file_tree,
+        clone_copy_agent_profile_files, clone_ensure_profile_destination_available,
+        clone_sanitize_config, clone_unique_name, codex_provider_session_is_new,
+        flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
         mark_agent_paused_off, normalize_spawn_folder, persisted_resume_session_for_provider,
         prepare_clear_config, prepare_resume_config, promote_fresh_provider_session_after_resume,
         provider_needs_obtain_session_id_on_clear, provider_uses_generated_session_id,
         reserve_spawn_session_name, resolve_requested_spawn_session_name,
-        restore_runtime_state_snapshot_after_resume, sync_resumed_input_sender,
-        AgentOrderPlacement,
+        restore_runtime_state_snapshot_after_resume, sync_resumed_input_sender, AgentOrderPlacement,
     };
     use crate::state::{ActiveAgent, AppState};
     use crate::utils::fs::create_directory_link;
@@ -1728,6 +1795,65 @@ mod tests {
         };
         assert_eq!(preview.skills, vec![expected.clone()]);
         assert_eq!(preview.default_selected_skills, vec![expected]);
+    }
+
+    #[test]
+    fn clone_preview_excludes_runtime_generated_and_skill_paths() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source_root = home.join("agents").join("source-agent");
+        std::fs::create_dir_all(source_root.join("nested")).expect("nested");
+        std::fs::create_dir_all(source_root.join("habitat")).expect("habitat");
+        std::fs::create_dir_all(source_root.join(".agents").join("skills").join("planner"))
+            .expect("skills");
+        std::fs::create_dir_all(source_root.join(".codex")).expect("codex");
+        std::fs::write(source_root.join("AGENTS.md"), "# Agent\n").expect("agents");
+        std::fs::write(source_root.join("nested").join("keep.md"), "keep").expect("keep");
+        std::fs::write(source_root.join("habitat").join("AGENTS.md"), "generated")
+            .expect("generated");
+        std::fs::write(
+            source_root
+                .join(".agents")
+                .join("skills")
+                .join("planner")
+                .join("SKILL.md"),
+            "skill",
+        )
+        .expect("skill");
+        std::fs::write(source_root.join(".codex").join("history.jsonl"), "{}").expect("history");
+
+        let files = clone_collect_eligible_file_tree(home, "source-agent").expect("files");
+        let paths = flatten_clone_file_paths(&files);
+
+        assert!(paths.contains(&"AGENTS.md".to_string()));
+        assert!(paths.contains(&"nested/keep.md".to_string()));
+        assert!(!paths.iter().any(|path| path.starts_with("habitat/")));
+        assert!(!paths
+            .iter()
+            .any(|path| path.starts_with(".agents/skills/")));
+        assert!(!paths.iter().any(|path| path.starts_with(".codex/")));
+    }
+
+    #[test]
+    fn clone_preview_omits_directory_links() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+        let source_root = home.join("agents").join("source-agent");
+        let external = home.join("external");
+        std::fs::create_dir_all(&source_root).expect("source root");
+        std::fs::create_dir_all(&external).expect("external");
+        std::fs::write(source_root.join("AGENTS.md"), "# Agent\n").expect("agents");
+        std::fs::write(external.join("secret.md"), "secret").expect("secret");
+
+        let linked = source_root.join("linked");
+        if create_directory_link(&external, &linked).is_err() {
+            return;
+        }
+
+        let files = clone_collect_eligible_file_tree(home, "source-agent").expect("files");
+        let paths = flatten_clone_file_paths(&files);
+
+        assert!(!paths.iter().any(|path| path.starts_with("linked/")));
     }
 
     #[test]

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -370,7 +370,10 @@ pub async fn open_library_folder(
     Ok(())
 }
 
-fn get_target_skills_dir(target_type: &str, target_id: &str) -> Result<std::path::PathBuf, String> {
+pub(crate) fn get_target_skills_dir(
+    target_type: &str,
+    target_id: &str,
+) -> Result<std::path::PathBuf, String> {
     let home = get_wardian_home().ok_or("Could not find Wardian home")?;
     let base = match target_type {
         "agent" => home.join("agents").join(target_id),
@@ -463,7 +466,7 @@ where
     }
 }
 
-fn deploy_skill_from_library(
+pub(crate) fn deploy_skill_from_library(
     source_path: &str,
     target_type: &str,
     target_id: &str,
@@ -602,7 +605,7 @@ fn source_path_for_deployed_skill(
     None
 }
 
-fn list_deployed_skill_refs_for_target(
+pub(crate) fn list_deployed_skill_refs_for_target(
     target_type: &str,
     target_id: &str,
 ) -> Result<Vec<DeployedSkillRef>, String> {

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -575,6 +575,7 @@ fn source_path_for_deployed_skill(
     deployed_path: &Path,
     deployed_name: &str,
     library_sources: &[(String, String, PathBuf)],
+    infer_same_name_source: bool,
 ) -> Option<String> {
     if let Some(marker_source) = read_deployed_skill_source_marker(deployed_path) {
         if library_sources
@@ -594,6 +595,10 @@ fn source_path_for_deployed_skill(
         }
     }
 
+    if !infer_same_name_source {
+        return None;
+    }
+
     let mut same_name_sources = library_sources
         .iter()
         .filter(|(_, name, _)| name == deployed_name);
@@ -605,9 +610,10 @@ fn source_path_for_deployed_skill(
     None
 }
 
-pub(crate) fn list_deployed_skill_refs_for_target(
+fn list_deployed_skill_refs_for_target_with_options(
     target_type: &str,
     target_id: &str,
+    infer_same_name_source: bool,
 ) -> Result<Vec<DeployedSkillRef>, String> {
     let home = get_wardian_home().ok_or("Could not find Wardian home")?;
     let target_skills_dir = get_target_skills_dir(target_type, target_id)?;
@@ -632,7 +638,8 @@ pub(crate) fn list_deployed_skill_refs_for_target(
         }
 
         let name = entry.file_name().to_string_lossy().to_string();
-        let source_path = source_path_for_deployed_skill(&path, &name, &library_sources);
+        let source_path =
+            source_path_for_deployed_skill(&path, &name, &library_sources, infer_same_name_source);
 
         deployed.push(DeployedSkillRef { name, source_path });
     }
@@ -645,6 +652,20 @@ pub(crate) fn list_deployed_skill_refs_for_target(
     });
 
     Ok(deployed)
+}
+
+pub(crate) fn list_deployed_skill_refs_for_target(
+    target_type: &str,
+    target_id: &str,
+) -> Result<Vec<DeployedSkillRef>, String> {
+    list_deployed_skill_refs_for_target_with_options(target_type, target_id, true)
+}
+
+pub(crate) fn list_deployed_skill_refs_for_target_strict(
+    target_type: &str,
+    target_id: &str,
+) -> Result<Vec<DeployedSkillRef>, String> {
+    list_deployed_skill_refs_for_target_with_options(target_type, target_id, false)
 }
 
 fn deployment_matches_source(

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -251,6 +251,7 @@ fn build_clone_agent_request(
         folder: None,
         agent_class: None,
         start: Some(true),
+        profile_selection: None,
     }
 }
 
@@ -1138,6 +1139,7 @@ mod tests {
         assert_eq!(req.folder, None);
         assert_eq!(req.agent_class, None);
         assert_eq!(req.start, Some(true));
+        assert!(req.profile_selection.is_none());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,6 +250,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::agent::spawn_agent,
             commands::agent::clone_agent,
+            commands::agent::get_agent_clone_preview,
             commands::agent::list_agents,
             commands::agent::list_agent_metrics,
             commands::agent::kill_agent,

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import type { AgentTeam, Watchlist } from "../layout/watchlist/types";
 import { getListsContainingAgent, getListsNotContainingAgent } from "../layout/watchlist/watchlistUtils";
+import type { CloneMode } from "../types";
 
 type MaybePromise = void | Promise<void>;
 
@@ -20,7 +21,7 @@ export interface AgentContextMenuProps {
   onPause: (agentId: string) => MaybePromise;
   onRestart: (agentId: string) => MaybePromise;
   onClear: (agentId: string) => MaybePromise;
-  onClone?: (agentId: string, mode: "fresh" | "profile") => MaybePromise;
+  onClone?: (agentId: string, mode: CloneMode) => MaybePromise;
   onAddToList: (listId: string, agentId: string) => MaybePromise;
   onRemoveFromList: (listId: string, agentId: string) => MaybePromise;
   onAddAgentsToList?: (listId: string, agentIds: string[]) => MaybePromise;
@@ -155,6 +156,15 @@ export const AgentContextMenu: React.FC<AgentContextMenuProps> = ({
                 }}
               >
                 Profile Clone
+              </button>
+              <button
+                className="context-menu-item"
+                onClick={async () => {
+                  await onClone?.(agentId, "custom");
+                  onClose();
+                }}
+              >
+                Custom Clone
               </button>
             </div>
           )}

--- a/src/features/agents/CustomCloneModal.test.tsx
+++ b/src/features/agents/CustomCloneModal.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CustomCloneModal } from "./CustomCloneModal";
+import type { AgentClonePreview } from "../../types";
+
+const invokeMock = vi.mocked(invoke);
+
+const preview: AgentClonePreview = {
+  source_session_id: "agent-1",
+  source_session_name: "Alpha",
+  suggested_session_name: "Alpha-copy",
+  provider: "claude",
+  agent_class: "Coder",
+  folder: "D:/Development/Wardian",
+  files: {
+    name: "agent-1",
+    path: "",
+    kind: "directory",
+    children: [
+      { name: "AGENTS.md", path: "AGENTS.md", kind: "file", children: [] },
+      { name: "notes.md", path: "notes.md", kind: "file", children: [] },
+    ],
+  },
+  default_selected_files: ["AGENTS.md", "notes.md"],
+  skills: [{ name: "planner", source_path: "group-a/planner" }],
+  default_selected_skills: [{ name: "planner", source_path: "group-a/planner" }],
+};
+
+const classes = [
+  { name: "Coder", description: "", is_default: true },
+  { name: "Reviewer", description: "", is_default: true },
+];
+
+describe("CustomCloneModal", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("loads preview when opened", async () => {
+    invokeMock.mockResolvedValue(preview);
+
+    render(
+      <CustomCloneModal
+        sourceSessionId="agent-1"
+        agentClasses={classes}
+        isOpen
+        onClose={() => {}}
+        onCloned={() => {}}
+      />,
+    );
+
+    expect(await screen.findByDisplayValue("Alpha-copy")).toBeInTheDocument();
+    expect(invokeMock).toHaveBeenCalledWith("get_agent_clone_preview", {
+      sourceSessionId: "agent-1",
+    });
+  });
+
+  it("shows a blocking error when preview fails", async () => {
+    invokeMock.mockRejectedValue(new Error("preview failed"));
+
+    render(
+      <CustomCloneModal
+        sourceSessionId="agent-1"
+        agentClasses={classes}
+        isOpen
+        onClose={() => {}}
+        onCloned={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText(/preview failed/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("submits edited identity fields and selected profile items", async () => {
+    const user = userEvent.setup();
+    const onCloned = vi.fn();
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "get_agent_clone_preview") return preview;
+      if (command === "clone_agent") return { session_id: "clone-1" };
+      return null;
+    });
+
+    render(
+      <CustomCloneModal
+        sourceSessionId="agent-1"
+        agentClasses={classes}
+        isOpen
+        onClose={() => {}}
+        onCloned={onCloned}
+      />,
+    );
+
+    await screen.findByDisplayValue("Alpha-copy");
+    await user.selectOptions(screen.getByLabelText("Provider Engine"), "codex");
+    await user.selectOptions(screen.getByLabelText("Agent Class"), "Reviewer");
+    await user.clear(screen.getByLabelText("Workspace Path"));
+    await user.type(screen.getByLabelText("Workspace Path"), "D:/Development/Wardian");
+    await user.click(screen.getByRole("checkbox", { name: "notes.md" }));
+    await user.click(screen.getByRole("checkbox", { name: /planner/ }));
+    await user.click(screen.getByRole("button", { name: "Clone" }));
+
+    expect(invokeMock).toHaveBeenCalledWith("clone_agent", {
+      req: expect.objectContaining({
+        source_session_id: "agent-1",
+        mode: "profile",
+        session_name: "Alpha-copy",
+        provider: "codex",
+        agent_class: "Reviewer",
+        folder: "D:/Development/Wardian",
+        profile_selection: {
+          files: ["AGENTS.md"],
+          skills: [],
+        },
+      }),
+    });
+    expect(onCloned).toHaveBeenCalled();
+  });
+
+  it("rejects a blank clone name without submitting", async () => {
+    const user = userEvent.setup();
+    invokeMock.mockResolvedValue(preview);
+
+    render(
+      <CustomCloneModal
+        sourceSessionId="agent-1"
+        agentClasses={classes}
+        isOpen
+        onClose={() => {}}
+        onCloned={() => {}}
+      />,
+    );
+
+    const nameInput = await screen.findByLabelText("Clone Name");
+    await user.clear(nameInput);
+    await user.click(screen.getByRole("button", { name: "Clone" }));
+
+    expect(screen.getByText(/Clone name is required/)).toBeInTheDocument();
+    expect(invokeMock).not.toHaveBeenCalledWith("clone_agent", expect.anything());
+  });
+
+  it("keeps the modal open when submit fails", async () => {
+    const user = userEvent.setup();
+    invokeMock.mockImplementation(async (command) => {
+      if (command === "get_agent_clone_preview") return preview;
+      if (command === "clone_agent") throw new Error("clone failed");
+      return null;
+    });
+
+    render(
+      <CustomCloneModal
+        sourceSessionId="agent-1"
+        agentClasses={classes}
+        isOpen
+        onClose={() => {}}
+        onCloned={() => {}}
+      />,
+    );
+
+    await screen.findByDisplayValue("Alpha-copy");
+    await user.click(screen.getByRole("button", { name: "Clone" }));
+
+    expect(await screen.findByText(/clone failed/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("dialog", { name: "Custom Clone" })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/agents/CustomCloneModal.tsx
+++ b/src/features/agents/CustomCloneModal.tsx
@@ -1,0 +1,331 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  AgentClassDefinition,
+  AgentClonePreview,
+  CloneFileTreeNode,
+  DeployedSkillRef,
+} from "../../types";
+
+interface CustomCloneModalProps {
+  sourceSessionId: string;
+  agentClasses: AgentClassDefinition[];
+  isOpen: boolean;
+  onClose: () => void;
+  onCloned: () => void;
+}
+
+const providerOptions = [
+  { value: "claude", label: "Claude" },
+  { value: "codex", label: "Codex" },
+  { value: "gemini", label: "Gemini" },
+  { value: "opencode", label: "OpenCode" },
+];
+
+const skillKey = (skill: DeployedSkillRef) => `${skill.name}\u0000${skill.source_path ?? ""}`;
+
+const descendantFilePaths = (node: CloneFileTreeNode): string[] => {
+  if (node.kind === "file") return [node.path];
+  return node.children.flatMap(descendantFilePaths);
+};
+
+const errorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+export const CustomCloneModal: React.FC<CustomCloneModalProps> = ({
+  sourceSessionId,
+  agentClasses,
+  isOpen,
+  onClose,
+  onCloned,
+}) => {
+  const [preview, setPreview] = useState<AgentClonePreview | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cloneName, setCloneName] = useState("");
+  const [provider, setProvider] = useState("claude");
+  const [agentClass, setAgentClass] = useState("");
+  const [folder, setFolder] = useState("");
+  const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set());
+  const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!isOpen || !sourceSessionId) return;
+
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    setPreview(null);
+
+    invoke<AgentClonePreview>("get_agent_clone_preview", { sourceSessionId })
+      .then((nextPreview) => {
+        if (cancelled) return;
+        setPreview(nextPreview);
+        setCloneName(nextPreview.suggested_session_name);
+        setProvider(nextPreview.provider || "claude");
+        setAgentClass(nextPreview.agent_class);
+        setFolder(nextPreview.folder);
+        setSelectedFiles(new Set(nextPreview.default_selected_files));
+        setSelectedSkills(new Set(nextPreview.default_selected_skills.map(skillKey)));
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(errorMessage(err));
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, sourceSessionId]);
+
+  const selectedSkillRefs = useMemo(() => {
+    if (!preview) return [];
+    return preview.skills.filter((skill) => selectedSkills.has(skillKey(skill)));
+  }, [preview, selectedSkills]);
+
+  if (!isOpen) return null;
+
+  const toggleFile = (path: string) => {
+    setSelectedFiles((current) => {
+      const next = new Set(current);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const toggleDirectory = (node: CloneFileTreeNode) => {
+    const paths = descendantFilePaths(node);
+    setSelectedFiles((current) => {
+      const next = new Set(current);
+      const allSelected = paths.every((path) => next.has(path));
+      for (const path of paths) {
+        if (allSelected) next.delete(path);
+        else next.add(path);
+      }
+      return next;
+    });
+  };
+
+  const toggleSkill = (skill: DeployedSkillRef) => {
+    const key = skillKey(skill);
+    setSelectedSkills((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!preview || isSubmitting) return;
+    if (!cloneName.trim()) {
+      setError("Clone name is required.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await invoke("clone_agent", {
+        req: {
+          source_session_id: preview.source_session_id,
+          mode: "profile",
+          session_name: cloneName.trim(),
+          provider,
+          agent_class: agentClass,
+          folder,
+          profile_selection: {
+            files: Array.from(selectedFiles).sort(),
+            skills: selectedSkillRefs,
+          },
+        },
+      });
+      onCloned();
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const renderFileNode = (node: CloneFileTreeNode, depth = 0): React.ReactNode => {
+    if (node.kind === "directory") {
+      const descendants = descendantFilePaths(node);
+      const checked = descendants.length > 0 && descendants.every((path) => selectedFiles.has(path));
+      return (
+        <div key={node.path || "__root"}>
+          {node.path && (
+            <label
+              className="flex items-center gap-2 px-2 py-1 text-xs text-muted-neutral"
+              style={{ paddingLeft: `${8 + depth * 16}px` }}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => toggleDirectory(node)}
+                className="accent-[var(--color-wardian-accent)]"
+                aria-label={node.path}
+              />
+              <span>{node.name}</span>
+            </label>
+          )}
+          {node.children.map((child) => renderFileNode(child, node.path ? depth + 1 : depth))}
+        </div>
+      );
+    }
+
+    return (
+      <label
+        key={node.path}
+        className="flex items-center gap-2 px-2 py-1 text-xs text-primary"
+        style={{ paddingLeft: `${8 + depth * 16}px` }}
+      >
+        <input
+          type="checkbox"
+          checked={selectedFiles.has(node.path)}
+          onChange={() => toggleFile(node.path)}
+          className="accent-[var(--color-wardian-accent)]"
+          aria-label={node.path}
+        />
+        <span className="font-mono">{node.path}</span>
+      </label>
+    );
+  };
+
+  return (
+    <div className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/55 px-4">
+      <form
+        role="dialog"
+        aria-label="Custom Clone"
+        data-testid="custom-clone-modal"
+        onSubmit={submit}
+        className="flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-wardian-border bg-[var(--color-wardian-card)] shadow-2xl"
+      >
+        <div className="flex items-center justify-between border-b border-wardian-border px-4 py-3">
+          <h2 className="text-sm font-bold text-primary">Custom Clone</h2>
+          <button type="button" onClick={onClose} className="text-sm text-muted-neutral hover:text-primary">
+            Close
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          {isLoading && <div className="text-sm text-muted-neutral">Loading...</div>}
+          {error && (
+            <div className="mb-3 rounded border border-wardian-error/40 bg-wardian-error/10 px-3 py-2 text-sm text-wardian-error">
+              {error}
+            </div>
+          )}
+          {preview && (
+            <div className="grid gap-4 md:grid-cols-[1fr_1fr]">
+              <div className="space-y-3">
+                <label className="block text-[10px] font-bold text-muted-neutral">
+                  Clone Name
+                  <input
+                    aria-label="Clone Name"
+                    value={cloneName}
+                    onChange={(event) => setCloneName(event.target.value)}
+                    className="mt-1 w-full rounded border border-wardian-border bg-[var(--color-wardian-input-bg)] px-3 py-2 text-sm text-primary focus:outline-none"
+                  />
+                </label>
+                <label className="block text-[10px] font-bold text-muted-neutral">
+                  Provider Engine
+                  <select
+                    aria-label="Provider Engine"
+                    data-testid="custom-clone-provider"
+                    value={provider}
+                    onChange={(event) => setProvider(event.target.value)}
+                    className="mt-1 w-full rounded border border-wardian-border bg-[var(--color-wardian-input-bg)] px-3 py-2 text-sm text-primary focus:outline-none"
+                  >
+                    {providerOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block text-[10px] font-bold text-muted-neutral">
+                  Agent Class
+                  <select
+                    aria-label="Agent Class"
+                    value={agentClass}
+                    onChange={(event) => setAgentClass(event.target.value)}
+                    className="mt-1 w-full rounded border border-wardian-border bg-[var(--color-wardian-input-bg)] px-3 py-2 text-sm text-primary focus:outline-none"
+                  >
+                    {agentClasses.map((agentClassOption) => (
+                      <option key={agentClassOption.name} value={agentClassOption.name}>
+                        {agentClassOption.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="block text-[10px] font-bold text-muted-neutral">
+                  Workspace Path
+                  <input
+                    aria-label="Workspace Path"
+                    value={folder}
+                    onChange={(event) => setFolder(event.target.value)}
+                    className="mt-1 w-full rounded border border-wardian-border bg-[var(--color-wardian-input-bg)] px-3 py-2 font-mono text-xs text-primary focus:outline-none"
+                  />
+                </label>
+              </div>
+
+              <div className="space-y-3">
+                <div>
+                  <h3 className="mb-1 text-[10px] font-bold text-muted-neutral">Files</h3>
+                  <div className="max-h-52 overflow-auto rounded border border-wardian-border bg-[var(--color-wardian-input-bg)] py-1">
+                    {preview.files.children.length === 0 ? (
+                      <div className="px-2 py-2 text-xs text-muted-neutral">No eligible files</div>
+                    ) : (
+                      preview.files.children.map((child) => renderFileNode(child))
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <h3 className="mb-1 text-[10px] font-bold text-muted-neutral">Skills</h3>
+                  <div className="max-h-40 overflow-auto rounded border border-wardian-border bg-[var(--color-wardian-input-bg)] py-1">
+                    {preview.skills.length === 0 ? (
+                      <div className="px-2 py-2 text-xs text-muted-neutral">No agent skills</div>
+                    ) : (
+                      preview.skills.map((skill) => (
+                        <label key={skillKey(skill)} className="flex items-center gap-2 px-2 py-1 text-xs text-primary">
+                          <input
+                            type="checkbox"
+                            checked={selectedSkills.has(skillKey(skill))}
+                            onChange={() => toggleSkill(skill)}
+                            className="accent-[var(--color-wardian-accent)]"
+                            aria-label={`${skill.name} ${skill.source_path ?? ""}`.trim()}
+                          />
+                          <span>{skill.name}</span>
+                          {skill.source_path && <span className="font-mono text-muted-neutral">{skill.source_path}</span>}
+                        </label>
+                      ))
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-wardian-border px-4 py-3">
+          <button type="button" onClick={onClose} className="rounded border border-wardian-border px-3 py-2 text-xs text-muted-neutral hover:text-primary">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="custom-clone-submit"
+            disabled={!preview || isLoading || isSubmitting}
+            className="rounded bg-[var(--color-wardian-accent)] px-4 py-2 text-xs font-bold text-[var(--color-wardian-bg)] disabled:opacity-50"
+          >
+            {isSubmitting ? "Cloning..." : "Clone"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/features/agents/CustomCloneModal.tsx
+++ b/src/features/agents/CustomCloneModal.tsx
@@ -29,6 +29,8 @@ const descendantFilePaths = (node: CloneFileTreeNode): string[] => {
   return node.children.flatMap(descendantFilePaths);
 };
 
+const testIdSuffix = (value: string) => value.replace(/[^a-zA-Z0-9_-]/g, "-");
+
 const errorMessage = (error: unknown) =>
   error instanceof Error ? error.message : String(error);
 
@@ -170,6 +172,7 @@ export const CustomCloneModal: React.FC<CustomCloneModalProps> = ({
                 onChange={() => toggleDirectory(node)}
                 className="accent-[var(--color-wardian-accent)]"
                 aria-label={node.path}
+                data-testid={`custom-clone-file-${testIdSuffix(node.path)}`}
               />
               <span>{node.name}</span>
             </label>
@@ -191,6 +194,7 @@ export const CustomCloneModal: React.FC<CustomCloneModalProps> = ({
           onChange={() => toggleFile(node.path)}
           className="accent-[var(--color-wardian-accent)]"
           aria-label={node.path}
+          data-testid={`custom-clone-file-${testIdSuffix(node.path)}`}
         />
         <span className="font-mono">{node.path}</span>
       </label>
@@ -299,6 +303,7 @@ export const CustomCloneModal: React.FC<CustomCloneModalProps> = ({
                             onChange={() => toggleSkill(skill)}
                             className="accent-[var(--color-wardian-accent)]"
                             aria-label={`${skill.name} ${skill.source_path ?? ""}`.trim()}
+                            data-testid={`custom-clone-skill-${testIdSuffix(skill.source_path ?? skill.name)}`}
                           />
                           <span>{skill.name}</span>
                           {skill.source_path && <span className="font-mono text-muted-neutral">{skill.source_path}</span>}

--- a/src/layout/watchlist/AgentWatchlist.test.tsx
+++ b/src/layout/watchlist/AgentWatchlist.test.tsx
@@ -176,7 +176,7 @@ describe('AgentWatchlist', () => {
     expect(mockOnClone).toHaveBeenCalledWith('agent-1', 'fresh');
   });
 
-  it('offers fresh and profile clone modes from the clone submenu', async () => {
+  it('offers fresh, profile, and custom clone modes from the clone submenu', async () => {
     render(<AgentWatchlist {...defaultProps} />);
     const agentRow = screen.getByText('Alpha').closest('.watchlist-row');
 
@@ -184,9 +184,21 @@ describe('AgentWatchlist', () => {
     fireEvent.mouseEnter(within(screen.getByTestId('agent-context-menu')).getByRole('button', { name: 'Clone' }));
 
     expect(screen.getByRole('button', { name: 'Fresh Clone' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Custom Clone' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Profile Clone' }));
 
     expect(mockOnClone).toHaveBeenCalledWith('agent-1', 'profile');
+  });
+
+  it('runs custom clone from the clone submenu', async () => {
+    render(<AgentWatchlist {...defaultProps} />);
+    const agentRow = screen.getByText('Alpha').closest('.watchlist-row');
+
+    fireEvent.contextMenu(agentRow!);
+    fireEvent.mouseEnter(within(screen.getByTestId('agent-context-menu')).getByRole('button', { name: 'Clone' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Custom Clone' }));
+
+    expect(mockOnClone).toHaveBeenCalledWith('agent-1', 'custom');
   });
 
   it('uses a bulk context menu when right-clicking inside a multi-selection', async () => {

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import type { AgentConfig, AgentTelemetry } from "../../types";
+import type { AgentConfig, AgentTelemetry, CloneMode } from "../../types";
 import type { Watchlist, ContextMenuState, WatchlistPrefs, AgentInteractions, SortableColumnId, OptionalColumnId, AgentTeam, WatchlistDisplayItem, WatchlistEntry } from "./types";
 import { DEFAULT_WATCHLIST_PREFS } from "./types";
 
@@ -74,7 +74,7 @@ interface AgentWatchlistProps {
   onPause: (agentId: string) => void;
   onRestart: (agentId: string) => void;
   onClear: (agentId: string) => void;
-  onClone?: (agentId: string, mode: "fresh" | "profile") => void;
+  onClone?: (agentId: string, mode: CloneMode) => void;
   onAddToList: (listId: string, agentId: string) => void;
   onRemoveFromList: (listId: string, agentId: string) => void;
   onAddAgentsToList?: (listId: string, agentIds: string[]) => void;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -169,3 +169,30 @@ export interface DeployedSkillRef {
     name: string;
     source_path?: string | null;
 }
+
+export type CloneMode = "fresh" | "profile" | "custom";
+
+export interface CloneFileTreeNode {
+    name: string;
+    path: string;
+    kind: "file" | "directory";
+    children: CloneFileTreeNode[];
+}
+
+export interface CloneProfileSelection {
+    files: string[];
+    skills: DeployedSkillRef[];
+}
+
+export interface AgentClonePreview {
+    source_session_id: string;
+    source_session_name: string;
+    suggested_session_name: string;
+    provider: string;
+    agent_class: string;
+    folder: string;
+    files: CloneFileTreeNode;
+    default_selected_files: string[];
+    skills: DeployedSkillRef[];
+    default_selected_skills: DeployedSkillRef[];
+}

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -4,7 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { EventCallback } from "@tauri-apps/api/event";
 import App from "./App";
-import type { AgentConfig, AgentClassDefinition } from "../types";
+import type { AgentConfig, AgentClassDefinition, AgentClonePreview } from "../types";
 import type { AgentTelemetry } from "../types";
 import { useLayoutStore } from "../store/useLayoutStore";
 import { useQueueStore } from "../store/useQueueStore";
@@ -123,6 +123,21 @@ function setupDefaultMocks(agents: AgentConfig[] = [], classes: AgentClassDefini
           }
         }
         return currentAgents[currentAgents.length - 1] ?? null;
+      case "get_agent_clone_preview": {
+        const source = currentAgents.find(a => a.session_id === args?.sourceSessionId);
+        return {
+          source_session_id: args?.sourceSessionId,
+          source_session_name: source?.session_name ?? "Agent",
+          suggested_session_name: `${source?.session_name ?? "Agent"}-copy`,
+          provider: source?.provider ?? "claude",
+          agent_class: source?.agent_class ?? "Coder",
+          folder: source?.folder ?? "C:/project",
+          files: { name: source?.session_id ?? "agent", path: "", kind: "directory", children: [] },
+          default_selected_files: [],
+          skills: [],
+          default_selected_skills: [],
+        } satisfies AgentClonePreview;
+      }
       case "get_agent_metrics":
         return [];
       case "attach_agent_pty":
@@ -760,6 +775,29 @@ describe("Agent Watchlist Sidebar", () => {
           mode: "fresh",
         },
       });
+    });
+  });
+
+  it("opens custom clone modal from the clone submenu", async () => {
+    setupDefaultMocks(sampleAgents, defaultClasses);
+    render(<App />);
+
+    const alphaWatchlistRow = await waitFor(() => {
+      const row = screen
+        .getAllByText("Alpha")
+        .map((node) => node.closest("div.watchlist-row"))
+        .find((candidate): candidate is HTMLElement => Boolean(candidate));
+      if (!row) throw new Error("Alpha watchlist row not found");
+      return row;
+    });
+
+    fireEvent.contextMenu(alphaWatchlistRow);
+    fireEvent.mouseEnter(within(screen.getByTestId("agent-context-menu")).getByRole("button", { name: "Clone" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Custom Clone" }));
+
+    expect(await screen.findByRole("dialog", { name: "Custom Clone" })).toBeInTheDocument();
+    expect(mockInvoke).toHaveBeenCalledWith("get_agent_clone_preview", {
+      sourceSessionId: "agent-1",
     });
   });
 

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useLayoutEffect, useRef, useCallback } from
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { AgentConfig, AgentJsonEvent, AgentTelemetry, AgentClassDefinition, AgentStatusUpdate, AppTelemetry } from "../types";
+import type { CloneMode } from "../types";
 import "../styles/App.css";
 
 import AgentWatchlist from "../layout/watchlist/AgentWatchlist";
@@ -41,6 +42,7 @@ import { useSettingsStore } from "../store/useSettingsStore";
 import { useLayoutStore } from "../store/useLayoutStore";
 import { submitInputToAgent, submitInputToAgents } from "../utils/terminalInput";
 import { RunPayloadModal } from "../features/workflows/RunPayloadModal";
+import { CustomCloneModal } from "../features/agents/CustomCloneModal";
 import {
   buildScheduledRunFromWorkflow,
   normalizeWorkflowForLaunch,
@@ -395,6 +397,7 @@ function AppBody() {
 
   const [draggedAgentId, setDraggedAgentId] = useState<string | null>(null);
   const [dragOverAgentId, setDragOverAgentId] = useState<string | null>(null);
+  const [customCloneSourceId, setCustomCloneSourceId] = useState<string | null>(null);
   const wasDraggingRef = useRef(false);
 
   const [agentClasses, setAgentClasses] = useState<AgentClassDefinition[]>([]);
@@ -808,7 +811,12 @@ function AppBody() {
     }
   };
 
-  const onClone = async (id: string, mode: "fresh" | "profile") => {
+  const onClone = async (id: string, mode: CloneMode) => {
+    if (mode === "custom") {
+      setCustomCloneSourceId(id);
+      return;
+    }
+
     try {
       await invoke("clone_agent", {
         req: {
@@ -1030,6 +1038,16 @@ function AppBody() {
               onCancel={() => setSidebarPendingWorkflowLaunch(null)}
             />
           )}
+          <CustomCloneModal
+            sourceSessionId={customCloneSourceId ?? ""}
+            agentClasses={agentClasses}
+            isOpen={Boolean(customCloneSourceId)}
+            onClose={() => setCustomCloneSourceId(null)}
+            onCloned={() => {
+              setCustomCloneSourceId(null);
+              fetchAgents();
+            }}
+          />
           {userTerminalOpen && (
             <UserTerminalPanel
               theme={theme}

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { AgentConfig, AgentTelemetry } from "../types";
+import type { AgentConfig, AgentTelemetry, CloneMode } from "../types";
 import { AgentTerminal } from "../features/terminal/AgentTerminal";
 import type { Watchlist } from "../layout/watchlist/types";
 import { AgentContextMenu } from "../components/AgentContextMenu";
@@ -39,7 +39,7 @@ interface GridViewProps {
   onPause: (agentId: string) => void;
   onRestart: (agentId: string) => void;
   onClear: (agentId: string) => void;
-  onClone?: (agentId: string, mode: "fresh" | "profile") => void;
+  onClone?: (agentId: string, mode: CloneMode) => void;
   onTerminalFocus?: (agentId: string) => void;
 }
 


### PR DESCRIPTION
## Description
Adds a custom agent clone flow for cherry-picking what survives into a clone.

- Adds Fresh/Profile/Custom clone choices while keeping direct **Clone** as an immediate Fresh clone.
- Adds a Custom Clone modal for clone name, provider engine, agent class, workspace path, eligible agent-profile files, and agent-specific skills.
- Adds backend clone preview/validation/copy support that excludes generated/runtime files, validates selected paths and skill identities, and refreshes profile include directories after provider-returned session ids.
- Documents clone behavior in the UI guide.

## Related Issues
Fixes #219

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `cd src-tauri && cargo clippy`
- [x] `cd src-tauri && cargo test` (365 passed, plus 5 mock-provider tests)
- [x] `cd src-tauri && cargo check`
- [x] `npm run lint`
- [x] `npm run test` (61 files / 523 tests passed; existing React `act(...)` warnings still print)
- [x] `npm run build` (passes; existing Vite large-chunk warning still prints)
- [x] `npm run test:e2e -- e2e/tests/agent-lifecycle.spec.ts` (7 passed / 4 native-only skipped)
- [x] `git diff --check origin/main...HEAD`
- [x] Reviewer agent pass: no Critical, Important, or Minor findings after final include-directory fix.

## Screenshots
Local feature screenshot evidence captured at:

`e2e/screenshots/custom-clone/2026-05-10T21-37-49-081Z/custom-clone-modal.png`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable