### PR TITLE
chore(tauri): rename desktop bundle identifier

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Wardian",
   "version": "0.3.4",
-  "identifier": "org.wardian.app",
+  "identifier": "org.wardian.desktop",
   "build": {
     "beforeDevCommand": "npm run vite",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Description
Renames the Tauri desktop bundle identifier from `org.wardian.app` to `org.wardian.desktop`.

This keeps the project-owned `org.wardian` namespace while avoiding Tauri's macOS warning about bundle identifiers ending in `.app`.

## Related Issues
Fixes #234

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test` - 61 files / 549 tests passed; existing React `act(...)` warnings still print in watchlist/app tests
- [x] `npm run build` - passes; existing Vite chunk-size warning still prints
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test` - 409 unit tests and 5 mock provider tests passed
- [x] `cd src-tauri && cargo clippy`
- [x] `npm run tauri -- build` - package build completed and the prior `.app` identifier warning is absent
- [x] `rg 'org\.wardian\.app'` - no remaining references

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable