### PR TITLE
feat(cli): add worktree and watchlist parity slice

### DIFF
--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -11,8 +11,38 @@ pub struct Cli {
 pub enum Command {
     Agent(AgentArgs),
     Workflow(WorkflowArgs),
+    Team(TeamArgs),
+    Watchlist(WatchlistArgs),
     Send(SendArgs),
     Ask(AskArgs),
+}
+
+// ---------------------------------------------------------------------------
+// wardian team / watchlist
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct TeamArgs {
+    #[command(subcommand)]
+    pub command: TeamCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum TeamCommand {
+    List,
+    Show { target: String },
+}
+
+#[derive(Debug, Args)]
+pub struct WatchlistArgs {
+    #[command(subcommand)]
+    pub command: WatchlistCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WatchlistCommand {
+    List,
+    Show { target: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -166,6 +196,10 @@ pub enum AgentCommand {
         #[arg(long)]
         name: Option<String>,
     },
+    Worktree {
+        #[command(subcommand)]
+        command: AgentWorktreeCommand,
+    },
     Watch {
         target: String,
         #[arg(long)]
@@ -189,6 +223,24 @@ pub enum AgentCommand {
         timeout: String,
         #[arg(long)]
         next: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AgentWorktreeCommand {
+    List,
+    Enable {
+        target: String,
+        #[arg(long)]
+        name: Option<String>,
+    },
+    Join {
+        target: String,
+        #[arg(long)]
+        worktree: String,
+    },
+    Disable {
+        target: String,
     },
 }
 
@@ -424,6 +476,119 @@ mod tests {
         assert!(matches!(
             args.command,
             Some(AgentCommand::Wait { next: true, .. })
+        ));
+    }
+
+    #[test]
+    fn parses_agent_worktree_list() {
+        let cli = Cli::try_parse_from(["wardian", "agent", "worktree", "list"]).unwrap();
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent command")
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Worktree {
+                command: AgentWorktreeCommand::List
+            })
+        ));
+    }
+
+    #[test]
+    fn parses_agent_worktree_enable_with_name() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "agent",
+            "worktree",
+            "enable",
+            "coder-a1",
+            "--name",
+            "review fixes",
+        ])
+        .unwrap();
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent command")
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Worktree {
+                command: AgentWorktreeCommand::Enable { ref target, ref name }
+            }) if target == "coder-a1" && name.as_deref() == Some("review fixes")
+        ));
+    }
+
+    #[test]
+    fn parses_agent_worktree_join() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "agent",
+            "worktree",
+            "join",
+            "coder-a1",
+            "--worktree",
+            "D:/Development/Wardian/.worktrees/review",
+        ])
+        .unwrap();
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent command")
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Worktree {
+                command: AgentWorktreeCommand::Join { ref target, ref worktree }
+            }) if target == "coder-a1" && worktree == "D:/Development/Wardian/.worktrees/review"
+        ));
+    }
+
+    #[test]
+    fn parses_agent_worktree_disable() {
+        let cli =
+            Cli::try_parse_from(["wardian", "agent", "worktree", "disable", "coder-a1"]).unwrap();
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent command")
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Worktree {
+                command: AgentWorktreeCommand::Disable { ref target }
+            }) if target == "coder-a1"
+        ));
+    }
+
+    #[test]
+    fn parses_team_list_and_show() {
+        let cli = Cli::try_parse_from(["wardian", "team", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Team(TeamArgs {
+                command: TeamCommand::List
+            })
+        ));
+
+        let cli = Cli::try_parse_from(["wardian", "team", "show", "review"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Team(TeamArgs {
+                command: TeamCommand::Show { ref target }
+            }) if target == "review"
+        ));
+    }
+
+    #[test]
+    fn parses_watchlist_list_and_show() {
+        let cli = Cli::try_parse_from(["wardian", "watchlist", "list"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Watchlist(WatchlistArgs {
+                command: WatchlistCommand::List
+            })
+        ));
+
+        let cli = Cli::try_parse_from(["wardian", "watchlist", "show", "main"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Watchlist(WatchlistArgs {
+                command: WatchlistCommand::Show { ref target }
+            }) if target == "main"
         ));
     }
 

--- a/crates/wardian-cli/src/disk.rs
+++ b/crates/wardian-cli/src/disk.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+use serde::Serialize;
 use wardian_core::models::WorkflowDefinition;
 
 pub fn list_workflows_from_disk() -> io::Result<Vec<WorkflowDefinition>> {
@@ -42,4 +43,236 @@ pub fn workflow_summaries(
             node_count: workflow.nodes.len(),
         })
         .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WatchlistState {
+    pub version: u8,
+    pub watchlists: Vec<WatchlistSummary>,
+    pub teams: Vec<TeamSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TeamSummary {
+    pub id: String,
+    pub name: String,
+    pub agent_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WatchlistSummary {
+    pub id: String,
+    pub name: String,
+    pub entries: Vec<WatchlistEntry>,
+    pub agent_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum WatchlistEntry {
+    Agent { agent_id: String },
+    Team { team_id: String },
+}
+
+impl WatchlistEntry {
+    #[cfg(test)]
+    pub fn agent_id(&self) -> Option<&str> {
+        match self {
+            Self::Agent { agent_id } => Some(agent_id),
+            Self::Team { .. } => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn team_id(&self) -> Option<&str> {
+        match self {
+            Self::Agent { .. } => None,
+            Self::Team { team_id } => Some(team_id),
+        }
+    }
+}
+
+pub fn load_watchlist_state() -> io::Result<WatchlistState> {
+    let home = wardian_core::paths::wardian_home()
+        .ok_or_else(|| io::Error::other("WARDIAN_HOME not set"))?;
+    let path = home.join("watchlists").join("index.json");
+    if !path.exists() {
+        return Ok(empty_watchlist_state());
+    }
+
+    let content = std::fs::read_to_string(path)?;
+    let value: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| io::Error::other(e.to_string()))?;
+    Ok(normalize_watchlist_state(&value))
+}
+
+fn empty_watchlist_state() -> WatchlistState {
+    WatchlistState {
+        version: 2,
+        watchlists: Vec::new(),
+        teams: Vec::new(),
+    }
+}
+
+fn normalize_watchlist_state(value: &serde_json::Value) -> WatchlistState {
+    if value.get("version").and_then(|v| v.as_u64()) == Some(2) {
+        return WatchlistState {
+            version: 2,
+            teams: value
+                .get("teams")
+                .and_then(|teams| teams.as_array())
+                .map(|teams| teams.iter().filter_map(parse_team).collect())
+                .unwrap_or_default(),
+            watchlists: value
+                .get("watchlists")
+                .and_then(|watchlists| watchlists.as_array())
+                .map(|watchlists| watchlists.iter().filter_map(parse_watchlist).collect())
+                .unwrap_or_default(),
+        };
+    }
+
+    WatchlistState {
+        version: 2,
+        teams: Vec::new(),
+        watchlists: value
+            .as_array()
+            .map(|watchlists| watchlists.iter().filter_map(parse_watchlist).collect())
+            .unwrap_or_default(),
+    }
+}
+
+fn parse_team(value: &serde_json::Value) -> Option<TeamSummary> {
+    let id = value.get("id")?.as_str()?.to_string();
+    let name = value
+        .get("name")
+        .and_then(|name| name.as_str())
+        .unwrap_or("Team")
+        .to_string();
+    Some(TeamSummary {
+        id,
+        name,
+        agent_ids: string_array(value, "agentIds")
+            .or_else(|| string_array(value, "agent_ids"))
+            .unwrap_or_default(),
+    })
+}
+
+fn parse_watchlist(value: &serde_json::Value) -> Option<WatchlistSummary> {
+    let id = value.get("id")?.as_str()?.to_string();
+    let name = value
+        .get("name")
+        .and_then(|name| name.as_str())
+        .unwrap_or("List")
+        .to_string();
+    let agent_ids = string_array(value, "agentIds")
+        .or_else(|| string_array(value, "agent_ids"))
+        .unwrap_or_default();
+    let entries = value
+        .get("entries")
+        .and_then(|entries| entries.as_array())
+        .map(|entries| entries.iter().filter_map(parse_watchlist_entry).collect())
+        .unwrap_or_else(|| {
+            agent_ids
+                .iter()
+                .map(|agent_id| WatchlistEntry::Agent {
+                    agent_id: agent_id.clone(),
+                })
+                .collect()
+        });
+
+    Some(WatchlistSummary {
+        id,
+        name,
+        entries,
+        agent_ids,
+    })
+}
+
+fn parse_watchlist_entry(value: &serde_json::Value) -> Option<WatchlistEntry> {
+    match value.get("type").and_then(|kind| kind.as_str()) {
+        Some("agent") => value
+            .get("agentId")
+            .or_else(|| value.get("agent_id"))
+            .and_then(|id| id.as_str())
+            .map(|agent_id| WatchlistEntry::Agent {
+                agent_id: agent_id.to_string(),
+            }),
+        Some("team") => value
+            .get("teamId")
+            .or_else(|| value.get("team_id"))
+            .and_then(|id| id.as_str())
+            .map(|team_id| WatchlistEntry::Team {
+                team_id: team_id.to_string(),
+            }),
+        _ => None,
+    }
+}
+
+fn string_array(value: &serde_json::Value, key: &str) -> Option<Vec<String>> {
+    Some(
+        value
+            .get(key)?
+            .as_array()?
+            .iter()
+            .filter_map(|item| item.as_str().map(str::to_string))
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn load_watchlist_state_accepts_v2_teams_and_entries() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("WARDIAN_HOME", temp.path());
+        let dir = temp.path().join("watchlists");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("index.json"),
+            r#"{
+              "version": 2,
+              "teams": [{"id":"team-1","name":"Review","agentIds":["agent-1","agent-2"]}],
+              "watchlists": [{"id":"list-1","name":"Main","entries":[{"type":"team","teamId":"team-1"}]}]
+            }"#,
+        )
+        .unwrap();
+
+        let state = load_watchlist_state().unwrap();
+
+        assert_eq!(state.version, 2);
+        assert_eq!(state.teams[0].agent_ids, vec!["agent-1", "agent-2"]);
+        assert_eq!(state.watchlists[0].entries[0].team_id(), Some("team-1"));
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn load_watchlist_state_accepts_legacy_array() {
+        let _guard = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("WARDIAN_HOME", temp.path());
+        let dir = temp.path().join("watchlists");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("index.json"),
+            r#"[{"id":"list-1","name":"Main","agentIds":["agent-1"]}]"#,
+        )
+        .unwrap();
+
+        let state = load_watchlist_state().unwrap();
+
+        assert_eq!(state.version, 2);
+        assert!(state.teams.is_empty());
+        assert_eq!(state.watchlists[0].agent_ids, vec!["agent-1"]);
+        assert_eq!(state.watchlists[0].entries[0].agent_id(), Some("agent-1"));
+        std::env::remove_var("WARDIAN_HOME");
+    }
 }

--- a/crates/wardian-cli/src/errors.rs
+++ b/crates/wardian-cli/src/errors.rs
@@ -54,11 +54,21 @@ impl CliError {
     }
 
     pub fn not_found(requested: &str) -> Self {
+        Self::not_found_entity("Agent", requested)
+    }
+
+    pub fn not_found_entity(entity: &'static str, requested: &str) -> Self {
         Self {
             exit_code: ExitCode::NotFound,
             code: "not_found",
-            message: format!("Agent was not found: {requested}"),
-            hint: Some("Run `wardian agent list --scope all` to inspect known agents.".to_string()),
+            message: format!("{entity} was not found: {requested}"),
+            hint: Some(match entity {
+                "Team" => "Run `wardian team list` to inspect known teams.".to_string(),
+                "Watchlist" => {
+                    "Run `wardian watchlist list` to inspect known watchlists.".to_string()
+                }
+                _ => "Run `wardian agent list --scope all` to inspect known agents.".to_string(),
+            }),
             details: Some(Box::new(serde_json::json!({ "requested": requested }))),
         }
     }

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -5,7 +5,8 @@ use std::{
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
-    AgentListResponse, AgentResponse, AgentWatchResponse, ControlRequest, DeliveryDetail,
+    AgentListResponse, AgentResponse, AgentWatchResponse, AgentWorktreeListResponse,
+    AgentWorktreeMutationResponse, AgentWorktreeSummary, ControlRequest, DeliveryDetail,
     MessageOrigin, SendMessageResponse, WorkflowListResponse, WorkflowResponse, WorkflowSummary,
 };
 use wardian_core::identity::AgentIdentity;
@@ -22,6 +23,10 @@ enum ControlOperation {
     AgentResume,
     AgentSpawn,
     AgentClone,
+    AgentWorktreeList,
+    AgentWorktreeEnable,
+    AgentWorktreeJoin,
+    AgentWorktreeDisable,
     WorkflowList,
     WorkflowShow,
     WorkflowRun,
@@ -250,6 +255,62 @@ pub fn agent_clone(target: &str, name: Option<&str>) -> io::Result<AgentIdentity
     let resp: AgentResponse =
         serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
     Ok(resp.agent)
+}
+
+pub fn agent_worktree_list() -> io::Result<Vec<AgentWorktreeSummary>> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::AgentWorktreeList,
+        send_request(ControlRequest::AgentWorktreeList),
+    )?;
+    let resp: AgentWorktreeListResponse =
+        serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
+    Ok(resp.worktrees)
+}
+
+pub fn agent_worktree_enable(
+    target: &str,
+    name: Option<&str>,
+) -> io::Result<AgentWorktreeMutationResponse> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::AgentWorktreeEnable,
+        send_request(ControlRequest::AgentWorktreeEnable {
+            target: target.to_string(),
+            name: name.map(str::to_string),
+        }),
+    )?;
+    serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
+}
+
+pub fn agent_worktree_join(
+    target: &str,
+    worktree: &str,
+) -> io::Result<AgentWorktreeMutationResponse> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::AgentWorktreeJoin,
+        send_request(ControlRequest::AgentWorktreeJoin {
+            target: target.to_string(),
+            worktree: worktree.to_string(),
+        }),
+    )?;
+    serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
+}
+
+pub fn agent_worktree_disable(target: &str) -> io::Result<AgentWorktreeMutationResponse> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::AgentWorktreeDisable,
+        send_request(ControlRequest::AgentWorktreeDisable {
+            target: target.to_string(),
+        }),
+    )?;
+    serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
 }
 
 pub fn workflow_list() -> io::Result<Vec<WorkflowSummary>> {
@@ -491,9 +552,13 @@ fn operation_timeout(operation: &ControlOperation) -> Duration {
         | ControlOperation::AgentResume
         | ControlOperation::AgentSpawn
         | ControlOperation::AgentClone
+        | ControlOperation::AgentWorktreeEnable
+        | ControlOperation::AgentWorktreeJoin
+        | ControlOperation::AgentWorktreeDisable
         | ControlOperation::WorkflowRun
         | ControlOperation::WorkflowStop
         | ControlOperation::SendMessage => CONTROL_MUTATION_TIMEOUT,
+        ControlOperation::AgentWorktreeList => CONTROL_TIMEOUT,
         ControlOperation::AgentWatch { requested, .. } => watch_timeout_for(*requested),
     }
 }
@@ -682,6 +747,30 @@ mod tests {
     fn spawn_and_clone_use_longer_control_timeout() {
         assert!(operation_timeout(&ControlOperation::AgentSpawn) > CONTROL_TIMEOUT);
         assert!(operation_timeout(&ControlOperation::AgentClone) > CONTROL_TIMEOUT);
+    }
+
+    #[test]
+    fn worktree_mutations_use_longer_control_timeout() {
+        assert_eq!(
+            operation_timeout(&ControlOperation::AgentWorktreeEnable),
+            CONTROL_MUTATION_TIMEOUT
+        );
+        assert_eq!(
+            operation_timeout(&ControlOperation::AgentWorktreeJoin),
+            CONTROL_MUTATION_TIMEOUT
+        );
+        assert_eq!(
+            operation_timeout(&ControlOperation::AgentWorktreeDisable),
+            CONTROL_MUTATION_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn worktree_list_keeps_short_control_timeout() {
+        assert_eq!(
+            operation_timeout(&ControlOperation::AgentWorktreeList),
+            CONTROL_TIMEOUT
+        );
     }
 
     #[test]

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -7,7 +7,8 @@ mod output;
 use std::{io::Read as _, time::Duration};
 
 use args::{
-    AgentArgs, AgentCommand, AskArgs, Cli, Command, SendArgs, WorkflowArgs, WorkflowCommand,
+    AgentArgs, AgentCommand, AgentWorktreeCommand, AskArgs, Cli, Command, SendArgs, TeamArgs,
+    TeamCommand, WatchlistArgs, WatchlistCommand, WorkflowArgs, WorkflowCommand,
 };
 use clap::Parser;
 use errors::{CliError, ExitCode};
@@ -26,6 +27,8 @@ fn run() -> i32 {
     let result = match cli.command {
         Command::Agent(args) => handle_agent(args),
         Command::Workflow(args) => handle_workflow(args),
+        Command::Team(args) => handle_team(args),
+        Command::Watchlist(args) => handle_watchlist(args),
         Command::Send(args) => handle_send(args),
         Command::Ask(args) => handle_ask(args),
     };
@@ -53,6 +56,60 @@ fn handle_parse_error(error: clap::Error) -> i32 {
 
     CliError::generic(error.to_string()).emit();
     ExitCode::Generic as i32
+}
+
+// ---------------------------------------------------------------------------
+// wardian team / watchlist
+// ---------------------------------------------------------------------------
+
+fn handle_team(args: TeamArgs) -> Result<String, CliError> {
+    let state = disk::load_watchlist_state().map_err(|e| CliError::generic(e.to_string()))?;
+    match args.command {
+        TeamCommand::List => serde_json::to_string_pretty(&serde_json::json!({
+            "schema": 1,
+            "teams": state.teams,
+        }))
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string())),
+        TeamCommand::Show { target } => {
+            let team = state
+                .teams
+                .into_iter()
+                .find(|team| team.id == target || team.name == target)
+                .ok_or_else(|| CliError::not_found_entity("Team", &target))?;
+            serde_json::to_string_pretty(&serde_json::json!({
+                "schema": 1,
+                "team": team,
+            }))
+            .map(|json| format!("{json}\n"))
+            .map_err(|e| CliError::generic(e.to_string()))
+        }
+    }
+}
+
+fn handle_watchlist(args: WatchlistArgs) -> Result<String, CliError> {
+    let state = disk::load_watchlist_state().map_err(|e| CliError::generic(e.to_string()))?;
+    match args.command {
+        WatchlistCommand::List => serde_json::to_string_pretty(&serde_json::json!({
+            "schema": 1,
+            "watchlists": state.watchlists,
+        }))
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string())),
+        WatchlistCommand::Show { target } => {
+            let watchlist = state
+                .watchlists
+                .into_iter()
+                .find(|watchlist| watchlist.id == target || watchlist.name == target)
+                .ok_or_else(|| CliError::not_found_entity("Watchlist", &target))?;
+            serde_json::to_string_pretty(&serde_json::json!({
+                "schema": 1,
+                "watchlist": watchlist,
+            }))
+            .map(|json| format!("{json}\n"))
+            .map_err(|e| CliError::generic(e.to_string()))
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -93,6 +150,7 @@ fn handle_agent(args: AgentArgs) -> Result<String, CliError> {
         Some(AgentCommand::Clone { target, name }) => {
             handle_agent_clone(target, name.as_deref(), &args)
         }
+        Some(AgentCommand::Worktree { command }) => handle_agent_worktree(command),
         Some(AgentCommand::Watch { follow, .. }) if *follow => Err(CliError::backend(
             ExitCode::Generic,
             "not_supported",
@@ -169,6 +227,47 @@ fn handle_agent_clone(
 ) -> Result<String, CliError> {
     let agent = live::agent_clone(target, name).map_err(control_error)?;
     render_show(&agent, &render_options(args))
+}
+
+fn handle_agent_worktree(command: &AgentWorktreeCommand) -> Result<String, CliError> {
+    match command {
+        AgentWorktreeCommand::List => {
+            let worktrees = live::agent_worktree_list().map_err(control_error)?;
+            render_worktree_list(&worktrees)
+        }
+        AgentWorktreeCommand::Enable { target, name } => {
+            let response =
+                live::agent_worktree_enable(target, name.as_deref()).map_err(control_error)?;
+            render_worktree_mutation_response(&response)
+        }
+        AgentWorktreeCommand::Join { target, worktree } => {
+            let response = live::agent_worktree_join(target, worktree).map_err(control_error)?;
+            render_worktree_mutation_response(&response)
+        }
+        AgentWorktreeCommand::Disable { target } => {
+            let response = live::agent_worktree_disable(target).map_err(control_error)?;
+            render_worktree_mutation_response(&response)
+        }
+    }
+}
+
+fn render_worktree_list(
+    worktrees: &[wardian_core::control::AgentWorktreeSummary],
+) -> Result<String, CliError> {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "schema": 1,
+        "worktrees": worktrees,
+    }))
+    .map(|json| format!("{json}\n"))
+    .map_err(|e| CliError::generic(e.to_string()))
+}
+
+fn render_worktree_mutation_response(
+    response: &wardian_core::control::AgentWorktreeMutationResponse,
+) -> Result<String, CliError> {
+    serde_json::to_string_pretty(response)
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string()))
 }
 
 fn handle_agent_wait(
@@ -468,6 +567,7 @@ fn control_error(e: std::io::Error) -> CliError {
             "not_supported" => backend_error(ExitCode::Generic, "not_supported"),
             "not_found" => backend_error(ExitCode::NotFound, "not_found"),
             "request_failed" => backend_error(ExitCode::Generic, "request_failed"),
+            "not_managed_worktree" => backend_error(ExitCode::Generic, "not_managed_worktree"),
             "watch_timeout" => backend_error(ExitCode::Generic, "watch_timeout"),
             "cursor_expired" => backend_error(ExitCode::Generic, "cursor_expired"),
             "gap_detected" => backend_error(ExitCode::Generic, "gap_detected"),
@@ -788,6 +888,49 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(&rendered).unwrap();
         assert_eq!(json["delivery"][0]["delivery_state"], "submitted");
         assert_eq!(json["output"]["text"], "done");
+    }
+
+    #[test]
+    fn render_worktree_mutation_response_keeps_schema_and_worktree_details() {
+        let response = wardian_core::control::AgentWorktreeMutationResponse {
+            schema: 1,
+            ok: true,
+            action: "join".to_string(),
+            agent: wardian_core::identity::AgentIdentity {
+                name: "coder-a1".to_string(),
+                uuid: "agent-1".to_string(),
+                class: "Coder".to_string(),
+                provider: "codex".to_string(),
+                status: "processing".to_string(),
+                pid: None,
+                started_at: None,
+                workspace: Some("D:/repo/worktrees/review".to_string()),
+                last_status_at: None,
+                status_source: wardian_core::identity::StatusSource::Live,
+            },
+            worktree: Some(wardian_core::control::AgentWorktreeSummary {
+                id: "D:/repo/worktrees/review".to_string(),
+                name: "review".to_string(),
+                source_folder: "D:/repo".to_string(),
+                worktree_folder: "D:/repo/worktrees/review".to_string(),
+                member_agent_ids: vec!["agent-1".to_string(), "agent-2".to_string()],
+            }),
+            previous_worktree: None,
+            previous_workspace: Some("D:/repo".to_string()),
+            current_workspace: Some("D:/repo/worktrees/review".to_string()),
+            branch_name: None,
+            cleared_session: true,
+        };
+
+        let rendered = render_worktree_mutation_response(&response).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+
+        assert_eq!(json["schema"], 1);
+        assert_eq!(json["action"], "join");
+        assert_eq!(json["agent"]["uuid"], "agent-1");
+        assert_eq!(json["worktree"]["source_folder"], "D:/repo");
+        assert_eq!(json["worktree"]["member_agent_ids"][1], "agent-2");
+        assert_eq!(json["cleared_session"], true);
     }
 
     #[test]

--- a/crates/wardian-cli/tests/watchlist_cli.rs
+++ b/crates/wardian-cli/tests/watchlist_cli.rs
@@ -1,0 +1,80 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+fn bin() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian-cli") {
+        return path.into();
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian_cli") {
+        return path.into();
+    }
+
+    let exe = if cfg!(windows) {
+        "wardian-cli.exe"
+    } else {
+        "wardian-cli"
+    };
+    std::env::current_exe()
+        .unwrap()
+        .parent()
+        .and_then(|deps| deps.parent())
+        .unwrap()
+        .join(exe)
+}
+
+fn seed_watchlist_home() -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let watchlists = dir.path().join("watchlists");
+    std::fs::create_dir_all(&watchlists).unwrap();
+    std::fs::write(
+        watchlists.join("index.json"),
+        r#"{
+          "version": 2,
+          "teams": [{"id":"team-1","name":"Review","agentIds":["agent-1","agent-2"]}],
+          "watchlists": [{"id":"list-1","name":"Main","entries":[{"type":"team","teamId":"team-1"}]}]
+        }"#,
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn team_list_outputs_schema_and_agent_ids() {
+    let home = seed_watchlist_home();
+    let output = Command::new(bin())
+        .args(["team", "list"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["schema"], 1);
+    assert_eq!(json["teams"][0]["id"], "team-1");
+    assert_eq!(json["teams"][0]["agent_ids"][1], "agent-2");
+}
+
+#[test]
+fn watchlist_show_outputs_entries() {
+    let home = seed_watchlist_home();
+    let output = Command::new(bin())
+        .args(["watchlist", "show", "Main"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["schema"], 1);
+    assert_eq!(json["watchlist"]["id"], "list-1");
+    assert_eq!(json["watchlist"]["entries"][0]["type"], "team");
+    assert_eq!(json["watchlist"]["entries"][0]["team_id"], "team-1");
+}

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -28,6 +28,18 @@ pub enum ControlRequest {
         target: String,
         name: Option<String>,
     },
+    AgentWorktreeList,
+    AgentWorktreeEnable {
+        target: String,
+        name: Option<String>,
+    },
+    AgentWorktreeJoin {
+        target: String,
+        worktree: String,
+    },
+    AgentWorktreeDisable {
+        target: String,
+    },
     WorkflowList,
     WorkflowShow {
         target: String,
@@ -174,6 +186,49 @@ impl AgentResponse {
             agent,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentWorktreeSummary {
+    pub id: String,
+    pub name: String,
+    pub source_folder: String,
+    pub worktree_folder: String,
+    pub member_agent_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentWorktreeListResponse {
+    pub schema: u8,
+    pub worktrees: Vec<AgentWorktreeSummary>,
+}
+
+impl AgentWorktreeListResponse {
+    pub fn new(worktrees: Vec<AgentWorktreeSummary>) -> Self {
+        Self {
+            schema: CONTROL_SCHEMA,
+            worktrees,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentWorktreeMutationResponse {
+    pub schema: u8,
+    pub ok: bool,
+    pub action: String,
+    pub agent: AgentIdentity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<AgentWorktreeSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_worktree: Option<AgentWorktreeSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_workspace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_workspace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch_name: Option<String>,
+    pub cleared_session: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -349,6 +404,77 @@ mod tests {
         assert!(json.contains(r#""command":"agent_watch""#));
         assert!(json.contains(r#""target":"Wardian-Codex""#));
         assert!(json.contains(r#""until":"status:idle""#));
+    }
+
+    #[test]
+    fn agent_worktree_requests_serialize() {
+        let list = serde_json::to_string(&ControlRequest::AgentWorktreeList).unwrap();
+        assert!(list.contains(r#""command":"agent_worktree_list""#));
+
+        let enable = serde_json::to_string(&ControlRequest::AgentWorktreeEnable {
+            target: "coder-a1".to_string(),
+            name: Some("review fixes".to_string()),
+        })
+        .unwrap();
+        assert!(enable.contains(r#""command":"agent_worktree_enable""#));
+        assert!(enable.contains(r#""target":"coder-a1""#));
+        assert!(enable.contains(r#""name":"review fixes""#));
+
+        let join = serde_json::to_string(&ControlRequest::AgentWorktreeJoin {
+            target: "coder-a1".to_string(),
+            worktree: "D:/repo/worktrees/review".to_string(),
+        })
+        .unwrap();
+        assert!(join.contains(r#""command":"agent_worktree_join""#));
+        assert!(join.contains(r#""worktree":"D:/repo/worktrees/review""#));
+
+        let disable = serde_json::to_string(&ControlRequest::AgentWorktreeDisable {
+            target: "coder-a1".to_string(),
+        })
+        .unwrap();
+        assert!(disable.contains(r#""command":"agent_worktree_disable""#));
+    }
+
+    #[test]
+    fn agent_worktree_response_serializes_automation_fields() {
+        let response = AgentWorktreeMutationResponse {
+            schema: CONTROL_SCHEMA,
+            ok: true,
+            action: "enable".to_string(),
+            agent: AgentResponse::new(AgentIdentity {
+                name: "coder-a1".to_string(),
+                uuid: "uuid-1".to_string(),
+                class: "Coder".to_string(),
+                provider: "codex".to_string(),
+                status: "processing".to_string(),
+                pid: None,
+                started_at: None,
+                workspace: Some("D:/repo/worktrees/review".to_string()),
+                last_status_at: None,
+                status_source: crate::identity::StatusSource::Live,
+            })
+            .agent,
+            worktree: Some(AgentWorktreeSummary {
+                id: "D:/repo/worktrees/review".to_string(),
+                name: "review".to_string(),
+                source_folder: "D:/repo".to_string(),
+                worktree_folder: "D:/repo/worktrees/review".to_string(),
+                member_agent_ids: vec!["uuid-1".to_string()],
+            }),
+            previous_worktree: None,
+            previous_workspace: Some("D:/repo".to_string()),
+            current_workspace: Some("D:/repo/worktrees/review".to_string()),
+            branch_name: Some("wardian/review".to_string()),
+            cleared_session: true,
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+
+        assert!(json.contains(r#""schema":1"#));
+        assert!(json.contains(r#""action":"enable""#));
+        assert!(json.contains(r#""source_folder":"D:/repo""#));
+        assert!(json.contains(r#""member_agent_ids":["uuid-1"]"#));
+        assert!(json.contains(r#""cleared_session":true"#));
     }
 
     #[test]

--- a/docs/developer/tauri-command-reference.md
+++ b/docs/developer/tauri-command-reference.md
@@ -32,6 +32,8 @@ This page documents the current command surface registered in `src-tauri/src/lib
 Worktree commands update agent config only. UI callers that move an agent between the source checkout and a worktree must follow the config command with `clear_agent_session` so the provider starts fresh in the new workspace instead of resuming across a cwd change.
 `enable_agent_worktree` accepts an optional `worktree_name`; when present, Wardian uses it for the `wardian/<slug>` branch and the per-agent `worktrees/<slug>` folder.
 
+The live control protocol exposes CLI wrappers for the same worktree operations: `agent_worktree_list`, `agent_worktree_enable`, `agent_worktree_join`, and `agent_worktree_disable`. Unlike the raw Tauri worktree commands, the control mutation handlers call `clear_agent_session` after moving an agent workspace so CLI behavior matches the GUI flow.
+
 ## Terminal (`commands/terminal.rs`)
 
 - `send_input_to_agent`
@@ -55,6 +57,8 @@ Worktree commands update agent config only. UI callers that move an agent betwee
 
 - `load_watchlists`
 - `save_watchlists`
+
+The CLI read-only `team` and `watchlist` commands read `watchlists/index.json` directly. They normalize the current v2 state shape and legacy flat watchlist arrays but do not use a separate persistence format.
 
 ## Filesystem and Explorer (`commands/fs.rs`)
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -46,9 +46,17 @@ wardian agent pause <name-or-uuid>
 wardian agent resume <name-or-uuid>
 wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace <absolute-workspace-path>
 wardian agent clone <name-or-uuid> --name coder-a2
+wardian agent worktree list
+wardian agent worktree enable <name-or-uuid> --name review-fixes
+wardian agent worktree join <name-or-uuid> --worktree <absolute-worktree-path-or-id>
+wardian agent worktree disable <name-or-uuid>
 wardian agent wait reviewer-a1 --until idle --timeout 10m
 wardian agent wait reviewer-a1 --until idle --next --timeout 10m
 wardian agent watch reviewer-a1 --until output:REVIEW_DONE --include status,output,delivery --timeout 10m
+wardian team list
+wardian team show <team-name-or-id>
+wardian watchlist list
+wardian watchlist show <watchlist-name-or-id>
 wardian workflow list
 wardian workflow show <id-or-name>
 wardian workflow run <id>
@@ -60,11 +68,15 @@ wardian send "status?" --to class:Coder
 wardian send "stand down" --to all
 ```
 
-Mutating commands use Wardian's local control endpoint and require the desktop app to be running for the same `WARDIAN_HOME`. This includes agent lifecycle commands, `workflow run`, `workflow stop`, and `send`.
+Mutating commands use Wardian's local control endpoint and require the desktop app to be running for the same `WARDIAN_HOME`. This includes agent lifecycle commands, agent worktree commands, `workflow run`, `workflow stop`, and `send`.
 
 `workflow list` and `workflow show` try the running app first, then read workflow JSON files from disk when the app is unavailable.
 
 `agent spawn` requires both `--provider` and `--class` so the created agent's runtime and role are explicit.
+
+`agent worktree list` returns the worktrees currently managed by Wardian with source folder, worktree folder, display name, and member agent IDs. `agent worktree enable`, `join`, and `disable` are live-control commands. They reuse the same backend logic as the Source Control panel and force a fresh agent session after changing the runtime workspace. `disable` removes the assignment only; it does not delete the physical worktree folder.
+
+`team list/show` and `watchlist list/show` read the existing watchlist state file. They accept the current v2 shape with global teams and legacy flat watchlist arrays, then return `schema: 1` JSON for automation. Team mutation and `send --to team:<name>` are not implemented yet.
 
 `agent wait <target> --until <status>` blocks inside the CLI process until a single agent name or UUID reaches a normalized status such as `idle`, `processing`, `action_required`, `off`, or `error`. Plain `wait` returns immediately when the target is already in the requested status. Add `--next` to wait for a newer matching observation. Use `--timeout` with `ms`, `s`, or `m` units.
 

--- a/docs/guide/source-control.md
+++ b/docs/guide/source-control.md
@@ -63,6 +63,15 @@ Source Control also exposes worktree actions:
 
 When enabled, Wardian creates a named worktree under `<wardian-home>/agents/<session-id>/worktrees/`, creates a matching `wardian/<worktree-name>` branch, shares supported build caches with the source checkout, and moves the agent runtime to that path with a fresh provider session. Joining an existing shared worktree assigns the same worktree path to another agent and also starts that agent fresh in the shared path.
 
+The same agent worktree controls are available from the CLI when the desktop app is running for the same `WARDIAN_HOME`:
+
+```bash
+wardian agent worktree list
+wardian agent worktree enable <agent-name-or-id> --name <worktree-name>
+wardian agent worktree join <agent-name-or-id> --worktree <absolute-worktree-path-or-id>
+wardian agent worktree disable <agent-name-or-id>
+```
+
 ## Safety Notes
 
 - Discard is destructive; Wardian asks for confirmation.

--- a/docs/guide/watchlists.md
+++ b/docs/guide/watchlists.md
@@ -35,6 +35,17 @@ Click any column header to sort by that column. Clicking again cycles through as
 ### Persistence
 Column visibility and sort state are saved to `~/.wardian/watchlists/prefs.json` and restored on next launch.
 
+The CLI can inspect persisted watchlist and team state without starting the desktop app:
+
+```bash
+wardian team list
+wardian team show <team-name-or-id>
+wardian watchlist list
+wardian watchlist show <watchlist-name-or-id>
+```
+
+These commands read the same `watchlists/index.json` file as the GUI and accept both the current v2 state shape with global teams and legacy flat watchlist arrays. They are read-only; team mutation and team send targeting are planned as separate CLI slices.
+
 ## 🗂️ Organizing with Watchlists
 As your swarm grows, a single list becomes difficult to manage. Wardian allows you to group agents into custom **Watchlists**.
 

--- a/docs/specs/037-cli-surface-parity.md
+++ b/docs/specs/037-cli-surface-parity.md
@@ -1,0 +1,54 @@
+# Spec 037: CLI Surface Parity Matrix
+
+- **Status:** Proposed
+- **Date:** 2026-05-12
+- **Decider:** User
+
+## Context
+
+Wardian's CLI is useful for agent identity, lifecycle, workflows, and prompt delivery, but the GUI/backend expose broader operational surfaces through Tauri commands and frontend state. This audit maps the current parity boundary and records the next high-leverage CLI slices.
+
+## Parity Matrix
+
+| Surface | GUI/backend capability | CLI status after this slice | Deferred follow-up |
+|---|---|---|---|
+| Agents | list/show/spawn/clone/pause/resume/kill/watch/wait/send/ask | Supported | Add rename, reorder, clear session, update config, and clone preview wrappers |
+| Agent worktrees | list/create/assign/join/disable through `list_agent_worktrees`, `enable_agent_worktree`, `assign_agent_worktree`, `disable_agent_worktree`, followed by `clear_agent_session` on workspace moves | Added `wardian agent worktree list`, `enable`, `join`, and `disable` through live control; mutations clear the agent session after moving workspace | Add native E2E coverage for real provider/runtime movement and optional branch detail in list output |
+| Teams/watchlists | Watchlist state v2 stores global `teams`, ordered team members, and watchlist entries for agents or teams; legacy flat arrays still load | Added read-only `wardian team list/show` and `wardian watchlist list/show` from the existing `watchlists/index.json` file, including legacy array normalization | Add mutations only through the same v2 state shape; add `wardian send --to team:<name>` only after explicit target-resolution tests |
+| Classes | list/create/delete/default/reset through `commands/class.rs` | Not added | Add read-only `wardian class list/show`; mutations need class-library file safety review |
+| Workflows/schedules | workflow list/show/save/delete/run/stop, scheduled runs, trigger pause/resume, run-now, library save/load | CLI has workflow list/show/run/stop | Add scheduled run list/show, trigger pause/resume, run-now, and library import/export as separate workflow slice |
+| Source control/git | GUI has status/log/diff/stage/unstage/discard/commit/pull/push/watch because it needs source-control buttons and panels | Worktree agent assignment added; broad git porcelain intentionally not added | Non-goal for the CLI by default. Terminal users should use real `git`; add only Wardian-specific coordination commands such as agent workspace/worktree inspection |
+| Queue | persisted queue items plus read/dismiss state | Not added | Add read-only queue list/show before any mutation |
+| Library/skills | library tree, metadata, deploy/remove skills, watches | Not added | Add read-only skills/library inspection before deploy/remove |
+| Settings | shell/provider/session persistence settings | Not added | Add read-only settings export; mutations need schema and backup policy |
+| Recent issue #228 | Slash-command delivery with `wardian send --as-command` | Not added | Separate focused CLI delivery issue; do not couple to parity worktree/team work |
+
+## Implemented Slice
+
+Worktree CLI commands route through the live control endpoint instead of reimplementing git worktree creation in the CLI:
+
+```bash
+wardian agent worktree list
+wardian agent worktree enable <agent> [--name <worktree-name>]
+wardian agent worktree join <agent> --worktree <absolute-worktree-path-or-id>
+wardian agent worktree disable <agent>
+```
+
+The backend control handler calls the existing Tauri worktree functions and then calls `clear_agent_session` so the provider starts fresh in the moved workspace. Disable only removes the assignment and returns the agent to the recorded source workspace; it does not delete physical worktree folders.
+
+Teams/watchlists are read-only in this slice:
+
+```bash
+wardian team list
+wardian team show <team-name-or-id>
+wardian watchlist list
+wardian watchlist show <watchlist-name-or-id>
+```
+
+The CLI reads the existing `watchlists/index.json`, accepts v2 `{ version, watchlists, teams }` objects and legacy watchlist arrays, and emits stable `schema: 1` JSON.
+
+## Risks
+
+- Worktree mutation correctness depends on the running desktop app because only the live app owns PTY lifecycle and `clear_agent_session`.
+- The CLI cannot prove real provider cwd movement without the native runtime harness.
+- Team/watchlist commands are read-only and do not normalize partial-team display exactly like the frontend rendering pipeline; mutation and team send targeting should remain follow-up work.

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -45,6 +45,7 @@ wardian agent list --scope all
 wardian agent list --scope all --status idle
 wardian agent list --scope all --class Coder
 wardian agent list --workspace <absolute-workspace-path>
+wardian agent worktree list
 ```
 
 Default list scope is `workspace` when the caller is a Wardian agent with a
@@ -83,6 +84,9 @@ app to be running for the same `WARDIAN_HOME`.
 ```bash
 wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace <absolute-workspace-path>
 wardian agent clone coder-a1 --name coder-a2
+wardian agent worktree enable coder-a1 --name review-fixes
+wardian agent worktree join coder-a1 --worktree <absolute-worktree-path-or-id>
+wardian agent worktree disable coder-a1
 wardian agent pause reviewer-a1
 wardian agent resume reviewer-a1
 wardian agent kill reviewer-a1
@@ -106,6 +110,13 @@ Use `--timeout` with `ms`, `s`, or `m` units.
 `agent watch <target>` returns status, retained output, events, delivery
 details, and a cursor. Use `--until output:<token>` when you need the response
 text itself. `--follow` is reserved and currently returns `not_supported`.
+
+`agent worktree` commands require the desktop app for the same `WARDIAN_HOME`.
+They route through Wardian's live control endpoint and reuse the GUI/backend
+worktree logic. `enable`, `join`, and `disable` clear the target agent session
+after moving its workspace so the provider starts fresh in the new location.
+`disable` removes only the assignment; it does not delete the physical worktree
+folder.
 
 Use `wardian ask` for one-off peer tasks where you need both delivery evidence
 and the target's response output:
@@ -182,6 +193,21 @@ workflow JSON files from disk when the app is unavailable. `workflow run` and
 Malformed workflow files may be reported as warnings or omitted depending on
 the CLI version. If `show` cannot find a workflow that exists on disk, inspect
 the workflow JSON for parse errors.
+
+## Teams And Watchlists
+
+```bash
+wardian team list
+wardian team show <team-name-or-id>
+wardian watchlist list
+wardian watchlist show <watchlist-name-or-id>
+```
+
+These commands are read-only and inspect the persisted `watchlists/index.json`
+file. They accept the current v2 watchlist state with global teams and legacy
+flat watchlist arrays. Do not assume `team:<name>` send targeting exists yet;
+use explicit agent names/UUIDs or `class:<ClassName>` until team send targeting
+is implemented.
 
 ## Orchestration Pattern
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1054,7 +1054,7 @@ fn slugify_worktree_name(name: &str) -> String {
     slug
 }
 
-fn resolve_agent_worktree_branch_name(worktree_name: &str) -> String {
+pub(crate) fn resolve_agent_worktree_branch_name(worktree_name: &str) -> String {
     let slug = slugify_worktree_name(worktree_name);
     format!("wardian/{slug}")
 }

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -7,7 +7,8 @@ use std::{
 use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
-    AgentListResponse, AgentResponse, AgentWatchResponse, ControlRequest, DeliveryDetail,
+    AgentListResponse, AgentResponse, AgentWatchResponse, AgentWorktreeListResponse,
+    AgentWorktreeMutationResponse, AgentWorktreeSummary, ControlRequest, DeliveryDetail,
     DeliveryErrorDetail, MessageOrigin, OkResponse, SendMessageResponse, WatchAgentSnapshot,
     WatchDeliverySnapshot, WorkflowListResponse, WorkflowResponse, WorkflowSummary,
 };
@@ -165,6 +166,24 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             ok_json(&AgentResponse::new(identity))
         }
 
+        ControlRequest::AgentWorktreeList => {
+            let state = app.state::<AppState>();
+            let worktrees = list_agent_worktree_summaries(state).await?;
+            ok_json(&AgentWorktreeListResponse::new(worktrees))
+        }
+
+        ControlRequest::AgentWorktreeEnable { target, name } => {
+            handle_agent_worktree_enable(app, &target, name).await
+        }
+
+        ControlRequest::AgentWorktreeJoin { target, worktree } => {
+            handle_agent_worktree_join(app, &target, &worktree).await
+        }
+
+        ControlRequest::AgentWorktreeDisable { target } => {
+            handle_agent_worktree_disable(app, &target).await
+        }
+
         ControlRequest::WorkflowList => {
             let workflows = crate::workflow_engine::list_workflows().unwrap_or_default();
             ok_json(&WorkflowListResponse::new(workflow_summaries(&workflows)))
@@ -273,6 +292,221 @@ fn workflow_summaries(
             node_count: w.nodes.len(),
         })
         .collect()
+}
+
+async fn list_agent_worktree_summaries(
+    state: tauri::State<'_, AppState>,
+) -> Result<Vec<AgentWorktreeSummary>, ControlError> {
+    crate::commands::agent::list_agent_worktrees(state)
+        .await
+        .map(|worktrees| worktrees.into_iter().map(core_worktree_summary).collect())
+        .map_err(ControlError::request_failed)
+}
+
+fn core_worktree_summary(
+    summary: crate::commands::agent::AgentWorktreeSummary,
+) -> AgentWorktreeSummary {
+    AgentWorktreeSummary {
+        id: summary.id,
+        name: summary.name,
+        source_folder: summary.source_folder,
+        worktree_folder: summary.worktree_folder,
+        member_agent_ids: summary.member_agent_ids,
+    }
+}
+
+fn worktree_for_member(
+    worktrees: &[AgentWorktreeSummary],
+    session_id: &str,
+) -> Option<AgentWorktreeSummary> {
+    worktrees
+        .iter()
+        .find(|worktree| {
+            worktree
+                .member_agent_ids
+                .iter()
+                .any(|member_id| member_id == session_id)
+        })
+        .cloned()
+}
+
+fn worktree_by_folder(
+    worktrees: &[AgentWorktreeSummary],
+    folder: &str,
+) -> Option<AgentWorktreeSummary> {
+    let normalized = folder.trim().replace('\\', "/");
+    worktrees
+        .iter()
+        .find(|worktree| worktree.worktree_folder == normalized || worktree.id == normalized)
+        .cloned()
+}
+
+async fn handle_agent_worktree_enable(
+    app: &AppHandle,
+    target: &str,
+    name: Option<String>,
+) -> Result<String, ControlError> {
+    let uuid = resolve_target_uuid(app, target)
+        .await
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
+    let previous_workspace = agent_workspace(app, &uuid).await;
+    let branch_name = agent_worktree_branch_name(app, &uuid, name.as_deref()).await?;
+
+    let state = app.state::<AppState>();
+    crate::commands::agent::enable_agent_worktree(uuid.clone(), name, state, app.clone())
+        .await
+        .map_err(ControlError::request_failed)?;
+    clear_agent_after_worktree_move(app, &uuid).await?;
+
+    let worktrees = list_agent_worktree_summaries(app.state::<AppState>()).await?;
+    let worktree = worktree_for_member(&worktrees, &uuid);
+    let agent = live_agent_identity(app, &uuid).await?;
+    let response = AgentWorktreeMutationResponse {
+        schema: wardian_core::control::CONTROL_SCHEMA,
+        ok: true,
+        action: "enable".to_string(),
+        previous_workspace,
+        current_workspace: agent.workspace.clone(),
+        agent,
+        worktree,
+        previous_worktree: None,
+        branch_name: Some(branch_name),
+        cleared_session: true,
+    };
+    ok_json(&response)
+}
+
+async fn handle_agent_worktree_join(
+    app: &AppHandle,
+    target: &str,
+    worktree: &str,
+) -> Result<String, ControlError> {
+    let uuid = resolve_target_uuid(app, target)
+        .await
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
+    let previous_workspace = agent_workspace(app, &uuid).await;
+    let state = app.state::<AppState>();
+    let before = list_agent_worktree_summaries(app.state::<AppState>()).await?;
+    let target_worktree = worktree_by_folder(&before, worktree).ok_or_else(|| {
+        ControlError::coded(
+            "not_managed_worktree",
+            format!("worktree is not managed by Wardian: {worktree}"),
+        )
+    })?;
+
+    crate::commands::agent::assign_agent_worktree(
+        uuid.clone(),
+        target_worktree.worktree_folder.clone(),
+        state,
+        app.clone(),
+    )
+    .await
+    .map_err(ControlError::request_failed)?;
+    clear_agent_after_worktree_move(app, &uuid).await?;
+
+    let worktrees = list_agent_worktree_summaries(app.state::<AppState>()).await?;
+    let agent = live_agent_identity(app, &uuid).await?;
+    let response = AgentWorktreeMutationResponse {
+        schema: wardian_core::control::CONTROL_SCHEMA,
+        ok: true,
+        action: "join".to_string(),
+        previous_workspace,
+        current_workspace: agent.workspace.clone(),
+        agent,
+        worktree: worktree_for_member(&worktrees, &uuid).or(Some(target_worktree)),
+        previous_worktree: None,
+        branch_name: None,
+        cleared_session: true,
+    };
+    ok_json(&response)
+}
+
+async fn handle_agent_worktree_disable(
+    app: &AppHandle,
+    target: &str,
+) -> Result<String, ControlError> {
+    let uuid = resolve_target_uuid(app, target)
+        .await
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
+    let previous_workspace = agent_workspace(app, &uuid).await;
+    let before = list_agent_worktree_summaries(app.state::<AppState>()).await?;
+    let previous_worktree = worktree_for_member(&before, &uuid);
+
+    let state = app.state::<AppState>();
+    crate::commands::agent::disable_agent_worktree(uuid.clone(), state, app.clone())
+        .await
+        .map_err(ControlError::request_failed)?;
+    clear_agent_after_worktree_move(app, &uuid).await?;
+
+    let agent = live_agent_identity(app, &uuid).await?;
+    let response = AgentWorktreeMutationResponse {
+        schema: wardian_core::control::CONTROL_SCHEMA,
+        ok: true,
+        action: "disable".to_string(),
+        previous_workspace,
+        current_workspace: agent.workspace.clone(),
+        agent,
+        worktree: None,
+        previous_worktree,
+        branch_name: None,
+        cleared_session: true,
+    };
+    ok_json(&response)
+}
+
+async fn clear_agent_after_worktree_move(
+    app: &AppHandle,
+    session_id: &str,
+) -> Result<(), ControlError> {
+    crate::commands::agent::clear_agent_session(
+        session_id.to_string(),
+        app.state::<AppState>(),
+        app.clone(),
+    )
+    .await
+    .map_err(ControlError::request_failed)
+}
+
+async fn agent_worktree_branch_name(
+    app: &AppHandle,
+    session_id: &str,
+    requested_name: Option<&str>,
+) -> Result<String, ControlError> {
+    let state = app.state::<AppState>();
+    let agents = state.agents.lock().await;
+    let agent = agents
+        .get(session_id)
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {session_id}")))?;
+    let config = agent
+        .config
+        .lock()
+        .map_err(|_| ControlError::request_failed("agent config lock poisoned"))?;
+    let source = requested_name
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&config.session_name);
+    Ok(crate::commands::agent::resolve_agent_worktree_branch_name(
+        source,
+    ))
+}
+
+async fn agent_workspace(app: &AppHandle, session_id: &str) -> Option<String> {
+    let state = app.state::<AppState>();
+    let agents = state.agents.lock().await;
+    let agent = agents.get(session_id)?;
+    let config = agent.config.lock().ok()?;
+    (!config.folder.trim().is_empty()).then(|| config.folder.clone())
+}
+
+async fn live_agent_identity(
+    app: &AppHandle,
+    session_id: &str,
+) -> Result<AgentIdentity, ControlError> {
+    live_agent_snapshots(app)
+        .await
+        .into_iter()
+        .find(|agent| agent.uuid == session_id)
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {session_id}")))
 }
 
 // ---------------------------------------------------------------------------
@@ -1393,6 +1627,41 @@ mod tests {
         assert_eq!(summaries[1].node_count, 0);
     }
 
+    #[test]
+    fn worktree_by_folder_matches_normalized_folder_or_id() {
+        let worktrees = vec![AgentWorktreeSummary {
+            id: "C:/repo/worktrees/review".to_string(),
+            name: "review".to_string(),
+            source_folder: "C:/repo".to_string(),
+            worktree_folder: "C:/repo/worktrees/review".to_string(),
+            member_agent_ids: vec!["agent-1".to_string()],
+        }];
+
+        let matched = worktree_by_folder(&worktrees, "C:\\repo\\worktrees\\review").unwrap();
+
+        assert_eq!(matched.id, "C:/repo/worktrees/review");
+    }
+
+    #[test]
+    fn worktree_for_member_returns_member_summary() {
+        let worktrees = vec![AgentWorktreeSummary {
+            id: "C:/repo/worktrees/review".to_string(),
+            name: "review".to_string(),
+            source_folder: "C:/repo".to_string(),
+            worktree_folder: "C:/repo/worktrees/review".to_string(),
+            member_agent_ids: vec!["agent-1".to_string(), "agent-2".to_string()],
+        }];
+
+        assert_eq!(
+            worktree_for_member(&worktrees, "agent-2")
+                .unwrap()
+                .name
+                .as_str(),
+            "review"
+        );
+        assert!(worktree_for_member(&worktrees, "missing").is_none());
+    }
+
     #[tokio::test]
     async fn target_resolution_matches_uuid_or_session_name() {
         let state = AppState::new();
@@ -1573,10 +1842,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(
-            rx.recv().await.unwrap(),
-            b"From PlannerOne: yes".to_vec()
-        );
+        assert_eq!(rx.recv().await.unwrap(), b"From PlannerOne: yes".to_vec());
         assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
     }
 


### PR DESCRIPTION
## Description
Adds a focused Wardian CLI parity slice for agent automation:

- Adds live-control agent worktree commands that reuse the GUI/backend worktree logic and clear the agent session after workspace moves.
- Adds read-only team and watchlist inspection backed by the existing `watchlists/index.json` v2/legacy state shape.
- Documents the CLI parity matrix, including deferred slices and broad git porcelain as a CLI non-goal.

## Related Issues
Fixes #241

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test` (61 files, 551 tests; existing React `act(...)` warnings emitted)
- [x] `npm run build` (existing Vite large chunk warning emitted)
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test` (415 unit tests + 5 mock provider tests)
- [x] `cd src-tauri && cargo clippy`
- [x] `cargo test -p wardian-cli`
- [x] `cargo test -p wardian-core control::tests::`
- [x] `cargo clippy -p wardian-cli`
- [x] `git diff --check`
- [x] `npm run test:e2e:native:fast -- e2e-native/tests/cli-shared-state-native.test.mjs` exited 0, but all 5 native cases skipped because no WebDriver binary was installed/configured.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable