### PR TITLE
fix(codex): share Windows sandbox support

### DIFF
--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -99,13 +99,24 @@ Current model:
   - `auth.json`
   - `config.toml`
   - `cap_sid`
-  - `history.jsonl`
-  - `session_index.jsonl`
+- Codex session and history files such as `history.jsonl`,
+  `session_index.jsonl`, and `sessions/**` remain per-agent so Wardian can
+  resume and read logs from the agent habitat without merging independent
+  provider threads.
 - Codex SQLite databases such as `state_5.sqlite*` and `logs_2.sqlite*` remain
   per-agent because SQLite journal/WAL files are path-sensitive and are not safe
   to hardlink across independent `CODEX_HOME` directories.
-- Codex runtime directories such as `sessions`, `log`, cache, sandbox, temp, and
+- Codex runtime directories such as `log`, cache, temp, and
   generated database files remain per-agent.
+- On Windows, Codex elevated sandbox support is treated separately from session
+  state:
+  - `.sandbox-secrets` and `.sandbox-bin` are projected from the user's Codex
+    home so every Wardian-created Codex home sees the same elevated sandbox
+    credentials and helpers.
+  - `.sandbox/setup_marker.json` is copied when present so a new projected home
+    can observe completed setup.
+  - `.sandbox` itself is not projected. Runtime files such as `sandbox.log` and
+    `setup_error.json` stay local to the agent or bootstrap home.
 - Codex system skills remain under `CODEX_HOME/skills/.system`
 - Wardian-assigned skills are projected into `CODEX_HOME/skills/<skill-name>`
 
@@ -118,11 +129,12 @@ Codex session IDs are still discovered from provider output, so fresh session cr
 Current sequence:
 
 1. Create a temporary bootstrap `CODEX_HOME` under `.wardian/provider-bootstrap/codex/session-*/.codex`.
-2. Seed it with shared Codex auth/trust files.
+2. Seed it with shared Codex auth/trust files and Windows sandbox support files when present.
 3. Launch Codex with the real workspace as `--cd`.
 4. Parse `thread.started` to get the provider session ID.
 5. Create the final habitat at `.wardian/agents/<provider_session_id>/habitat/.codex`.
-6. Migrate session artifacts from the bootstrap home into the final agent home.
+6. Project any bootstrap-generated Windows sandbox support into the final home.
+7. Migrate session artifacts from the bootstrap home into the final agent home while leaving reusable sandbox support in the bootstrap home.
 
 If Codex starts asking for trust every launch again, first verify that the session was born with the real workspace as `cwd`, not the bootstrap path.
 

--- a/docs/specs/009-codex-provider.md
+++ b/docs/specs/009-codex-provider.md
@@ -30,7 +30,9 @@ We will add Codex as a first-class provider in the Rust backend and expose it in
 
 ### 3. Codex Native Projection
 - Codex receives a projected `CODEX_HOME` inside the habitat rather than reading Wardian context directly from `--add-dir`.
-- The projected Codex home preserves native Codex state by mirroring the user’s real `~/.codex` home for auth, config, sessions, and logs.
+- The projected Codex home preserves only shared native Codex profile files from the user's real Codex home: `auth.json`, `config.toml`, and `cap_sid`.
+- Per-session Codex state remains local to the Wardian agent home, including `history.jsonl`, `session_index.jsonl`, `sessions/**`, provider logs, and SQLite state.
+- On Windows, Codex elevated sandbox support is projected narrowly: `.sandbox-secrets` and `.sandbox-bin` are shared, and `.sandbox/setup_marker.json` is copied. The `.sandbox` runtime directory itself remains local so sandbox logs and setup errors are not merged across agents.
 - The projected `skills/` directory overlays Wardian’s merged skill set on top of the user’s existing Codex skills and system skills.
 
 ### 4. Telemetry

--- a/docs/specs/036-codex-windows-sandbox-projection.md
+++ b/docs/specs/036-codex-windows-sandbox-projection.md
@@ -1,0 +1,37 @@
+# Spec 036: Codex Windows Sandbox Projection
+
+* **Status:** Implemented
+* **Date:** 2026-05-12
+* **Decider:** Architect
+
+## Context and Problem Statement
+
+Wardian creates per-agent Codex homes under `<wardian-home>/agents/<session-id>/habitat/.codex` and temporary bootstrap homes under `<wardian-home>/provider-bootstrap/codex/<workspace-key>/.codex`.
+
+On Windows, Codex's elevated sandbox stores reusable support artifacts in the user's Codex home. When Wardian projects a fresh Codex home without those artifacts, Codex can treat the projected home as a new sandbox environment and run setup again. That setup may require Windows elevation and can rotate or regenerate credentials.
+
+The fix must not share provider session state. Wardian still relies on per-agent Codex logs, `sessions/**`, `history.jsonl`, `session_index.jsonl`, and SQLite files for resume and telemetry boundaries.
+
+## Decision
+
+Wardian projects Windows sandbox support separately from Codex session state:
+
+- Project `.sandbox-secrets` from the user's Codex home into each Wardian-created Codex home.
+- Project `.sandbox-bin` from the user's Codex home into each Wardian-created Codex home.
+- Copy `.sandbox/setup_marker.json` when present.
+- Keep `.sandbox` itself local to the agent or bootstrap home.
+- Keep `.sandbox/sandbox.log`, `.sandbox/setup_error.json`, Codex sessions, history, index files, logs, and SQLite state per-agent.
+
+Bootstrap migration leaves `.sandbox`, `.sandbox-bin`, and `.sandbox-secrets` in the reusable bootstrap home instead of moving them into the final agent home. If a first-run bootstrap creates sandbox support before the user's Codex home has it, migration projects those bootstrap-generated support artifacts into the final agent home before moving session logs.
+
+## Consequences
+
+- **Positive:** Fresh Wardian Codex homes can observe existing Windows sandbox setup without sharing provider session state.
+- **Positive:** Codex resume and Wardian log lookup still read from the agent habitat because sessions and indexes remain per-agent.
+- **Positive:** Sandbox diagnostic files stay scoped to the home that produced them.
+- **Negative:** The projection depends on Codex keeping the elevated sandbox credential/helper layout under `.sandbox-secrets` and `.sandbox-bin`.
+
+## Verification
+
+- Unit tests cover Windows sandbox projection and bootstrap migration.
+- Native verification must include a Windows run that spawns Codex through Wardian and confirms sandbox support is projected without merging session logs or requiring a repeated sandbox setup.

--- a/e2e-native/tests/codex-windows-sandbox-native.test.mjs
+++ b/e2e-native/tests/codex-windows-sandbox-native.test.mjs
@@ -1,0 +1,154 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  createNativeHarness,
+  ensureNativeAppBuilt,
+  prepareIsolatedHome,
+  startNativeSession,
+  waitForAppShell,
+} from "../lib/harness.mjs";
+
+const runRealCodexSandbox = process.env.WARDIAN_E2E_REAL_CODEX_SANDBOX === "1";
+const skipNativeBuild = process.env.WARDIAN_NATIVE_SKIP_BUILD === "1";
+
+async function pathExists(candidate) {
+  try {
+    await fs.lstat(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function realPath(candidate) {
+  return await fs.realpath(candidate);
+}
+
+test("native Codex spawn projects Windows sandbox support without sharing runtime state", { timeout: 180000 }, async (t) => {
+  if (process.platform !== "win32") {
+    t.skip("Codex elevated sandbox projection is Windows-specific.");
+    return;
+  }
+  if (!runRealCodexSandbox) {
+    t.skip("Set WARDIAN_E2E_REAL_CODEX_SANDBOX=1 to run real Codex sandbox native E2E.");
+    return;
+  }
+
+  const realCodexHome = path.join(os.homedir(), ".codex");
+  const realSandboxSecrets = path.join(realCodexHome, ".sandbox-secrets");
+  const realSandboxBin = path.join(realCodexHome, ".sandbox-bin");
+  const realSandbox = path.join(realCodexHome, ".sandbox");
+  const realSetupMarker = path.join(realSandbox, "setup_marker.json");
+  for (const requiredPath of [realSandboxSecrets, realSandboxBin, realSetupMarker]) {
+    if (!(await pathExists(requiredPath))) {
+      t.skip(`Codex Windows sandbox support is not initialized at ${requiredPath}.`);
+      return;
+    }
+  }
+
+  const harness = await createNativeHarness();
+  try {
+    if (!skipNativeBuild) {
+      ensureNativeAppBuilt(harness);
+    }
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  prepareIsolatedHome(harness);
+
+  const workspacePath = process.env.WARDIAN_E2E_REAL_WORKSPACE || harness.repoRoot;
+  let spawnedSessionId = null;
+
+  let session;
+  try {
+    session = await startNativeSession(harness);
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  t.after(async () => {
+    try {
+      if (spawnedSessionId) {
+        await session.driver.executeAsyncScript((sid, done) => {
+          window.__TAURI_INTERNALS__.invoke("kill_agent", { sessionId: sid }).then(
+            () => done(null),
+            () => done(null),
+          );
+        }, spawnedSessionId);
+      }
+    } catch {
+      // The native app or WebDriver session may already be closed after a
+      // provider-start failure; keep cleanup from masking the assertion result.
+    }
+
+    try {
+      await session.close();
+    } catch (error) {
+      if (!/valid session ID|NoSuchSession/i.test(String(error))) {
+        throw error;
+      }
+    }
+  });
+
+  await waitForAppShell(session.driver, 20000);
+
+  const spawnResult = await session.driver.executeAsyncScript(
+    (folder, done) => {
+      window.__TAURI_INTERNALS__.invoke("spawn_agent", {
+        req: {
+          sessionName: `NativeCodexSandbox-${Date.now().toString(36)}`,
+          agentClass: "TestClass",
+          folder,
+          resumeSession: null,
+          isOff: false,
+          configOverride: {
+            provider: "codex",
+            custom_args: "-c tui.show_tooltips=false",
+          },
+        },
+      }).then(
+        (agent) => done({ ok: true, agent }),
+        (error) => done({ ok: false, error: String(error) }),
+      );
+    },
+    workspacePath,
+  );
+
+  if (!spawnResult.ok && /program not found|No such file|cannot find/i.test(spawnResult.error)) {
+    t.skip(`Codex executable is unavailable: ${spawnResult.error}`);
+    return;
+  }
+  assert.equal(spawnResult.ok, true, `spawn_agent failed: ${spawnResult.error}`);
+  assert.equal(typeof spawnResult.agent?.session_id, "string");
+  spawnedSessionId = spawnResult.agent.session_id;
+
+  const projectedCodexHome = path.join(
+    harness.isolatedHome,
+    "agents",
+    spawnedSessionId,
+    "habitat",
+    ".codex",
+  );
+  const projectedSandbox = path.join(projectedCodexHome, ".sandbox");
+
+  assert.equal(
+    await realPath(path.join(projectedCodexHome, ".sandbox-secrets")),
+    await realPath(realSandboxSecrets),
+  );
+  assert.equal(
+    await realPath(path.join(projectedCodexHome, ".sandbox-bin")),
+    await realPath(realSandboxBin),
+  );
+  assert.notEqual(await realPath(projectedSandbox), await realPath(realSandbox));
+  assert.equal(
+    await fs.readFile(path.join(projectedSandbox, "setup_marker.json"), "utf8"),
+    await fs.readFile(realSetupMarker, "utf8"),
+  );
+});

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -603,7 +603,8 @@ mod tests {
 
         let cargo_config =
             std::fs::read_to_string(worktree.join(".cargo").join("config.toml")).unwrap();
-        let expected_target = workspace
+        let expected_target = absolute_existing_path(&workspace)
+            .unwrap()
             .join("target")
             .to_string_lossy()
             .replace('\\', "\\\\");

--- a/src-tauri/src/manager/codex.rs
+++ b/src-tauri/src/manager/codex.rs
@@ -1,4 +1,4 @@
-use crate::utils::fs::get_wardian_home;
+use crate::utils::fs::{get_wardian_home, sync_codex_windows_sandbox_support};
 pub(crate) fn codex_bootstrap_workspace_key(workspace_cwd: &std::path::Path) -> String {
     let normalized = workspace_cwd.to_string_lossy().to_ascii_lowercase();
     let mut hash = 0xcbf29ce484222325u64;
@@ -332,6 +332,7 @@ pub(crate) fn migrate_codex_bootstrap_home(
     }
 
     std::fs::create_dir_all(final_home).map_err(|e| e.to_string())?;
+    sync_codex_windows_sandbox_support(bootstrap_home, final_home)?;
 
     let entries = std::fs::read_dir(bootstrap_home).map_err(|e| e.to_string())?;
     for entry in entries.flatten() {
@@ -351,6 +352,9 @@ pub(crate) fn migrate_codex_bootstrap_home(
                 | "logs_2.sqlite"
                 | "logs_2.sqlite-shm"
                 | "logs_2.sqlite-wal"
+                | ".sandbox"
+                | ".sandbox-bin"
+                | ".sandbox-secrets"
         ) {
             continue;
         }
@@ -607,6 +611,92 @@ mod tests {
         assert!(!final_home.join("state_5.sqlite").exists());
         assert!(!final_home.join("logs_2.sqlite").exists());
         assert!(final_home.join("sessions").join("session.jsonl").exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn migrate_codex_bootstrap_home_projects_windows_sandbox_support_without_moving_it() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let bootstrap_home = temp.path().join("bootstrap").join(".codex");
+        let final_home = temp.path().join("final").join(".codex");
+
+        std::fs::create_dir_all(bootstrap_home.join(".sandbox-secrets"))
+            .expect("create sandbox secrets");
+        std::fs::create_dir_all(bootstrap_home.join(".sandbox-bin")).expect("create sandbox bin");
+        std::fs::create_dir_all(bootstrap_home.join(".sandbox")).expect("create sandbox dir");
+        std::fs::create_dir_all(final_home.join(".sandbox")).expect("create final sandbox dir");
+        std::fs::create_dir_all(bootstrap_home.join("sessions")).expect("create sessions dir");
+        std::fs::write(
+            bootstrap_home
+                .join(".sandbox-secrets")
+                .join("sandbox_users.json"),
+            "secrets",
+        )
+        .expect("write secrets");
+        std::fs::write(
+            bootstrap_home
+                .join(".sandbox-bin")
+                .join("codex-command-runner.exe"),
+            "runner",
+        )
+        .expect("write runner");
+        std::fs::write(
+            bootstrap_home.join(".sandbox").join("setup_marker.json"),
+            "marker",
+        )
+        .expect("write marker");
+        std::fs::write(bootstrap_home.join(".sandbox").join("sandbox.log"), "log")
+            .expect("write log");
+        std::fs::write(final_home.join(".sandbox").join("sandbox.log"), "final log")
+            .expect("write final log");
+        std::fs::write(
+            bootstrap_home
+                .join("sessions")
+                .join("bootstrap-session.jsonl"),
+            "session",
+        )
+        .expect("write session");
+
+        migrate_codex_bootstrap_home(&bootstrap_home, &final_home).expect("migrate bootstrap home");
+
+        assert!(bootstrap_home.join(".sandbox-secrets").exists());
+        assert!(bootstrap_home.join(".sandbox-bin").exists());
+        assert!(bootstrap_home.join(".sandbox").exists());
+        assert_eq!(
+            std::fs::read_to_string(
+                final_home
+                    .join(".sandbox-secrets")
+                    .join("sandbox_users.json")
+            )
+            .expect("read final secrets"),
+            "secrets"
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                final_home
+                    .join(".sandbox-bin")
+                    .join("codex-command-runner.exe")
+            )
+            .expect("read final runner"),
+            "runner"
+        );
+        assert_eq!(
+            std::fs::read_to_string(final_home.join(".sandbox").join("setup_marker.json"))
+                .expect("read final marker"),
+            "marker"
+        );
+        assert_eq!(
+            std::fs::read_to_string(final_home.join(".sandbox").join("sandbox.log"))
+                .expect("read final log"),
+            "final log"
+        );
+        assert!(
+            final_home
+                .join("sessions")
+                .join("bootstrap-session.jsonl")
+                .exists(),
+            "session logs must still migrate for resume/log tracking"
+        );
     }
 
     #[test]

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -1,5 +1,10 @@
 #[cfg(windows)]
+use std::os::windows::fs::MetadataExt;
+#[cfg(windows)]
 use std::os::windows::process::CommandExt;
+
+#[cfg(windows)]
+const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
 
 pub struct ClaudePermissionHookPaths {
     pub settings_arg: String,
@@ -382,6 +387,8 @@ pub(crate) fn sync_codex_agent_home(
         }
     }
 
+    sync_codex_windows_sandbox_support(real_codex_home, projected_home)?;
+
     let projected_skills = projected_home.join("skills");
     std::fs::create_dir_all(&projected_skills).map_err(|e| e.to_string())?;
 
@@ -406,6 +413,85 @@ pub(crate) fn sync_codex_agent_home(
 }
 
 const CODEX_SHARED_HOME_FILES: &[&str] = &["auth.json", "config.toml", "cap_sid"];
+
+#[cfg(windows)]
+const CODEX_WINDOWS_SHARED_SANDBOX_DIRS: &[&str] = &[".sandbox-secrets", ".sandbox-bin"];
+
+#[cfg(windows)]
+const CODEX_WINDOWS_SANDBOX_SETUP_FILES: &[&str] = &["setup_marker.json"];
+
+pub(crate) fn sync_codex_windows_sandbox_support(
+    real_codex_home: &std::path::Path,
+    projected_home: &std::path::Path,
+) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        for shared_name in CODEX_WINDOWS_SHARED_SANDBOX_DIRS {
+            let source = real_codex_home.join(shared_name);
+            if source.is_dir() {
+                project_directory_link(&source, &projected_home.join(shared_name))?;
+            }
+        }
+
+        let real_sandbox = real_codex_home.join(".sandbox");
+        if real_sandbox.is_dir() {
+            let projected_sandbox = projected_home.join(".sandbox");
+            std::fs::create_dir_all(&projected_sandbox).map_err(|e| e.to_string())?;
+            for file_name in CODEX_WINDOWS_SANDBOX_SETUP_FILES {
+                let source = real_sandbox.join(file_name);
+                if source.is_file() {
+                    project_file(&source, &projected_sandbox.join(file_name))?;
+                }
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = (real_codex_home, projected_home);
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn project_directory_link(
+    source: &std::path::Path,
+    target: &std::path::Path,
+) -> Result<(), String> {
+    if projected_link_matches_target(target, source) {
+        return Ok(());
+    }
+
+    remove_projected_path(target)?;
+    create_directory_link(source, target)
+}
+
+#[cfg(windows)]
+fn remove_projected_path(path: &std::path::Path) -> Result<(), String> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.to_string()),
+    };
+
+    if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        if metadata.is_dir() {
+            return std::fs::remove_dir(path)
+                .or_else(|_| std::fs::remove_file(path))
+                .map_err(|e| e.to_string());
+        }
+        return std::fs::remove_file(path)
+            .or_else(|_| std::fs::remove_dir(path))
+            .map_err(|e| e.to_string());
+    }
+
+    if metadata.is_dir() {
+        std::fs::remove_dir_all(path).map_err(|e| e.to_string())
+    } else {
+        std::fs::remove_file(path).map_err(|e| e.to_string())
+    }
+}
 
 const CODEX_LEGACY_GLOBAL_HARDLINK_GROUPS: &[(&str, &[&str], bool)] = &[
     ("history.jsonl", &[], true),
@@ -883,6 +969,117 @@ mod tests {
         assert!(!projected_home.join("logs_2.sqlite-wal").exists());
         assert!(!projected_home.join("sandbox.log").exists());
         assert!(!projected_home.join("sessions").exists());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn codex_home_projection_shares_windows_sandbox_support_without_runtime_logs() {
+        let root = unique_temp_dir("codex-home-windows-sandbox-support");
+        let real_home = root.join("real-codex-home");
+        let projected_home = root.join("projected-home");
+        let wardian_skills = root.join("wardian-skills");
+        let stale_secrets_target = root.join("stale-secrets-target");
+
+        std::fs::create_dir_all(real_home.join(".sandbox-secrets")).expect("create real secrets");
+        std::fs::create_dir_all(real_home.join(".sandbox-bin")).expect("create real helpers");
+        std::fs::create_dir_all(real_home.join(".sandbox")).expect("create real sandbox");
+        std::fs::create_dir_all(projected_home.join(".sandbox")).expect("create local sandbox");
+        std::fs::create_dir_all(&wardian_skills).expect("create wardian skills");
+        std::fs::create_dir_all(&stale_secrets_target).expect("create stale secrets target");
+
+        std::fs::write(
+            real_home
+                .join(".sandbox-secrets")
+                .join("sandbox_users.json"),
+            "real secrets",
+        )
+        .expect("write real secrets");
+        std::fs::write(
+            real_home
+                .join(".sandbox-bin")
+                .join("codex-command-runner.exe"),
+            "runner",
+        )
+        .expect("write helper");
+        std::fs::write(
+            real_home.join(".sandbox").join("setup_marker.json"),
+            "real setup marker",
+        )
+        .expect("write marker");
+        std::fs::write(real_home.join(".sandbox").join("sandbox.log"), "real log")
+            .expect("write real log");
+        std::fs::write(
+            real_home.join(".sandbox").join("setup_error.json"),
+            "real setup error",
+        )
+        .expect("write real setup error");
+        std::fs::write(
+            projected_home.join(".sandbox").join("sandbox.log"),
+            "agent log",
+        )
+        .expect("write projected log");
+        std::fs::write(
+            projected_home.join(".sandbox").join("setup_error.json"),
+            "agent setup error",
+        )
+        .expect("write projected setup error");
+        std::fs::write(stale_secrets_target.join("sentinel.txt"), "do not delete")
+            .expect("write stale target sentinel");
+        create_directory_link(
+            &stale_secrets_target,
+            &projected_home.join(".sandbox-secrets"),
+        )
+        .expect("create stale projected secrets link");
+
+        sync_codex_agent_home(&real_home, &projected_home, &wardian_skills)
+            .expect("sync codex agent home");
+
+        assert!(projected_link_matches_target(
+            &projected_home.join(".sandbox-secrets"),
+            &real_home.join(".sandbox-secrets")
+        ));
+        assert!(projected_link_matches_target(
+            &projected_home.join(".sandbox-bin"),
+            &real_home.join(".sandbox-bin")
+        ));
+        assert!(
+            !projected_link_matches_target(
+                &projected_home.join(".sandbox"),
+                &real_home.join(".sandbox")
+            ),
+            "the sandbox runtime directory must stay per-agent"
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                projected_home
+                    .join(".sandbox-secrets")
+                    .join("sandbox_users.json")
+            )
+            .expect("read projected secrets"),
+            "real secrets"
+        );
+        assert_eq!(
+            std::fs::read_to_string(projected_home.join(".sandbox").join("setup_marker.json"))
+                .expect("read projected marker"),
+            "real setup marker"
+        );
+        assert_eq!(
+            std::fs::read_to_string(projected_home.join(".sandbox").join("sandbox.log"))
+                .expect("read projected log"),
+            "agent log"
+        );
+        assert_eq!(
+            std::fs::read_to_string(projected_home.join(".sandbox").join("setup_error.json"))
+                .expect("read projected setup error"),
+            "agent setup error"
+        );
+        assert_eq!(
+            std::fs::read_to_string(stale_secrets_target.join("sentinel.txt"))
+                .expect("stale target should not be deleted when replacing junction"),
+            "do not delete"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }


### PR DESCRIPTION
## Description
Fixes Wardian-created Codex homes on Windows so fresh agents reuse Codex elevated sandbox support instead of causing repeated sandbox setup/elevation prompts.

- Project `.sandbox-secrets` and `.sandbox-bin` into Wardian Codex homes while keeping `.sandbox` runtime logs/errors local.
- Copy `.sandbox/setup_marker.json` so projected homes can observe completed setup.
- Project bootstrap-generated sandbox support into the final agent home before migrating session artifacts.
- Document the projection contract and add native opt-in coverage for real Windows Codex spawning.

## Related Issues
Fixes #237

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `cargo check` passed.
- `cargo test -- --test-threads=1` passed: 415 lib/bin tests and 5 mock provider e2e tests.
- `cargo clippy --all-targets --all-features` passed.
- `npm run lint` passed.
- `npm run test` passed: 61 files, 551 tests.
- `npm run build` passed.
- `WARDIAN_E2E_REAL_CODEX_SANDBOX=1 WARDIAN_E2E_REAL_WORKSPACE=<repo> node --test e2e-native/tests/codex-windows-sandbox-native.test.mjs` passed against real native Codex/Tauri on Windows.
- Reviewer re-check reported no blockers after the bootstrap-generated sandbox support fix.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable