### PR TITLE
fix(queue): prevent overflow cards from shrinking

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,8 @@ Fixes # (issue)
 Please describe the tests that you ran to verify your changes.
 
 ## Screenshots
-<!-- For UI/layout changes: embed feature-specific screenshots that demonstrate the changed interaction/state. Do not include generic empty-state screenshots. -->
+<!-- For frontend feature/fix/layout changes: embed a feature-specific screenshot directly in this PR using markdown image syntax or an <img> tag. Do not provide only a local path. -->
+<!-- The PR CI check requires an embedded HTTPS image in this PR body when frontend files change. -->
 <!-- For non-UI changes: delete this section. -->
 
 ## Checklist:
@@ -25,4 +26,4 @@ Please describe the tests that you ran to verify your changes.
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
-- [ ] (UI changes) Feature-specific screenshot evidence embedded above, or not applicable
+- [ ] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -36,6 +38,11 @@ jobs:
           cache: "npm"
       - name: Install dependencies
         run: npm ci
+      - name: Require frontend screenshot evidence
+        if: github.event_name == 'pull_request'
+        run: npm run check:frontend-screenshot -- origin/${{ github.base_ref }} HEAD
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
       - name: Lint (TypeScript)
         run: npm run lint
       - name: Unit Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Before requesting a commit or finalizing a task, ensure the following steps are 
    - [ ] Document strategic decisions in a new **Spec** in `docs/specs/`.
    - [ ] Update related guides in `docs/guide/` or `docs/developer/`.
    - [ ] Ensure public APIs/complex logic have appropriate JSDoc or Rust docstrings.
-   - [ ] **UI changes**: If visual behavior changed, capture feature-specific local screenshots that demonstrate the changed interaction/state and embed the useful ones in the PR description.
+   - [ ] **Frontend/UI changes**: If frontend behavior or visual behavior changed, capture feature-specific screenshots that demonstrate the changed interaction/state and embed at least one representative image directly in the PR description using markdown image syntax or an `<img>` tag. A local path alone does not satisfy the requirement.
 3. **Safety & Integrity**:
    - [ ] **Secrets Check**: Verify no API keys, credentials, or `.env` files are being committed.
    - [ ] **Git Status**: Run `git status` to ensure only intended files are staged.
@@ -112,7 +112,13 @@ If a browser E2E test **requires** a higher layer to be meaningful, wrap it in `
 
 ### Screenshot Documentation
 
-Screenshots are local, feature-specific evidence rather than a generic CI artifact. For UI changes, use Playwright or the running app to capture only the interaction/state changed by the PR, write images under `e2e/screenshots/<feature>/<timestamp>/`, and embed the representative images in the PR description. Do not add empty-window or app-tour screenshots that do not explain the change.
+Screenshots are feature-specific PR evidence rather than generic CI artifacts. For frontend changes, use Playwright or the running app to capture only the interaction/state changed by the PR, write images under `e2e/screenshots/<feature>/<timestamp>/`, upload or attach at least one representative image, and embed it in the PR description. Do not add empty-window or app-tour screenshots that do not explain the change.
+
+The PR workflow runs `npm run check:frontend-screenshot` and fails frontend PRs without an embedded HTTPS image in the PR body. A local-only path such as `e2e/screenshots/<feature>/<timestamp>/<name>.png` is not enough. Use the GitHub web attachment flow or another approved GitHub-hosted image URL, then embed it with markdown:
+
+```markdown
+![feature-state](https://github.com/<owner>/<repo>/.../<screenshot>.png)
+```
 
 ### Mock Provider
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "tauri": "tauri",
     "stage-cli": "node scripts/stage-cli.mjs",
     "lint": "tsc --noEmit",
+    "check:frontend-screenshot": "node scripts/verify-frontend-screenshot.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:coverage:rust": "cd src-tauri && cargo llvm-cov --lcov --output-path ../coverage/rust-lcov.info",

--- a/scripts/verify-frontend-screenshot.mjs
+++ b/scripts/verify-frontend-screenshot.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+
+const MARKDOWN_IMAGE_PATTERN = /!\[[^\]]*]\(https:\/\/[^)\s]+\.(?:png|jpe?g|webp|gif)(?:[?#][^)\s]*)?\)/i;
+const HTML_IMAGE_PATTERN = /<img\b[^>]*\bsrc=["']https:\/\/[^"']+\.(?:png|jpe?g|webp|gif)(?:[?#][^"']*)?["'][^>]*>/i;
+
+const FRONTEND_PATTERNS = [
+  /^src\/.+\.(css|ts|tsx)$/,
+  /^public\//,
+  /^index\.html$/,
+  /^vite\.config\.ts$/,
+  /^vitest\.config\.ts$/,
+  /^package(-lock)?\.json$/,
+];
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function changedFiles(base, head) {
+  const output = git(["diff", "--name-status", "--diff-filter=ACMRT", `${base}...${head}`]);
+  if (!output) return [];
+
+  return output.split(/\r?\n/).flatMap((line) => {
+    const fields = line.split(/\t+/).filter(Boolean);
+    if (fields.length < 2) return [];
+    return fields[0].startsWith("R") || fields[0].startsWith("C")
+      ? [fields[fields.length - 1]]
+      : [fields[1]];
+  });
+}
+
+function isFrontendFile(file) {
+  return FRONTEND_PATTERNS.some((pattern) => pattern.test(file));
+}
+
+function prBody() {
+  return process.env.PR_BODY ?? "";
+}
+
+function hasEmbeddedScreenshot(body) {
+  return MARKDOWN_IMAGE_PATTERN.test(body) || HTML_IMAGE_PATTERN.test(body);
+}
+
+const base = process.argv[2] ?? process.env.SCREENSHOT_BASE ?? "origin/main";
+const head = process.argv[3] ?? process.env.SCREENSHOT_HEAD ?? "HEAD";
+const files = changedFiles(base, head);
+const frontendFiles = files.filter(isFrontendFile);
+
+if (frontendFiles.length === 0) {
+  console.log("No frontend changes detected; screenshot evidence is not required.");
+  process.exit(0);
+}
+
+if (hasEmbeddedScreenshot(prBody())) {
+  console.log("Frontend screenshot evidence found in the PR body.");
+  process.exit(0);
+}
+
+console.error("Frontend changes require embedded screenshot evidence in the PR body.");
+console.error("Changed frontend files:");
+for (const file of frontendFiles) {
+  console.error(`- ${file}`);
+}
+console.error("");
+console.error("Attach or upload a feature-specific screenshot, then embed it with markdown such as:");
+console.error("  ![queue-overflow.png](https://github.com/<owner>/<repo>/.../queue-overflow.png)");
+process.exit(1);

--- a/src/views/QueueView.test.tsx
+++ b/src/views/QueueView.test.tsx
@@ -198,4 +198,23 @@ describe("QueueView", () => {
     expect(screen.queryByText("Read Agent")).not.toBeInTheDocument();
     expect(screen.getByText("Unread Workflow")).toBeInTheDocument();
   });
+
+  it("keeps queue cards from shrinking when the list overflows", () => {
+    useQueueStore.setState({
+      items: Array.from({ length: 24 }, (_, index) => ({
+        id: `item-${index}`,
+        type: "agent_completed",
+        timestamp: Date.now() - index,
+        read: false,
+        agent_name: `Agent ${index}`,
+        summary: `Completed task ${index}.`,
+      })),
+    });
+
+    render(<QueueView />);
+
+    const firstCard = screen.getByText("Agent 0").closest(".group");
+    expect(firstCard).toHaveClass("shrink-0");
+    expect(firstCard?.parentElement).toHaveClass("flex-1", "min-h-0", "overflow-y-auto");
+  });
 });

--- a/src/views/QueueView.tsx
+++ b/src/views/QueueView.tsx
@@ -74,7 +74,7 @@ function QueueCard({ item }: { item: QueueItem }) {
 
   return (
     <div
-      className={`group relative overflow-hidden rounded-lg border transition-colors cursor-pointer ${
+      className={`group relative shrink-0 overflow-hidden rounded-lg border transition-colors cursor-pointer ${
         item.read
           ? "border-wardian-border bg-wardian-card-bg-muted"
           : "border-[var(--color-wardian-accent)]/30 bg-wardian-card-bg"
@@ -181,7 +181,7 @@ export function QueueView() {
           <p className="text-sm text-muted-neutral">No completions yet.</p>
         </div>
       ) : (
-        <div className="flex flex-col gap-3 overflow-y-auto">
+        <div className="flex flex-1 min-h-0 flex-col gap-3 overflow-y-auto pr-1">
           {items.map((item) => (
             <QueueCard key={item.id} item={item} />
           ))}


### PR DESCRIPTION
## Description
Fixes Queue view overflow rendering so populated queues keep readable card heights instead of compressing entries into thin horizontal lines.

Changes:
- Make each queue card a non-shrinking flex item.
- Make the queue item list the explicit scroll region with `flex-1 min-h-0 overflow-y-auto`.
- Add a regression test for the overflow layout contract.
- Add a CI guard requiring embedded screenshot evidence for frontend PRs.

## Related Issues
Fixes #226

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run test -- src/views/QueueView.test.tsx` — 10/10 passed
- [x] `npm run test` — 547/547 passed; existing React `act(...)` warnings appeared in unrelated watchlist/app tests
- [x] `npm run lint` — passed
- [x] `npm run build` — passed; existing Vite large chunk warning
- [x] Browser screenshot smoke with seeded queue entries — first card height 94px, list clientHeight 640px, scrollHeight 3684px
- [x] Wardian-Reviewer review — no blocking issues found
- [x] `node scripts/verify-frontend-screenshot.mjs origin/main HEAD` fails without PR screenshot evidence
- [x] `npm run check:frontend-screenshot -- origin/main HEAD` passes with this PR body screenshot embedded

## Screenshots
![Queue overflow rendering with stable card heights](https://github.com/tangemicioglu/Wardian/releases/download/_gh-attach-assets/queue-overflow.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, or no new hard-to-understand code was added
- [x] I have made corresponding changes to the documentation, or documentation is not applicable for this scoped layout bugfix
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable