### PR TITLE
fix(agent-status): gate live status transitions

### DIFF
--- a/docs/developer/state-management.md
+++ b/docs/developer/state-management.md
@@ -21,7 +21,7 @@ Located in `src-tauri/src/state/active_agent.rs`, this struct represents a singl
 
 ### Logical Components:
 - **`output_buffer`**: A thread-safe string buffer that collects PTY output until the UI drains it.
-- **`current_status`**: Real-time status indicator (e.g., "Idle", "Processing", "Action Needed").
+- **`current_status`**: Real-time status indicator (e.g., "Off", "Idle", "Processing...", "Action Needed"). Live status changes should go through the backend status setter so duplicate observations do not emit duplicate UI events, watch events, or `last_status_at` updates.
 - **`query_count`**: Tracks how many prompts have been sent to the agent in the current session.
 
 ## 📡 Data Flow
@@ -30,3 +30,4 @@ Located in `src-tauri/src/state/active_agent.rs`, this struct represents a singl
 3. **Drain**: The UI responds by calling `read_agent_pty` until the command returns `null`, which drains the buffer in-order without a timer-based polling loop.
 4. **Live Terminal Host**: The frontend keeps a long-lived xterm instance per session and only detaches or reattaches its DOM host when panes remount, preserving parser and buffer state in memory.
 5. **Events**: JSON logs emitted by agents (e.g., via the Gemini CLI's `--output-format stream-json`) are intercepted in the PTY reader thread and emitted as `agent-json-event` for the UI to process.
+6. **Startup Replay Boundary**: During app startup, provider log parsing may recover metadata such as query count, log path, resume session, and timestamps, but initial log replay must not create fresh status transitions. Queue completions and CLI `watch --until status:*` evidence come from live transitions after hydration.

--- a/docs/specs/036-agent-status-transition-gate.md
+++ b/docs/specs/036-agent-status-transition-gate.md
@@ -1,0 +1,26 @@
+# Spec 036: Agent Status Transition Gate
+
+- **Status:** Implemented
+- **Date:** 2026-05-12
+- **Decider:** User
+
+## Context
+
+Agent status drives the roster, telemetry, Queue completions, and CLI watch/wait/ask behavior. Before this change, startup log replay and restored-agent hydration could look like fresh live work because old provider logs were parsed from the beginning. Some command paths also changed `current_status` directly and then emitted a status event separately, bypassing the backend duplicate suppression path.
+
+GitHub issue #59 reported that agents still loading had unpredictable status. The required behavior is deterministic: startup and restored metadata enrichment must not replay old lifecycle transitions, and user-visible status events should be emitted once per real transition.
+
+## Decision
+
+Wardian treats provider log replay during startup as metadata enrichment only. The first telemetry parse of a discovered provider log may update metadata such as query count, start timestamp, and log path, but it does not record a status transition, update `last_status_at`, append a watch status event, or create Queue completion evidence.
+
+Restored Codex and Claude log watchers begin at the current end of the provider log. They only consume new appended provider events after the restored runtime is active. Fresh live events still flow through the existing provider parser paths.
+
+Frontend Queue flushing seeds status from the first metrics snapshot. It only treats later metrics changes as completion evidence, while direct live `agent-status-updated` events and buffered provider output still create completions for real turns.
+
+## Consequences
+
+- Restored agents no longer replay old `Processing... -> Idle` history as fresh completion evidence.
+- Duplicate command-path status observations are routed through the backend status setter where practical.
+- CLI `watch`, `wait --next`, `send --wait-until`, and `ask` continue to rely on live watch events created after their cursor, not stale startup state.
+- Initial Queue state is deterministic and does not flush stale restored buffers from metrics alone.

--- a/e2e-native/tests/cli-shared-state-native.test.mjs
+++ b/e2e-native/tests/cli-shared-state-native.test.mjs
@@ -367,6 +367,10 @@ test("native CLI control commands operate through the running app", { timeout: 1
     ]);
     const watched = JSON.parse(watchResult.stdout);
     assert.match(watched.output.text, /Action approved/);
+    const idleStatusEvents = watched.events.filter(
+      (event) => event.kind === "status" && event.payload?.status === "idle",
+    );
+    assert.equal(idleStatusEvents.length, 1, JSON.stringify(watched.events));
 
     await watchStep(harness, `Cloning ${CONTROL_SESSION_NAME} through the CLI`);
     const cloneResult = runCliOk(cliPath, harness, [

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,4 +1,8 @@
 fn main() {
     println!("cargo:rerun-if-changed=tauri.conf.json");
+    #[cfg(windows)]
+    if let Some(out_dir) = std::env::var_os("OUT_DIR") {
+        println!("cargo:rustc-link-search=native={}", out_dir.to_string_lossy());
+    }
     tauri_build::build()
 }

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -784,6 +784,7 @@ fn sync_resumed_input_sender(
     }
 }
 
+#[cfg(test)]
 fn agent_status_update_payload(session_id: &str, current_status: &str) -> serde_json::Value {
     serde_json::json!({
         "session_id": session_id,
@@ -1827,6 +1828,7 @@ pub async fn pause_agent(
         // For opencode: capture the real ses_xxx session ID from the log so
         // resume can pass --session ses_xxx rather than the internal UUID.
         capture_opencode_pause_resume_session(agent);
+        manager::set_agent_status(&app, &session_id, &agent.current_status, "Off");
         mark_agent_paused_off(agent);
 
         // Remove from input_senders
@@ -1835,10 +1837,6 @@ pub async fn pause_agent(
         }
         manager::save_state(&app, &agents, &order);
         let _ = app.emit("agents-updated", ());
-        let _ = app.emit(
-            "agent-status-updated",
-            agent_status_update_payload(&session_id, "Off"),
-        );
         Ok(())
     } else {
         Err(format!("Agent {} not found", session_id))
@@ -1901,10 +1899,6 @@ pub async fn resume_agent(
         terminal_cleared_payload(&session_id),
     );
     let _ = app.emit("agents-updated", ());
-    let _ = app.emit(
-        "agent-status-updated",
-        agent_status_update_payload(&session_id, "Idle"),
-    );
     let _ = app.emit(
         "agent-pty-output-ready",
         terminal_cleared_payload(&session_id),

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -74,10 +74,7 @@ pub async fn send_input_to_agent(
                 if is_interrupt {
                     let agents = state.agents.lock().await;
                     if let Some(agent) = agents.get(&session_id) {
-                        if let Ok(mut status) = agent.current_status.lock() {
-                            *status = "Idle".to_string();
-                        }
-                        manager::emit_agent_status(&app, &session_id, "Idle");
+                        manager::set_agent_status(&app, &session_id, &agent.current_status, "Idle");
                     }
                 } else if is_submit {
                     let agents = state.agents.lock().await;
@@ -86,7 +83,12 @@ pub async fn send_input_to_agent(
                         if (provider == "opencode" || provider == "gemini")
                             && manager::mark_agent_prompt_started(agent)
                         {
-                            manager::emit_agent_status(&app, &session_id, "Processing...");
+                            manager::set_agent_status(
+                                &app,
+                                &session_id,
+                                &agent.current_status,
+                                "Processing...",
+                            );
                         }
                     }
                 }
@@ -178,7 +180,12 @@ pub async fn submit_prompt_to_agent(
             let agents = state.agents.lock().await;
             if let Some(agent) = agents.get(&session_id) {
                 if manager::mark_agent_prompt_started(agent) {
-                    manager::emit_agent_status(&_app, &session_id, "Processing...");
+                    manager::set_agent_status(
+                        &_app,
+                        &session_id,
+                        &agent.current_status,
+                        "Processing...",
+                    );
                 }
             }
         }
@@ -203,13 +210,14 @@ pub async fn submit_prompt_to_agent(
                 {
                     let agents = state.agents.lock().await;
                     if let Some(agent) = agents.get(&session_id) {
-                        if let Ok(mut status) = agent.current_status.lock() {
-                            *status = "Error".to_string();
-                        }
+                        manager::set_agent_status(
+                            &_app,
+                            &session_id,
+                            &agent.current_status,
+                            "Error",
+                        );
                     }
                 }
-
-                manager::emit_agent_status(&_app, &session_id, "Error");
 
                 return Err(error);
             }
@@ -252,13 +260,9 @@ pub async fn submit_prompt_to_agent(
         {
             let agents = state.agents.lock().await;
             if let Some(agent) = agents.get(&session_id) {
-                if let Ok(mut status) = agent.current_status.lock() {
-                    *status = "Idle".to_string();
-                }
+                manager::set_agent_status(&_app, &session_id, &agent.current_status, "Idle");
             }
         }
-
-        manager::emit_agent_status(&_app, &session_id, "Idle");
 
         return Ok(());
     }
@@ -267,7 +271,12 @@ pub async fn submit_prompt_to_agent(
         let agents = state.agents.lock().await;
         if let Some(agent) = agents.get(&session_id) {
             if manager::mark_agent_prompt_started(agent) {
-                manager::emit_agent_status(&_app, &session_id, "Processing...");
+                manager::set_agent_status(
+                    &_app,
+                    &session_id,
+                    &agent.current_status,
+                    "Processing...",
+                );
             }
         }
     }

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -374,7 +374,6 @@ async fn deliver_message_to_target(
             .collect::<std::collections::HashMap<_, _>>()
     };
 
-    let message = message_with_origin(state, message, origin).await;
     let mut delivered = 0usize;
     let mut delivered_session_ids = Vec::new();
     let mut failures = Vec::new();
@@ -382,12 +381,15 @@ async fn deliver_message_to_target(
     for info in target_infos {
         match senders.get(&info.uuid).and_then(Clone::clone) {
             Some(tx) => {
+                let outbound_message =
+                    message_with_origin(state, message, origin, info.status == "action_required")
+                        .await;
                 let result = match wait_for_terminal_ready_for_control_send(state, &info).await {
                     Ok(()) => {
                         crate::utils::terminal_input::submit_prompt_chunks_via_sender(
                             &tx,
                             &info.provider,
-                            &message,
+                            &outbound_message,
                         )
                         .await
                     }
@@ -464,7 +466,12 @@ async fn message_with_origin(
     state: &AppState,
     message: &str,
     origin: Option<&MessageOrigin>,
+    allow_bare_approval_response: bool,
 ) -> String {
+    if allow_bare_approval_response && is_bare_approval_response(message) {
+        return message.to_string();
+    }
+
     let Some(MessageOrigin::WardianAgent { session_id }) = origin else {
         return message.to_string();
     };
@@ -473,6 +480,13 @@ async fn message_with_origin(
         Some(name) => format!("From {name}: {message}"),
         None => format!("From Wardian agent {session_id}: {message}"),
     }
+}
+
+fn is_bare_approval_response(message: &str) -> bool {
+    matches!(
+        message.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes" | "n" | "no"
+    )
 }
 
 async fn resolve_agent_name_in_state(state: &AppState, session_id: &str) -> Option<String> {
@@ -588,7 +602,12 @@ async fn mark_delivered_agents_prompt_started(
         if let Some(agent) = agents.get(session_id) {
             if crate::manager::mark_agent_prompt_started(agent) {
                 if let Some(app) = app {
-                    crate::manager::emit_agent_status(app, session_id, "Processing...");
+                    crate::manager::set_agent_status(
+                        app,
+                        session_id,
+                        &agent.current_status,
+                        "Processing...",
+                    );
                 }
             }
         }
@@ -1453,10 +1472,7 @@ mod tests {
         {
             let agents = state.agents.lock().await;
             let agent = agents.get("agent-1").unwrap();
-            assert_eq!(
-                agent.current_status.lock().unwrap().as_str(),
-                "Processing..."
-            );
+            assert_eq!(agent.current_status.lock().unwrap().as_str(), "Idle");
             assert_eq!(*agent.query_count.lock().unwrap(), 1);
         }
     }
@@ -1489,6 +1505,77 @@ mod tests {
         assert_eq!(
             rx.recv().await.unwrap(),
             b"From PlannerOne: check this".to_vec()
+        );
+        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+    }
+
+    #[tokio::test]
+    async fn message_delivery_keeps_bare_approval_responses_unprefixed() {
+        let state = AppState::new();
+        insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Action Needed".to_string();
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "y",
+            None,
+            Some(&wardian_core::control::MessageOrigin::WardianAgent {
+                session_id: "source-1".to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(rx.recv().await.unwrap(), b"y".to_vec());
+        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+    }
+
+    #[tokio::test]
+    async fn message_delivery_prefixes_bare_approval_response_when_target_not_action_needed() {
+        let state = AppState::new();
+        insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "yes",
+            None,
+            Some(&wardian_core::control::MessageOrigin::WardianAgent {
+                session_id: "source-1".to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            b"From PlannerOne: yes".to_vec()
         );
         assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,13 @@ pub mod utils;
 pub mod workflow_engine;
 pub use wardian_core::models;
 
+// Tauri's Windows resource contains the Common Controls v6 manifest required by
+// wry/tao imports such as TaskDialogIndirect. Cargo links it for app binaries,
+// but the library unit-test harness needs the same resource explicitly.
+#[cfg(all(test, windows))]
+#[link(name = "resource", kind = "static")]
+extern "C" {}
+
 use crate::state::AppState;
 use tauri::{Emitter, Manager};
 use wardian_core::models::AgentConfig;

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -191,18 +191,6 @@ pub(crate) fn set_agent_status(
     }
 }
 
-pub(crate) fn emit_agent_status(app: &AppHandle, session_id: &str, current_status: &str) {
-    let _ = wardian_core::db::update_agent_status(session_id, current_status, None);
-
-    let _ = app.emit(
-        "agent-status-updated",
-        serde_json::json!({
-            "session_id": session_id,
-            "current_status": current_status,
-        }),
-    );
-}
-
 pub(crate) fn emit_agent_turn_completed(app: &AppHandle, session_id: &str) {
     let _ = app.emit(
         "agent-turn-completed",
@@ -226,14 +214,7 @@ pub(crate) fn mark_agent_prompt_started(agent: &crate::state::ActiveAgent) -> bo
         *count += 1;
     }
 
-    if let Ok(mut status) = agent.current_status.lock() {
-        if *status != "Processing..." {
-            *status = "Processing...".to_string();
-            return true;
-        }
-    }
-
-    false
+    current_status != "Processing..."
 }
 
 pub(crate) fn debug_preview_bytes(bytes: &[u8], limit: usize) -> String {
@@ -786,15 +767,12 @@ mod tests {
     }
 
     #[test]
-    fn mark_agent_prompt_started_sets_processing_and_counts_query() {
+    fn mark_agent_prompt_started_counts_query_and_requests_processing_transition() {
         let agent = test_active_agent("Idle");
 
         assert!(mark_agent_prompt_started(&agent));
 
-        assert_eq!(
-            agent.current_status.lock().unwrap().as_str(),
-            "Processing..."
-        );
+        assert_eq!(agent.current_status.lock().unwrap().as_str(), "Idle");
         assert_eq!(*agent.query_count.lock().unwrap(), 1);
     }
 

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -654,6 +654,7 @@ pub async fn spawn_agent(
         let watcher_current_status = current_status.clone();
         let watcher_log_path = log_path.clone();
         let watcher_config = config_lock.clone();
+        let watcher_skip_existing_log = is_restored;
         let wardian_agent_dir = get_wardian_home()
             .map(|home| home.join("agents").join(&watcher_session))
             .filter(|path| path.exists())
@@ -662,6 +663,7 @@ pub async fn spawn_agent(
         std::thread::spawn(move || {
             let mut offset: u64 = 0;
             let mut last_lookup_session = String::new();
+            let mut positioned_initial_log = !watcher_skip_existing_log;
             loop {
                 let current = watcher_current_status
                     .lock()
@@ -692,6 +694,7 @@ pub async fn spawn_agent(
                         if last_lookup_session != lookup_session {
                             *lock = None;
                             offset = 0;
+                            positioned_initial_log = !watcher_skip_existing_log;
                             last_lookup_session = lookup_session.clone();
                         }
                         if lock.is_none() {
@@ -717,6 +720,10 @@ pub async fn spawn_agent(
                         if let Ok(metadata) = file.metadata() {
                             if metadata.len() < offset {
                                 offset = 0;
+                            }
+                            if !positioned_initial_log {
+                                offset = metadata.len();
+                                positioned_initial_log = true;
                             }
                         }
                         if file.seek(std::io::SeekFrom::Start(offset)).is_ok() {
@@ -763,12 +770,14 @@ pub async fn spawn_agent(
         let watcher_current_status = current_status.clone();
         let watcher_log_path = log_path.clone();
         let watcher_folder = expected_folder.clone();
+        let watcher_skip_existing_log = is_restored;
         let hook_event_log = claude_hook.as_ref().map(|hook| hook.event_log_path.clone());
         let waiting_for_permission = std::sync::Arc::new(std::sync::Mutex::new(false));
         let log_waiting_for_permission = waiting_for_permission.clone();
 
         std::thread::spawn(move || {
             let mut offset: u64 = 0;
+            let mut positioned_initial_log = !watcher_skip_existing_log;
             loop {
                 let current = watcher_current_status
                     .lock()
@@ -803,6 +812,11 @@ pub async fn spawn_agent(
                         if let Ok(metadata) = file.metadata() {
                             if metadata.len() < offset {
                                 offset = 0;
+                                positioned_initial_log = true;
+                            }
+                            if !positioned_initial_log {
+                                offset = metadata.len();
+                                positioned_initial_log = true;
                             }
                         }
                         if file.seek(std::io::SeekFrom::Start(offset)).is_ok() {

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -64,6 +64,13 @@ fn set_snapshot_status(snap: &AgentSnapshot, next_status: &str) {
     }
 }
 
+fn set_snapshot_status_from_log(snap: &AgentSnapshot, next_status: &str, is_initial_replay: bool) {
+    if is_initial_replay {
+        return;
+    }
+    set_snapshot_status(snap, next_status);
+}
+
 fn collect_descendant_pids(
     pid: u32,
     children_map: &HashMap<u32, Vec<u32>>,
@@ -327,12 +334,18 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
             if let Some(ref path) = *log_path_lock {
                 let mut should_parse = true;
                 let mut new_mtime = None;
+                let mut is_initial_log_replay = snap
+                    .log_last_modified
+                    .lock()
+                    .map(|last| last.is_none())
+                    .unwrap_or(false);
                 if let Ok(metadata) = std::fs::metadata(path) {
                     if let Ok(modified) = metadata.modified() {
                         let last_mod = *snap.log_last_modified.lock().unwrap();
                         if last_mod == Some(modified) {
                             should_parse = false;
                         } else {
+                            is_initial_log_replay = last_mod.is_none();
                             new_mtime = Some(modified);
                         }
                     }
@@ -374,7 +387,11 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                 }
 
                                 if let Some(status) = codex_status_from_log(&lines) {
-                                    set_snapshot_status(snap, &status);
+                                    set_snapshot_status_from_log(
+                                        snap,
+                                        &status,
+                                        is_initial_log_replay,
+                                    );
                                 }
                             }
                             "claude" => {
@@ -418,7 +435,11 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                     && !current_status_snap.starts_with("Action Needed")
                                 {
                                     if let Some(status) = claude_status_from_log(&lines) {
-                                        set_snapshot_status(snap, &status);
+                                        set_snapshot_status_from_log(
+                                            snap,
+                                            &status,
+                                            is_initial_log_replay,
+                                        );
                                     }
                                 }
                             }
@@ -431,7 +452,7 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                     &mut i_ts,
                                     &mut status,
                                 );
-                                set_snapshot_status(snap, &status);
+                                set_snapshot_status_from_log(snap, &status, is_initial_log_replay);
                             }
                             _ => {
                                 // Gemini logs are a single JSON object with a messages array
@@ -456,11 +477,19 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                                     last_msg.get("role").and_then(|v| v.as_str())
                                                 });
                                             if msg_type == Some("user") {
-                                                set_snapshot_status(snap, "Processing...");
+                                                set_snapshot_status_from_log(
+                                                    snap,
+                                                    "Processing...",
+                                                    is_initial_log_replay,
+                                                );
                                             } else if msg_type == Some("gemini")
                                                 || msg_type == Some("assistant")
                                             {
-                                                set_snapshot_status(snap, "Idle");
+                                                set_snapshot_status_from_log(
+                                                    snap,
+                                                    "Idle",
+                                                    is_initial_log_replay,
+                                                );
                                             }
                                         }
                                     }
@@ -685,5 +714,46 @@ mod tests {
             .snapshot_since(None, None)
             .unwrap();
         assert!(snapshot.events.is_empty());
+    }
+
+    #[test]
+    fn initial_log_replay_does_not_record_status_transition() {
+        let snap = test_snapshot("Off");
+
+        super::set_snapshot_status_from_log(&snap, "Idle", true);
+
+        assert_eq!(*snap.current_status.lock().unwrap(), "Off");
+        assert!(snap.last_status_at.lock().unwrap().is_none());
+        let snapshot = snap
+            .watch_state
+            .lock()
+            .unwrap()
+            .snapshot_since(None, None)
+            .unwrap();
+        assert!(snapshot.events.is_empty());
+    }
+
+    #[test]
+    fn live_log_update_records_status_transition() {
+        let snap = test_snapshot("Processing...");
+
+        super::set_snapshot_status_from_log(&snap, "Idle", false);
+
+        assert_eq!(*snap.current_status.lock().unwrap(), "Idle");
+        assert!(snap.last_status_at.lock().unwrap().is_some());
+        let snapshot = snap
+            .watch_state
+            .lock()
+            .unwrap()
+            .snapshot_since(None, None)
+            .unwrap();
+        assert_eq!(snapshot.events.len(), 1);
+        assert_eq!(
+            snapshot.events[0]
+                .payload
+                .get("status")
+                .and_then(|value| value.as_str()),
+            Some("idle")
+        );
     }
 }

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -493,6 +493,7 @@ describe("Agent Watchlist Sidebar", () => {
     mockInvoke.mockClear();
 
     await act(async () => {
+      emitStatus({ session_id: "agent-1", current_status: "Processing..." });
       emitJson({
         session_id: "agent-1",
         data: { type: "result", result: "Finished the requested update." },
@@ -574,6 +575,70 @@ describe("Agent Watchlist Sidebar", () => {
         }),
       );
     });
+  });
+
+  it("does not flush stale agent queue content from the initial Idle metrics snapshot", async () => {
+    setupDefaultMocks(sampleAgents, defaultClasses);
+    useQueueStore.setState({
+      items: [],
+      _agentBuffers: { "agent-1": "stale restored output" },
+      _workflowLastOutput: {},
+    });
+    const emitAgentMetrics = captureAgentMetricsListener();
+
+    await act(async () => {
+      render(<App />);
+    });
+    await screen.findByText("All Agents");
+    mockInvoke.mockClear();
+
+    await act(async () => {
+      emitAgentMetrics([
+        {
+          session_id: "agent-1",
+          current_status: "Idle",
+          cpu_usage: 0,
+          memory_mb: 0,
+          uptime_seconds: 1,
+          query_count: 1,
+          init_timestamp: null,
+          log_path: null,
+        },
+      ]);
+    });
+
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "save_queue_items",
+      expect.objectContaining({ items: expect.any(Array) }),
+    );
+    expect(useQueueStore.getState().items).toHaveLength(0);
+  });
+
+  it("does not flush stale queue content from a non-active Idle status event", async () => {
+    setupDefaultMocks(sampleAgents, defaultClasses);
+    useQueueStore.setState({
+      items: [],
+      _agentBuffers: { "agent-1": "stale restored output" },
+      _workflowLastOutput: {},
+    });
+    const { emitStatus } = captureQueueAgentListeners();
+
+    await act(async () => {
+      render(<App />);
+    });
+    await screen.findByText("All Agents");
+    mockInvoke.mockClear();
+
+    await act(async () => {
+      emitStatus({ session_id: "agent-1", current_status: "Off" });
+      emitStatus({ session_id: "agent-1", current_status: "Idle" });
+    });
+
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "save_queue_items",
+      expect.objectContaining({ items: expect.any(Array) }),
+    );
+    expect(useQueueStore.getState().items).toHaveLength(0);
   });
 
   it("uses OpenCode assistant database text when an OpenCode agent completes", async () => {

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -94,14 +94,13 @@ function AppBody() {
   const createScheduledRun = useWorkflowStore(s => s.createScheduledRun);
   const fetchLibraryTree = useLibraryStore(s => s.fetchLibraryTree);
   const appendAgentEvent = useQueueStore((s) => s.appendAgentEvent);
-  const hasAgentBufferedContent = useQueueStore((s) => s.hasAgentBufferedContent);
   const flushAgentCompletion = useQueueStore((s) => s.flushAgentCompletion);
   const trackWorkflowNodeOutput = useQueueStore((s) => s.trackWorkflowNodeOutput);
   const addWorkflowCompletion = useQueueStore((s) => s.addWorkflowCompletion);
   const loadQueueItems = useQueueStore((s) => s.loadItems);
   const maybeFlushAgentQueueCompletion = useCallback((sessionId: string, currentStatus: string, previousStatus?: string) => {
     const wasActive = previousStatus ? ACTIVE_STATUSES.has(previousStatus) : false;
-    if (currentStatus === "Idle" && (wasActive || hasAgentBufferedContent(sessionId))) {
+    if (currentStatus === "Idle" && wasActive) {
       if (pendingQueueFlushRef.current.has(sessionId)) return;
       pendingQueueFlushRef.current.add(sessionId);
       const agent = agentsRef.current.find((a) => a.session_id === sessionId);
@@ -122,7 +121,7 @@ function AppBody() {
         finishFlush();
       }
     }
-  }, [flushAgentCompletion, hasAgentBufferedContent]);
+  }, [flushAgentCompletion]);
 
   useEffect(() => {
     const unlistenWorkflow = listen<any>("workflow-telemetry", (event) => {
@@ -622,7 +621,10 @@ function AppBody() {
       const mapping: Record<string, AgentTelemetry> = {};
       for (const m of event.payload) mapping[m.session_id] = m;
       for (const [sessionId, metric] of Object.entries(mapping)) {
-        maybeFlushAgentQueueCompletion(sessionId, metric.current_status, agentStatusRef.current[sessionId]);
+        const previousStatus = agentStatusRef.current[sessionId];
+        if (previousStatus !== undefined) {
+          maybeFlushAgentQueueCompletion(sessionId, metric.current_status, previousStatus);
+        }
         agentStatusRef.current[sessionId] = metric.current_status;
       }
       setTelemetry(prev => {


### PR DESCRIPTION
## Description
Fixes Wardian agent status transition behavior so startup/restored-agent hydration does not replay fake lifecycle completions, duplicate observations do not emit duplicate watch/status/Queue events, and live turns transition through the canonical states predictably.

Changes:
- Route live status changes through a single backend `set_agent_status` gate that suppresses duplicate status events, watch events, persistence writes, and `last_status_at` churn.
- Keep restored/log-replayed agents stable as `Off` until Wardian verifies a live runtime/control path and enough provider state.
- Preserve provider metadata replay for query counts, log paths, resume sessions, timestamps, and provider-specific parsing without emitting startup completion transitions.
- Guard Queue completion flushing so initial metrics/status snapshots and non-active Idle observations do not create Queue items.
- Keep bare `y/yes/n/no` approval sends unprefixed only for targets currently in `Action Needed`; normal inter-agent replies keep origin context.

## Related Issues
Fixes #59

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] Wardian-Reviewer review — initial Medium finding fixed; follow-up review found no blocking issues
- [x] `npm run lint` — passed
- [x] `npm run test` — 61 files, 551 tests passed; existing React `act(...)` warnings appeared in unrelated watchlist/app tests
- [x] `npm run build` — passed; existing Vite large chunk warning
- [x] `npm run test:e2e` — 40 passed, 17 skipped (`@native-only`)
- [x] `cd src-tauri && cargo check` — passed
- [x] `cd src-tauri && cargo test` — 413 lib tests + 5 mock provider tests passed
- [x] `cd src-tauri && cargo clippy` — passed
- [x] `npm run tauri -- build --debug --no-bundle` — passed
- [x] `npm run test:e2e:native:fast -- e2e-native/tests/cli-shared-state-native.test.mjs` with Vite dev server on `127.0.0.1:1420` — 4 passed, 1 skipped real-Codex test
- [x] `git diff origin/main..HEAD --check` — passed
- [x] Secrets scan over `git diff origin/main..HEAD` — no matches

## Screenshots
![Queue remains empty on startup without restored status completion noise](https://github.com/tangemicioglu/Wardian/releases/download/_gh-attach-assets/queue-startup-empty.png)

## Notes
Repeated native fast-runner attempts without an explicit Vite server intermittently launched the debug WebView against an unreachable `localhost:1420`; the same native CLI tests passed once the configured dev server prerequisite was running, and targeted reruns of the status/control subtests passed.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, or no new hard-to-understand code was added
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable