### PR TITLE
docs: highlight CLI, Queue, and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img src="public/icon.png" width="128" alt="Wardian Logo" />
 
-**Local command center for multi-agent CLI workflows** — see every session, swap skills on the fly, and chain agents into deterministic pipelines.
+**GUI command center for multi-agent CLI workflows** — see every session, collect completed work in a queue, and give agents a CLI surface for coordinating and controlling Wardian.
 
 [![CI](https://github.com/tangemicioglu/Wardian/actions/workflows/ci.yml/badge.svg)](https://github.com/tangemicioglu/Wardian/actions/workflows/ci.yml)
 [![Frontend Coverage](https://codecov.io/gh/tangemicioglu/Wardian/branch/main/graph/badge.svg?flag=frontend&label=frontend%20coverage)](https://codecov.io/gh/tangemicioglu/Wardian)
@@ -21,7 +21,7 @@
 
 > 🚧 **Early development.** Wardian is under active construction. Expect rough edges: APIs, on-disk formats, and UI layouts can change between releases without notice. Pin a version if you depend on it, and please [file an issue](https://github.com/tangemicioglu/Wardian/issues) when something breaks.
 
-Wardian is an **Integrated Agent Environment** — a desktop governance layer for AI orchestration. It centralizes PTY management, telemetry, and shared context into a unified Command Center, designed for developers who need to manage multiple long-running agent sessions across multiple projects.
+Wardian is an **Integrated Agent Environment** — a GUI-first governance layer for AI orchestration. It centralizes PTY management, live telemetry, completion queues, workflow execution, and shared context into a unified desktop Command Center for developers managing many long-running agent sessions across multiple projects. The bundled `wardian` CLI gives agents a textual control surface for discovering their own identity, coordinating peers, and controlling Wardian without driving the graphical app.
 
 ---
 
@@ -72,6 +72,7 @@ For complete user and developer docs, start here:
 - [Documentation Index](docs/index.md)
 - [User Guide Index](docs/guide/index.md)
 - [Wardian CLI](docs/guide/cli.md)
+- [Queue](docs/guide/queue.md)
 - [Workflow Reference](docs/workflows/index.md)
 - [Developer Index](docs/developer/index.md)
 
@@ -98,6 +99,8 @@ Unlike generic terminal wrappers or monolithic prompt orchestrators, Wardian foc
 
 - **Scoped Skill Management**: Wardian doesn't just send system prompts. It uses filesystem-based junctions to inject or strip real capabilities (scripts, tools, configs) from an agent's workspace in real-time.
 - **Deterministic-Agentic Hybrid**: Wardian's pulse-based workflow engine pairs strict, deterministic execution with agentic flexibility. Instead of opaque, API-driven chains, you build complex automation **locally**—retaining full control over the execution flow while allowing agents to handle the creative problem-solving within each node.
+- **Agent-Facing Control Plane**: The `wardian` CLI shares state and live-control protocols with the desktop app, so agents can inspect rosters, spawn reviewers, send prompts, wait for status changes, watch output, and run workflows without scraping or automating the GUI.
+- **Completion Queue**: Wardian captures agent completions and workflow outcomes into a durable Queue view so finished work does not disappear into terminal scrollback.
 - **High-Fidelity Status Tracking**: Wardian actively parses raw PTY streams to detect complex occupancy states (`Idle`, `Processing`, `Action Needed`) while monitoring per-process CPU and memory usage.
 
 > Explore our [Key Features guide](docs/features.md) for more technical comparisons.
@@ -120,10 +123,15 @@ Scale your workflows by coordinating independent, specialized agents rather than
 
 - **Persona Class System**: Spawn new agents from pre-configured default classes (e.g., Coder, Architect, Researcher) or define custom personas tailored exactly to your repository's conventions.
 - **Broadcast & Bulk Actions**: Dispatch unified instructions, project context, or terminal commands to all agents or a filtered subset simultaneously via the global Command Panel.
+- **Queue View**: Review unread completions from agents and workflow runs, expand long summaries, and clear completed items after triage.
 
 ### Wardian CLI
 
-The desktop app installs a `wardian` command into the user Wardian bin directory. Use `wardian agent`, `wardian agent <name-or-uuid>`, and `wardian agent list --scope all` to inspect active or persisted agent identity from a terminal. See the [CLI guide](docs/guide/cli.md) for output fields, filters, environment variables, and exit codes.
+The desktop app installs a `wardian` command into the user Wardian bin directory for agents and automation. Agents use it to inspect active or persisted peers, spawn and clone sessions, manage Wardian worktrees, send prompts, wait for status transitions, watch retained output, and run saved workflows through the app-owned backend. See the [CLI guide](docs/guide/cli.md) for command examples, output fields, filters, environment variables, live-control requirements, and exit codes.
+
+### Workflow Engine
+
+Wardian workflows combine a visual builder with a Rust execution engine. Manual triggers, scheduled triggers, file listeners, agent nodes, branch/loop/wait control, shared storage, and run telemetry all flow through the same deterministic runtime model.
 
 ---
 
@@ -145,8 +153,8 @@ Wardian leverages native OS capabilities for high-performance terminal emulation
 
 Wardian is evolving toward a fully autonomous home for your agents.
 
-- **Phase 1-2**: Dual-Sidebar UI, PTY Grid, Shared Habitat, CLI Utility. [ALMOST-DONE]
-- **Phase 3-4**: Agent-to-Agent IPC, Human-in-the-loop Queue, and Cross-Platform Hardening. [ACTIVE]
+- **Phase 1-2**: Dual-Sidebar UI, PTY Grid, Shared Habitat, CLI Utility, live CLI control, agent cloning, worktrees, and scheduled workflow foundations. [DONE]
+- **Phase 3-4**: Agent-to-Agent IPC, HITL approval queue expansion, workflow hardening, and cross-platform runtime polish. [ACTIVE]
 - **Phase 5**: Swarm Visualization, Plugins, and File-System Watcher Hooks. [PLANNED]
 
 Full details available in [ROADMAP.md](ROADMAP.md).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <img src="public/icon.png" width="128" alt="Wardian Logo" />
 
-**GUI command center for multi-agent CLI workflows** — see every session, collect completed work in a queue, and give agents a CLI surface for coordinating and controlling Wardian.
+**Local command center for multi-agent CLI workflows** — see every session, collect completed work in a queue, and give agents a CLI surface for coordinating and controlling Wardian.
 
 [![CI](https://github.com/tangemicioglu/Wardian/actions/workflows/ci.yml/badge.svg)](https://github.com/tangemicioglu/Wardian/actions/workflows/ci.yml)
 [![Frontend Coverage](https://codecov.io/gh/tangemicioglu/Wardian/branch/main/graph/badge.svg?flag=frontend&label=frontend%20coverage)](https://codecov.io/gh/tangemicioglu/Wardian)
@@ -21,7 +21,7 @@
 
 > 🚧 **Early development.** Wardian is under active construction. Expect rough edges: APIs, on-disk formats, and UI layouts can change between releases without notice. Pin a version if you depend on it, and please [file an issue](https://github.com/tangemicioglu/Wardian/issues) when something breaks.
 
-Wardian is an **Integrated Agent Environment** — a GUI-first governance layer for AI orchestration. It centralizes PTY management, live telemetry, completion queues, workflow execution, and shared context into a unified desktop Command Center for developers managing many long-running agent sessions across multiple projects. The bundled `wardian` CLI gives agents a textual control surface for discovering their own identity, coordinating peers, and controlling Wardian without driving the graphical app.
+Wardian is an **Integrated Agent Environment** — a local, app-first governance layer for AI orchestration. It centralizes PTY management, live telemetry, completion queues, workflow execution, and shared context into a unified desktop Command Center for developers managing many long-running agent sessions across multiple projects. The bundled `wardian` CLI gives agents a textual control surface for discovering their own identity, coordinating peers, and controlling Wardian without driving the graphical app.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,29 +6,29 @@ Wardian is an advanced Agent Terminal Manager designed for managing multiple aut
 
 _Goal: Provide a professional-grade command center for agent orchestration.
 
-- [ ] **Dual-Sidebar "Command Center" Architecture**
+- [x] **Dual-Sidebar "Command Center" Architecture**
   - **Left Sidebar (Primary)**:
     - A thin **Icon Bar** for switching between views (Explorer, Connections, Workflows, Settings).
     - A collapsible **Content Pane** that displays the menu for the active icon (e.g., Spawn Instance form, SSH hosts).
   - **Right Sidebar (Secondary)**:
     - A **collapsible, searchable agent list** for rapid selection, status monitoring, and drag-drop reordering.
   - Support for multi-select in the right sidebar and main grid views.
-- [ ] **Dynamic Grid Layouts**
+- [x] **Dynamic Grid Layouts**
   - Implement predefined grid templates (Single, 2x2, 1+2, etc.).
   - Support for drag-and-drop reordering of terminals.
   - Ability to "move" selected agents between grid slots or view layers.
   - Perspective/Layout saving and restoration across sessions.
-- [ ] **Dashboard Command Matrix Refresh**
+- [x] **Dashboard Command Matrix Refresh**
   - Replace generic buttons with standard action set:
     - **Delete**: Terminates the active process and removes it from the roster.
     - **Pause**: Suspends the terminal process but preserves agent session and metadata in `Wardian_state.json`.
     - **Query**: A versatile prompt injection tool (evolution of "Summarize") for rapid context extraction.
     - **Restart**: Resets the PTY session and re-initializes the agent from its current configuration.
-- [ ] **Selection-Based Orchestration**
+- [x] **Selection-Based Orchestration**
   - Target broadcasting to only selected agents.
   - Bulk actions (terminate, restart, group) for selected instances.
   - "Pinning" agents to specific grid slots from the sidebar list.
-- [ ] **Identity & Customization**
+- [x] **Identity & Customization**
   - Support for renaming agents (display names vs. session IDs).
   - Custom color coding and icons for different agent roles.
 
@@ -36,27 +36,28 @@ _Goal: Provide a professional-grade command center for agent orchestration.
 
 _Goal: Empower agents with local persistence and self-awareness._
 
-- [ ] **Home Directories**
-  - Automate creation of `~/.Wardian/agents/<session_id>/` for each instance.
+- [x] **Home Directories**
+  - Automate creation of per-agent state under the Wardian home for each instance.
   - Isolate temporary and permanent files per agent.
-- [ ] **Wardian CLI Utility**
-  - Implement a lightweight binary/script accessible within the agent's PTY.
-  - `Wardian whoami`: Returns current session ID and role.
-  - `Wardian notify "message"`: Triggers a UI notification from the agent.
-- [ ] **Session Branching (Forking)**
-  - Support for "cloning" a session ID to start a new parallel conversation from a snapshot.
-- [ ] **Agent-Specific Include Directories**
+- [x] **Wardian CLI Utility**
+  - Implement a lightweight binary accessible from terminals and managed agent processes.
+  - `wardian agent`: Returns the current managed session when `WARDIAN_SESSION_ID` is set.
+  - `wardian agent list --scope all`: Lists live or persisted agents for coordination.
+  - `wardian send`, `wardian ask`, `wardian agent wait`, and `wardian agent watch`: Provide terminal-native coordination and response evidence.
+  - `wardian workflow list/show/run/stop`: Expose workflow inspection and live run control from the shell.
+- [x] **Session Branching (Forking)**
+  - Support cloning an agent configuration into a new parallel session.
+- [x] **Agent-Specific Include Directories**
   - Ability to specify additional `include` paths for each agent to monitor or reference beyond its base `folder`.
-- [ ] **CLI Portability Tools**
-  - Implement a "Copy Full CLI Command" button in the agent UI.
-  - Generates the exact command needed to resume the session manually in an external terminal (e.g., `cd D:\Project && gemini --resume 1a2b3c...`).
-- [ ] **Optional Startup Management**
-  - Ability to toggle "Spawn at Startup" on a per-agent basis.
-  - Agents with startup disabled will appear in the roster but remain in a "Hibernating" state until manually started.
-- [ ] **Scheduled Task Engine**
-  - Implement a scheduler for recurring agent tasks (e.g., "Every 2 hours, audit the codebase for tech debt").
-  - Support for one-off scheduled prompts ("At 5 PM, summarize the day's progress").
-  - UI for managing, pausing, and auditing scheduled executions.
+- [x] **CLI Portability Tools**
+  - Expose agent identity, workspace, provider, status, and worktree state through scriptable CLI commands.
+  - Keep direct provider resume commands as provider-runtime implementation details rather than the primary user contract.
+- [x] **Session Lifecycle Management**
+  - Preserve inactive agents in the roster and allow users to start, pause, resume, kill, clone, and reassign sessions explicitly.
+- [x] **Scheduled Task Engine**
+  - Implement scheduled workflow triggers and scheduled run instances.
+  - Support interval, daily, weekly, and one-time scheduled workflow launches.
+  - Provide UI and backend commands for managing, pausing, running, and deleting scheduled executions.
 
 ## Phase 3: Communication & Orchestration
 
@@ -66,7 +67,7 @@ _Goal: Enable collaborative workflows between isolated agent instances._
   - Implement a message bus (Pub/Sub) in the Rust backend.
   - **Deterministic Routing Engine**: Define UI-based rules for routing JSON outputs between agents.
 - [ ] **Human-in-the-Loop (HITL) Queue**
-  - Centralized approval UI for sensitive agent actions.
+  - Expand the current completion Queue into a centralized approval and interruption surface for sensitive agent actions.
 - [ ] **Context Janitor (Memory Management)**
   - Automated summarization workflows to compress context windows when token limits are approached.
 

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -16,12 +16,13 @@ Wardian is built as a **High-Performance Hybrid Environment**, using **Rust (Tau
 - **Worker Threads**:
   - **Heartbeat (Scheduler)**: Handles periodic tasks and cron triggers.
   - **Metrics Push**: Pushes system/agent resource usage to the UI via Tauri events.
+- **Queue Persistence**: Completion triage state is stored under the active Wardian home so agent and workflow outcomes survive app restarts.
 
 ### 2. The Logical Layer (Workflow Engine)
 
 - **Deterministic Execution**: Detailed in [Workflow Engine Architecture](./workflow-engine.md).
 - **Shared Registry**: A global Handlebars-based registry where agent outputs are stored for cross-agent referencing.
-- **Node Execution**: Deterministic execution of workflow nodes (loops, triggers, agent calls).
+- **Node Execution Queue**: Deterministic execution of workflow nodes (loops, triggers, waits, branches, memory, commands, and agent calls) through a backend queue of candidate node IDs.
 - **Injection Logic**: Solves CLI input limits by writing prompts to temp files (`~\.gemini\tmp\wardian-1`) and using `<` redirection.
 
 ### 2.5 Memory and Knowledge
@@ -36,6 +37,7 @@ Wardian is built as a **High-Performance Hybrid Environment**, using **Rust (Tau
 - **Passive Observation**: The UI primarily observes and edits the state; it does not manage process lifecycles.
 - **Visual Builder**: A specialized canvas for designing complex multi-agent workflows, featuring the [Integrated Variable Assistant](./visual-builder.md).
 - **Dynamic Grid**: A responsive grid system for monitoring multiple terminal TUIs simultaneously.
+- **Queue View**: A triage surface for unread agent completions and workflow outcomes.
 
 ## 📡 Communication (IPC)
 
@@ -48,4 +50,4 @@ Wardian uses a bidirectional event system, detailed in [IPC and Event Governance
 
 ## Wardian CLI
 
-The `crates/wardian-cli` binary shares DTOs, paths, migrations, identity filters, and the live control protocol through `wardian-core`. For read commands it first tries the running desktop app's local control endpoint for the same `WARDIAN_HOME` and falls back to `$WARDIAN_HOME/state.db` when the app is not running. The desktop app stages the binary as a Tauri resource and installs it into the user Wardian bin directory on startup.
+The `crates/wardian-cli` binary shares DTOs, paths, migrations, identity filters, and the live control protocol through `wardian-core`. Wardian remains GUI/app-first; the CLI exists so agents and automation can inspect and control Wardian through a stable textual surface. For read commands it first tries the running desktop app's local control endpoint for the same `WARDIAN_HOME` and falls back to `$WARDIAN_HOME/state.db` when the app is not running. Live-control commands cover agent lifecycle, message delivery, watch/wait coordination, worktree assignment, and workflow run control. The desktop app stages the binary as a Tauri resource and installs it into the user Wardian bin directory on startup.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -16,13 +16,13 @@ Wardian is built as a **High-Performance Hybrid Environment**, using **Rust (Tau
 - **Worker Threads**:
   - **Heartbeat (Scheduler)**: Handles periodic tasks and cron triggers.
   - **Metrics Push**: Pushes system/agent resource usage to the UI via Tauri events.
-- **Queue Persistence**: Completion triage state is stored under the active Wardian home so agent and workflow outcomes survive app restarts.
+- **App Queue Persistence**: Completion triage state is stored under the active Wardian home so agent and workflow outcomes survive app restarts.
 
 ### 2. The Logical Layer (Workflow Engine)
 
 - **Deterministic Execution**: Detailed in [Workflow Engine Architecture](./workflow-engine.md).
 - **Shared Registry**: A global Handlebars-based registry where agent outputs are stored for cross-agent referencing.
-- **Node Execution Queue**: Deterministic execution of workflow nodes (loops, triggers, waits, branches, memory, commands, and agent calls) through a backend queue of candidate node IDs.
+- **Workflow Candidate Queue**: Deterministic execution of workflow nodes (loops, triggers, waits, branches, memory, commands, and agent calls) through the engine's internal candidate-node FIFO.
 - **Injection Logic**: Solves CLI input limits by writing prompts to temp files (`~\.gemini\tmp\wardian-1`) and using `<` redirection.
 
 ### 2.5 Memory and Knowledge

--- a/docs/developer/workflow-engine.md
+++ b/docs/developer/workflow-engine.md
@@ -1,6 +1,6 @@
 # Workflow Engine Architecture
 
-The Wardian Workflow Engine is a **Deterministic, Event-Driven Execution Environment** designed for multi-agent orchestration. It supports manual, scheduled, and listener-style triggers; conditional logic; loops; waits; agent execution modes; shared storage; and telemetry that feeds both the workflow UI and the user-facing Queue.
+The Wardian Workflow Engine is a **Deterministic, Event-Driven Execution Environment** designed for multi-agent orchestration. It supports manual, scheduled, and listener-style triggers; conditional logic; loops; waits; agent execution modes; shared storage; and workflow run telemetry.
 
 ## 🧱 Core Concepts
 
@@ -16,7 +16,7 @@ Unlike traditional DAGs, Wardian supports **Cycles** and **Loops** through a pul
 - **Consumption**: A downstream node only executes if it has "unconsumed pulses" from its dependencies.
 - **Wait Nodes**: Specifically require a pulse from *every* dependency before triggering.
 
-### 3. The Execution Queue
+### 3. Internal Candidate Queue
 Each run owns a FIFO queue of candidate node IDs. The engine seeds the queue from trigger entry points, pops one node at a time, validates dependency consumption, executes the node, stores output in the registry, and enqueues downstream candidates. This keeps graph execution inspectable without making each agent node responsible for orchestrating the rest of the graph.
 
 ## 🚀 Execution Flow
@@ -35,7 +35,7 @@ Each run owns a FIFO queue of candidate node IDs. The engine seeds the queue fro
    - Updates the `Registry` and pulses downstream nodes.
 4. **Finalization**:
    - Emits telemetry events (`workflow-telemetry`) for real-time UI visualization.
-   - Emits workflow completion status so the frontend can add completion or failure cards to the Queue.
+   - Emits workflow completion status for app-level subscribers.
    - Persists `shared_storage.json` if memory nodes were used.
 
 ## 🧩 Node Types & Logic

--- a/docs/developer/workflow-engine.md
+++ b/docs/developer/workflow-engine.md
@@ -1,6 +1,6 @@
 # Workflow Engine Architecture
 
-The Wardian Workflow Engine is a **Deterministic, Event-Driven Execution Environment** designed for multi-agent orchestration. It supports periodic triggers, conditional logic, and stateful memory.
+The Wardian Workflow Engine is a **Deterministic, Event-Driven Execution Environment** designed for multi-agent orchestration. It supports manual, scheduled, and listener-style triggers; conditional logic; loops; waits; agent execution modes; shared storage; and telemetry that feeds both the workflow UI and the user-facing Queue.
 
 ## 🧱 Core Concepts
 
@@ -16,6 +16,9 @@ Unlike traditional DAGs, Wardian supports **Cycles** and **Loops** through a pul
 - **Consumption**: A downstream node only executes if it has "unconsumed pulses" from its dependencies.
 - **Wait Nodes**: Specifically require a pulse from *every* dependency before triggering.
 
+### 3. The Execution Queue
+Each run owns a FIFO queue of candidate node IDs. The engine seeds the queue from trigger entry points, pops one node at a time, validates dependency consumption, executes the node, stores output in the registry, and enqueues downstream candidates. This keeps graph execution inspectable without making each agent node responsible for orchestrating the rest of the graph.
+
 ## 🚀 Execution Flow
 
 1. **Trigger Phase**:
@@ -24,14 +27,15 @@ Unlike traditional DAGs, Wardian supports **Cycles** and **Loops** through a pul
    - **Manual**: Triggered via the `run_workflow` Tauri command.
 2. **Initialization**:
    - Resolves the `WorkflowDefinition` from JSON.
-   - Sets up the `Registry` and `Queue` (identifying entry points).
+   - Sets up the `Registry` and execution queue by identifying entry-point candidates.
 3. **The Loop**:
-   - Pops a node ID from the `Queue`.
+   - Pops a candidate node ID from the execution queue.
    - Validates dependency satisfaction (Transactional Logic).
    - Executes node-specific logic (see below).
    - Updates the `Registry` and pulses downstream nodes.
 4. **Finalization**:
    - Emits telemetry events (`workflow-telemetry`) for real-time UI visualization.
+   - Emits workflow completion status so the frontend can add completion or failure cards to the Queue.
    - Persists `shared_storage.json` if memory nodes were used.
 
 ## 🧩 Node Types & Logic

--- a/docs/features.md
+++ b/docs/features.md
@@ -7,12 +7,14 @@ This page maps Wardian's major capabilities to their detailed guides.
 - High-density Grid and Dashboard views for active session monitoring
 - Left control rail for spawning, commands, workflows, explorer, and settings
 - Right roster with status lights, thought snippets, and watchlists
+- Queue tab for unread agent completions and workflow outcomes
 
 Related docs:
 
 - [UI Overview](./guide/ui-overview.md)
 - [Getting Started](./guide/getting-started.md)
 - [Watchlists](./guide/watchlists.md)
+- [Queue](./guide/queue.md)
 
 ## Agent Classes and Reusable Library
 
@@ -35,6 +37,19 @@ Related docs:
 
 - [Command Panel](./guide/command-panel.md)
 
+## Agent-Facing Wardian CLI
+
+- Give agents a textual control surface for inspecting live or persisted Wardian state
+- Let agents spawn, clone, pause, resume, kill, wait on, and watch peers through the same backend control layer used by the desktop app
+- Send prompts from inline text, standard input, or files; use `wardian ask` for bounded peer handoffs with response evidence
+- List workflows, show workflow definitions, and start or stop workflow runs when the desktop app is available
+- Inspect Wardian-managed agent worktrees, teams, and watchlists for automation-friendly coordination without treating the CLI as the primary human UI
+
+Related docs:
+
+- [Wardian CLI](./guide/cli.md)
+- [Native E2E Harness](./developer/native-e2e.md)
+
 ## Source Control Per Agent
 
 - Git status, staging/unstaging, discard, commit, pull/push
@@ -51,6 +66,7 @@ Related docs:
 - Visual node-based builder with variable assistant
 - Manual, scheduled, and listener-style trigger behaviors
 - Scheduled run management and run-time role assignment
+- Deterministic Rust workflow engine with candidate queue execution, pulse consumption, branch/loop/wait control, agent execution modes, shared storage, and live telemetry
 
 Related docs:
 
@@ -58,6 +74,19 @@ Related docs:
 - [Building Workflows](./workflows/building-workflows.md)
 - [Node Reference](./workflows/node-reference.md)
 - [Triggers](./workflows/triggers.md)
+- [Workflow Engine Architecture](./developer/workflow-engine.md)
+
+## Queue and Completion Triage
+
+- Captures agent completions when active terminal output settles back to Idle
+- Captures workflow completions and failures from workflow telemetry
+- Persists queue items under the Wardian home so unread work survives app restarts
+- Supports unread badges, mark-read, clear-read, dismiss, and expandable long summaries
+
+Related docs:
+
+- [Queue](./guide/queue.md)
+- [Workflow Overview](./workflows/index.md)
 
 ## Runtime Shell and Session Policy Controls
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -66,7 +66,7 @@ Related docs:
 - Visual node-based builder with variable assistant
 - Manual, scheduled, and listener-style trigger behaviors
 - Scheduled run management and run-time role assignment
-- Deterministic Rust workflow engine with candidate queue execution, pulse consumption, branch/loop/wait control, agent execution modes, shared storage, and live telemetry
+- Deterministic Rust workflow engine with pulse-driven candidate-node execution, branch/loop/wait control, agent execution modes, shared storage, and live telemetry
 
 Related docs:
 
@@ -79,7 +79,7 @@ Related docs:
 ## Queue and Completion Triage
 
 - Captures agent completions when active terminal output settles back to Idle
-- Captures workflow completions and failures from workflow telemetry
+- Records completed and failed workflow outcomes for later review
 - Persists queue items under the Wardian home so unread work survives app restarts
 - Supports unread badges, mark-read, clear-read, dismiss, and expandable long summaries
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,6 +1,6 @@
 # Wardian CLI
 
-Wardian includes a standalone `wardian` command for inspecting known agent sessions from a terminal or from inside an agent process.
+Wardian includes a standalone `wardian` command for agents and automation to inspect, coordinate, and control known agent sessions. Wardian remains GUI/app-first for humans; the CLI is the textual control surface agents use when they need to discover themselves, coordinate peers, or ask the running app to perform live actions for the same `WARDIAN_HOME`.
 
 ## Installation
 
@@ -68,6 +68,39 @@ wardian send "status?" --to class:Coder
 wardian send "stand down" --to all
 ```
 
+## Common Workflows
+
+Inspect the live roster before an agent coordinates work:
+
+```bash
+wardian agent list --scope all --fields name,class,provider,workspace,status,status_source
+```
+
+Hand a bounded review task to a peer and wait for response evidence:
+
+```bash
+wardian ask reviewer-a1 --file review-prompt.md --until output:REVIEW_DONE --timeout 10m
+```
+
+Send a prompt to an existing agent and wait for the next Idle transition:
+
+```bash
+wardian send --file prompt.md --to coder-a1 --wait-until idle --timeout 10m
+```
+
+Watch retained output for a deterministic marker:
+
+```bash
+wardian agent watch coder-a1 --until output:READY_FOR_REVIEW --include status,output,delivery --timeout 10m
+```
+
+Run a saved workflow through the app-owned backend:
+
+```bash
+wardian workflow list
+wardian workflow run workflow-id
+```
+
 Mutating commands use Wardian's local control endpoint and require the desktop app to be running for the same `WARDIAN_HOME`. This includes agent lifecycle commands, agent worktree commands, `workflow run`, `workflow stop`, and `send`.
 
 `workflow list` and `workflow show` try the running app first, then read workflow JSON files from disk when the app is unavailable.
@@ -100,7 +133,7 @@ Output options:
 - `--field status` returns one bare value plus a newline.
 - `--field status_source` returns `live` or `persisted`.
 - `--verbose` adds `pid`, `started_at`, and `last_status_at`.
-- `--pretty` returns aligned text for humans instead of JSON.
+- `--pretty` returns aligned text for interactive inspection instead of JSON.
 
 Default JSON is indented for terminal readability. It includes `schema: 1` and an `agent` or `agents` payload with `name`, `uuid`, `class`, `provider`, `workspace`, and `status`.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with Wardian
 
-Wardian is an integrated habitat for managing multiple autonomous agents. This guide will help you spawn your first agent and navigate the "Blueprint" system.
+Wardian is an integrated habitat for managing multiple autonomous agents. This guide will help you spawn your first agent, monitor completed work in the Queue, and understand how the `wardian` CLI lets agents coordinate and control Wardian from inside their own terminals.
 
 ## 1. Prerequisites
 - **Node.js** (v18+)
@@ -32,7 +32,24 @@ From the **Roster (Right Sidebar)**, you can monitor and control your agents:
     - **Red**: Error (crashed or encountered a fatal bug).
 - **Control Icons**: Hover over an agent in the Roster to reveal icons for **Pause**, **Restart**, or **Delete**.
 
-## 5. Interacting with the Grid
+## 5. Review Completed Work in the Queue
+
+Click **Queue** in the top bar to review completed agent tasks and workflow runs. Wardian adds unread items when an active agent settles back to Idle, or when a workflow reports completion or failure. Use the unread badge to spot new work, expand long summaries when needed, mark items read after triage, and clear read items when they are no longer useful.
+
+## 6. Understand the Wardian CLI
+
+The desktop app installs a `wardian` command into the Wardian bin directory. The app remains the primary human interface; the CLI exists so agents and automation can inspect and control Wardian without manipulating the GUI. From inside a managed agent terminal, `wardian agent` identifies the current session. From other terminals or scripts, use explicit names or UUIDs:
+
+```bash
+wardian agent list --scope all --fields name,status,workspace
+wardian agent reviewer-a1 --field status
+wardian send --file prompt.md --to reviewer-a1 --wait-until idle --timeout 10m
+wardian workflow list
+```
+
+Live-control commands such as `send`, `spawn`, `pause`, `resume`, `kill`, `workflow run`, and `workflow stop` require the desktop app to be running for the same `WARDIAN_HOME`.
+
+## 7. Interacting with the Grid
 Click **GRID** in the top bar to see all active agents in a high-density terminal grid.
 - **Direct Input**: Click into any terminal to type directly to that agent.
 - **Drag & Drop**: Drag the header of any terminal to reorder your workspace.
@@ -42,6 +59,8 @@ Click **GRID** in the top bar to see all active agents in a high-density termina
 - Learn how to manage reusable prompts in the [Library System](./library.md).
 - Browse your agent's local files in the [Explorer](./explorer.md).
 - Coordinate multi-agent instructions in the [Command Panel](./command-panel.md).
+- Let agents and automation control Wardian with the [Wardian CLI](./cli.md).
+- Triage completed work in the [Queue](./queue.md).
 - Manage per-agent Git operations in [Source Control](./source-control.md).
 - Configure runtime behavior and shell defaults in [Settings](./settings.md).
 - Automate complex tasks with [Visual Workflows](./workflows.md).

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -14,6 +14,7 @@ Use this index to find user-facing documentation by task.
 - [Library](./library.md)
 - [Command Panel](./command-panel.md)
 - [Watchlists](./watchlists.md)
+- [Queue](./queue.md)
 - [Explorer](./explorer.md)
 
 ## Source Control and Runtime Settings

--- a/docs/guide/queue.md
+++ b/docs/guide/queue.md
@@ -1,0 +1,48 @@
+# Queue
+
+The Queue is Wardian's triage surface for completed work. It keeps agent and workflow outcomes visible after the terminal or workflow canvas has moved on.
+
+## What Appears in the Queue
+
+Wardian currently records two item types:
+
+- **Agent task completed**: added when an agent that was active returns to Idle. Wardian uses captured provider or terminal output when available; otherwise it records a generic completion summary.
+- **Workflow completed** or **Workflow failed**: added when workflow telemetry reports the final run status. If a workflow node emitted text output, Wardian uses that as the queue summary.
+
+The Queue is not yet the full human-in-the-loop approval system from the roadmap. Provider approval prompts still surface through agent status and provider-specific UI behavior. The current Queue is for completion review and failure triage.
+
+## Reading Queue Items
+
+Open **Queue** from the top workspace tabs. Unread items appear at the top and increment the Queue tab badge.
+
+Each item shows:
+
+- source type and status
+- agent name or workflow name
+- relative completion time
+- summary text or failure details
+
+Long summaries are collapsed by default. Use **Show details** to expand them, or **Hide details** to collapse them again.
+
+## Triage Actions
+
+- Click an item to mark it read.
+- Use **Mark all read** when the full queue has been reviewed.
+- Use **Clear read** to remove reviewed items.
+- Use the trash icon on an individual item to dismiss it immediately.
+
+Queue items are persisted under the active Wardian home, so unread work survives app restarts. Items older than seven days are ignored when the Queue loads.
+
+## Practical Workflow
+
+1. Let agents or workflows run from the Grid, Command Panel, CLI, or Workflow view.
+2. Watch the Queue badge for new completions.
+3. Open Queue, review summaries, and expand details when the summary was truncated.
+4. Follow up in the source agent terminal, workflow run, or repository if the item needs action.
+5. Mark reviewed items read and clear them when they are no longer needed.
+
+## Related Docs
+
+- [Getting Started](./getting-started.md)
+- [Wardian CLI](./cli.md)
+- [Workflows](../workflows/index.md)

--- a/docs/guide/queue.md
+++ b/docs/guide/queue.md
@@ -1,13 +1,13 @@
 # Queue
 
-The Queue is Wardian's triage surface for completed work. It keeps agent and workflow outcomes visible after the terminal or workflow canvas has moved on.
+The Queue is Wardian's app-level triage surface for completed work. It is separate from the workflow engine: agents and workflows can produce outcomes, and the Queue keeps those outcomes visible after the originating terminal or workflow run has moved on.
 
 ## What Appears in the Queue
 
 Wardian currently records two item types:
 
 - **Agent task completed**: added when an agent that was active returns to Idle. Wardian uses captured provider or terminal output when available; otherwise it records a generic completion summary.
-- **Workflow completed** or **Workflow failed**: added when workflow telemetry reports the final run status. If a workflow node emitted text output, Wardian uses that as the queue summary.
+- **Workflow completed** or **Workflow failed**: added when the app receives a final workflow run status. If the workflow produced text output, Wardian can use that as the queue summary.
 
 The Queue is not yet the full human-in-the-loop approval system from the roadmap. Provider approval prompts still surface through agent status and provider-specific UI behavior. The current Queue is for completion review and failure triage.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@ This folder contains user guides, workflow references, developer architecture no
 
 - [Getting Started](./guide/getting-started.md)
 - [UI Overview](./guide/ui-overview.md)
+- [Wardian CLI](./guide/cli.md)
+- [Queue](./guide/queue.md)
 - [Workflows](./workflows/index.md)
 - [Key Features](./features.md)
 - [Provider Runtimes](./providers.md)
@@ -18,6 +20,8 @@ This folder contains user guides, workflow references, developer architecture no
 - [Explorer](./guide/explorer.md)
 - [Watchlists](./guide/watchlists.md)
 - [Command Panel](./guide/command-panel.md)
+- [Wardian CLI](./guide/cli.md)
+- [Queue](./guide/queue.md)
 - [Source Control](./guide/source-control.md)
 - [Settings](./guide/settings.md)
 

--- a/docs/workflows/building-workflows.md
+++ b/docs/workflows/building-workflows.md
@@ -2,6 +2,8 @@
 
 Use the Workflow Builder when you want to create, edit, or test workflow logic directly on the canvas.
 
+The canvas is the authoring surface; the Rust workflow engine is the runtime. When you run a workflow, Wardian saves the graph, resolves launch-time input, then processes candidate nodes through a backend queue that records node output, pulses downstream ports, and emits telemetry for the UI and Queue.
+
 ## Builder Layout
 
 The Workflow view is made of four main working areas:
@@ -68,6 +70,8 @@ That usually means one or both of these are true:
 
 If neither is needed, the workflow launches immediately based on its trigger type.
 
+Completed and failed workflow runs are added to the [Queue](../guide/queue.md) so the final outcome remains visible after you leave the canvas.
+
 ## Builder vs Library
 
 Use the **Workflow Builder** when you need to:
@@ -88,4 +92,5 @@ Use the **Workflow Library** when you need to:
 - [Triggers](./triggers.md)
 - [Node Reference](./node-reference.md)
 - [Agent Assignment](./agent-assignment.md)
+- [Queue](../guide/queue.md)
 - [Visual Builder Architecture](../developer/visual-builder.md)

--- a/docs/workflows/building-workflows.md
+++ b/docs/workflows/building-workflows.md
@@ -2,7 +2,7 @@
 
 Use the Workflow Builder when you want to create, edit, or test workflow logic directly on the canvas.
 
-The canvas is the authoring surface; the Rust workflow engine is the runtime. When you run a workflow, Wardian saves the graph, resolves launch-time input, then processes candidate nodes through a backend queue that records node output, pulses downstream ports, and emits telemetry for the UI and Queue.
+The canvas is the authoring surface; the Rust workflow engine is the runtime. When you run a workflow, Wardian saves the graph, resolves launch-time input, then processes candidate nodes through the engine's internal execution loop, records node output, pulses downstream ports, and emits run telemetry.
 
 ## Builder Layout
 
@@ -70,7 +70,7 @@ That usually means one or both of these are true:
 
 If neither is needed, the workflow launches immediately based on its trigger type.
 
-Completed and failed workflow runs are added to the [Queue](../guide/queue.md) so the final outcome remains visible after you leave the canvas.
+After a workflow finishes, the app can add its completed or failed outcome to the separate [Queue](../guide/queue.md) triage surface.
 
 ## Builder vs Library
 

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -1,14 +1,15 @@
 # Workflows
 
-Wardian workflows are reusable automations built from nodes, connections, and runtime assignment data. This section is the main user-facing reference for building workflows, understanding how they launch, and managing scheduled or live workflow behavior over time.
+Wardian workflows are reusable automations built from nodes, connections, and runtime assignment data. A visual builder defines the graph, while the Rust workflow engine executes it as a deterministic queue of candidate node work, pulses, registry updates, and telemetry events. This section is the main user-facing reference for building workflows, understanding how they launch, and managing scheduled or live workflow behavior over time.
 
 ## Workflow Mental Model
 
-A workflow has three layers:
+A workflow has four layers:
 
 - **Template**: the saved graph of nodes, edges, and workflow settings.
 - **Launch behavior**: whether that template runs manually, creates a scheduled task, or starts a live listener.
 - **Runtime state**: active runs, scheduled instances, listener status, node outputs, and role mappings.
+- **Engine loop**: the backend queue that decides which nodes are ready, consumes dependency pulses, executes each node, and emits run telemetry back to the UI.
 
 In practice, you usually move through workflows in this order:
 
@@ -27,11 +28,12 @@ In practice, you usually move through workflows in this order:
 
 ## Workflow Surfaces
 
-Wardian exposes workflows in three main surfaces:
+Wardian exposes workflows in four main surfaces:
 
 - **Workflow Builder**: best for authoring, wiring, configuring, and testing workflows.
 - **Workflow Library**: best for launching saved workflows quickly without opening the canvas.
 - **Active Monitoring**: best for watching active runs, live listeners, and scheduled task instances.
+- **Wardian CLI**: best for agents and automation to list, show, run, and stop workflows through the running desktop app.
 
 ## What This Section Covers
 
@@ -42,6 +44,7 @@ This workflow section focuses on user-visible behavior:
 - how scheduled tasks behave
 - what happens when a workflow is launched from different surfaces
 - how agent assignments affect execution
+- how completed and failed workflow runs appear in the [Queue](../guide/queue.md)
 
 For backend implementation details, see:
 

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -1,6 +1,6 @@
 # Workflows
 
-Wardian workflows are reusable automations built from nodes, connections, and runtime assignment data. A visual builder defines the graph, while the Rust workflow engine executes it as a deterministic queue of candidate node work, pulses, registry updates, and telemetry events. This section is the main user-facing reference for building workflows, understanding how they launch, and managing scheduled or live workflow behavior over time.
+Wardian workflows are reusable automations built from nodes, connections, and runtime assignment data. A visual builder defines the graph, while the Rust workflow engine executes it through a deterministic candidate-node loop with pulses, registry updates, and telemetry events. This section is the main user-facing reference for building workflows, understanding how they launch, and managing scheduled or live workflow behavior over time.
 
 ## Workflow Mental Model
 
@@ -9,7 +9,7 @@ A workflow has four layers:
 - **Template**: the saved graph of nodes, edges, and workflow settings.
 - **Launch behavior**: whether that template runs manually, creates a scheduled task, or starts a live listener.
 - **Runtime state**: active runs, scheduled instances, listener status, node outputs, and role mappings.
-- **Engine loop**: the backend queue that decides which nodes are ready, consumes dependency pulses, executes each node, and emits run telemetry back to the UI.
+- **Engine loop**: the internal candidate-node loop that decides which nodes are ready, consumes dependency pulses, executes each node, and emits run telemetry back to the UI.
 
 In practice, you usually move through workflows in this order:
 
@@ -44,7 +44,7 @@ This workflow section focuses on user-visible behavior:
 - how scheduled tasks behave
 - what happens when a workflow is launched from different surfaces
 - how agent assignments affect execution
-- how completed and failed workflow runs appear in the [Queue](../guide/queue.md)
+- where workflow outcomes can surface after a run completes
 
 For backend implementation details, see:
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Wardian"
 version = "0.3.4"
-description = "GUI command center for multi-agent CLI workflows — see every session, collect completed work in a queue, and give agents a CLI surface for coordinating and controlling Wardian."
+description = "Local command center for multi-agent CLI workflows — see every session, collect completed work in a queue, and give agents a CLI surface for coordinating and controlling Wardian."
 authors = ["Tan Gemicioglu"]
 edition = "2021"
 build = "build.rs"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Wardian"
 version = "0.3.4"
-description = "Local command center for multi-agent CLI workflows — see every session, swap skills on the fly, and chain agents into deterministic pipelines."
+description = "GUI command center for multi-agent CLI workflows — see every session, collect completed work in a queue, and give agents a CLI surface for coordinating and controlling Wardian."
 authors = ["Tan Gemicioglu"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
## Description
Refreshes Wardian's top-level and guide documentation so the current CLI, Queue, and workflow engine capabilities are easier to discover and accurately framed.

Positioning:
- Wardian remains a local, app-first command center for humans: the desktop Command Center is the primary interface for monitoring, triage, workflows, and agent operations.
- The bundled `wardian` CLI is the agent-facing textual control surface for self-identity, peer coordination, message delivery, watch/wait flows, worktrees, and workflow run control through the app-owned backend.
- The Queue and workflow engine are separate components: the workflow engine executes workflow graphs, while the app-level Queue displays completed agent and workflow outcomes for triage.

Highlights:
- Foregrounds the `wardian` CLI as the way agents and automation coordinate with Wardian without driving the graphical app.
- Adds a dedicated Queue guide and links it from the README, docs index, guide index, getting started guide, and features page.
- Updates workflow docs to explain the visual builder plus deterministic Rust engine model, while avoiding conflation with the app-level Queue.
- Marks roadmap Phase 1/2 items complete while keeping HITL approval queue expansion future-facing.
- Updates the Tauri package description to match the refreshed local command-center framing.

## Related Issues
Fixes #248

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` (61 test files, 551 tests passed; existing React `act(...)` warnings still print in watchlist/app tests)
- `npm run build` (passes; Vite still reports the existing large chunk warning)
- `npm run check:frontend-screenshot` (No frontend changes detected; screenshot evidence is not required.)
- `$env:CARGO_TARGET_DIR = "$env:TEMP\wardian-docs-pr-target"; cargo clippy`
- `$env:CARGO_TARGET_DIR = "$env:TEMP\wardian-docs-pr-target"; cargo test` (417 unit tests + 5 mock provider tests passed)
- `$env:CARGO_TARGET_DIR = "$env:TEMP\wardian-docs-pr-target"; cargo check`
- `git diff --check`
- Markdown link check over touched docs
- Secret-pattern scan over changed docs/metadata files

Backend Cargo commands were run with an isolated `CARGO_TARGET_DIR` because this worktree has a pre-existing local `.cargo/config.toml` change that points at a shared target directory.

After the positioning and Queue/workflow separation review notes, focused follow-up verification included:
- `npm run check:frontend-screenshot`
- `$env:CARGO_TARGET_DIR = "$env:TEMP\wardian-docs-pr-target"; cargo check`
- `git diff --check`
- Markdown link check over touched docs

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable