### PR TITLE
fix(workflows): detect live agent turn completion

### DIFF
--- a/e2e-native/tests/workflow-completion-native.test.mjs
+++ b/e2e-native/tests/workflow-completion-native.test.mjs
@@ -1,0 +1,252 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  createNativeHarness,
+  ensureNativeAppBuilt,
+  prepareIsolatedHome,
+  startNativeSession,
+  waitForAppShell,
+} from "../lib/harness.mjs";
+
+const skipNativeBuild = process.env.WARDIAN_NATIVE_SKIP_BUILD === "1";
+
+function writeSingleTurnMockScript(harness, { sessionId, markerPath }) {
+  const mockScript = path.join(harness.isolatedHome, "single-turn-live-mock.cjs");
+  fs.writeFileSync(
+    mockScript,
+    `
+const fs = require("node:fs");
+const sessionId = process.env.WARDIAN_MOCK_SESSION_ID || "mock-session";
+const markerPath = process.env.WARDIAN_MOCK_MARKER;
+const emit = (obj) => process.stdout.write(JSON.stringify(obj) + "\\n");
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+emit({ type: "init", session_id: sessionId, timestamp: new Date().toISOString() });
+emit({ type: "action_required", message: "waiting for workflow prompt" });
+
+let buffer = "";
+let completed = false;
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", async (chunk) => {
+  if (completed) return;
+  buffer += chunk;
+  if (buffer.includes("\\r") || buffer.includes("\\n")) {
+    completed = true;
+    emit({ type: "model", content: "partial model response, not a turn completion" });
+    await sleep(1200);
+    emit({ type: "result", status: "success" });
+    if (markerPath) {
+      fs.writeFileSync(markerPath, JSON.stringify({
+        completed: true,
+        input: buffer,
+        at: new Date().toISOString(),
+      }));
+    }
+    setInterval(() => {}, 1000);
+  }
+});
+process.stdin.resume();
+`,
+    "utf8",
+  );
+  return mockScript;
+}
+
+function seedWorkflow(harness, { workflowId, sessionId }) {
+  const workflowsDir = path.join(harness.isolatedHome, "workflows");
+  fs.mkdirSync(workflowsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(workflowsDir, `${workflowId}.json`),
+    JSON.stringify(
+      {
+        id: workflowId,
+        name: "Agent Completion Repro",
+        settings: { max_iterations: 10, on_limit_reached: "stop" },
+        nodes: [
+          {
+            id: "agent-node-1",
+            type: "agent",
+            name: "Live mock agent node",
+            config: {
+              agent_id: sessionId,
+              mode: "inherit_resume",
+              prompt: "Complete this workflow node.",
+              output_format: "text",
+              timeout_ms: 1500,
+            },
+            dependencies: null,
+          },
+        ],
+        role_mappings: {},
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}
+
+async function spawnMockAgent(driver, { sessionId, sessionName, folder }) {
+  const result = await driver.executeAsyncScript((sessionId, sessionName, folder, done) => {
+    window.__TAURI_INTERNALS__.invoke("spawn_agent", {
+      req: {
+        sessionName,
+        agentClass: "TestClass",
+        folder,
+        resumeSession: sessionId,
+        isOff: false,
+        configOverride: { provider: "mock" },
+      },
+    }).then(
+      (agent) => done({ ok: true, agent }),
+      (error) => done({ ok: false, error: String(error) }),
+    );
+  }, sessionId, sessionName, folder);
+
+  assert.equal(result.ok, true, `spawn_agent failed: ${result.error}`);
+  return result.agent;
+}
+
+async function invokeWorkflowRun(driver, workflowId) {
+  const result = await driver.executeAsyncScript((workflowId, done) => {
+    window.__TAURI_INTERNALS__.invoke("run_workflow", { id: workflowId, payload: null }).then(
+      () => done({ ok: true }),
+      (error) => done({ ok: false, error: String(error) }),
+    );
+  }, workflowId);
+
+  assert.equal(result.ok, true, `run_workflow failed: ${result.error}`);
+}
+
+async function readLatestWorkflowTrace(harness, workflowId, timeoutMs = 10000) {
+  const logDir = path.join(harness.isolatedHome, "logs", "workflows", workflowId);
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (fs.existsSync(logDir)) {
+      const jsonFiles = fs
+        .readdirSync(logDir)
+        .filter((name) => name.endsWith(".json"))
+        .map((name) => path.join(logDir, name))
+        .sort();
+
+      const newest = jsonFiles.at(-1);
+      if (newest) {
+        try {
+          const events = JSON.parse(fs.readFileSync(newest, "utf8"));
+          if (Array.isArray(events) && events.length > 0) {
+            return { file: newest, events };
+          }
+        } catch {
+          // The workflow may still be writing the trace file.
+        }
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  assert.fail(`Timed out waiting for workflow trace in ${logDir}`);
+}
+
+async function readAgentMetric(driver, sessionId) {
+  const result = await driver.executeAsyncScript((done) => {
+    window.__TAURI_INTERNALS__.invoke("list_agent_metrics").then(
+      (metrics) => done({ ok: true, metrics }),
+      (error) => done({ ok: false, error: String(error) }),
+    );
+  });
+
+  assert.equal(result.ok, true, `list_agent_metrics failed: ${result.error}`);
+  return result.metrics.find((entry) => entry.session_id === sessionId);
+}
+
+test("workflow detects live agent turn completion instead of timing out", { timeout: 180000 }, async (t) => {
+  const harness = await createNativeHarness();
+  assert.ok(harness.appPath);
+
+  try {
+    if (!skipNativeBuild) {
+      ensureNativeAppBuilt(harness);
+    }
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  prepareIsolatedHome(harness);
+
+  const runId = `${process.pid}-${Date.now()}`;
+  const workflowId = `wf-agent-completion-${runId}`;
+  const sessionId = `workflow-completion-agent-${runId}`;
+  const sessionName = `Workflow-Completion-Agent-${runId}`;
+  const markerPath = path.join(harness.isolatedHome, "agent-turn-completed-marker.json");
+
+  const previousMockScript = process.env.WARDIAN_MOCK_SCRIPT;
+  const previousMockSessionId = process.env.WARDIAN_MOCK_SESSION_ID;
+  const previousMockMarker = process.env.WARDIAN_MOCK_MARKER;
+  let session;
+
+  t.after(async () => {
+    if (session) {
+      await session.close();
+    }
+    if (previousMockScript === undefined) {
+      delete process.env.WARDIAN_MOCK_SCRIPT;
+    } else {
+      process.env.WARDIAN_MOCK_SCRIPT = previousMockScript;
+    }
+    if (previousMockSessionId === undefined) {
+      delete process.env.WARDIAN_MOCK_SESSION_ID;
+    } else {
+      process.env.WARDIAN_MOCK_SESSION_ID = previousMockSessionId;
+    }
+    if (previousMockMarker === undefined) {
+      delete process.env.WARDIAN_MOCK_MARKER;
+    } else {
+      process.env.WARDIAN_MOCK_MARKER = previousMockMarker;
+    }
+  });
+
+  process.env.WARDIAN_MOCK_SCRIPT = writeSingleTurnMockScript(harness, {
+    sessionId,
+    markerPath,
+  });
+  process.env.WARDIAN_MOCK_SESSION_ID = sessionId;
+  process.env.WARDIAN_MOCK_MARKER = markerPath;
+
+  seedWorkflow(harness, { workflowId, sessionId });
+
+  try {
+    session = await startNativeSession(harness);
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  await waitForAppShell(session.driver, 20000);
+  await spawnMockAgent(session.driver, {
+    sessionId,
+    sessionName,
+    folder: path.join(harness.repoRoot, "e2e-native"),
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 750));
+  await invokeWorkflowRun(session.driver, workflowId);
+
+  const trace = await readLatestWorkflowTrace(harness, workflowId);
+  const marker = fs.existsSync(markerPath)
+    ? JSON.parse(fs.readFileSync(markerPath, "utf8"))
+    : null;
+  const metric = await readAgentMetric(session.driver, sessionId);
+
+  assert.equal(marker?.completed, true, "mock provider did not complete its turn");
+  assert.equal(metric?.current_status, "Idle");
+  assert.match(trace.events[0]?.output?.text ?? "", /"result","status":"success"|type":"result"/);
+  assert.deepEqual(
+    trace.events.map((event) => ({ node_id: event.node_id, status: event.status, error: event.error })),
+    [{ node_id: "agent-node-1", status: "completed", error: null }],
+  );
+});

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -203,6 +203,15 @@ pub(crate) fn emit_agent_status(app: &AppHandle, session_id: &str, current_statu
     );
 }
 
+pub(crate) fn emit_agent_turn_completed(app: &AppHandle, session_id: &str) {
+    let _ = app.emit(
+        "agent-turn-completed",
+        serde_json::json!({
+            "session_id": session_id,
+        }),
+    );
+}
+
 pub(crate) fn mark_agent_prompt_started(agent: &crate::state::ActiveAgent) -> bool {
     let current_status = agent
         .current_status
@@ -323,6 +332,7 @@ pub(crate) fn apply_agent_event(
         }
         AgentEvent::TurnCompleted => {
             set_agent_status(app, session_id, current_status, "Idle");
+            emit_agent_turn_completed(app, session_id);
         }
         AgentEvent::ActionRequired { .. } => {
             set_agent_status(app, session_id, current_status, "Action Needed");
@@ -346,6 +356,7 @@ pub(crate) fn apply_agent_status_event(
         }
         AgentEvent::TurnCompleted => {
             set_agent_status(app, session_id, current_status, "Idle");
+            emit_agent_turn_completed(app, session_id);
         }
         AgentEvent::ActionRequired { .. } => {
             set_agent_status(app, session_id, current_status, "Action Needed");

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -466,7 +466,15 @@ pub async fn spawn_agent(
                                         "Action Needed",
                                     );
                                 }
-                                AgentEvent::TurnCompleted | AgentEvent::ModelResponse => {
+                                AgentEvent::ModelResponse => {
+                                    set_agent_status(
+                                        &pty_app,
+                                        &sid_for_pty,
+                                        &current_status_clone,
+                                        "Idle",
+                                    );
+                                }
+                                AgentEvent::TurnCompleted => {
                                     set_agent_status(
                                         &pty_app,
                                         &sid_for_pty,

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -227,7 +227,7 @@ impl AgentProvider for CodexProvider {
                 })
             }
             "turn.started" => Some(AgentEvent::UserQuery),
-            "turn.completed" => Some(AgentEvent::ModelResponse),
+            "turn.completed" => Some(AgentEvent::TurnCompleted),
             "item.completed" => {
                 let item_type = parsed
                     .get("item")
@@ -279,7 +279,7 @@ impl AgentProvider for CodexProvider {
                     }
                     "user_message" => Some(AgentEvent::UserQuery),
                     "agent_message" => Some(AgentEvent::Unknown),
-                    "task_complete" => Some(AgentEvent::ModelResponse),
+                    "task_complete" => Some(AgentEvent::TurnCompleted),
                     "exec_approval_request" => {
                         let message = parsed
                             .get("payload")
@@ -437,7 +437,7 @@ mod tests {
     fn parse_output_turn_completed_event() {
         let p = make_provider();
         let line = r#"{"type":"turn.completed","usage":{"input_tokens":1}}"#;
-        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::ModelResponse);
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::TurnCompleted);
     }
 
     #[test]
@@ -458,7 +458,7 @@ mod tests {
     fn parse_output_task_complete_event() {
         let p = make_provider();
         let line = r#"{"type":"event_msg","payload":{"type":"task_complete","turn_id":"abc"}}"#;
-        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::ModelResponse);
+        assert_eq!(p.parse_output(line).unwrap(), AgentEvent::TurnCompleted);
     }
 
     #[test]

--- a/src-tauri/src/workflow_engine/mod.rs
+++ b/src-tauri/src/workflow_engine/mod.rs
@@ -2306,21 +2306,12 @@ pub async fn run_workflow(
                                                 }
                                             }
                                         } else {
-                                            if let Err(err) =
-                                        crate::utils::terminal_input::submit_prompt_via_sender(
-                                            &tx, &prompt, &provider_name
-                                        )
-                                        .await
-                                    {
-                                        node_error = Some(err);
-                                    }
+                                            let (completion_tx, mut completion_rx) =
+                                                tokio::sync::mpsc::channel::<Value>(1);
+                                            let agent_id_clone = agent_id.to_string();
 
-                                            if node_error.is_none() {
-                                                let (completion_tx, mut completion_rx) =
-                                                    tokio::sync::mpsc::channel::<Value>(1);
-                                                let agent_id_clone = agent_id.to_string();
-
-                                                let handler_id = app.listen_any(
+                                            let handler_id =
+                                                app.listen_any(
                                                     "agent-turn-completed",
                                                     move |event| {
                                                         if let Ok(parsed) =
@@ -2340,6 +2331,18 @@ pub async fn run_workflow(
                                                     },
                                                 );
 
+                                            if let Err(err) =
+                                                crate::utils::terminal_input::submit_prompt_via_sender(
+                                                    &tx,
+                                                    &prompt,
+                                                    &provider_name,
+                                                )
+                                                .await
+                                            {
+                                                node_error = Some(err);
+                                            }
+
+                                            if node_error.is_none() {
                                                 let completion = match timeout_ms {
                                                     Some(ms) => match tokio::time::timeout(
                                                         std::time::Duration::from_millis(ms),
@@ -2368,8 +2371,8 @@ pub async fn run_workflow(
                                                     }
                                                     Err(err) => node_error = Some(err),
                                                 }
-                                                app.unlisten(handler_id);
                                             }
+                                            app.unlisten(handler_id);
                                         }
                                     } else {
                                         // Agent is OFFLINE: Fallback to Headless Execution


### PR DESCRIPTION
## Description
Fixes workflow live-agent node completion detection by emitting `agent-turn-completed` on definitive provider `TurnCompleted` events, registering the workflow listener before prompt submission, and mapping Codex completion events to `TurnCompleted`.

Adds native regression coverage with a delayed mock `model`/`result` sequence so partial model responses do not complete workflow nodes and completed live turns no longer time out.

## Related Issues
Fixes #229

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] `cargo fmt`
- [x] `cd src-tauri; cargo check`
- [x] `cd src-tauri; cargo clippy`
- [x] `cd src-tauri; cargo test`
- [x] `npm run lint`
- [x] `npm run test` (passes; existing React `act(...)` warnings remain)
- [x] `npm run build`
- [x] `npm run tauri -- build --debug --no-bundle`
- [x] `npm run test:e2e:native:fast -- e2e-native/tests/workflow-completion-native.test.mjs`
- [x] `git diff --check`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A: internal bug fix with native regression coverage)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes