### PR TITLE
docs(research): add roadmap reference maps

### DIFF
--- a/docs/developer/native-e2e.md
+++ b/docs/developer/native-e2e.md
@@ -89,7 +89,7 @@ It starts the native app with an isolated `WARDIAN_HOME`, creates agents through
 Real-provider checks are opt-in. Keep them isolated and only use them when the mock provider cannot prove the behavior.
 
 ```bash
-WARDIAN_E2E_REAL_OPENCODE=1 WARDIAN_E2E_REAL_WORKSPACE=/path/to/workspace npm run test:e2e:native
+WARDIAN_E2E_REAL_OPENCODE=1 WARDIAN_E2E_REAL_WORKSPACE=<absolute-workspace-path> npm run test:e2e:native
 ```
 
 On PowerShell, use the same placeholder with a Windows absolute path:
@@ -100,4 +100,8 @@ $env:WARDIAN_E2E_REAL_WORKSPACE='<absolute-workspace-path>'
 npm run test:e2e:native
 ```
 
-The harness uses an isolated `WARDIAN_HOME` by default, so native E2E runs should not modify production `~/.wardian` state.
+The harness uses an isolated `WARDIAN_HOME` by default, so native E2E runs should not modify production `<wardian-home>` state.
+
+## Related Research
+
+- [Agent Evaluation References](../research/agent-evaluation-references.md)

--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -187,3 +187,8 @@ When provider behavior breaks, start with the provider-specific seam instead of 
 - Claude problems: inspect `CLAUDE.md` discovery, permission hooks, and explicit session flags.
 - Codex problems: inspect `CODEX_HOME`, `--cd`, bootstrap migration, and sandbox approval transitions.
 - OpenCode problems: inspect `OPENCODE_CONFIG_CONTENT`, real-workspace `cwd`, and JSON session parsing.
+
+## Related Research
+
+- [Agent Protocol and UI References](../research/agent-protocol-and-ui-references.md)
+- [Agent Runtime Sandbox References](../research/agent-runtime-sandbox-references.md)

--- a/docs/developer/state-management.md
+++ b/docs/developer/state-management.md
@@ -31,3 +31,7 @@ Located in `src-tauri/src/state/active_agent.rs`, this struct represents a singl
 4. **Live Terminal Host**: The frontend keeps a long-lived xterm instance per session and only detaches or reattaches its DOM host when panes remount, preserving parser and buffer state in memory.
 5. **Events**: JSON logs emitted by agents (e.g., via the Gemini CLI's `--output-format stream-json`) are intercepted in the PTY reader thread and emitted as `agent-json-event` for the UI to process.
 6. **Startup Replay Boundary**: During app startup, provider log parsing may recover metadata such as query count, log path, resume session, and timestamps, but initial log replay must not create fresh status transitions. Queue completions and CLI `watch --until status:*` evidence come from live transitions after hydration.
+
+## Related Research
+
+- [Local-First State References](../research/local-first-state-references.md)

--- a/docs/developer/visual-builder.md
+++ b/docs/developer/visual-builder.md
@@ -32,3 +32,8 @@ Users can click any variable in the IVA tree (e.g., `gatekeeper.decision`). The 
 
 ### Shared Storage
 The IVA also constantly displays the `storage.*` namespace, allowing easy access to the persistent Key-Value store shared across all workflows and agents.
+
+## Related Research
+
+- [Workflow Design References](../research/workflow-design-references.md)
+- [Graph Visualization References](../research/graph-visualization-references.md)

--- a/docs/developer/workflow-engine.md
+++ b/docs/developer/workflow-engine.md
@@ -59,3 +59,7 @@ Performs `get`, `set`, or `delete` operations on the `shared_storage.json` file.
 ## 🔒 Security & Isolation
 - **Headless Execution**: Uses `tokio::process::Command` with strictly limited `current_dir` validation via `validate_workspace_path`.
 - **Interpolation**: All strings (prompts, paths, commands) are safely interpolated using `{{nodes.id.output.path}}` syntax before execution.
+
+## Related Research
+
+- [Workflow Design References](../research/workflow-design-references.md)

--- a/docs/guide/library.md
+++ b/docs/guide/library.md
@@ -10,7 +10,7 @@ The Library is the centralized repository for all reusable agent assets in Wardi
 
 Prompts are reusable text injections that you can send directly to an agent's terminal.
 
-- **Organization**: Prompts are stored as `.md` files in `~/.wardian/library/prompts/`. You can organize them into physical folders on your disk.
+- **Organization**: Prompts are stored as `.md` files in `<wardian-home>/library/prompts/`. You can organize them into physical folders on your disk.
 - **Quick Injection**: "Star" your favorite prompts to make them appear in the **Command** sidebar tab for one-click execution.
 - **Dynamic Context**: Use prompts to quickly set up environments, run test suites, or provide complex task instructions.
 
@@ -51,3 +51,7 @@ To run a prompt from the Library:
 ## 🚀 Advanced: Skill Auto-Patching
 
 If you use custom modular skills, ensure the **"Auto-patch Gemini CLI"** setting is enabled in the **Settings** panel. This ensures the underlying CLI is patched at launch to recognize the physical skill folders in your agent directories.
+
+## Related Research
+
+- [Skill Manager References](../research/skill-manager-references.md)

--- a/docs/guide/ui-overview.md
+++ b/docs/guide/ui-overview.md
@@ -49,7 +49,7 @@ Use the single-agent roster context menu to create Fresh, Profile, or Custom clo
 
 ### "Physical-First" Navigation
 
-Wardian mirrors your local file system. Most items in the **Library** or **Explorer** correspond to physical files on your disk (`~/.wardian/`), ensuring your work is transparent and portable.
+Wardian mirrors your local file system. Most items in the **Library** or **Explorer** correspond to physical files on your disk (`<wardian-home>/`), ensuring your work is transparent and portable.
 
 ### Contextual Awareness
 
@@ -70,3 +70,9 @@ Wardian preserves terminal state across grid remounts so interactive TUIs, inclu
 - [Command Panel](./command-panel.md)
 - [Source Control](./source-control.md)
 - [Settings](./settings.md)
+
+## Related Research
+
+- [Dashboard Observability References](../research/dashboard-observability-references.md)
+- [Graph Visualization References](../research/graph-visualization-references.md)
+- [Multi-Agent Orchestrator References](../research/multi-agent-orchestrator-references.md)

--- a/docs/guide/watchlists.md
+++ b/docs/guide/watchlists.md
@@ -33,7 +33,7 @@ Click the **gear icon** (⚙) in the watchlist header to open the column picker.
 Click any column header to sort by that column. Clicking again cycles through ascending → descending → unsorted. The **Agent** column header sorts alphabetically by name. Sorting applies on top of your custom watchlist order; drag-to-reorder still works when no sort is active.
 
 ### Persistence
-Column visibility and sort state are saved to `~/.wardian/watchlists/prefs.json` and restored on next launch.
+Column visibility and sort state are saved to `<wardian-home>/watchlists/prefs.json` and restored on next launch.
 
 ## 🗂️ Organizing with Watchlists
 As your swarm grows, a single list becomes difficult to manage. Wardian allows you to group agents into custom **Watchlists**.
@@ -54,3 +54,7 @@ Hover over any agent in the Roster to access instant control icons:
 - **Pause/Resume**: Suspend the PTY process to save CPU.
 - **Restart**: Re-spawn the agent with its initial instructions.
 - **Quick-Jump**: Double-click an agent to center the main Grid view on that agent's terminal.
+
+## Related Research
+
+- [Dashboard Observability References](../research/dashboard-observability-references.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Wardian Documentation
 
-This folder contains user guides, workflow references, developer architecture notes, and long-form specs.
+This folder contains user guides, workflow references, developer architecture notes, research references, and long-form specs.
 
 ## Start Here
 
@@ -45,6 +45,19 @@ This folder contains user guides, workflow references, developer architecture no
 - [Native E2E Harness](./developer/native-e2e.md)
 - [Theming](./developer/theming.md)
 - [Screenshot Documentation](./developer/screenshot-documentation.md)
+
+## Research References
+
+- [Research Index](./research/index.md)
+- [Agent Evaluation References](./research/agent-evaluation-references.md)
+- [Agent Protocol and UI References](./research/agent-protocol-and-ui-references.md)
+- [Agent Runtime Sandbox References](./research/agent-runtime-sandbox-references.md)
+- [Dashboard Observability References](./research/dashboard-observability-references.md)
+- [Graph Visualization References](./research/graph-visualization-references.md)
+- [Local-First State References](./research/local-first-state-references.md)
+- [Multi-Agent Orchestrator References](./research/multi-agent-orchestrator-references.md)
+- [Skill Manager References](./research/skill-manager-references.md)
+- [Workflow Design References](./research/workflow-design-references.md)
 
 ## Specs and Design
 

--- a/docs/research/agent-evaluation-references.md
+++ b/docs/research/agent-evaluation-references.md
@@ -1,0 +1,212 @@
+# Agent Evaluation References
+
+This document maps public agent evaluation, benchmark, observability, and security-testing systems to design patterns relevant to Wardian's verification strategy, workflow run evidence, provider comparison, and agent safety posture.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: entries were selected through public research and checked against public project pages, repositories, papers, or documentation where available.
+
+## Design Axes
+
+- **Task success**: whether an agent actually completed the requested work, not just produced plausible text.
+- **Trajectory evidence**: whether steps, tool calls, file changes, terminal output, and decisions are captured for replay.
+- **Verifier model**: whether scoring is deterministic, test-based, rubric-based, LLM-judged, or human-reviewed.
+- **Security robustness**: whether prompt injection, data exfiltration, unsafe commands, and credential misuse are tested.
+- **Regression loop**: whether production failures can become repeatable evals.
+- **Provider comparability**: whether different agents/providers can be measured under the same task harness.
+- **Workflow observability**: whether evaluation data can map onto Wardian workflow nodes and run history.
+
+## Summary Map
+
+| System | Primary Pattern | Wardian Takeaway |
+|---|---|---|
+| [Inspect](https://inspect.aisi.org.uk/) | General evaluation framework with agent and tool support. | Strong reference for Wardian's own provider/workflow evaluation harness. |
+| [SWE-bench](https://github.com/swe-bench) | Software engineering issue-resolution benchmark. | Useful for coding-agent task realism and reproducible environment discipline. |
+| [tau-bench](https://sierra.ai/uk/resources/research/tau-bench) | Tool-agent-user benchmark for dynamic real-world interactions. | Useful for evaluating multi-turn tool use and policy adherence. |
+| [Claw Bench](https://github.com/claw-bench/claw-bench) | Real agent benchmark with pytest verifiers across many domains. | Directly relevant to agent-run scoring and skill-like task instructions. |
+| [AgentDojo](https://arxiv.org/abs/2406.13352) | Prompt-injection attack and defense benchmark for tool-using agents. | Strong reference for treating tool outputs and web content as untrusted. |
+| [Phoenix](https://github.com/Arize-ai/phoenix) | Open-source AI observability and eval platform. | Reference for trace-to-debug workflows and OpenTelemetry alignment. |
+| [Helicone](https://github.com/Helicone/helicone) | LLM observability, cost, prompt, and request analytics. | Useful for model/provider cost and request visibility. |
+| [OpenLLMetry](https://github.com/traceloop/openllmetry) | OpenTelemetry instrumentation for LLM providers and vector DBs. | Strong reference for emitting portable telemetry instead of bespoke logs. |
+| [Future AGI](https://github.com/future-agi/future-agi) | End-to-end tracing, evals, simulation, gateway, and guardrails. | Useful as a broad platform reference for trace/eval/guardrail convergence. |
+| [Braintrust](https://www.braintrust.dev/) | Trace-to-eval production workflow. | Relevant for turning Wardian failures into repeatable regression cases. |
+
+## Reference Profiles
+
+### Inspect
+
+**Source basis:** Public docs checked.
+
+**What it includes:** Inspect is an open-source framework for frontier AI evaluations from the UK AI Security Institute and Meridian Labs. It supports coding, agentic tasks, reasoning, knowledge, behavior, multimodal understanding, tool calling, built-in agents, multi-agent evaluation, external agents, and human baselines.
+
+**Distinctive components:**
+
+- Reusable evaluation interfaces.
+- Built-in tools such as bash, Python, editing, browsing, and computer tools.
+- Agent Bridge for third-party agent frameworks.
+- Inspect View for monitoring and visualizing evaluations.
+- Multi-agent and custom-agent evaluation patterns.
+
+**Wardian relevance:** Inspect is a relevant reference for Wardian's future verification layer. Wardian can use similar concepts internally: task definitions, solvers/providers, tools, scorers, logs, and replayable evidence.
+
+### SWE-bench
+
+**Source basis:** Public organization/repo checked.
+
+**What it includes:** SWE-bench evaluates AI systems on real GitHub issues. The broader SWE-* ecosystem includes SWE-agent, SWE-smith, experiments, leaderboards, environment artifacts, and supporting infrastructure.
+
+**Distinctive components:**
+
+- Real-world software engineering tasks.
+- Reproducible environment setup.
+- Patch/test-oriented scoring.
+- Public trajectories and experiment data.
+- Agent harnesses and small reference agents.
+
+**Wardian relevance:** SWE-bench matters less as a benchmark Wardian must run and more as a quality bar. Wardian workflows that claim to validate coding work need environment setup, tests, artifacts, and failure evidence that are as explicit as benchmark harnesses.
+
+### tau-bench
+
+**Source basis:** Public research page checked.
+
+**What it includes:** tau-bench evaluates conversational AI agents in realistic domains with dynamic user and tool interaction. It is aimed at measuring performance and reliability in real-world settings rather than static answer quality.
+
+**Distinctive components:**
+
+- Simulated user-agent-tool interactions.
+- Domain-specific policies and APIs.
+- Multi-turn task completion.
+- Reliability focus.
+
+**Wardian relevance:** tau-bench is relevant for Wardian workflows that involve humans, tools, and policies. Wardian should eventually test not only "did the agent edit code?" but also "did the agent follow policy, ask when needed, and use tools correctly over several turns?"
+
+### Claw Bench
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Claw Bench evaluates real AI agent products directly across hundreds of curated tasks and domains. Agents read task instructions, complete the work, and submit results. Scoring uses pytest verifiers with weighted checks and dimensions such as efficiency, security, skills, and UX.
+
+**Distinctive components:**
+
+- Real agent execution rather than adapter-only scoring.
+- Task library across many domains.
+- Pytest verifiers with weighted checks.
+- Dimension scoring.
+- Public leaderboard and anti-abuse validation.
+- Agent-readable skill/task instructions.
+
+**Wardian relevance:** Claw Bench is very relevant to Wardian because it resembles what Wardian should produce for itself: task files, run artifacts, deterministic verifiers, weighted checks, and a visible record of how a provider/class performed.
+
+### AgentDojo
+
+**Source basis:** Public paper checked.
+
+**What it includes:** AgentDojo is an evaluation framework for prompt-injection attacks and defenses in tool-using agents. It includes realistic tasks, security test cases, and attack/defense paradigms around untrusted external tool data.
+
+**Distinctive components:**
+
+- Realistic tool-using tasks such as email, banking, and travel.
+- Prompt-injection attack cases.
+- Defense evaluation.
+- Extensible environment for new attacks and tasks.
+- Emphasis on tool outputs as untrusted data.
+
+**Wardian relevance:** This should influence Wardian's runtime model. Any workflow node that reads web pages, GitHub issues, emails, docs, or tool output should preserve a trust boundary between user instructions, agent reasoning, and untrusted data.
+
+### Phoenix
+
+**Source basis:** Public repo/docs checked.
+
+**What it includes:** Phoenix is an open-source AI observability and evaluation platform. Its public positioning emphasizes OpenTelemetry/OpenInference instrumentation, tracing, debugging, datasets, evals, and integration with common LLM frameworks.
+
+**Distinctive components:**
+
+- OpenTelemetry-compatible tracing.
+- OpenInference instrumentation.
+- LLM, tool, and retrieval traces.
+- Evaluation and debugging workflows.
+- Local and hosted usage patterns.
+
+**Wardian relevance:** Phoenix is useful as an observability reference. Wardian's workflow run history should be exportable or mappable to trace concepts: spans, tool calls, attributes, errors, timing, cost, and artifacts.
+
+### Helicone
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Helicone is an open-source LLM observability platform covering monitoring, analytics, evaluation, prompt management, cost visibility, and provider integrations.
+
+**Distinctive components:**
+
+- Provider request monitoring.
+- Cost and model pricing data.
+- Prompt and experiment tooling.
+- Integrations with LLM frameworks and providers.
+- Data export and MCP-related data access.
+
+**Wardian relevance:** Helicone is relevant to Wardian's provider/runtime accounting. Users supervising many agents need cost, token, latency, and provider error visibility alongside PTY status and workflow node state.
+
+### OpenLLMetry
+
+**Source basis:** Public repo checked.
+
+**What it includes:** OpenLLMetry provides OpenTelemetry-based instrumentation for LLM providers and vector databases, plus SDK support for emitting standard telemetry to existing observability stacks.
+
+**Distinctive components:**
+
+- Standard OpenTelemetry output.
+- Instrumentations for providers and vector databases.
+- SDK-based adoption.
+- Compatibility with existing observability tooling.
+
+**Wardian relevance:** Wardian should avoid inventing an isolated telemetry format for everything. A local event model can be Wardian-native, but exports should align with OpenTelemetry concepts where possible.
+
+### Future AGI
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Future AGI is an open-source platform spanning simulation, evaluation, guardrails, OpenTelemetry-native tracing, gateway/routing, optimization, datasets, and dashboards.
+
+**Distinctive components:**
+
+- Multi-turn simulation.
+- Evaluation metrics and guardrail scanners.
+- OpenTelemetry-native tracing.
+- OpenAI-compatible gateway.
+- Provider routing, caching, and virtual keys.
+- Trace-to-optimization loops.
+
+**Wardian relevance:** Future AGI is useful as a convergence reference: observability, evaluation, gateway control, and guardrails are moving toward one platform layer. Wardian should keep these concerns separate internally but let them meet in run history and workflow evidence.
+
+### Braintrust
+
+**Source basis:** Public product/research material checked.
+
+**What it includes:** Braintrust focuses on evaluations, traces, datasets, prompt iteration, and production feedback loops for AI systems.
+
+**Distinctive components:**
+
+- Trace-to-eval workflow.
+- Dataset and experiment management.
+- CI-style evaluation gates.
+- Production failure capture.
+
+**Wardian relevance:** Braintrust's important pattern is not vendor-specific: production failures should become reusable test cases. Wardian should make it easy to turn a bad agent run into a regression fixture for the relevant provider, class, skill, or workflow.
+
+## Wardian Positioning
+
+Wardian should make verification visible at the same level as execution:
+
+```text
+task/run -> observed trajectory -> artifacts -> verifier/evaluator -> score and regression case
+```
+
+Near-term implications:
+
+- Store run evidence in a structured form, not only terminal transcripts.
+- Attach verifiers to workflow nodes where possible.
+- Treat "agent got stuck" as an evaluable failure mode.
+- Track provider/class/skill performance over repeatable tasks.
+- Preserve trust boundaries for untrusted tool outputs.
+- Allow a failed run to become a replayable regression case.

--- a/docs/research/agent-protocol-and-ui-references.md
+++ b/docs/research/agent-protocol-and-ui-references.md
@@ -1,0 +1,175 @@
+# Agent Protocol and UI References
+
+This document maps public agent interoperability and agent-generated UI systems to design patterns relevant to Wardian's workflow builder, command center, agent-facing APIs, and human-observable control surfaces.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: entries were selected through public research and checked against public project pages, repositories, or specifications where available.
+
+## Design Axes
+
+- **Agent-to-tool protocol**: how agents invoke tools, read resources, or use external context.
+- **Agent-to-agent protocol**: how independent agents discover each other, delegate, negotiate tasks, and exchange artifacts.
+- **Agent-to-UI protocol**: how agents communicate progress, ask for input, update shared state, or generate safe UI surfaces.
+- **Declarative construction**: whether agent systems can be described as portable text or structured specs.
+- **Trust boundary**: whether the protocol treats remote agents, generated UI, and tool outputs as untrusted data.
+- **Human observability**: whether protocol events can be projected into visible UI state, logs, approvals, and workflow nodes.
+
+## Summary Map
+
+| System | Primary Pattern | Wardian Takeaway |
+|---|---|---|
+| [Model Context Protocol](https://modelcontextprotocol.io/) | Tool/resource protocol for model applications. | Wardian should expose skills, workflows, memory, and app actions through structured protocols where practical. |
+| [Agent2Agent / A2A](https://github.com/google-a2a/A2A) | Agent-to-agent discovery and task communication. | Useful reference for cross-agent delegation that does not depend on shared internals. |
+| [OpenClaw ACPX](https://github.com/openclaw/acpx) | Headless client for stateful Agent Client Protocol sessions. | Relevant as a structured alternative to PTY scraping for coding agents. |
+| [AG-UI](https://github.com/ag-ui-protocol/ag-ui) | Agent-user interaction protocol for frontend applications. | Strong reference for turning backend agent events into user-facing shared state and controls. |
+| [A2UI](https://github.com/google/A2UI) | Declarative, safe agent-generated UI format. | Directly relevant to "agents construct, humans observe" without letting agents emit executable UI code. |
+| [Open Agent Spec](https://github.com/oracle/agent-spec) | Declarative language for agents, workflows, and multi-agent systems. | Useful reference for portable agent/workflow definitions. |
+| [agent.json](https://agent-json.com/) | Web discovery document for agent-facing services. | Useful later if Wardian exposes local or shared capabilities to external agents. |
+| [LSP](https://microsoft.github.io/language-server-protocol/) and [DAP](https://microsoft.github.io/debug-adapter-protocol/) | Mature editor/tool protocols. | Good governance references for stable schemas, capabilities, versioning, and client/server separation. |
+
+## Reference Profiles
+
+### Model Context Protocol
+
+**Source basis:** Public protocol site checked.
+
+**What it includes:** MCP defines a structured way for AI applications to connect models to tools, resources, prompts, and external context. It is becoming a baseline integration protocol for agent tooling.
+
+**Distinctive components:**
+
+- Client/server protocol for tools and resources.
+- Typed capabilities and tool schemas.
+- Stdio and remote transport patterns.
+- Growing ecosystem of MCP servers and clients.
+
+**Wardian relevance:** Wardian should treat MCP as a first-class interoperability boundary. Skills, workspace files, workflow operations, agent roster state, and command-center actions should be exposed through stable structured interfaces where useful, not only through UI clicks or terminal text.
+
+### Agent2Agent / A2A
+
+**Source basis:** Public spec and repo checked.
+
+**What it includes:** A2A is an open protocol for communication and interoperability between independent agentic applications. Its goals include agent discovery, capability negotiation, collaborative task management, and structured exchange without requiring access to another agent's internal memory or tools.
+
+**Distinctive components:**
+
+- Agent cards and capability discovery.
+- Task-oriented communication.
+- Modality-agnostic exchange of text, files, structured data, and UI references.
+- Peer-to-peer agent collaboration model.
+
+**Wardian relevance:** Wardian's internal agent roster is local-first, but its long-term roadmap will need external agent interoperability. A2A is useful as a reference for describing what an agent can do without exposing all Wardian internals.
+
+### OpenClaw ACPX
+
+**Source basis:** Public repo and OpenClaw docs checked.
+
+**What it includes:** ACPX is a headless CLI client for stateful Agent Client Protocol sessions. OpenClaw uses ACP concepts to run external coding harnesses through a structured backend plugin rather than treating every agent as an opaque terminal.
+
+**Distinctive components:**
+
+- Structured sessions over coding-agent harnesses.
+- External adapters for different agent runtimes.
+- Separation between agent runtime control and terminal text.
+- OpenClaw integration with MCP and ACP-style session management.
+
+**Wardian relevance:** Wardian currently values visible PTYs, but PTYs should not be the only control plane. ACP-style adapters point toward a future where Wardian can run agents visibly while also receiving structured status, messages, tool calls, and artifacts.
+
+### AG-UI
+
+**Source basis:** Public repo and protocol site checked.
+
+**What it includes:** AG-UI is an Agent-User Interaction protocol for connecting user-facing applications with agentic backends. It emphasizes shared state, tool-based generative UI, agentic chat, human-in-the-loop interactions, and frontend/backend event flow.
+
+**Distinctive components:**
+
+- Bidirectional agent-to-application runtime.
+- Client support across frontend platforms and community SDKs.
+- Shared state and human-in-the-loop primitives.
+- Examples for focused protocol building blocks.
+- Terminal-and-agent client support.
+
+**Wardian relevance:** AG-UI is relevant because Wardian is a command center, not just an agent launcher. Workflow nodes, action-needed prompts, approvals, agent messages, tool calls, and generated controls could all be represented as structured UI events instead of bespoke ad hoc IPC messages.
+
+### A2UI
+
+**Source basis:** Public repo checked.
+
+**What it includes:** A2UI is an early public-preview format for updatable agent-generated user interfaces. Agents send declarative JSON describing UI intent; the client maps those abstract components to a trusted component catalog and renders them natively.
+
+**Distinctive components:**
+
+- Declarative data format rather than executable generated code.
+- Trusted host component catalog.
+- Incrementally updatable component graph.
+- LLM-friendly flat structure with ID references.
+- Compatible with transports such as A2A and AG-UI.
+- Renderers for web and Flutter-oriented clients.
+
+**Wardian relevance:** A2UI is highly relevant to Wardian's workflow builder. Agents could propose workflow nodes, forms, inspectors, or approval panels as data, while Wardian decides how to render them using safe local components. This keeps construction agent-friendly without letting agents own the UI runtime.
+
+### Open Agent Spec
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Open Agent Spec is a framework-agnostic declarative language for defining standalone agents, structured agentic workflows, and multi-agent compositions.
+
+**Distinctive components:**
+
+- YAML/spec-oriented agent definitions.
+- Reusable building blocks for agents and workflows.
+- Multi-agent composition concepts.
+- Framework-neutral positioning.
+
+**Wardian relevance:** Wardian should track this class of declarative agent specs. Even if Wardian has its own workflow format, import/export adapters will matter if agent definitions become portable across tools.
+
+### agent.json
+
+**Source basis:** Public proposal site checked.
+
+**What it includes:** `agent.json` proposes a `.well-known` discovery document that lets websites describe agent-facing capabilities, messaging, responses, and callbacks.
+
+**Distinctive components:**
+
+- Web discovery endpoint.
+- Capability metadata.
+- Agent-facing service description.
+- Callback and message-oriented interaction framing.
+
+**Wardian relevance:** This is a later-stage reference. If Wardian exposes local or network-visible capabilities, a discovery document pattern could let other agents identify available Wardian actions without custom setup.
+
+### LSP and DAP
+
+**Source basis:** Public protocol sites checked at a high level.
+
+**What they include:** LSP and DAP are mature protocols that separate editor UIs from language servers and debugger implementations. They are not AI-agent protocols, but their capability negotiation, schema stability, and client/server boundaries are useful references.
+
+**Distinctive components:**
+
+- Capability negotiation.
+- Stable JSON-RPC style contracts.
+- Clear client/server ownership.
+- Broad multi-editor ecosystem.
+- Versioned protocol evolution.
+
+**Wardian relevance:** Wardian should learn governance discipline from LSP and DAP. Agent protocols will churn; Wardian's internal IPC and CLI contracts should remain explicit, versioned, and capability-based.
+
+## Wardian Positioning
+
+Wardian should separate three surfaces:
+
+```text
+agent runtime protocol -> normalized Wardian event/state model -> human UI projection
+```
+
+PTYs remain important because humans need to see real agent sessions. But as protocols mature, Wardian should prefer structured events for status, tool calls, approvals, artifacts, and generated controls.
+
+Near-term implications:
+
+- Add protocol-adapter boundaries instead of hardcoding provider behavior into UI components.
+- Treat generated UI as declarative data mapped through trusted Wardian components.
+- Keep workflow and agent definitions import/export-friendly.
+- Version internal event schemas like public protocols.
+- Use PTY text as evidence, but not the only source of truth when structured events exist.

--- a/docs/research/agent-runtime-sandbox-references.md
+++ b/docs/research/agent-runtime-sandbox-references.md
@@ -1,0 +1,190 @@
+# Agent Runtime Sandbox References
+
+This document maps public agent runtime, sandbox, browser automation, and policy systems to design patterns relevant to Wardian's provider execution model, terminal safety, workflow approvals, and future isolated workspaces.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: entries were selected through public research and checked against public project pages, repositories, or documentation where available.
+
+## Design Axes
+
+- **Execution boundary**: whether agents run directly on the host, in a PTY, in a worktree, in a container, in a VM, in a browser session, or in a remote sandbox.
+- **Policy model**: how filesystem, network, secrets, shell, browser, and desktop permissions are granted or denied.
+- **Persistence model**: whether sandbox state is disposable, resumable, snapshot-based, or long-running.
+- **Human intervention**: whether users can inspect, attach, approve, pause, or terminate execution.
+- **Agent API**: whether sandbox lifecycle can be managed through CLI, REST, MCP, SDK, or UI.
+- **Audit trail**: whether commands, browser actions, file changes, credentials, and network access are logged.
+
+## Summary Map
+
+| System | Primary Pattern | Wardian Takeaway |
+|---|---|---|
+| [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) | Private agent runtime with declarative YAML policies. | Strong reference for permissioned local execution and data-exfiltration controls. |
+| [Agent-Sandbox](https://github.com/agent-sandbox/agent-sandbox) | Kubernetes-backed multi-tenant agent sandbox with REST and MCP lifecycle management. | Useful for future remote/isolated Wardian workers. |
+| [E2B](https://e2b.dev/) | Cloud sandbox for AI-generated code and agents. | Reference for disposable execution environments and agent-accessible terminals. |
+| [Daytona](https://github.com/daytonaio/daytona) | Development-environment sandbox infrastructure. | Relevant to isolated workspaces and repeatable dev environments. |
+| [Stagehand](https://github.com/browserbase/stagehand) | AI browser automation primitives over Chromium. | Useful if Wardian adds browser panels or browser workflow nodes. |
+| [Browserbase MCP](https://github.com/browserbase/mcp-server-browserbase) | MCP access to managed browser sessions. | Reference for browser sessions as agent tools with replay and lifecycle control. |
+| [browser-use](https://github.com/browser-use/browser-use) | Python browser automation for agents. | Useful for comparing free-form browser agent loops against deterministic primitives. |
+| [Playwright MCP](https://github.com/microsoft/playwright-mcp) | Browser automation exposed through MCP. | Relevant for local, inspectable browser tooling in workflows. |
+| [Skyvern](https://github.com/Skyvern-AI/skyvern) | AI browser automation for web workflows. | Useful as an adjacent workflow/browser automation reference. |
+
+## Reference Profiles
+
+### NVIDIA OpenShell
+
+**Source basis:** Public repo checked.
+
+**What it includes:** OpenShell is a safe private runtime for autonomous AI agents. It provides sandboxed execution environments governed by declarative YAML policies intended to prevent unauthorized file access, data exfiltration, and uncontrolled network activity.
+
+**Distinctive components:**
+
+- Sandboxed execution for coding agents such as Claude, OpenCode, Codex, and Copilot.
+- Declarative policy files.
+- File access controls.
+- Network and exfiltration-oriented governance.
+- Terminal UI for debugging.
+
+**Wardian relevance:** OpenShell is the most directly relevant policy reference. Wardian should eventually represent what an agent may read, write, execute, and exfiltrate as explicit policy, not only as user trust in a provider.
+
+### Agent-Sandbox
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Agent-Sandbox is an AI-first sandbox system built around Kubernetes. It supports code execution, browser automation, computer use, shell commands, multi-session and multi-tenant isolation, REST APIs, MCP lifecycle management, storage, logs, terminal access, and UI surfaces.
+
+**Distinctive components:**
+
+- Sandbox lifecycle API.
+- MCP server for agents to create/access/delete sandboxes.
+- Code, browser, computer, and shell runtime categories.
+- Multi-session and multi-tenant isolation.
+- Unified storage across sandbox types.
+- Kubernetes-backed deployment.
+
+**Wardian relevance:** This is more cloud-native than Wardian's near-term local desktop runtime, but its lifecycle model matters. Wardian should model execution environments explicitly: host PTY, worktree, container, remote sandbox, browser session, and future VM should be different environment types with different guarantees.
+
+### E2B
+
+**Source basis:** Public documentation checked.
+
+**What it includes:** E2B provides secure cloud environments for running AI-generated code and agents. It is commonly used as a sandbox runtime by agent systems such as OpenHands.
+
+**Distinctive components:**
+
+- Isolated cloud sandboxes.
+- Programmatic SDKs and CLI access.
+- Terminal connection to running sandboxes.
+- File and command execution APIs.
+- Agent-runtime orientation.
+
+**Wardian relevance:** E2B is useful as a reference for disposable and remote execution. Wardian should not require cloud sandboxes, but workflow nodes should be able to declare whether they run on the host, in a worktree, or in an isolated runtime.
+
+### Daytona
+
+**Source basis:** Public repo checked at a high level.
+
+**What it includes:** Daytona provides development-environment infrastructure for creating and managing isolated dev environments. It is relevant less as an agent system and more as a repeatable workspace/runtime abstraction.
+
+**Distinctive components:**
+
+- Environment provisioning.
+- Workspace lifecycle management.
+- Developer-tool integration.
+- Remote and reproducible development environments.
+
+**Wardian relevance:** Wardian's worktree model may eventually need richer environment provisioning: dependencies, services, ports, secrets, and remote machines. Daytona belongs in the long-term environment-management reference set.
+
+### Stagehand
+
+**Source basis:** Public site checked.
+
+**What it includes:** Stagehand is an open-source AI browser automation framework with primitives such as `act`, `extract`, `observe`, and `agent`. It can run locally with Chromium and optionally use Browserbase for managed sessions, replay, captcha handling, and identity.
+
+**Distinctive components:**
+
+- Natural-language browser automation primitives.
+- Deterministic step-by-step control with an agent option for multi-step flows.
+- Local Chromium support.
+- Optional managed Browserbase sessions.
+- Support across major model providers.
+
+**Wardian relevance:** Stagehand is relevant if Wardian adds browser workflow nodes or browser panels. Its split between deterministic primitives and autonomous agent mode maps well to Wardian's distinction between workflow control and agent autonomy.
+
+### Browserbase MCP
+
+**Source basis:** Public changelog/repo checked.
+
+**What it includes:** Browserbase exposes browser automation through an MCP server powered by Stagehand and managed browser infrastructure.
+
+**Distinctive components:**
+
+- MCP interface for browser actions.
+- Managed cloud browser sessions.
+- Session persistence and replay.
+- Production browser automation infrastructure.
+
+**Wardian relevance:** Browserbase MCP shows how browser sessions can become structured tools. Wardian should be able to attach a browser surface to a workflow run while preserving replayable action logs and human inspection.
+
+### browser-use
+
+**Source basis:** Public repo checked at a high level.
+
+**What it includes:** browser-use is a Python framework for letting agents control browsers, typically through Playwright-style automation and model-driven loops.
+
+**Distinctive components:**
+
+- Browser control for agents.
+- Model-agnostic automation loops.
+- Python developer ergonomics.
+- Broad community adoption.
+
+**Wardian relevance:** browser-use is useful as a caution and comparison point. Fully autonomous browser loops are powerful, but Wardian should prefer structured action logs, selectors, permissions, and replay where possible.
+
+### Playwright MCP
+
+**Source basis:** Public repo checked at a high level.
+
+**What it includes:** Playwright MCP exposes browser automation capabilities through MCP, allowing agents to operate browsers through a structured tool interface.
+
+**Distinctive components:**
+
+- Local browser automation through Playwright.
+- MCP tool interface.
+- Structured browser actions.
+- Screenshot/DOM-driven inspection patterns.
+
+**Wardian relevance:** This is likely the most practical browser automation reference for local-first Wardian workflows. A browser node should be observable, replayable, and interruptible, not just a hidden agent tool call.
+
+### Skyvern
+
+**Source basis:** Public repo checked at a high level.
+
+**What it includes:** Skyvern is an AI browser automation system for web workflows. It is relevant as part of the broader browser-agent automation landscape.
+
+**Distinctive components:**
+
+- Browser workflow automation.
+- AI-assisted interaction with web pages.
+- Task execution and workflow posture.
+
+**Wardian relevance:** Skyvern is a later-stage reference. Wardian does not need to become a browser automation product, but browser workflows will matter if agents need to operate web apps during visible runs.
+
+## Wardian Positioning
+
+Wardian should model runtime as a first-class part of every agent and workflow node:
+
+```text
+task -> runtime environment -> permissions -> observable session -> artifacts and audit log
+```
+
+Near-term implications:
+
+- Represent host PTY, worktree, browser, container, and remote sandbox as distinct execution environments.
+- Add policy metadata before adding powerful automation.
+- Keep secrets and network access explicit.
+- Make sandbox attach/inspect/terminate operations visible in the command center.
+- Log runtime actions as workflow evidence, not just terminal text.
+- Prefer deterministic browser/tool primitives for critical workflow steps, with autonomous agents reserved for exploration.

--- a/docs/research/dashboard-observability-references.md
+++ b/docs/research/dashboard-observability-references.md
@@ -1,0 +1,196 @@
+# Dashboard Observability References
+
+This document maps public complex-system dashboards, Kubernetes/operator UIs, monitoring tools, and trace dashboards to design patterns relevant to Wardian's dashboard view, command-center telemetry, agent roster, watchlists, and drill-down monitoring paths.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: entries were selected through public research and checked against public project pages, repositories, or documentation where available.
+
+## Design Axes
+
+- **Operator surface**: dashboard, resource browser, dense table, topology summary, trace search, log viewer, or alert panel.
+- **Status projection**: how health, freshness, ownership, stuckness, current execution state, and incident severity are summarized.
+- **Drill-down path**: how users move from overview to resource details, logs, terminal output, metrics, traces, events, files, and actions.
+- **Information density**: whether the UI supports repeated monitoring at scale without forcing decorative or low-density cards.
+- **Layout persistence**: whether dashboards and views can be saved, provisioned, versioned, or reproduced across machines.
+- **Action locality**: whether pause, restart, inspect, filter, port-forward, logs, or other actions sit near the monitored object.
+- **Dashboard scope**: whether the surface is cluster-wide, team-wide, workflow-wide, resource-specific, or time-window-specific.
+
+## Summary Map
+
+| System | Primary Pattern | Wardian Takeaway |
+|---|---|---|
+| [Headlamp](https://github.com/kubernetes-sigs/headlamp) | Extensible Kubernetes web UI. | Reference for resource trees, plugin-driven panes, and operator workflows. |
+| [Octant](https://octant.dev/) | Developer-centric Kubernetes dashboard. | Useful for related-object views, live logs, filtered resources, and extensibility. |
+| [K9s](https://github.com/derailed/k9s) | Keyboard-first Kubernetes TUI. | Reference for dense, fast, repeated monitoring without losing command access. |
+| [Grafana](https://grafana.com/) | Provisionable monitoring dashboards. | Reference for dashboard-as-code, panel composition, variables, alerts, and time-series drill-down. |
+| [Jaeger UI](https://github.com/jaegertracing/jaeger-ui) | Distributed trace search and trace detail UI. | Relevant to Wardian run traces, causality, and time-window investigation. |
+| [Kiali](https://kiali.io/) | Service-mesh observability dashboard. | Reference for combining topology, health, metrics, traces, and external dashboard links. |
+| [Airflow](https://github.com/apache/airflow) | Workflow monitoring dashboard with DAG and run status. | Reference for joining run grids, environment summaries, code view, and per-run details. |
+| [Temporal UI](https://docs.temporal.io/web-ui/) | Durable workflow execution inspection. | Reference for long-running execution history, retries, and failure evidence. |
+| [Prefect](https://github.com/PrefectHQ/prefect) | Flow-run dashboard and task/artifact observability. | Reference for API-backed run visibility with graph, artifact, and size limits. |
+
+## Reference Profiles
+
+### Headlamp
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Headlamp is a Kubernetes web UI described as fully-featured, user-friendly, and extensible. Its public surface emphasizes Kubernetes debugging, monitoring, orchestration, dashboarding, and plugins.
+
+**Distinctive components:**
+
+- Resource browser for Kubernetes objects.
+- Extensible plugin model.
+- Cluster/operator dashboard posture.
+- Debugging and monitoring orientation.
+
+**Wardian relevance:** Headlamp is a command-center reference. Wardian has a similar problem shape: many live objects, nested resource kinds, status badges, logs, actions, plugins, and operator workflows. The dashboard should make the object graph navigable without hiding raw state.
+
+### Octant
+
+**Source basis:** Public project site checked.
+
+**What it includes:** Octant is a developer-centric web interface for inspecting Kubernetes clusters and applications. It emphasizes visualization, extensibility, real-time updates, related-object views, filtering labels, streaming logs, port-forward actions, and gRPC plugins.
+
+**Distinctive components:**
+
+- Related-object views.
+- Real-time cluster updates.
+- Plugin API.
+- Label filtering and log streaming.
+- Developer debugging actions such as port forwarding.
+
+**Wardian relevance:** Octant's related-object model maps well to Wardian's dashboard: from an agent, a user should be able to reach workspace, PTY, workflow run, skills, files changed, logs, messages, approvals, and errors. Dashboard cards and tables should be navigation into concrete evidence.
+
+### K9s
+
+**Source basis:** Public repo checked at a high level.
+
+**What it includes:** K9s is a terminal UI for managing and debugging Kubernetes clusters. It is known for dense keyboard-driven navigation over live resource tables, logs, describes, and actions.
+
+**Distinctive components:**
+
+- Keyboard-first live resource navigation.
+- Dense tabular status views.
+- Fast switching between contexts and resources.
+- Logs and command actions near the resource list.
+- TUI posture for repeated operator use.
+
+**Wardian relevance:** K9s is relevant because a serious Wardian dashboard needs dense lists, fast keyboard control, filters, and logs at hand. The dashboard view should not become a slow, ornamental overview that sends operators elsewhere for every action.
+
+### Grafana
+
+**Source basis:** Public docs checked.
+
+**What it includes:** Grafana is a monitoring/dashboard platform. Its provisioning docs show dashboards and data sources managed through files, making dashboards version-controllable and reproducible.
+
+**Distinctive components:**
+
+- Panel-based dashboards.
+- Data-source abstraction.
+- JSON/YAML dashboard definitions.
+- File-based provisioning and GitOps workflows.
+- Time range, variables, drill-downs, and alerts.
+
+**Wardian relevance:** Grafana is a reference for dashboard-as-code. Wardian dashboard layouts, watchlists, and observability panels should be saveable as files, reviewed in specs, and recreated across machines where practical.
+
+### Jaeger UI
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Jaeger UI visualizes distributed traces collected by Jaeger. It supports trace search and trace detail views around spans, services, timing, and causality.
+
+**Distinctive components:**
+
+- Trace search.
+- Trace detail and span timing views.
+- Distributed causality inspection.
+- Integration with tracing backends and OpenTelemetry pipelines.
+
+**Wardian relevance:** Wardian dashboard drill-downs should answer operational questions such as "why did this run take so long?", "which agent blocked the flow?", and "which step caused this failure?" Jaeger-style trace search and detail views are relevant once the dashboard links into run evidence.
+
+### Kiali
+
+**Source basis:** Public site and docs checked.
+
+**What it includes:** Kiali is a service-mesh observability and configuration dashboard. It integrates service topology, health, metrics, tracing, and links to systems such as Grafana and Jaeger.
+
+**Distinctive components:**
+
+- Service topology summary.
+- Health overlays.
+- Metrics and tracing integration.
+- Ownership/custom information patterns.
+- Links out to deeper dashboards.
+
+**Wardian relevance:** Kiali is useful for the dashboard-to-detail pattern: a high-level system view should show health and relationships while preserving fast links into metrics, traces, configuration, and ownership.
+
+### Airflow
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Airflow is a platform to programmatically author, schedule, and monitor workflows. Its UI includes DAG overview, asset dependencies, grid timelines, graph views with per-run status, environment summaries, backfill views, and source-code viewing.
+
+**Distinctive components:**
+
+- Grid view across time/runs.
+- Per-run status projection.
+- Environment and scheduling summaries.
+- Code view for workflow definitions.
+- Backfill and scheduling surfaces.
+
+**Wardian relevance:** Airflow is relevant where Wardian's dashboard needs to summarize workflow health across many runs. The useful pattern is not only the DAG graph; it is the combination of current status, historical run grid, schedules, code, and logs.
+
+### Temporal UI
+
+**Source basis:** Public docs and repo checked.
+
+**What it includes:** Temporal UI is used to inspect durable workflow executions: running workflows, workflow history, retries, failures, and execution details for long-running business logic.
+
+**Distinctive components:**
+
+- Durable workflow execution inspection.
+- Event history and replay-oriented debugging.
+- Long-running execution visibility.
+- Retry/failure state inspection.
+
+**Wardian relevance:** Temporal is relevant where Wardian dashboard cards need to represent long-lived, retryable work. A status badge is not enough; operators need durable execution history and a way to inspect what the engine believed at each step.
+
+### Prefect
+
+**Source basis:** Public docs/API reference checked.
+
+**What it includes:** Prefect exposes flow run dashboards and APIs for flow run graphs, task runs, subflow runs, artifacts, and graph limits. It treats flow-run graphs as an API-backed view with max-node and max-artifact settings.
+
+**Distinctive components:**
+
+- Flow and flow-run dashboards.
+- Task/subflow run graph APIs.
+- Artifact display tied to run state.
+- Limits for large run graphs and artifacts.
+- API-backed run details.
+
+**Wardian relevance:** Prefect is useful for dashboard implementation discipline. Wardian should treat dashboard data as bounded API output: changed-since queries, max rows, artifacts, and progressive loading matter once agent workflows and run histories get large.
+
+## Wardian Positioning
+
+Wardian's dashboard should be a monitoring surface, not a universal graph surface:
+
+```text
+system dashboard -> roster/watchlists -> focused detail panes -> logs/traces/artifacts/actions
+```
+
+The dashboard should summarize active agents, stuck work, resource pressure, recent failures, approvals, workflow runs, schedules, and provider health. Graph surfaces can be linked from the dashboard, but the dashboard itself should prioritize fast scanning, filtering, and drill-down.
+
+Near-term implications:
+
+- Keep dashboard view separate from workflow graph editing and communication graph exploration.
+- Use dense rows, tables, and compact panels where they beat large cards.
+- Put common actions near the monitored object: pause, resume, inspect, jump to terminal, open logs, open run details.
+- Treat dashboard layouts and watchlists as versionable artifacts where practical.
+- Preserve direct drill-downs from dashboard summaries into PTY output, logs, artifacts, approvals, skills, files, and run history.
+- Add API limits, time windows, and changed-since queries before dashboard data grows large.
+- Keep keyboard navigation and filtering central to repeated operator use.

--- a/docs/research/graph-visualization-references.md
+++ b/docs/research/graph-visualization-references.md
@@ -1,0 +1,210 @@
+# Graph Visualization References
+
+This document maps public graph-visualization libraries, workflow graph UIs, topology maps, and trace-oriented visualizations to design patterns relevant to Wardian's workflow builder, workflow run graph, and future agent communication graph.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: entries were selected through public research and checked against public project pages, repositories, or documentation where available.
+
+## Design Axes
+
+- **Graph purpose**: construction graph, dependency graph, communication graph, topology map, trace graph, or artifact graph.
+- **Source of truth**: whether the graph is hand-authored, generated from code/configuration, projected from runtime events, or reconstructed from traces.
+- **Scale behavior**: whether the UI handles tens, hundreds, thousands, or tens of thousands of nodes and edges.
+- **Layout model**: manual placement, automatic layout, hierarchical DAG layout, force-directed layout, clustered topology, or timeline-adjacent trace layout.
+- **Status overlay**: how health, freshness, ownership, stuckness, current execution state, or causality is layered onto graph structure.
+- **Drill-down path**: how users move from a node or edge to logs, terminal output, messages, files, approvals, artifacts, traces, or run history.
+- **Text as source**: whether graph definitions can be saved, reviewed, versioned, and regenerated.
+
+## Summary Map
+
+| System | Primary Pattern | Wardian Takeaway |
+|---|---|---|
+| [React Flow](https://reactflow.dev/) | Node-based editor and interactive diagram library. | Relevant to Wardian's workflow construction surface. |
+| [Cytoscape.js](https://github.com/cytoscape/cytoscape.js/) | Graph theory and interactive network visualization library. | Relevant to agent interaction, communication, dependency, and ownership networks. |
+| [sigma.js](https://v4.sigmajs.org/) | WebGL-powered large-graph rendering. | Useful if Wardian needs dense agent/message/trace graphs at large scale. |
+| [Graphviz](https://graphviz.org/) and [Mermaid](https://mermaid.js.org/) | Text-defined graph rendering. | Reinforces "code/text as construction, graph as projection." |
+| [Kiali](https://kiali.io/) | Service-mesh topology visualization. | Relevant to overlaying health, traffic, traces, and ownership onto communication graphs. |
+| [Airflow](https://github.com/apache/airflow) | Workflow UI with DAG graph and run status. | Reference for dependency graph plus per-run status projection. |
+| [Dagster](https://github.com/dagster-io/dagster) | Asset graph and orchestration observability. | Useful for scaling dependency visualization and artifact/run status. |
+| [Temporal UI](https://docs.temporal.io/web-ui/) | Durable workflow execution inspection. | Reference for workflow history, retries, and long-running execution evidence. |
+| [Prefect](https://github.com/PrefectHQ/prefect) | Flow-run graph and task/subflow observability. | Reference for API-backed run graphs with update limits and artifacts. |
+| [Jaeger UI](https://github.com/jaegertracing/jaeger-ui) | Distributed trace detail UI. | Relevant to Wardian run traces, causality, and sequence/flame views. |
+
+## Reference Profiles
+
+### React Flow
+
+**Source basis:** Public project site checked.
+
+**What it includes:** React Flow is an open-source React library for building node-based editors and interactive diagrams. It provides nodes, edges, selection, keyboard operations, panning, zooming, and a component model for custom workflow-style surfaces.
+
+**Distinctive components:**
+
+- Custom node and edge rendering.
+- Interactive editing with keyboard and pointer support.
+- Library posture for builders, workflows, and node-based tools.
+- Broad ecosystem adoption and examples.
+
+**Wardian relevance:** React Flow is a construction-surface reference. Wardian should use similar interaction concepts for workflow editing, but the graph should remain a projection of Wardian's normalized workflow model rather than becoming a separate source of truth.
+
+### Cytoscape.js
+
+**Source basis:** Public repo and documentation checked.
+
+**What it includes:** Cytoscape.js is a graph-theory library for visualization and analysis. It includes a graph model, optional renderer, layouts, traversal, filtering, and interaction support for rich network views.
+
+**Distinctive components:**
+
+- Graph model and renderer are separable.
+- Directed, undirected, mixed, compound, and other graph use cases.
+- Traversal and graph algorithms.
+- Layout and interaction ecosystem.
+- Usable headlessly for analysis or in-browser for UI.
+
+**Wardian relevance:** Cytoscape.js is relevant to non-construction graphs: agent communication, dependency maps, memory/reference networks, skill usage, workflow run causality, and ownership. These graphs should support analysis and filtering, not only manual node placement.
+
+### sigma.js
+
+**Source basis:** Public project site checked.
+
+**What it includes:** sigma.js is a WebGL-powered library for rendering large interactive graphs in the browser. It is built on graphology and emphasizes smooth rendering for complex networks.
+
+**Distinctive components:**
+
+- GPU-accelerated graph rendering.
+- Built-in pan, zoom, hover, and multi-touch.
+- Framework-agnostic integration.
+- Graphology algorithms for layouts, metrics, and community detection.
+- Large-graph examples such as thousands of research-paper nodes.
+
+**Wardian relevance:** sigma.js is relevant if Wardian eventually visualizes thousands of events, messages, memories, or interactions. The lesson is to separate "large graph exploration" from "workflow editing"; they have different performance and interaction needs.
+
+### Graphviz and Mermaid
+
+**Source basis:** Public project docs checked at a high level.
+
+**What they include:** Graphviz and Mermaid generate diagrams from text definitions. Graphviz emphasizes graph layout algorithms and DOT; Mermaid emphasizes Markdown-friendly diagrams and documentation.
+
+**Distinctive components:**
+
+- Text-defined graph source.
+- Repeatable rendering.
+- Good fit for documentation and generated diagrams.
+- Different balance between layout power and authoring convenience.
+
+**Wardian relevance:** These tools reinforce Wardian's documentation posture. Workflow graphs, class relationships, and reference maps should be exportable to text-defined diagrams for specs, reviews, and agent-authored documentation.
+
+### Kiali
+
+**Source basis:** Public site and docs checked.
+
+**What it includes:** Kiali is a service-mesh observability and configuration dashboard. Its graph surface shows service topology, health, traffic, and links to deeper metrics and tracing systems.
+
+**Distinctive components:**
+
+- Service topology graph.
+- Health overlays.
+- Metrics and tracing integration.
+- Ownership/custom information patterns.
+- Links out to deeper dashboards.
+
+**Wardian relevance:** Kiali is a useful analogy for agent communication graphs. Wardian can show which agents, workflows, skills, and tools are interacting, then overlay stuckness, cost, error rate, approvals, and ownership.
+
+### Airflow
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Airflow is a platform to programmatically author, schedule, and monitor workflows. Its UI includes DAG overview, asset dependencies, grid timelines, graph views with per-run status, environment summaries, backfill views, and source-code viewing.
+
+**Distinctive components:**
+
+- DAG dependency graph.
+- Per-run status projection.
+- Code view for workflow definitions.
+- Time-oriented run grid next to graph-oriented dependency views.
+
+**Wardian relevance:** Airflow is relevant for combining source-defined workflows with graph and run-state projections. Wardian should similarly show definitions, graph structure, current run status, historical run evidence, and logs without splitting them into unrelated screens.
+
+### Dagster
+
+**Source basis:** Public repo/docs and UI scaling material checked.
+
+**What it includes:** Dagster is an orchestration platform for developing, producing, and observing data assets. It emphasizes software-defined assets, asset dependency graphs, materialization status, and scalable graph visualization for large asset sets.
+
+**Distinctive components:**
+
+- Asset graph rather than only task graph.
+- Dependency visualization.
+- Materialization and freshness status.
+- Large graph scaling work.
+- Code-defined assets and UI observation.
+
+**Wardian relevance:** Dagster's asset graph is relevant because Wardian workflows should not only show tasks; they should show produced artifacts, files, PRs, reports, memories, and skill outputs. Asset-centered graphs may be more useful than task-only graphs for long agent work.
+
+### Temporal UI
+
+**Source basis:** Public docs and repo checked.
+
+**What it includes:** Temporal UI is used to inspect durable workflow executions: running workflows, workflow history, retries, failures, and execution details for long-running business logic.
+
+**Distinctive components:**
+
+- Durable workflow execution inspection.
+- Event history and replay-oriented debugging.
+- Long-running execution visibility.
+- Retry/failure state inspection.
+
+**Wardian relevance:** Temporal is relevant where Wardian workflows become long-lived and retryable. A node graph is not enough; Wardian needs durable execution history and a way to inspect what the engine believed at each step.
+
+### Prefect
+
+**Source basis:** Public docs/API reference checked.
+
+**What it includes:** Prefect exposes flow run dashboards and APIs for flow run graphs, task runs, subflow runs, artifacts, and graph limits. It treats flow-run graphs as an API-backed view with max-node and max-artifact settings.
+
+**Distinctive components:**
+
+- Flow and flow-run graph APIs.
+- Task/subflow run graph APIs.
+- Artifact display tied to run graph.
+- Limits for large run graphs.
+- Flow visualization through Graphviz in SDK contexts.
+
+**Wardian relevance:** Prefect is useful for implementation discipline. Wardian should treat graph visualization as a bounded API problem: max nodes, changed-since queries, artifacts, and progressive loading matter once agent workflows get large.
+
+### Jaeger UI
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Jaeger UI visualizes distributed traces collected by Jaeger. It supports trace search and trace detail views around spans, services, timing, and causality.
+
+**Distinctive components:**
+
+- Trace search.
+- Trace detail and span timing views.
+- Distributed causality inspection.
+- Integration with tracing backends and OpenTelemetry pipelines.
+
+**Wardian relevance:** Wardian workflow and agent runs are effectively distributed traces across humans, agents, tools, terminals, and files. Jaeger-style views are relevant for "why did this run take so long?", "which agent blocked the flow?", and "which node caused this failure?"
+
+## Wardian Positioning
+
+Wardian should treat graph surfaces as projections over specific relationship models:
+
+```text
+workflow definition graph -> workflow run graph -> agent communication graph -> trace/detail graph
+```
+
+These views can share event data and entity IDs, but they should not share one universal interaction model. A workflow editor, agent communication map, dependency graph, and trace view each answer different questions.
+
+Near-term implications:
+
+- Keep the workflow builder graph separate from large-scale communication/trace graphs.
+- Add graph exports for docs and specs.
+- Design graph node drill-downs to PTY output, logs, artifacts, approvals, skills, files, and run history.
+- Use status overlays consistently: processing, idle, action required, failed, stale, unknown.
+- Add API limits and progressive loading before graph data grows large.
+- Preserve dense list and keyboard workflows alongside visual graphs.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,0 +1,17 @@
+# Research and Design References
+
+This section collects neutral research notes on related systems, public design patterns, and architectural references that inform Wardian.
+
+Research documents are not product evaluations, affiliation claims, endorsements, or implementation commitments. Use them to understand the design landscape behind Wardian decisions; use `docs/specs/` for planned changes and `docs/developer/` for current architecture.
+
+## Reference Maps
+
+- [Agent Evaluation References](./agent-evaluation-references.md)
+- [Agent Protocol and UI References](./agent-protocol-and-ui-references.md)
+- [Agent Runtime Sandbox References](./agent-runtime-sandbox-references.md)
+- [Dashboard Observability References](./dashboard-observability-references.md)
+- [Graph Visualization References](./graph-visualization-references.md)
+- [Local-First State References](./local-first-state-references.md)
+- [Multi-Agent Orchestrator References](./multi-agent-orchestrator-references.md)
+- [Skill Manager References](./skill-manager-references.md)
+- [Workflow Design References](./workflow-design-references.md)

--- a/docs/research/local-first-state-references.md
+++ b/docs/research/local-first-state-references.md
@@ -1,0 +1,180 @@
+# Local-First State References
+
+This document maps public local-first state, sync, and embedded-database systems to design patterns relevant to Wardian's disk-inspectable state, live desktop UI, CLI interoperability, and future multi-device or multi-agent sync.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: entries were selected through public research and checked against public project pages, repositories, or documentation where available.
+
+## Design Axes
+
+- **Local authority**: whether the application can continue to read and write useful state without a server.
+- **Sync primitive**: whether the system syncs events, CRDT operations, row changes, database snapshots, or application-specific mutations.
+- **Conflict model**: whether conflicts are impossible by construction, resolved automatically, rebased, rejected by a backend, or surfaced to humans.
+- **Observable truth**: whether durable state can be inspected through files, SQLite, event logs, Markdown, or structured records.
+- **Reactive UI**: whether local writes update the UI synchronously before remote propagation.
+- **Agent compatibility**: whether agents can safely read, write, replay, or repair state without depending on a hidden cloud service.
+- **Schema evolution**: whether on-disk state has explicit versions, migrations, and compatibility boundaries.
+
+## Summary Map
+
+| System | Primary Pattern | Wardian Takeaway |
+|---|---|---|
+| [LiveStore](https://github.com/livestorejs/livestore) | Reactive SQLite state layer with event-sourced sync. | Strong reference for separating local materialized state from replayable events. |
+| [PowerSync](https://powersync.com/) | Backend-database-to-local-SQLite sync engine. | Useful for local UI responsiveness with explicit backend write acceptance. |
+| [Triplit](https://github.com/aspen-cloud/triplit) | Full-stack syncing database with client/server real-time sync. | Query-scoped sync and property-level conflict handling are relevant to roster/workflow views. |
+| [Jazz](https://github.com/garden-co/jazz) | Distributed local-first relational database. | Strong reference for relational semantics plus history, permissions, and sync. |
+| [SQLite Sync](https://github.com/sqliteai/sqlite-sync) | CRDT-based offline-first sync extension for SQLite. | Directly relevant to Wardian because it mentions AI agent memory and Markdown knowledge-base sync. |
+| [Automerge](https://github.com/automerge/automerge) | CRDT document model and sync. | Useful where Wardian needs collaborative document/workflow editing. |
+| [Yjs](https://github.com/yjs/yjs) | Mature shared-data CRDT ecosystem. | Useful for graph or editor collaboration if Wardian later adds multi-user live editing. |
+| [ElectricSQL](https://github.com/electric-sql/electric) | Postgres-to-local reactive sync. | Relevant if Wardian ever mirrors local state from a team/shared service. |
+
+## Reference Profiles
+
+### LiveStore
+
+**Source basis:** Public repo and docs checked.
+
+**What it includes:** LiveStore is a client-centric state-management framework built around reactive embedded SQLite and built-in sync. Its public design uses event sourcing: local events are persisted, synced, and materialized into SQLite tables used by the app.
+
+**Distinctive components:**
+
+- Reactive SQLite as the application data layer.
+- Event log separate from materialized state.
+- Pull-before-push sync and local event rebase.
+- Synchronous UI updates from local materialized queries.
+- Explicit design discussion around compaction, conflicts, and partitioning.
+
+**Wardian relevance:** Wardian already has multiple truths: app state, CLI-readable state, Markdown/docs, workflow files, PTY streams, and provider telemetry. LiveStore suggests a useful split: store append-only events for replay and audit, then materialize fast local views for the command center.
+
+### PowerSync
+
+**Source basis:** Public site checked.
+
+**What it includes:** PowerSync keeps a local in-app SQLite database updated from a backend database, with offline reads/writes and upload queues for local mutations. Writes can be applied locally immediately and then sent to a backend API that accepts or rejects them according to application logic.
+
+**Distinctive components:**
+
+- Local SQLite as the app-facing database.
+- Automatic partial sync from backend database to client.
+- Local write queue for offline use.
+- Backend-controlled write validation.
+- SDK orientation across client platforms.
+
+**Wardian relevance:** PowerSync is useful where Wardian needs fast local interaction but eventual authoritative validation. For example, workflow edits, agent roster changes, and skill activation changes could become immediate local events while still allowing a later validator to accept, reject, or repair them.
+
+### Triplit
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Triplit is a full-stack syncing database that runs across server and client. It syncs data between server and browser in real time, supports pluggable storage such as IndexedDB, SQLite, and Durable Objects, and handles incremental updates and conflict resolution.
+
+**Distinctive components:**
+
+- TypeScript-first client/server data layer.
+- Real-time query sync.
+- Incremental update propagation.
+- Property-level conflict handling.
+- Framework adapters for common frontend stacks.
+
+**Wardian relevance:** Wardian's command center is query-heavy: "which agents are active?", "which workflows are stuck?", "which skills are enabled?", "which runs changed?". Triplit is a useful reference for making those views query-scoped and reactive instead of rebuilding a whole global state object.
+
+### Jazz
+
+**Source basis:** Public repo summary and architecture material checked.
+
+**What it includes:** Jazz is a distributed local-first database with relational semantics, TypeScript client layers, Rust core work, storage/sync abstractions, permissions, schema concepts, history, and replayable state.
+
+**Distinctive components:**
+
+- Relational model with local-first distribution.
+- Row histories and reserved metadata columns.
+- Query-scoped sync.
+- Schema files, permissions, and migrations.
+- Reactive subscriptions over local state.
+- Architecture docs that explicitly separate current state, history, sync, and durability.
+
+**Wardian relevance:** Jazz is a strong conceptual reference for Wardian because Wardian needs both inspectable local truth and structured relational views. Agent sessions, workflow runs, skills, classes, workspaces, and events are relational enough that a durable table-first model may stay clearer than ad hoc JSON blobs.
+
+### SQLite Sync
+
+**Source basis:** Public repo checked.
+
+**What it includes:** SQLite Sync is an offline-first sync extension for SQLite using CRDTs. It syncs with SQLite Cloud, PostgreSQL, and Supabase and explicitly calls out AI agent memory, Markdown knowledge bases, and distributed pipelines as use cases.
+
+**Distinctive components:**
+
+- SQLite extension rather than a full app framework.
+- CRDT-based conflict-free sync.
+- Local writes with later merge.
+- AI-agent memory and Markdown sync positioning.
+- Block-level last-writer-wins behavior intended to preserve different document sections.
+
+**Wardian relevance:** This is directly relevant to Wardian's "Markdown-as-Truth" and multi-agent habitat framing. Even if Wardian does not adopt SQLite Sync, its problem statement is close: many agents and surfaces may edit shared local knowledge, and the product needs a strategy for merging without hiding what happened.
+
+### Automerge
+
+**Source basis:** Public repo checked at a high level.
+
+**What it includes:** Automerge is a CRDT library for building local-first applications where users or processes can independently edit shared documents and merge changes later.
+
+**Distinctive components:**
+
+- JSON-like document model.
+- Conflict-free merge.
+- Offline editing.
+- Sync protocol and storage ecosystem.
+- Collaboration-first posture.
+
+**Wardian relevance:** Automerge is most relevant to Wardian workflow definitions, notes, and agent-authored documents. It is less directly relevant to high-volume telemetry, where event logs or SQLite tables are likely a better fit.
+
+### Yjs
+
+**Source basis:** Public repo checked at a high level.
+
+**What it includes:** Yjs is a mature CRDT ecosystem used for collaborative editing, shared data structures, and real-time synced application state.
+
+**Distinctive components:**
+
+- Shared maps, arrays, text, and XML-like structures.
+- Provider ecosystem for WebSocket, WebRTC, IndexedDB, and other transports.
+- Strong editor integration ecosystem.
+- Awareness/presence patterns.
+
+**Wardian relevance:** Yjs matters if Wardian adds true multi-user graph editing, collaborative workflow authoring, or live shared notes. It should not be the default for core agent telemetry unless Wardian needs collaborative document semantics.
+
+### ElectricSQL
+
+**Source basis:** Public repo/site checked at a high level.
+
+**What it includes:** ElectricSQL is a local-first sync system oriented around Postgres and local reactive clients. It is useful as part of the broader local-first database landscape even though Wardian's near-term posture is local desktop state rather than cloud-backed team sync.
+
+**Distinctive components:**
+
+- Postgres-backed sync.
+- Shape/query-driven local replication.
+- Local reactive reads.
+- Web app integration posture.
+
+**Wardian relevance:** ElectricSQL becomes more relevant if Wardian adds team/workspace sync, remote dashboards, or shared organizational state. For the near-term local-first app, event logs and embedded SQLite are probably more immediately actionable.
+
+## Wardian Positioning
+
+Wardian should avoid choosing between "files as truth" and "database as truth" too early. The stronger pattern is layered:
+
+```text
+filesystem artifacts + event log -> normalized local database -> reactive UI and CLI views
+```
+
+That keeps agent-readable files and Markdown visible while allowing the app to query status, dependencies, run history, and activation state efficiently.
+
+Near-term implications:
+
+- Treat important state changes as replayable events, not only mutable rows.
+- Keep stable file formats for workflows, skills, and specs.
+- Use SQLite/materialized views for fast command-center queries.
+- Version all durable state formats explicitly.
+- Separate local acceptance from later validation or remote sync.
+- Make merge/conflict events visible to humans and agents.

--- a/docs/research/multi-agent-orchestrator-references.md
+++ b/docs/research/multi-agent-orchestrator-references.md
@@ -1,0 +1,488 @@
+# Multi-Agent Orchestrator References
+
+This document maps public multi-agent orchestration systems to design patterns relevant to Wardian's command center, workflow runtime, and local agent roster.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: the local-agent and worktree-manager entries in this note were rechecked against their public repositories where available. Repo-checked means the README plus project metadata and visible source layout were inspected. When a public website and repository disagreed, the repository was treated as the higher-confidence source.
+
+## Surface Taxonomy
+
+Wardian should distinguish interaction surface from orchestration model:
+
+- **GUI/web command centers**: emphasize dashboards, visual configuration, run history, and team-level visibility.
+- **CLI/TUI/local-terminal systems**: emphasize fast keyboard control, local worktrees, terminal multiplexing, and developer-loop ergonomics.
+- **Libraries/frameworks**: emphasize programmable agent composition, state models, message routing, tools, memory, and runtime APIs.
+- **Hybrid systems**: expose more than one surface, often pairing a code or YAML source of truth with a GUI or CLI execution surface.
+
+This distinction matters because Wardian is not only an agent framework. It is a local command center for visible, long-running agent sessions. Systems that look similar at the orchestration layer can feel very different when the primary control surface is a browser, a terminal, a Python API, or a workspace-local YAML file.
+
+## Summary Map
+
+| System | Primary Surface | Relevant Pattern | Wardian Takeaway |
+|---|---|---|---|
+| [Gas Town](https://github.com/gastownhall/gastown) | Hybrid CLI/TUI + web dashboard | Workspace manager for many coding agents, Git worktrees, task bundles, health patrol, merge queues, and real-time feeds. | Persistent agent identity, work units, watchdogs, and dashboards are as important as terminal panes. |
+| [Gas City](https://github.com/gastownhall/gascity) | SDK/CLI infrastructure | Orchestration-builder SDK with runtime providers, config packs, controller/supervisor loops, and health patrol. | Treat construction APIs and visual observability as separate layers; Gas City is source-level orchestration infrastructure, not a GUI reference. |
+| [Beehive](https://github.com/storozhenko98/beehive) | Desktop GUI + TUI | One-window repo/workspace manager for isolated clones, persistent PTYs, agent panes, and shared GUI/TUI config. | The "agent colony" metaphor aligns with Wardian's habitat framing when it exposes concrete repos, branches, panes, and persisted layout. |
+| [Agent of Empires](https://github.com/njbrake/agent-of-empires) | TUI + web dashboard | tmux-backed session manager for many CLI coding agents, worktrees, optional Docker sandboxes, and remote browser access. | Dense, low-latency agent supervision is its own UX class. |
+| [Hive](https://github.com/cristicretu/hive) | CLI/TUI | Small Ink-based worktree manager for creating, listing, merging, and dropping parallel agent workspaces. | Some adjacent tools are intentionally narrow; Wardian should keep the fast worktree loop simple even as the command center grows. |
+| [Apiari](https://github.com/ApiariTools/apiari) | Coordinator daemon + TUI/web surfaces | Rust workspace chat hub plus Swarm worker multiplexer for bots, signal watching, schedules, and worktree workers. | Wardian workflows should distinguish agent execution from coordination, review, notification, and merge ownership. |
+| [Orca](https://github.com/stablyai/orca) | Desktop IDE + CLI | Agent development environment with worktrees, terminal panes, source control, inline review, browser/design mode, and agent-driving CLI. | Terminal panes, diffs, unread markers, status, and notifications belong in one command center. |
+| [Daintree](https://github.com/daintreehq/daintree) | Desktop agent console | Electron local control plane for panels, worktrees, CLI agents, state detection, context injection, recipes, MCP, and review workflows. | Wardian's habitat metaphor should stay grounded in concrete worktrees, diffs, resource pressure, and action-needed states. |
+| [Biomelab](https://github.com/mdelapenya/biomelab) | Desktop GUI | Fyne desktop dashboard for Git worktrees, process-detected agents, PR/CI state, terminal/IDE detection, and Docker sandboxes. | Visual dashboards can make worktree ownership, branch health, and agent isolation inspectable without owning the agent runtime. |
+| [Agor](https://github.com/preset-io/agor) | GUI/Web | Multiplayer spatial canvas for coordinating coding assistants, worktrees, and sessions. | Spatial dashboards are useful when they expose ownership, environment, and live conversation state. |
+| [webmux](https://github.com/windmill-labs/webmux) | Web dashboard + CLI | Parallel AI agent dashboard with YAML-defined layouts, tmux terminals, worktrees, service ports, PR/CI, Linear, and Docker sandboxes. | A web command center can remain reproducible if its layout and runtime assumptions are text-defined. |
+| [OctoAlly](https://github.com/ai-genius-automations/octoally) | Web dashboard + Electron | Local-first Claude Code/Codex dashboard with tmux persistence, sessions grid, specialist agents, source control, and voice input. | Agent dashboards should treat live output, task lifecycle, terminals, and source control as one surface. |
+| [Overstory](https://github.com/jayminwest/overstory) | CLI + web UI + TUI dashboard | Multi-agent coding orchestration with worktrees, runtime adapters, SQLite mail, watchdogs, web UI, TUI dashboard, and conflict resolution. | Agent-agent messaging, health monitoring, and merge coordination are key pieces beyond simply spawning workers. |
+| [Archon](https://github.com/coleam00/Archon) | Hybrid CLI/web | YAML workflows, isolated worktrees, visual execution. | Treat agent work as inspectable workflow runs with source-controlled definitions. |
+| [AWS CLI Agent Orchestrator](https://github.com/awslabs/cli-agent-orchestrator) | CLI/TUI | Terminal-native orchestration of multiple coding agents in Git worktrees. | TUI-style agent rosters and worktree dispatch are directly relevant to Wardian. |
+| [Claude Squad](https://github.com/smtg-ai/claude-squad) | TUI/local terminal | Manage multiple AI coding agents in isolated workspaces from one terminal UI. | Local multiplexing, resumable sessions, and per-agent workspace isolation are first-class UX concerns. |
+| [OpenHands](https://github.com/All-Hands-AI/OpenHands) | GUI/web + CLI | Software engineering agents with browser/app UI, runtime sandboxing, and task execution. | Humans benefit from seeing agent work products, logs, browser state, and code changes together. |
+| [AutoGen](https://github.com/microsoft/autogen) | Framework + Studio | Multi-agent conversation framework with an optional no-code studio. | A library-level orchestration model can power both programmatic and visual control surfaces. |
+| [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) | Framework | Enterprise-oriented multi-agent orchestration with workflow, memory, tools, MCP, A2A, and observability concepts. | Protocol and governance boundaries matter when agents become long-lived infrastructure. |
+| [CrewAI](https://github.com/crewAIInc/crewAI) | Framework + platform | Role-based crews plus deterministic flows. | Separate autonomous team collaboration from deterministic workflow control. |
+| [AgentScope](https://github.com/agentscope-ai/agentscope) | Framework | Multi-agent framework with message hub orchestration, MCP/A2A support, observability, and deployment options. | Agent systems need observability, structured messages, and deployment-aware orchestration. |
+| [MetaGPT](https://github.com/FoundationAgents/MetaGPT) | Framework/CLI | Software-company metaphor with role-specialized agents. | Role contracts and artifact handoffs help humans reason about multi-agent output. |
+| [CAMEL](https://github.com/camel-ai/camel) | Framework | Communicative agent framework and society simulation patterns. | Message protocols and role-play interactions are useful primitives, but need operational visibility. |
+| [SuperAGI](https://github.com/TransformerOptimus/SuperAGI) | GUI/web platform | Agent platform with marketplace, tools, memory, and execution visibility. | Web dashboards can make agent lifecycle visible, but local-first inspection remains Wardian's differentiator. |
+| [AutoGPT Platform](https://github.com/Significant-Gravitas/AutoGPT) | GUI/web + server | Visual block-based agent workflows with marketplace/server components. | Block-based agent graphs show how visual composition and reusable agent components fit together. |
+| [Flowise](https://github.com/FlowiseAI/Flowise) | GUI/web | Low-code LLM app, agent, and workflow builder. | Visual construction is accessible, but Wardian should retain text-native definitions for agent authors. |
+
+## CLI, TUI, and Local-Terminal Systems
+
+### Emerging TUI Workspace Managers
+
+Several newer systems focus less on agent-framework abstractions and more on the day-to-day surface for supervising many local coding agents. This cluster includes Gas Town, Beehive, Agent of Empires, Hive, Apiari/Swarm, Orca, Daintree, Biomelab, webmux, OctoAlly, and related tools.
+
+**What they include:** These systems usually provide a keyboard-first terminal interface for launching, naming, switching between, and monitoring multiple coding agents. Most pair each agent with a Git worktree, branch, task, or isolated workspace so many agents can work in parallel without directly colliding in the same checkout.
+
+**Distinctive components:**
+
+- Persistent TUI dashboards for multiple agent sessions.
+- Worktree or workspace isolation as a default execution model.
+- Fast keyboard switching between agents and tasks.
+- Agent-aware status surfaces rather than generic terminal multiplexing.
+- Task ownership and review handoff patterns for parallel coding work.
+
+**Wardian relevance:** This is a core adjacent category for Wardian. These tools show that multi-agent orchestration is becoming a developer environment problem, not only a backend framework problem. Wardian should learn from their low-latency navigation, dense roster displays, and worktree-aware task ownership while preserving its broader habitat model: provider diversity, visible PTYs, workflow telemetry, skills, memory, and disk-inspectable state.
+
+### Gas Town
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Gas Town is a hybrid local orchestration system for coordinating Claude Code, GitHub Copilot, Codex, Gemini, and other coding agents across Git-backed workspaces. Its command surface includes a real-time TUI feed, agent/task commands, and a web dashboard for agents, work bundles, hooks, queues, issues, and escalations.
+
+**Distinctive components:**
+
+- Mayor/coordinator, rigs/project containers, persistent worker identities, and Git-backed hook storage.
+- Convoys and beads for task/work tracking rather than only terminal sessions.
+- `gt feed` real-time TUI with agent tree, event stream, problems view, nudges, and handoffs.
+- Web dashboard, telemetry, health patrol/watchdog concepts, and a refinery-style merge queue.
+- Session discovery/continuation from agent event logs.
+
+**Wardian relevance:** Gas Town reinforces that a useful command center is not just many terminals. Wardian should model durable agent identity, work ownership, event feeds, stuck-agent handling, merge readiness, and escalation state alongside the PTY.
+
+### Gas City
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Gas City is an orchestration-builder SDK for multi-agent systems, not a GUI. It packages the Gas Town patterns as composable Go infrastructure: declarative `city.toml` config, runtime providers, work routing, formulas, orders, health patrol, and controller/supervisor loops.
+
+**Distinctive components:**
+
+- Runtime provider abstraction with implementations such as tmux, subprocess, exec, ACP, and Kubernetes.
+- Config and pack composition for reusable orchestration setups.
+- Controller/supervisor loop that reconciles desired state to running state.
+- Beads store abstraction and health patrol concepts.
+- CLI wiring around a reusable orchestration package.
+
+**Wardian relevance:** Gas City is relevant to Wardian's agent-friendly construction layer. It supports the split the user described: code/config as construction, observable nodes/status as presentation. The important correction is that it should be cited as SDK/CLI orchestration infrastructure, not as a desktop or web GUI reference.
+
+### Orca
+
+**Source basis:** Public repo and project site checked.
+
+**What it includes:** Orca is a desktop agent development environment with a companion CLI. It runs Claude Code, Codex, OpenCode, Gemini, Cursor CLI, Copilot, Pi, and other CLI agents side by side in isolated worktrees with terminal panes, file editing, source control, browser/design mode, remote SSH worktrees, notifications, unread markers, and agent-visible automation commands.
+
+**Distinctive components:**
+
+- Ghostty-inspired terminal surface for many agents.
+- Worktree-first feature isolation.
+- Built-in source control, diff comments that can be sent back to agents, and PR/CI review surfaces.
+- Per-worktree browser/design mode and remote worktree support.
+- First-class CLI so agents can create worktrees, snapshot, click, and fill.
+- Cross-agent/provider support within one local command center.
+
+**Wardian relevance:** Orca is close to Wardian's desired command-center feel. It treats terminals as live work surfaces while adding just enough surrounding UI to make agent state, unread work, and code diffs legible.
+
+### Apiari
+
+**Source basis:** Public repos for `ApiariTools/apiari` and `ApiariTools/swarm` checked; public product site checked for positioning.
+
+**What it includes:** Apiari is better treated as a toolchain than a single TUI. The `apiari` repo is a Rust daemon and React SPA workspace chat hub for bots, provider SDKs, signals, schedules, and swarm-worker integration. The `swarm` repo is a TUI/CLI agent multiplexer that runs Claude, Codex, and Gemini agents in isolated Git worktrees.
+
+**Distinctive components:**
+
+- Bot/coordinator layer with workspace configs, context files, scheduled runs, and GitHub watch bots.
+- Swarm TUI for multiple workers, each with branch/worktree isolation.
+- Worker daemon processes, persistent `.swarm/` state, PR tracking, and merge/close operations.
+- Provider SDK crates for Claude, Codex, and Gemini.
+- Public positioning around CI/review/PR/Telegram coordination.
+
+**Wardian relevance:** Apiari is useful because it separates worker execution from coordinator responsibility. Wardian workflows should similarly model dispatch, supervision, review, notification, and merge readiness as separate states, not just "agent is running."
+
+### Beehive
+
+**Source basis:** Public repo and project site checked.
+
+**What it includes:** Beehive is a Tauri desktop GUI plus standalone Rust TUI for managing repos, isolated workspace clones, persistent PTY panes, terminals, and CLI agents side by side. The GUI and TUI share config and data.
+
+**Distinctive components:**
+
+- One-window workspace for repos, terminals, and agents.
+- Hive/nest/comb model: linked repository, optional groups, and isolated clone per branch.
+- Persistent terminals and agent panes using real PTYs.
+- Tauri GUI with React/xterm.js and Rust backend; Ratatui/Crossterm TUI with portable-pty/vt100.
+- Custom quick-launch buttons, layout persistence, branch tracking, and copyable workspaces.
+- GUI currently macOS-oriented; TUI supports macOS and Linux x64.
+
+**Wardian relevance:** Beehive is conceptually close to Wardian's habitat metaphor. Wardian should use its own ecological framing carefully: agent colonies are useful when they make ownership and status visible, not when they obscure concrete files, tasks, and run state.
+
+### Agent of Empires
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Agent of Empires is a terminal session manager for AI coding agents with a TUI, optional browser dashboard, and ACP cockpit. Agents run in tmux sessions, usually in Git worktrees, with optional Docker sandboxing and session resume.
+
+**Distinctive components:**
+
+- TUI and browser dashboard for multiple agent sessions.
+- tmux-backed persistence, worktree isolation, multi-repo workspaces, and diff view.
+- Broad CLI-agent support including Claude Code, OpenCode, Codex, Gemini, Cursor, Copilot, Hermes, Kiro, Qwen, and others.
+- Status detection for running, waiting, and idle states.
+- Remote access patterns for phone/tablet use; Linux/macOS focus with WSL2 for Windows.
+
+**Wardian relevance:** Agent of Empires is useful as a UX pressure reference. Wardian needs comparable speed for agent switching and task inspection even though it exposes a richer desktop command center.
+
+### Hive
+
+**Source basis:** Public repo and project site checked.
+
+**What it includes:** Hive is a narrow Bun/TypeScript CLI and Ink TUI for managing parallel AI-agent workspaces using Git worktrees. It creates new workspaces, lists them, merges them back to main, or drops them.
+
+**Distinctive components:**
+
+- Parallel coding-agent sessions.
+- Git worktree isolation.
+- Ink-based interactive TUI plus direct commands.
+- Minimal branch/workspace lifecycle: new, list, merge, drop.
+- Emphasis on avoiding branch/file conflicts, not on a full dashboard.
+
+**Wardian relevance:** Hive reinforces that worktree isolation is becoming the default answer for parallel coding agents. Wardian should keep workspace identity, branch/worktree state, and merge/review state visible wherever agents appear.
+
+### Daintree
+
+**Source basis:** Public repo and project site checked.
+
+**What it includes:** Daintree is an Electron desktop agent console for supervising multiple CLI agents in local worktrees. It combines a worktree dashboard, panel grid, terminal/agent sessions, browser/dev previews, context injection, recipes, MCP tools, GitHub integration, and review-oriented diffs.
+
+**Distinctive components:**
+
+- Habitat metaphor around agents and worktrees.
+- Support for many CLI agents, including Claude Code, Gemini CLI, Codex, OpenCode, Cursor Agent, Kiro, Copilot, Goose, Aider, and others.
+- Agent state detection such as idle, working, waiting, completed, and failed.
+- Context injection through CopyTree-style structured context.
+- Recipes for multi-terminal launch presets and variable substitution.
+- MCP server exposing Daintree actions such as creating worktrees, spawning terminals, injecting context, and running Git operations.
+- Resource profiles and worktree monitoring as local fleet-management infrastructure.
+
+**Wardian relevance:** Daintree is directly relevant to Wardian's ecological framing. It shows the metaphor becomes concrete when tied to practical surfaces: worktree identity, branch state, diffs, and action-needed signals.
+
+### Biomelab
+
+**Source basis:** Public repo and project site checked.
+
+**What it includes:** Biomelab is a Go/Fyne desktop GUI for managing Git worktrees and the coding agents running inside them. It is more of a monitoring and worktree dashboard than an agent runtime: it detects running agents, IDEs, terminals, branch status, PR/MR status, and CI status.
+
+**Distinctive components:**
+
+- Multi-repo tree with worktree cards.
+- Process scanning for Claude, Kiro, Copilot, Codex, OpenCode, and Gemini.
+- Terminal and IDE detection per worktree.
+- PR/MR status through GitHub/GitLab CLIs.
+- Docker Sandbox mode with one sandbox per agent per repo.
+- Keyboard-first desktop GUI actions for create/delete worktree, fetch PR, push/create PR, open terminal/editor, and sandbox lifecycle.
+
+**Wardian relevance:** Biomelab reinforces that worktree state should be visible at the same level as agent state. Wardian should not treat workspace paths as incidental metadata; they are part of the agent's operational identity.
+
+### AWS CLI Agent Orchestrator
+
+**Source basis:** Public repo checked.
+
+**What it includes:** AWS CLI Agent Orchestrator is a Python local orchestrator for AI coding CLIs. It runs agents in isolated tmux sessions and coordinates supervisor-worker patterns over MCP. It exposes CLI commands, a bundled web UI, REST APIs, and MCP management/control surfaces.
+
+**Distinctive components:**
+
+- Supervisor-worker orchestration using `handoff`, `assign`, and `send_message`.
+- tmux session isolation with human attach/steer support.
+- Cross-provider profiles for Kiro CLI, Claude Code, Codex, Amazon Q, Gemini, Kimi, Copilot, and OpenCode.
+- Web UI, CLI, REST API, MCP server, and ops MCP server as separate control planes.
+- Tool restrictions, scheduled flows, skills, plugins, terminal restore, and outbound event hooks.
+
+**Wardian relevance:** This is a useful surface-level reference for Wardian. It validates a terminal-native orchestration layer where agents are visible, task-scoped, and workspace-aware. Wardian should go further by preserving persistent roster identity, UI observability, provider-specific PTY state, and Markdown/disk-inspectable truth.
+
+### Claude Squad
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Claude Squad is a Go terminal app for managing multiple Claude Code, Codex, Gemini, Aider, and other local-agent sessions in separate Git workspaces. It uses tmux for isolated terminal sessions and Git worktrees for branch/workspace isolation.
+
+**Distinctive components:**
+
+- TUI for a squad of coding agents.
+- Local terminal multiplexing.
+- Worktree-backed session creation, pause/resume, checkout, and commit/push actions.
+- Preview and diff tabs inside the TUI.
+- Configurable profiles for alternate agent commands.
+- Charm Bubble Tea/Lip Gloss-style TUI stack plus PTY and Git dependencies.
+
+**Wardian relevance:** Claude Squad highlights the ergonomic value of a compact roster, keyboard-first navigation, and local session switching. Wardian's GUI should keep these same virtues: dense status, rapid switching, clear activity indicators, and no hidden agent work.
+
+### Archon
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Archon defines agentic development workflows as YAML and runs them through a deterministic harness. It combines CLI execution, workflow definitions, worktree isolation, and a web UI for building and observing workflows.
+
+**Distinctive components:**
+
+- YAML workflow source of truth.
+- Deterministic and AI-driven node types.
+- Worktree isolation for parallel runs.
+- Visual workflow builder and execution view.
+- Adapters for developer and collaboration surfaces.
+
+**Wardian relevance:** Archon is both a workflow-system reference and a multi-agent orchestrator reference. For Wardian, the most important lesson is that agents need a construction surface that can be reviewed as text, while humans need a visible run surface with node state, logs, approvals, and artifacts.
+
+## GUI and Web Command Centers
+
+### Agor
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Agor is a web command center and shared spatial canvas for coding agents and long-lived assistants. Worktrees are the anchor entity: sessions, environments, prompts, PRs, comments, and boards converge around each worktree.
+
+**Distinctive components:**
+
+- Spatial canvas for agentic work.
+- Boards and zones that can trigger templated prompts when sessions/worktrees move through the canvas.
+- Real-time multiplayer features, comments, terminals, and shared sessions.
+- MCP endpoint so agents can operate Agor actions themselves.
+- Rich chat UX with token/cost accounting, structured tool blocks, model/effort selectors, and conversation trees.
+- Environment management with dev servers and unique ports.
+
+**Wardian relevance:** Agor shows a distinct GUI pattern: place-based orchestration rather than only lists or tabs. Wardian should treat spatial layout carefully, using it where it clarifies ownership and workflow state rather than as decoration.
+
+### webmux
+
+**Source basis:** Public repo and project site checked.
+
+**What it includes:** webmux is a Bun/TypeScript CLI plus web dashboard for managing parallel AI coding agents. It owns worktree lifecycle, tmux layout, runtime events, service health checks, PR/CI display, Linear integration, Docker sandboxes, and a separate mobile-friendly chat view.
+
+**Distinctive components:**
+
+- WebSocket terminal streaming from tmux-managed worktrees.
+- `.webmux.yaml` source of truth for worktree root, services, pane layout, profiles, runtime, sandboxes, linked repos, startup envs, and lifecycle hooks.
+- Docker sandbox profiles with mount and env-passthrough controls.
+- PR, CI, review comment, Linear issue, and service health surfaces.
+- Auto-name support using configured LLM provider keys.
+
+**Wardian relevance:** webmux is relevant because it connects GUI observability with text-defined runtime configuration. Wardian should follow that line: dashboards should be reproducible from durable definitions, not only ad hoc UI state.
+
+### OctoAlly
+
+**Source basis:** Public repo and project site checked.
+
+**What it includes:** OctoAlly is a local-first web dashboard with optional Electron desktop shell for Claude Code and OpenAI Codex sessions. It manages projects, sessions, specialist agents, interactive terminals, source control, browser panels, and voice dictation from one dashboard.
+
+**Distinctive components:**
+
+- Active sessions grid with live WebSocket output.
+- tmux and dtach-backed persistence, including pop-out/adopt-back terminal flows.
+- 36 built-in specialist agents plus custom `.claude/agents/*.md` definitions.
+- Git source control with diffs, staging, commit history, and file explorer.
+- SQLite/Fastify backend, React dashboard, Electron desktop app, and local/cloud speech-to-text.
+
+**Wardian relevance:** OctoAlly is a useful reference for web-based session visibility. Wardian should provide comparable real-time output awareness while preserving local PTY truth and persistent roster identity.
+
+### Overstory
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Overstory is a multi-agent orchestration system for AI coding agents with CLI, web UI, and TUI dashboard surfaces. It spawns worker agents in isolated Git worktrees, coordinates them through SQLite mail, supports pluggable runtime adapters, and merges work back with conflict-resolution logic. Newer Claude workers run headless by default and surface through the web UI, with tmux as an opt-in live-steering escape hatch.
+
+**Distinctive components:**
+
+- Worker agents in isolated Git worktrees.
+- SQLite-backed mail system with typed messages and broadcast support.
+- Pluggable `AgentRuntime` adapters for Claude, Pi, Copilot, Codex, Gemini, Sapling, OpenCode, Cursor, Aider, Goose, Amp, and custom adapters.
+- Web UI via `ov serve`, live TUI dashboard via `ov dashboard`, and detailed CLI observability commands.
+- FIFO merge queue with tiered conflict resolution.
+- Tiered watchdog/monitor system, tool-call guards, checkpoint restore, trace/replay/log/cost views, and persistent coordinator/orchestrator roles.
+
+**Wardian relevance:** Overstory is important because it goes beyond launching many agents. It treats inter-agent communication and merge coordination as first-class orchestration responsibilities. Wardian should similarly model cross-agent messages, ownership, dependencies, and merge/readiness states rather than leaving them as hidden chat transcript details.
+
+### OpenHands
+
+**What it includes:** OpenHands is a software engineering agent platform with web and CLI surfaces. It provides a runtime where agents can modify code, run commands, browse, and produce development artifacts while humans supervise from an application surface.
+
+**Distinctive components:**
+
+- Browser-accessible software engineering agent workspace.
+- Runtime sandbox for command execution and code edits.
+- Visibility into agent actions, files, and task progress.
+- Developer-oriented loop rather than generic chat only.
+
+**Wardian relevance:** OpenHands shows the value of combining terminal output, file changes, browser state, and task progress in one observable surface. Wardian's differentiator is the persistent multi-agent habitat: many named agents, long-running sessions, local provider terminals, and workflow telemetry in the same command center.
+
+### SuperAGI
+
+**What it includes:** SuperAGI is an open-source autonomous agent platform with a web interface, tool integrations, memory, marketplace concepts, and agent execution management.
+
+**Distinctive components:**
+
+- Web dashboard for creating and running agents.
+- Tool and agent marketplace concepts.
+- Memory and knowledge support for autonomous agents.
+- Execution monitoring from a platform UI.
+
+**Wardian relevance:** SuperAGI is a useful reference for lifecycle visibility and agent management through a GUI. Wardian should avoid becoming only a web-style control panel; its local-first strength is that all sessions, skills, workspace state, and telemetry remain inspectable on disk.
+
+### AutoGPT Platform
+
+**What it includes:** AutoGPT has evolved into a platform for creating, deploying, and managing continuous agents. Its platform direction includes a frontend, server, marketplace, and block-based agent workflow construction.
+
+**Distinctive components:**
+
+- Visual block-based agent workflows.
+- Server and frontend separation.
+- Marketplace for reusable blocks or agents.
+- Continuous-agent orientation.
+
+**Wardian relevance:** AutoGPT Platform is useful for understanding how agent building blocks can become reusable products. Wardian should apply that idea locally: reusable workflow blocks, agent classes, and skills should remain filesystem-visible and source-controllable.
+
+### Flowise
+
+**What it includes:** Flowise is a low-code visual builder for LLM applications, including chatflows, agentflows, assistants, tools, memory, and deployment integrations.
+
+**Distinctive components:**
+
+- Web canvas for LLM and agent flows.
+- Agentflow and sequential agentflow concepts.
+- Integration nodes for tools, vector stores, models, and memory.
+- Deployment and API surfaces around visual flows.
+
+**Wardian relevance:** Flowise demonstrates the accessibility of node-first configuration. Wardian should support visual composition, but not require humans or agents to treat the canvas as the only authoring surface.
+
+## Libraries and Frameworks
+
+### AutoGen
+
+**What it includes:** AutoGen is a Microsoft framework for building applications with multiple conversational agents. It includes agent abstractions, group chat patterns, tool use, distributed runtimes, and related Studio tooling for no-code prototyping.
+
+**Distinctive components:**
+
+- Multi-agent conversation patterns.
+- Group chat and speaker-selection orchestration.
+- Tool-use and code-execution agent patterns.
+- Optional Studio surface for prototyping agent teams.
+
+**Wardian relevance:** AutoGen is a strong reference for message-level multi-agent coordination. Wardian should learn from its group conversation patterns while adding the operational layer AutoGen does not own by itself: terminal sessions, provider process lifecycle, persistent roster state, and filesystem truth.
+
+### Microsoft Agent Framework
+
+**What it includes:** Microsoft Agent Framework is an open-source framework for multi-agent applications. Its public positioning emphasizes agents, workflows, memory, tools, observability, MCP, and A2A-style interoperability.
+
+**Distinctive components:**
+
+- Enterprise-oriented agent and workflow primitives.
+- Protocol-aware interoperability posture.
+- Memory, tools, and observability concepts.
+- Multi-agent orchestration beyond a single chat loop.
+
+**Wardian relevance:** This is relevant less as a UI reference and more as a governance reference. Wardian should keep clean contracts for provider runtime, agent identity, tools, memory, workflow events, and cross-agent communication so it can interoperate instead of becoming a closed local island.
+
+### CrewAI
+
+**What it includes:** CrewAI is a framework for multi-agent automation. It separates autonomous role-based crews from flows that provide more precise event-driven control.
+
+**Distinctive components:**
+
+- Role-based agent crews.
+- Task and process abstractions.
+- Deterministic flows alongside autonomous teams.
+- YAML scaffolding for agent and task definitions.
+
+**Wardian relevance:** CrewAI's distinction between crews and flows maps cleanly to Wardian's need to differentiate agent delegation from workflow control. A Wardian workflow node that delegates to an agent should be visibly different from a node that enforces control logic.
+
+### AgentScope
+
+**What it includes:** AgentScope is a framework for building multi-agent applications. It includes agent abstractions, structured message passing, service/tool use, human-in-the-loop steering, memory, planning, MCP and A2A support, observability, and deployment options.
+
+**Distinctive components:**
+
+- Multi-agent message and service abstractions.
+- Distributed execution patterns.
+- Message hub and pipeline APIs for multi-agent conversations and workflows.
+- OpenTelemetry-oriented observability and local/cloud deployment options.
+- Structured APIs for agent communication and runtime integration.
+
+**Wardian relevance:** AgentScope is a useful reference for separating the agent programming model from the observability surface. Wardian should give each agent message, status change, and workflow event enough structure to support both UI display and machine-readable coordination.
+
+### MetaGPT
+
+**What it includes:** MetaGPT organizes agents using a software-company metaphor. It assigns roles such as product manager, architect, engineer, and QA, then coordinates artifact production and handoffs through a structured multi-agent process.
+
+**Distinctive components:**
+
+- Role-specialized agents modeled after software teams.
+- Standard operating procedure style coordination.
+- Artifact handoffs across product, design, engineering, and QA roles.
+- CLI/framework orientation for generating software outputs.
+
+**Wardian relevance:** MetaGPT's value is its legible role structure. Wardian agent classes, teams, and workflow role mappings should make responsibilities explicit enough that humans can understand who is supposed to produce what.
+
+### CAMEL
+
+**What it includes:** CAMEL is a framework and research ecosystem for communicative agents, role-playing agent societies, data generation, and multi-agent collaboration.
+
+**Distinctive components:**
+
+- Role-playing communicative agent patterns.
+- Multi-agent society and simulation concepts.
+- Toolkits, memory, and data generation components.
+- Research-oriented agent collaboration primitives.
+
+**Wardian relevance:** CAMEL is useful as a conceptual reference for agent-agent communication. Wardian should operationalize those conversations: who spoke, what task context they had, which workspace they touched, what artifacts changed, and how the interaction is replayed.
+
+## Adjacent Local Agent Surfaces
+
+Some systems are not primarily multi-agent orchestrators, but they still inform Wardian's interaction design:
+
+- [OpenCode](https://github.com/sst/opencode): terminal-native AI coding agent with strong local developer ergonomics.
+- [Goose](https://github.com/block/goose): local agent experience with CLI and desktop surfaces.
+- [Aider](https://github.com/Aider-AI/aider): terminal-first pair programming agent with strong Git workflow integration.
+
+These are useful references for single-agent ergonomics, provider interaction, and developer trust. They should not be treated as direct multi-agent command center references unless they add explicit orchestration or roster semantics.
+
+## Wardian Positioning
+
+Wardian sits at the intersection of these categories:
+
+- GUI/web systems prove the value of human-observable dashboards.
+- CLI/TUI systems prove the value of fast local control and worktree-aware dispatch.
+- Frameworks prove the value of structured agent roles, messages, tools, and workflow state.
+
+Wardian's direction should be hybrid and local-first: visible agent terminals, durable roster state, workflow graph telemetry, filesystem-inspectable skills and definitions, and enough structured APIs that agents can construct and operate the system without depending on fragile UI actions.

--- a/docs/research/skill-manager-references.md
+++ b/docs/research/skill-manager-references.md
@@ -1,0 +1,218 @@
+# Skill Manager References
+
+This document maps public skill-management systems to design patterns relevant to Wardian's skill library, agent habitats, and future workflow-builder integration.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: AGHub and Chops were specifically requested and were checked against their public repositories. Other entries were selected through public search plus repo inspection where available. The Assistant agent was also queried for additional candidates; its most relevant extra suggestion, Everything Claude Code, is listed as an adjacent harness pack rather than a skill manager.
+
+## Design Axes
+
+- **Discovery surface**: how humans or agents find skills by name, tags, source, provider, purpose, trust, or compatibility.
+- **Install semantics**: whether installation means copy, symlink, junction, package install, plugin install, or registry subscription.
+- **Scope model**: whether skills are global, project-local, tool-local, workspace-local, or synced across several targets.
+- **Source of truth**: whether the canonical copy lives in a central repo, a registry, a tool dotfolder, a package cache, or a workspace folder.
+- **Skill and agent duality**: whether the manager treats skills, subagents, commands, prompts, hooks, and plugins as one ecosystem or separate object types.
+- **Human observability**: whether users can inspect the real files, metadata, activation state, provenance, and target paths.
+- **Agent friendliness**: whether agents can install, update, query, and author skills through stable CLI/API/file contracts.
+- **Trust and lifecycle**: whether the system supports versioning, pinning, review, moderation, update checks, security metadata, or provenance.
+
+## Summary Map
+
+| System | Primary Surface | Relevant Pattern | Wardian Takeaway |
+|---|---|---|---|
+| [AGHub / Agent Skills Hub](https://github.com/agent-skills-hub/agent-skills-hub) | Registry repo + NPX CLI | Large cross-agent catalog with targeted install flags and project-local override guidance. | Useful as a bulk import and compatibility reference, but Wardian should add stronger provenance, curation, and local observability. |
+| [Chops](https://github.com/Shpigford/chops) | Native macOS app | Local scanner/editor for skills and agents across coding tools, with file watching, collections, search, and frontmatter parsing. | Useful reference for a human-observable local library: inspect real files, organize without moving source, and watch dotfolders continuously. |
+| [Vercel `skills`](https://github.com/vercel-labs/skills) | CLI/package manager | Open agent-skills installer with many source formats, project/global scopes, symlink/copy modes, list/find/remove/update/init commands, and broad agent target matrix. | Strong reference for agent-friendly install contracts and normalized target resolution. |
+| [Skills Hub Desktop](https://github.com/qufei1993/skills-hub) | Cross-platform Tauri desktop app | Central skill repository synced to many tool-specific global or project directories, preferring symlink/junction and falling back to copy. | Relevant implementation reference for Wardian's local-first central skill store and cross-tool activation state. |
+| [Quiver](https://github.com/sam-blakeman/quiver) | Local web UI + CLI | Claude Code skill inventory over local skills and marketplace plugins, with add/remove/import/export, sync, registry browsing, and simple REST routes. | Useful pattern for a small, agent-operable local HTTP/CLI layer over disk skills. |
+| [ClawHub](https://github.com/openclaw/clawhub) | Hosted registry + CLI/API | OpenClaw public skill registry with publish/version/search, vector search, pinning, install/update, comments, moderation, package catalog, and security metadata. | Useful trust-lifecycle reference: Wardian should separate local activation from registry provenance, pinning, and review state. |
+| [Trail of Bits Skills](https://github.com/trailofbits/skills) | Domain marketplace / skill pack | Security-focused Claude plugin marketplace with Codex sidecar support and curated domain skills. | Useful for vertical curation: Wardian should support themed packs without treating every skill source as equally trusted. |
+| [HOL Registry Broker Skills](https://github.com/hashgraph-online/registry-broker-skills) | Registry skill pack + SDK/API | Universal agentic registry skills with CLI, MCP, TypeScript SDK, verification/publish commands, trust scores, and GitHub Action publishing. | Adjacent reference for registry interoperability, skill publishing, and trust metadata around agents and skills. |
+| [Everything Claude Code](https://github.com/affaan-m/everything-claude-code) | Harness pack + installer | Large cross-harness system of skills, agents, hooks, commands, rules, dashboards, install manifests, and security tooling. | Not a skill manager, but relevant as a stress test for managing bundles that mix skills, hooks, agents, rules, and runtime policy. |
+
+## Reference Profiles
+
+### AGHub / Agent Skills Hub
+
+**Source basis:** Public repo checked.
+
+**What it includes:** AGHub is a centralized open-source registry of Markdown `SKILL.md` folders distributed through an NPX-first CLI. The repo catalog advertises more than 790 skills and targets Claude Code, Gemini CLI, Cursor, Kiro, Codex, Antigravity, OpenCode, AdaL, OpenClaw, and custom paths.
+
+**Distinctive components:**
+
+- Bulk install into a global agent-skills location.
+- Project-local clone guidance where local skills override global skills.
+- Target flags for common agent environments.
+- Specific skill install by name.
+- Simple contribution model: add a folder containing `SKILL.md`.
+- Roadmap items around versioning, dependency graphs, and marketplace integrations.
+
+**Wardian relevance:** AGHub is useful as a catalog-scale reference, especially for import and search. It is less useful as a complete governance model because it does not appear to own a rich local inventory, trust workflow, or human-observable activation view. Wardian should be able to ingest from a catalog like this while preserving local source-of-truth records, source URL, install target, activation state, and review notes.
+
+### Chops
+
+**Source basis:** Public repo checked, including `ToolSource.swift`.
+
+**What it includes:** Chops is a native macOS SwiftUI/SwiftData app for discovering, organizing, editing, and creating coding-agent skills and agents. It scans local tool directories, parses Markdown frontmatter and Cursor MDC files, watches the filesystem through FSEvents, and stores user collections as metadata rather than moving source files.
+
+**Distinctive components:**
+
+- Three-column native layout: tool filters, filtered skill/agent list, detail editor.
+- Built-in monospaced editor with save behavior and metadata display.
+- File watcher that rescans when skill files change on disk.
+- Full-text search across name, description, and content.
+- Collections that organize skills without modifying source files.
+- Deduplication by resolved symlink path so one skill can appear under several tools.
+- Support for both skills and agents across Claude Code, Cursor, Codex, Amp, OpenCode, OpenClaw, Hermes, Antigravity, Augment, Pi, and custom paths.
+
+**Wardian relevance:** Chops is a relevant local-observability reference. Wardian should treat skills and agents as inspectable filesystem objects first, then layer organization, filters, collections, and activation badges on top. The important product pattern is "organize without hiding the file."
+
+### Vercel `skills`
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Vercel's `skills` package is a CLI for installing agent skills from GitHub shorthands, GitHub URLs, direct repo paths, GitLab URLs, arbitrary git URLs, and local paths. It supports project and global scopes, targeted agents, targeted skills, list/find/remove/update/init commands, symlink versus copy install modes, and a large supported-agent matrix.
+
+**Distinctive components:**
+
+- `add`, `list`, `find`, `remove`, `update`, and `init` command set.
+- Project scope as the default, global scope by flag.
+- Install all skills, specific skills, specific agents, or all agents.
+- Symlink by default for canonical source-of-truth behavior, copy as fallback.
+- Discovery of skills from common layouts such as root `SKILL.md`, `skills/`, `.agents/skills/`, `.claude/skills/`, `.codex/skills/`, and agent-specific directories.
+- Plugin manifest discovery through Claude plugin manifest layouts.
+- Compatibility posture around a shared Agent Skills specification.
+
+**Wardian relevance:** This is a useful CLI contract reference. Wardian should expose similarly scriptable skill operations, but resolve them through Wardian's own library state so the UI can show where every skill came from, which agents can see it, whether the target is copied or linked, and when it was last updated.
+
+### Skills Hub Desktop
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Skills Hub is a Tauri + React desktop app that manages a central skill repository and syncs skills into global or project-level directories for many AI coding tools. It supports curated browsing, online search, one-click install and sync, tags, detail rendering, onboarding migration from existing tools, local folder import, Git URL import, update from source, and detection of newly installed tools.
+
+**Distinctive components:**
+
+- Central repo as canonical local storage.
+- Global and project sync modes.
+- Per-tool activation status.
+- Symlink/junction preferred, copy fallback for restricted platforms or incompatible tools.
+- Onboarding migration that scans existing tool skills and imports them into the central repo.
+- Import workflows for local folders and multi-skill Git repositories.
+- Scope controls and project-directory management.
+- Broad tool matrix, including Claude Code, Cursor, Codex, OpenCode, Antigravity, Amp, Kimi, Augment, OpenClaw, Cline, Continue, Kiro, OpenHands, Pi, Qwen, Goose, Gemini, Copilot, Droid, Windsurf, Hermes, and others.
+
+**Wardian relevance:** Skills Hub is a relevant structural reference if Wardian wants a central habitat/library that syncs into provider-specific directories. The key Wardian extension should be stronger observability: a skill should show canonical path, sync target, link/copy mode, owning collection, enabled agents, last validation, and provenance.
+
+### Quiver
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Quiver is a small local web UI and CLI for Claude Code skills. It scans local skills and Claude plugin marketplace layouts, serves a searchable interface, and exposes CLI commands for list, add, remove, import, export, registry browsing, sync, and local web-server startup.
+
+**Distinctive components:**
+
+- Local Express server and Preact UI.
+- REST-style routes for listing, reading, saving, adding, deleting, importing, and exporting skills.
+- CLI wrappers around the same inventory operations.
+- Symlink add by default, copy add by flag.
+- Zip-based import/export.
+- Marketplace plugin browsing with source toggles and category/search filters.
+- Remote sync commands for skill state across machines.
+
+**Wardian relevance:** Quiver is useful because it keeps the management surface small and automatable. Wardian should consider a local API/CLI layer for skills that mirrors UI operations, so agents can ask "what skills are installed, where, and for whom?" without scraping the app.
+
+### ClawHub
+
+**Source basis:** Public repo checked.
+
+**What it includes:** ClawHub is a hosted public skill registry for OpenClaw with a web app, Convex backend, shared API schema, CLI flows, vector search, publishing/versioning, comments, moderation, local install management, package catalog, pinning, and soft-delete/restore semantics. It also includes skill metadata for runtime requirements and security analysis.
+
+**Distinctive components:**
+
+- Publish new skill versions with changelogs, tags, and `latest`.
+- Rename and merge owned skills while preserving old slugs.
+- Vector search over skills.
+- Star/comment and moderation/approval hooks.
+- Local install commands: install, pin, unpin, uninstall, list, update.
+- Skill and package catalogs under one registry surface.
+- Runtime requirement metadata for environment variables, binaries, config, and install specs.
+- Security analysis that compares declared requirements with behavior.
+
+**Wardian relevance:** ClawHub is a relevant provenance and trust reference. Wardian does not need to become a hosted registry to learn from it: local skills should support version source, pinning, update policy, required capabilities, and review status. Registry metadata should remain separate from local activation so a user can install, inspect, pin, or quarantine without ambiguity.
+
+### Trail of Bits Skills
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Trail of Bits Skills is a curated Claude Code plugin marketplace for security analysis, testing, reverse engineering, mobile security, smart contracts, verification, infrastructure, and development workflows. It also includes a Codex-oriented sidecar under `.codex/skills/`.
+
+**Distinctive components:**
+
+- Domain-specific curated skill marketplace.
+- Claude Code plugin marketplace install flow.
+- Codex sidecar installation support.
+- Large security-specialist taxonomy.
+- Authoring guidance through repository instructions.
+
+**Wardian relevance:** This is useful as a pack and curation reference. Wardian should support curated skill bundles and domain packs while exposing the specific files and provenance of each installed skill. A "security pack" should be inspectable as individual skills, not a black-box plugin.
+
+### HOL Registry Broker Skills
+
+**Source basis:** Public repo checked.
+
+**What it includes:** HOL Registry Broker Skills provides skills and tooling for a Universal Agentic Registry. It supports search over live agent inventory, chat with agents, registration, publishing, verification, a CLI, MCP server, TypeScript SDK, direct API use, and GitHub Action-based publishing.
+
+**Distinctive components:**
+
+- CLI commands for config, init, lint, list, verify, publish, quote, and job status.
+- MCP and SDK access to registry operations.
+- Keyword, vector, and capability search.
+- Agent details, trust scores, and similar-agent queries.
+- Publish workflow that validates package files and records repo/commit metadata.
+
+**Wardian relevance:** This is adjacent rather than a simple skill manager because it manages agent registry concerns too. Wardian should track it for interoperability: skills, agents, trust, and capability discovery are converging, and Wardian's local library should not assume skills are the only reusable object type.
+
+### Everything Claude Code
+
+**Source basis:** Assistant-suggested candidate; public repo checked.
+
+**What it includes:** Everything Claude Code is a broad harness-performance system rather than a skill manager. It bundles skills, agents, hooks, rules, commands, install manifests, security scanning, memory/session patterns, dashboard tooling, and cross-harness support for Claude Code, Codex, Cursor, OpenCode, Gemini, and others.
+
+**Distinctive components:**
+
+- Selective installation profiles and component manifests.
+- Skills mixed with agents, rules, hooks, commands, and security tooling.
+- Cross-harness packaging and compatibility documentation.
+- Session/state infrastructure and dashboard commands.
+- Security and cost-control components alongside skill content.
+
+**Wardian relevance:** This is a useful warning case. Real-world "skill libraries" quickly become bundles of runtime policy, hooks, commands, subagents, and safety tooling. Wardian should model these object types explicitly instead of flattening everything into "skill" or hiding non-skill side effects behind an install button.
+
+## Implications for Wardian
+
+Wardian should treat skill management as a local-library problem with registry hooks, not only as a package-install problem.
+
+The likely model is:
+
+```text
+external source -> Wardian library record -> canonical local copy -> per-agent activation target -> observable status
+```
+
+That keeps the filesystem inspectable while still allowing catalogs, registries, and CLIs to feed the library.
+
+Near-term design implications:
+
+- Maintain a canonical Wardian skill library before syncing into provider-specific directories.
+- Store provenance for every skill: source URL/path, source type, import date, last update check, pinned state, and trust/review notes.
+- Distinguish `skill`, `agent`, `command`, `hook`, `rule`, `plugin`, and `bundle` as separate object types.
+- Expose activation state per provider and per project, including whether the target is linked, junctioned, copied, disabled, missing, or stale.
+- Keep human-facing organization metadata separate from source files, as Chops does with collections.
+- Offer agent-friendly CLI/API operations for install, list, find, sync, pin, update, validate, and explain.
+- Add compatibility adapters, but keep Wardian's own record as the source of truth.
+- Treat registry trust metadata as advisory until the user or project policy accepts it.
+
+The pattern that fits Wardian's current direction is not "download skills into dotfolders." It is "make skills visible habitat objects, then project them into the tool-specific places agents already know how to read."

--- a/docs/research/workflow-design-references.md
+++ b/docs/research/workflow-design-references.md
@@ -1,0 +1,219 @@
+# Workflow Design References
+
+This document maps public workflow and agent-orchestration systems to design patterns relevant to Wardian's workflow builder and runtime.
+
+This is not an endorsement, affiliation claim, product evaluation, or competitive teardown. The notes below describe public architecture and design pressure only.
+
+Last reviewed: 2026-05-12.
+
+Source basis: Orla and Archon were rechecked against their public repositories because they anchor the "code as construction, graph as observability" framing. Other entries are prior-art references based on public project documentation and repositories.
+
+## Design Axes
+
+- **Code-first construction**: workflows can be created, reviewed, versioned, and modified by agents or developers as text.
+- **Observable graph projection**: workflow state can be inspected as nodes, edges, ports, and execution status.
+- **Durable execution**: runs can tolerate retries, pauses, resumes, and long-lived state.
+- **Human-in-the-loop control**: humans can approve, interrupt, redirect, or inspect execution without losing the underlying run context.
+- **Trace and replay evidence**: execution leaves enough telemetry to understand what ran, why it ran, and what each step produced.
+
+## Summary Map
+
+| System | Relevant Pattern | Wardian Takeaway |
+|---|---|---|
+| [Orla](https://github.com/harvard-cns/orla) | Code-first stage execution with scheduling, routing, and shared inference state. | Keep workflow policy separate from provider/runtime mechanics so orchestration can evolve without tying the builder to one execution backend. |
+| [Archon](https://github.com/coleam00/Archon) | Hybrid workflow construction with durable text definitions and visual execution surfaces. | Treat code or structured files as the construction surface, then project that model into a human-observable graph. |
+| [Apache Burr](https://github.com/apache/burr) | State-machine workflows with a UI for tracking execution state and transitions. | Model workflow progress as explicit state transitions that can be logged, inspected, and resumed. |
+| [LangGraph](https://github.com/langchain-ai/langgraph) | Stateful agent graphs with persistence, streaming, and human-in-the-loop patterns. | Agent workflows need first-class state, checkpoints, and interruption points rather than only linear task chains. |
+| [Mastra](https://github.com/mastra-ai/mastra) | TypeScript-first workflow API with steps, branches, parallelism, and durable pauses. | A fluent or typed construction API can coexist with a graph view when both compile to the same workflow model. |
+| [CrewAI](https://github.com/crewAIInc/crewAI) | Distinguishes autonomous agent crews from more deterministic flows. | Wardian should preserve the distinction between agent autonomy and deterministic workflow control. |
+| [Dify](https://github.com/langgenius/dify) | Visual workflow and agent builder with node-level observability. | Node-first workflows are approachable for humans, but Wardian should still expose a text-native model for agent construction. |
+| [n8n](https://github.com/n8n-io/n8n) | Mature visual automation graph with code escape hatches. | Visual authoring benefits from predictable node contracts, searchable blocks, and inspectable run history. |
+| [ComfyUI](https://github.com/Comfy-Org/ComfyUI) | Node-first generative AI pipelines with visible dataflow. | Dense node graphs can stay understandable when ports, typed edges, previews, and execution feedback are clear. |
+| [Dagger](https://github.com/dagger/dagger) | Code-defined DAGs with observable execution traces. | "Code as construction, graph as observability" is a strong fit for agent-authored Wardian workflows. |
+| [Temporal](https://github.com/temporalio/temporal) | Durable workflow execution with history, retries, and a web UI. | Long-running workflows need execution history and replayable evidence, not only live status indicators. |
+| [Pydantic AI](https://github.com/pydantic/pydantic-ai) | Typed agent and graph construction with structured outputs. | Typed schemas reduce ambiguity when agents create workflow definitions or pass outputs between nodes. |
+
+## Reference Profiles
+
+### Orla
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Orla is a Go library with Python bindings for building and running LLM-based agentic systems. Its public architecture centers on workflows defined as stages, with runtime components for model/backend routing, stage scheduling and execution, and shared inference state.
+
+**Distinctive components:**
+
+- Stage Mapper for routing stages across heterogeneous models and backends.
+- Workflow Orchestrator for scheduling and executing stages.
+- Memory Manager for sharing KV-cache or inference state across stages.
+
+**Wardian relevance:** Orla is a useful reference for separating workflow-level intent from provider execution mechanics. Wardian should preserve that separation: workflow definitions should describe agent, command, branch, wait, and memory semantics, while the Rust backend resolves provider, PTY, headless, and scheduling details.
+
+### Archon
+
+**Source basis:** Public repo checked.
+
+**What it includes:** Archon is a workflow engine and harness builder for AI coding agents. It defines coding processes as YAML workflows under `.archon/workflows/`, supports deterministic and AI-driven nodes, runs jobs in isolated git worktrees, and exposes workflow activity through CLI, web UI, and platform adapters.
+
+**Distinctive components:**
+
+- YAML workflow definitions that encode planning, implementation, validation, review, approval, and PR steps.
+- Visual workflow builder and workflow execution view.
+- Isolation environments for parallel worktree-based runs.
+- Platform adapters for CLI, web, Slack, Telegram, GitHub, and Discord.
+- Built-in development workflows for issue fixing, idea-to-PR, review, validation, conflict resolution, and refactoring.
+
+**Wardian relevance:** Archon is a relevant reference for "code as construction, nodes for observability." Wardian can use the same broad posture while staying local-first: durable workflow files should be agent-editable, and the UI should project those files into a tactile graph with run state, logs, approvals, and history.
+
+### Apache Burr
+
+**What it includes:** Burr is a Python library for applications that make decisions, including chatbots, agents, simulations, and other stateful systems. Applications are expressed as state machines or flowcharts composed from Python actions, with transitions, persisted state, and a telemetry UI.
+
+**Distinctive components:**
+
+- Low-abstraction action functions that read and write explicit state.
+- State-machine graph model rather than only acyclic DAGs.
+- UI for real-time monitoring, tracing, and debugging.
+- Pluggable persisters for saving and loading application state.
+- Framework-agnostic integration posture for LLMs, storage, telemetry, and other libraries.
+
+**Wardian relevance:** Burr's state-machine framing fits Wardian's loops, waits, and pulse-based execution better than a pure DAG framing. Wardian should make state transitions visible: why a node became runnable, which dependency pulse was consumed, what state changed, and where execution can resume.
+
+### LangGraph
+
+**What it includes:** LangGraph is a low-level orchestration framework for building long-running, stateful agents. It emphasizes durable execution, human-in-the-loop interruptions, memory, deployment, and debugging through the broader LangChain/LangSmith ecosystem.
+
+**Distinctive components:**
+
+- Durable agent execution that can resume after failures.
+- Human-in-the-loop mechanisms for inspecting and modifying state.
+- Short-term and long-term memory patterns.
+- Execution-path and state-transition visibility through LangSmith.
+- Support for branching, subgraphs, streaming, persistence, and deployment patterns.
+
+**Wardian relevance:** LangGraph highlights that agent workflows need durable checkpoints and human intervention points as first-class concepts. Wardian's workflow builder should avoid reducing agent orchestration to static boxes connected by arrows; each node needs state, interruption behavior, and resumability semantics.
+
+### Mastra
+
+**What it includes:** Mastra is a TypeScript framework for AI applications and agents. It includes model routing, agents, graph-based workflows, human-in-the-loop suspension, storage-backed execution state, context management, MCP servers, evals, and observability.
+
+**Distinctive components:**
+
+- TypeScript-first workflow syntax with `.then()`, `.branch()`, and `.parallel()`.
+- Explicit split between autonomous agents and controlled workflows.
+- Human-in-the-loop suspension that can pause indefinitely and resume from stored state.
+- Model routing across many providers.
+- Production tooling for evals and observability.
+
+**Wardian relevance:** Mastra is a useful TypeScript-side reference for an eventual agent-authored construction API. Wardian can expose a builder-friendly structured model today and later layer a fluent or typed authoring surface on top, as long as both compile into the same normalized graph model.
+
+### CrewAI
+
+**What it includes:** CrewAI is a Python framework for multi-agent automation. It distinguishes between Crews, which emphasize autonomous role-based collaboration, and Flows, which emphasize event-driven execution control and structured state.
+
+**Distinctive components:**
+
+- Crews for role-based autonomous agent collaboration.
+- Flows for precise event-driven orchestration.
+- YAML configuration for agents and tasks in scaffolded projects.
+- Human input support and control-plane observability in the broader CrewAI suite.
+- Patterns for combining autonomous agent teams with deterministic flow control.
+
+**Wardian relevance:** CrewAI's Crew versus Flow distinction is worth preserving conceptually. Wardian workflow nodes should make clear whether a step delegates autonomy to an agent/team or executes deterministic control logic owned by the workflow engine.
+
+### Dify
+
+**What it includes:** Dify is an open-source LLM application development platform. It combines AI workflows, RAG pipelines, agent capabilities, model management, observability integrations, and production deployment concerns behind an approachable visual interface.
+
+**Distinctive components:**
+
+- Visual AI workflow builder for LLM applications.
+- RAG pipeline and dataset management surfaces.
+- Agent, model, and prompt management in one product surface.
+- Observability integrations such as Opik, Langfuse, and Arize Phoenix.
+- Prototype-to-production orientation for LLM apps.
+
+**Wardian relevance:** Dify shows how much of an AI system can be made observable through a visual builder. Wardian should borrow the clarity of node-level setup and execution feedback, but keep its source of truth local, text-inspectable, and friendly to agent edits.
+
+### n8n
+
+**What it includes:** n8n is a workflow automation platform with a visual editor, native AI capabilities, custom code support, self-hosting, and a large integration library.
+
+**Distinctive components:**
+
+- Visual node-based automation editor.
+- JavaScript and Python escape hatches inside workflows.
+- Native AI workflows based on LangChain and user-provided data/models.
+- Large integration and template ecosystem.
+- Self-hosting and enterprise deployment controls.
+
+**Wardian relevance:** n8n is a mature example of visual workflows with code escape hatches. Wardian should apply that pattern in reverse for agents: text/code construction first, visual editing and observation always available, and predictable node contracts to keep both paths coherent.
+
+### ComfyUI
+
+**What it includes:** ComfyUI is a modular AI content creation engine with a graph/nodes interface. It supports image, video, audio, and 3D model workflows, local and cloud usage, API endpoints, workflow JSON, execution queues, and partial re-execution of changed graph regions.
+
+**Distinctive components:**
+
+- Dense node graph interface for complex generative pipelines.
+- Workflow save/load as JSON, including workflows embedded in generated media.
+- Asynchronous queue and history surfaces.
+- Partial re-execution that only reruns changed workflow regions.
+- App Mode for exposing sophisticated graphs through simpler user interfaces.
+
+**Wardian relevance:** ComfyUI is not an agent workflow system, but it is a strong visual reference for complex graph ergonomics. Wardian should make graph density manageable with clear ports, labels, grouping, queue/history views, and execution feedback.
+
+### Dagger
+
+**What it includes:** Dagger is a programmable software delivery automation engine that runs locally, in CI, or in the cloud. It provides SDKs, reusable modules, containerized execution, caching, a CLI/TUI, and OpenTelemetry tracing.
+
+**Distinctive components:**
+
+- Code-defined automation instead of proprietary YAML.
+- Multi-language SDKs and reusable modules.
+- Local-first execution with consistent behavior across laptop, AI sandbox, CI, and cloud.
+- Containerized, typed, repeatable operations with incremental caching.
+- Built-in tracing with live CLI/TUI and OpenTelemetry export.
+
+**Wardian relevance:** Dagger strongly validates the pattern "programmatic construction, observable execution." Wardian's equivalent should be workflow definitions and future APIs for construction, plus live telemetry, trace logs, and graph projection for observation.
+
+### Temporal
+
+**What it includes:** Temporal is a durable execution platform. Its server runs workflows and activities resiliently, handles intermittent failures and retries, and exposes CLI and web UI surfaces for interacting with workflow executions.
+
+**Distinctive components:**
+
+- Workflows and Activities as separate runtime concepts.
+- Durable execution history for long-running application logic.
+- Retry and failure handling as runtime behavior.
+- Worker model with SDKs in supported languages.
+- Web UI for inspecting executing workflows.
+
+**Wardian relevance:** Temporal is the reference for durability discipline. Wardian does not need Temporal's distributed architecture to learn from its model: workflow runs should have durable identity, history, retry/failure semantics, and inspectable state.
+
+### Pydantic AI
+
+**What it includes:** Pydantic AI is a Python framework for production-grade agent applications. It emphasizes type safety, model-provider flexibility, observability, evals, composable capabilities, MCP/A2A/UI event-stream standards, tool approval, durable execution, streamed structured outputs, and graph support.
+
+**Distinctive components:**
+
+- Type-safe agent definitions and structured outputs.
+- YAML/JSON agent definitions in addition to code.
+- Human-in-the-loop tool approval.
+- Durable agents for long-running and restart-tolerant workflows.
+- Graph support backed by Python type hints.
+- Observability through OpenTelemetry-compatible tooling.
+
+**Wardian relevance:** Pydantic AI is useful for schema discipline. Wardian workflow definitions should keep node inputs, outputs, config, role assignments, and structured agent outputs typed enough that both humans and agents can safely compose them.
+
+## Wardian Positioning
+
+Wardian's direction is hybrid: agents and developers should be able to construct workflows through durable, reviewable definitions, while humans should be able to observe and edit those workflows as tactile node graphs.
+
+The core pattern is:
+
+```text
+workflow definition -> normalized graph model -> Rust execution -> telemetry and run log -> observable node graph
+```
+
+This keeps the builder agent-friendly without making humans read raw workflow definitions during execution. It also keeps the visual graph honest: nodes are an observable projection of the workflow model, not a separate source of truth.


### PR DESCRIPTION
## Description
Adds a neutral `docs/research/` section for Wardian roadmap reference maps. The new docs cover workflow builders, multi-agent orchestrators, skill managers, graph visualization, dashboard observability, local-first state, agent protocol/UI patterns, runtime sandboxes, and evaluation systems.

The main docs index links to the full research index for discovery. Individual research notes are also linked only from directly relevant pages: Library for skill-manager research, Provider Runtime Notes for runtime/protocol research, Visual Builder for workflow and graph visualization research, State Management for local-first state research, Native E2E for evaluation research, UI/Watchlists for dashboard observability, and UI overview for multi-agent orchestration.

Graph and dashboard references are intentionally split: graph visualization covers workflow graphs, communication graphs, topology maps, and trace graphs; dashboard observability covers dashboard view, monitoring panels, watchlists, operator drill-downs, and complex-system telemetry surfaces.

## Related Issues
Fixes #239

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `rg -n "Graph and Dashboard|graph-and-dashboard" docs`
- `rg -n "C:\\|D:\\|Users\\|~[/\\]|/path/to" docs/research docs/index.md docs/developer/index.md docs/developer/workflow-engine.md docs/developer/visual-builder.md docs/developer/provider-runtimes.md docs/developer/state-management.md docs/developer/native-e2e.md docs/guide/library.md docs/guide/ui-overview.md docs/guide/watchlists.md`
- `rg -n "TODO|TBD|FIXME|/path/to" docs/research docs/index.md docs/developer/index.md docs/developer/workflow-engine.md docs/developer/visual-builder.md docs/developer/provider-runtimes.md docs/developer/state-management.md docs/developer/native-e2e.md docs/guide/library.md docs/guide/ui-overview.md docs/guide/watchlists.md`
- `git diff --check`

No frontend/backend test suite was run because this is a docs-only change.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
