### PR TITLE
feat(cli): add command send mode

### DIFF
--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -91,6 +91,10 @@ pub struct SendArgs {
     #[arg(long)]
     pub thread: Option<String>,
 
+    /// Send the message body as a provider slash command without sender attribution
+    #[arg(long = "as-command")]
+    pub as_command: bool,
+
     /// Wait until the target reaches this status after sending
     #[arg(long = "wait-until")]
     pub wait_until: Option<String>,
@@ -253,6 +257,26 @@ mod tests {
     fn parses_agent_target_shorthand() {
         let cli = Cli::try_parse_from(["wardian", "agent", "coder-a1"]).unwrap();
         assert!(matches!(cli.command, Command::Agent(_)));
+    }
+
+    #[test]
+    fn parses_send_as_command() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "send",
+            "--to",
+            "Wardian-Codex",
+            "--as-command",
+            "/goal test",
+        ])
+        .unwrap();
+        let Command::Send(args) = cli.command else {
+            panic!("expected Send command")
+        };
+
+        assert!(args.as_command);
+        assert_eq!(args.to, "Wardian-Codex");
+        assert_eq!(args.message.as_deref(), Some("/goal test"));
     }
 
     #[test]

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -7,7 +7,8 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
     AgentListResponse, AgentResponse, AgentWatchResponse, AgentWorktreeListResponse,
     AgentWorktreeMutationResponse, AgentWorktreeSummary, ControlRequest, DeliveryDetail,
-    MessageOrigin, SendMessageResponse, WorkflowListResponse, WorkflowResponse, WorkflowSummary,
+    MessageInputMode, MessageOrigin, SendMessageResponse, WorkflowListResponse, WorkflowResponse,
+    WorkflowSummary,
 };
 use wardian_core::identity::AgentIdentity;
 use wardian_core::models::WorkflowDefinition;
@@ -366,6 +367,15 @@ pub fn send_message(
     message: &str,
     thread: Option<&str>,
 ) -> io::Result<SendMessageResponse> {
+    send_message_with_input_mode(target, message, thread, MessageInputMode::Message)
+}
+
+pub fn send_message_with_input_mode(
+    target: &str,
+    message: &str,
+    thread: Option<&str>,
+    input_mode: MessageInputMode,
+) -> io::Result<SendMessageResponse> {
     let runtime = build_runtime()?;
     let value = timeout_block(
         &runtime,
@@ -374,6 +384,7 @@ pub fn send_message(
             target: target.to_string(),
             message: message.to_string(),
             thread: thread.map(str::to_string),
+            input_mode,
             origin: current_message_origin(),
         }),
     )?;
@@ -459,18 +470,19 @@ pub fn send_message_and_watch(
     target: &str,
     message: &str,
     thread: Option<&str>,
+    input_mode: MessageInputMode,
     until: &str,
     timeout: Duration,
-) -> io::Result<AgentWatchResponse> {
-    let response = send_message_and_watch_condition(
+) -> io::Result<AskAgentResponse> {
+    send_message_and_watch_condition(
         target,
         message,
         thread,
+        input_mode,
         &format!("status:{until}"),
         Some(4096),
         timeout,
-    )?;
-    Ok(response.watch)
+    )
 }
 
 pub fn ask_agent(
@@ -485,6 +497,7 @@ pub fn ask_agent(
         target,
         message,
         thread,
+        MessageInputMode::Message,
         condition,
         tail_bytes,
         timeout,
@@ -496,12 +509,13 @@ pub fn send_message_and_watch_condition(
     target: &str,
     message: &str,
     thread: Option<&str>,
+    input_mode: MessageInputMode,
     condition: &str,
     tail_bytes: Option<usize>,
     timeout: Duration,
 ) -> io::Result<AskAgentResponse> {
     send_message_and_watch_condition_with_output_echo_guard(
-        target, message, thread, condition, tail_bytes, timeout, None,
+        target, message, thread, input_mode, condition, tail_bytes, timeout, None,
     )
 }
 
@@ -509,6 +523,7 @@ fn send_message_and_watch_condition_with_output_echo_guard(
     target: &str,
     message: &str,
     thread: Option<&str>,
+    input_mode: MessageInputMode,
     condition: &str,
     tail_bytes: Option<usize>,
     timeout: Duration,
@@ -527,7 +542,7 @@ fn send_message_and_watch_condition_with_output_echo_guard(
         false,
         Duration::from_secs(5),
     )?;
-    let sent = send_message(target, message, thread)?;
+    let sent = send_message_with_input_mode(target, message, thread, input_mode)?;
     let watch = agent_watch_with_output_echo_guard(
         target,
         Some(&initial.cursor),

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -13,6 +13,7 @@ use args::{
 use clap::Parser;
 use errors::{CliError, ExitCode};
 use output::{render_list, render_show, RenderOptions};
+use wardian_core::control::MessageInputMode;
 use wardian_core::identity::{self, ListFilters, Scope};
 
 fn main() {
@@ -373,33 +374,53 @@ fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
 
 fn handle_send(args: SendArgs) -> Result<String, CliError> {
     let message = read_message_input(args.message.as_deref(), args.stdin, args.file.as_deref())?;
+    let input_mode = if args.as_command {
+        validate_single_agent_target(&args.to, "send --as-command")?;
+        validate_send_command_thread(args.thread.as_deref())?;
+        MessageInputMode::Command
+    } else {
+        MessageInputMode::Message
+    };
 
     let response = if let Some(until) = args.wait_until.as_deref() {
         validate_single_agent_target(&args.to, "send --wait-until")?;
         let timeout = parse_timeout(&args.timeout)?;
-        let watch = live::send_message_and_watch(
+        let response = live::send_message_and_watch(
             &args.to,
             &message,
             args.thread.as_deref(),
+            input_mode,
             until,
             timeout,
         )
+        .map_err(control_error)?;
+        let watch = response.watch;
+        serde_json::json!({
+            "schema": 1,
+            "ok": true,
+            "target": args.to,
+            "input_mode": input_mode,
+            "status": watch.agent.status,
+            "delivery": response.delivery,
+            "cursor": watch.cursor,
+        })
+    } else {
+        let sent = if input_mode == MessageInputMode::Message {
+            live::send_message(&args.to, &message, args.thread.as_deref())
+        } else {
+            live::send_message_with_input_mode(
+                &args.to,
+                &message,
+                args.thread.as_deref(),
+                input_mode,
+            )
+        }
         .map_err(control_error)?;
         serde_json::json!({
             "schema": 1,
             "ok": true,
             "target": args.to,
-            "status": watch.agent.status,
-            "delivery": watch.delivery.delivery,
-            "cursor": watch.cursor,
-        })
-    } else {
-        let sent = live::send_message(&args.to, &message, args.thread.as_deref())
-            .map_err(control_error)?;
-        serde_json::json!({
-            "schema": 1,
-            "ok": true,
-            "target": args.to,
+            "input_mode": input_mode,
             "delivery": sent.delivery,
         })
     };
@@ -465,6 +486,17 @@ fn validate_ask_thread(thread: Option<&str>) -> Result<(), CliError> {
             ExitCode::Generic,
             "not_supported",
             "--thread is not supported by wardian ask yet",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_send_command_thread(thread: Option<&str>) -> Result<(), CliError> {
+    if thread.is_some() {
+        return Err(CliError::backend(
+            ExitCode::Generic,
+            "not_supported",
+            "--as-command cannot be combined with --thread",
         ));
     }
     Ok(())
@@ -859,6 +891,7 @@ mod tests {
                 provider: "mock".to_string(),
                 runtime_state: "live_pty_available".to_string(),
                 delivery_state: "submitted".to_string(),
+                input_mode: MessageInputMode::Message,
                 error: None,
             }],
             watch: wardian_core::control::AgentWatchResponse {

--- a/crates/wardian-cli/tests/send_cli.rs
+++ b/crates/wardian-cli/tests/send_cli.rs
@@ -108,3 +108,56 @@ fn send_wait_until_rejects_class_selector_before_app_lookup() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     assert!(stderr.contains(r#""code":"not_supported""#));
 }
+
+#[test]
+fn send_as_command_to_all_rejects_before_app_lookup() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args(["send", "--to", "all", "--as-command", "/goal test"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"not_supported""#));
+    assert!(stderr.contains("--as-command requires a single agent name or uuid"));
+}
+
+#[test]
+fn send_as_command_to_class_rejects_before_app_lookup() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args(["send", "--to", "class:Coder", "--as-command", "/status"])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"not_supported""#));
+    assert!(stderr.contains("--as-command requires a single agent name or uuid"));
+}
+
+#[test]
+fn send_as_command_rejects_thread_before_app_lookup() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args([
+            "send",
+            "--to",
+            "coder-a1",
+            "--thread",
+            "review",
+            "--as-command",
+            "/goal test",
+        ])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"not_supported""#));
+    assert!(stderr.contains("--as-command cannot be combined with --thread"));
+}

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -54,6 +54,8 @@ pub enum ControlRequest {
         target: String,
         message: String,
         thread: Option<String>,
+        #[serde(default, skip_serializing_if = "MessageInputMode::is_message")]
+        input_mode: MessageInputMode,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         origin: Option<MessageOrigin>,
     },
@@ -74,6 +76,20 @@ pub enum ControlRequest {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MessageOrigin {
     WardianAgent { session_id: String },
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageInputMode {
+    #[default]
+    Message,
+    Command,
+}
+
+impl MessageInputMode {
+    pub fn is_message(&self) -> bool {
+        matches!(self, Self::Message)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -125,6 +141,8 @@ pub struct DeliveryDetail {
     pub provider: String,
     pub runtime_state: String,
     pub delivery_state: String,
+    #[serde(default)]
+    pub input_mode: MessageInputMode,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<DeliveryErrorDetail>,
 }
@@ -347,6 +365,7 @@ mod tests {
             target: "all".to_string(),
             message: "hello".to_string(),
             thread: None,
+            input_mode: MessageInputMode::Message,
             origin: None,
         };
         let json = serde_json::to_string(&req).unwrap();
@@ -361,6 +380,7 @@ mod tests {
             target: "CoderOne".to_string(),
             message: "hello".to_string(),
             thread: None,
+            input_mode: MessageInputMode::Message,
             origin: Some(MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -374,6 +394,23 @@ mod tests {
     }
 
     #[test]
+    fn send_message_request_serializes_command_input_mode() {
+        let req = ControlRequest::SendMessage {
+            target: "CoderOne".to_string(),
+            message: "/goal test".to_string(),
+            thread: None,
+            input_mode: MessageInputMode::Command,
+            origin: Some(MessageOrigin::WardianAgent {
+                session_id: "source-1".to_string(),
+            }),
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+
+        assert!(json.contains(r#""input_mode":"command""#));
+    }
+
+    #[test]
     fn send_message_request_accepts_missing_origin() {
         let json = r#"{"command":"send_message","target":"all","message":"hello","thread":null}"#;
         let req: ControlRequest = serde_json::from_str(json).unwrap();
@@ -384,6 +421,7 @@ mod tests {
                 target: "all".to_string(),
                 message: "hello".to_string(),
                 thread: None,
+                input_mode: MessageInputMode::Message,
                 origin: None,
             }
         );
@@ -509,6 +547,7 @@ mod tests {
             provider: "codex".to_string(),
             runtime_state: "live_pty_available".to_string(),
             delivery_state: "submitted".to_string(),
+            input_mode: MessageInputMode::Message,
             error: None,
         };
 
@@ -529,6 +568,7 @@ mod tests {
                 provider: "codex".to_string(),
                 runtime_state: "live_pty_available".to_string(),
                 delivery_state: "submitted".to_string(),
+                input_mode: MessageInputMode::Command,
                 error: None,
             }],
         };
@@ -537,6 +577,7 @@ mod tests {
 
         assert!(json.contains(r#""ok":true"#));
         assert!(json.contains(r#""delivery_state":"submitted""#));
+        assert!(json.contains(r#""input_mode":"command""#));
     }
 
     #[test]

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -63,6 +63,7 @@ wardian workflow run <id>
 wardian workflow stop <run-instance-id>
 wardian ask reviewer-a1 --stdin --until output:REVIEW_DONE --timeout 10m
 wardian send "review this" --to coder-a1
+wardian send --as-command "/goal test" --to coder-a1
 wardian send "review this" --to reviewer-a1 --wait-until idle --timeout 10m
 wardian send "status?" --to class:Coder
 wardian send "stand down" --to all
@@ -117,9 +118,24 @@ Mutating commands use Wardian's local control endpoint and require the desktop a
 
 `ask <target>` sends one prompt to one live agent and returns the response evidence observed after a pre-send watch cursor. It accepts the same message sources as `send`: inline text, `--stdin`, or `--file <path>`. The default completion condition is `status:idle`; use `--until output:<token>` for deterministic task handoff. `ask` rejects `all`, `class:<ClassName>`, and reserved `--thread` usage with `not_supported`.
 
-`send` submits a provider-aware message into the target agent runtime. Targets can be an agent name, UUID, `class:<ClassName>`, or `all`. `--stdin` reads the message from standard input, and `--file <path>` reads it from a file. `--wait-until <status>` is available for single-agent targets and waits from a pre-send watch cursor for a newer matching status observation. `--thread` is reserved but not implemented yet; when the app is running, using it returns `not_supported`.
+`send` submits a provider-aware message into the target agent runtime. Targets can be an agent name, UUID, `class:<ClassName>`, or `all`. `--stdin` reads the message from standard input, and `--file <path>` reads it from a file. By default, Wardian keeps inter-agent attribution and delivers messages with a `From <sender>:` prefix when sender context is available. Use `--as-command` for provider slash commands that must start at the first input token:
 
-Successful `send` responses include `delivery[]`. Failed or partial delivery returns a nonzero exit with JSON on stderr and `details.delivery[]`, including `runtime_state`, `delivery_state`, and provider-specific input errors.
+```bash
+wardian send --as-command "/goal test" --to coder-a1
+printf '%s' '/status' | wardian send --stdin --as-command --to coder-a1
+```
+
+PowerShell:
+
+```powershell
+"/status" | wardian send --stdin --as-command --to coder-a1
+```
+
+`--as-command` sends the exact message body without the attribution prefix while still using the normal provider-aware submit path. It accepts only one explicit agent name or UUID, rejects `all` and `class:<ClassName>` with `not_supported`, and cannot be combined with `--thread`.
+
+`--wait-until <status>` is available for single-agent targets and waits from a pre-send watch cursor for a newer matching status observation. `--thread` is reserved but not implemented yet; when the app is running, using it returns `not_supported`.
+
+Successful `send` responses include `input_mode` and `delivery[]`; command sends also include `delivery[].input_mode` so automation can confirm command delivery. Failed or partial delivery returns a nonzero exit with JSON on stderr and `details.delivery[]`, including `runtime_state`, `delivery_state`, and provider-specific input errors.
 
 List filters:
 

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -141,6 +141,7 @@ Use `wardian send` for live inter-agent communication:
 wardian send "review this patch" --to reviewer-a1
 wardian send --stdin --to reviewer-a1
 wardian send --file prompt.md --to reviewer-a1
+wardian send --as-command "/goal test" --to reviewer-a1
 wardian send "status?" --to class:Coder
 wardian send "stand down" --to all
 wardian send "review this patch" --to reviewer-a1 --wait-until idle --timeout 10m
@@ -150,9 +151,30 @@ Targets can be an agent name, UUID, `class:<ClassName>`, or `all`. Use
 `--wait-until` only with a single-agent target; broadcasts are for messages that
 should not block the current command.
 
+Normal sends preserve inter-agent attribution when Wardian knows the sender.
+Use `--as-command` when delivering provider slash commands that must be the
+first input token:
+
+```bash
+wardian send --as-command "/goal test" --to reviewer-a1
+printf '%s' '/status' | wardian send --stdin --as-command --to reviewer-a1
+```
+
+PowerShell:
+
+```powershell
+"/status" | wardian send --stdin --as-command --to reviewer-a1
+```
+
+`--as-command` sends the exact message body without a `From <sender>:` prefix,
+while still using the provider-aware submit path. It accepts only one explicit
+agent name or UUID and rejects `all`, `class:<ClassName>`, and `--thread` with
+`not_supported`.
+
 Successful sends include `delivery[]`. Failed delivery emits JSON on stderr with
-`details.delivery[]`, including `runtime_state`, `delivery_state`, and any input
-channel error.
+`details.delivery[]`, including `runtime_state`, `delivery_state`,
+`input_mode`, and any input channel error. Successful command sends also expose
+`input_mode: "command"` in the response for automation.
 
 `--thread` is reserved for grouped conversations. Until threading is implemented
 end-to-end, the running app rejects it with `not_supported` instead of silently

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -9,8 +9,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
     AgentListResponse, AgentResponse, AgentWatchResponse, AgentWorktreeListResponse,
     AgentWorktreeMutationResponse, AgentWorktreeSummary, ControlRequest, DeliveryDetail,
-    DeliveryErrorDetail, MessageOrigin, OkResponse, SendMessageResponse, WatchAgentSnapshot,
-    WatchDeliverySnapshot, WorkflowListResponse, WorkflowResponse, WorkflowSummary,
+    DeliveryErrorDetail, MessageInputMode, MessageOrigin, OkResponse, SendMessageResponse,
+    WatchAgentSnapshot, WatchDeliverySnapshot, WorkflowListResponse, WorkflowResponse,
+    WorkflowSummary,
 };
 use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
 
@@ -214,6 +215,7 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             target,
             message,
             thread,
+            input_mode,
             origin,
         } => {
             let state = app.state::<AppState>();
@@ -223,6 +225,7 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
                 &target,
                 &message,
                 thread.as_deref(),
+                input_mode,
                 origin.as_ref(),
             )
             .await?;
@@ -601,9 +604,10 @@ async fn deliver_message_to_target(
     target: &str,
     message: &str,
     thread: Option<&str>,
+    input_mode: MessageInputMode,
     origin: Option<&MessageOrigin>,
 ) -> Result<Vec<DeliveryDetail>, ControlError> {
-    validate_send_message_thread(thread)?;
+    validate_send_message_options(target, thread, input_mode)?;
     let session_ids = resolve_send_targets_in_state(state, target).await;
     if session_ids.is_empty() {
         return Err(ControlError::not_found(format!(
@@ -630,9 +634,14 @@ async fn deliver_message_to_target(
     for info in target_infos {
         match senders.get(&info.uuid).and_then(Clone::clone) {
             Some(tx) => {
-                let outbound_message =
-                    message_with_origin(state, message, origin, info.status == "action_required")
-                        .await;
+                let outbound_message = message_with_origin(
+                    state,
+                    message,
+                    input_mode,
+                    origin,
+                    info.status == "action_required",
+                )
+                .await;
                 let result = match wait_for_terminal_ready_for_control_send(state, &info).await {
                     Ok(()) => {
                         crate::utils::terminal_input::submit_prompt_chunks_via_sender(
@@ -653,6 +662,7 @@ async fn deliver_message_to_target(
                             provider: info.provider,
                             runtime_state: "live_pty_available".to_string(),
                             delivery_state: "submitted".to_string(),
+                            input_mode,
                             error: None,
                         };
                         delivered_session_ids.push(detail.uuid.clone());
@@ -666,6 +676,7 @@ async fn deliver_message_to_target(
                             "live_pty_available",
                             "send_failed",
                             error,
+                            input_mode,
                         );
                         record_delivery_attempt(state, &detail).await;
                         delivery.push(detail);
@@ -684,6 +695,7 @@ async fn deliver_message_to_target(
                     runtime_state,
                     "no_input_channel",
                     "missing sender",
+                    input_mode,
                 );
                 record_delivery_attempt(state, &detail).await;
                 delivery.push(detail);
@@ -714,9 +726,14 @@ async fn deliver_message_to_target(
 async fn message_with_origin(
     state: &AppState,
     message: &str,
+    input_mode: MessageInputMode,
     origin: Option<&MessageOrigin>,
     allow_bare_approval_response: bool,
 ) -> String {
+    if input_mode == MessageInputMode::Command {
+        return message.to_string();
+    }
+
     if allow_bare_approval_response && is_bare_approval_response(message) {
         return message.to_string();
     }
@@ -1214,6 +1231,23 @@ fn validate_send_message_thread(thread: Option<&str>) -> Result<(), ControlError
     Ok(())
 }
 
+fn validate_send_message_options(
+    target: &str,
+    thread: Option<&str>,
+    input_mode: MessageInputMode,
+) -> Result<(), ControlError> {
+    validate_send_message_thread(thread)?;
+
+    if input_mode == MessageInputMode::Command && (target == "all" || target.starts_with("class:"))
+    {
+        return Err(ControlError::not_supported(
+            "--as-command requires a single agent name or uuid",
+        ));
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Clone)]
 struct DeliveryTargetInfo {
     uuid: String,
@@ -1256,6 +1290,7 @@ fn failed_delivery_detail(
     runtime_state: &str,
     error_code: &str,
     error_message: impl Into<String>,
+    input_mode: MessageInputMode,
 ) -> DeliveryDetail {
     DeliveryDetail {
         uuid: info.uuid,
@@ -1263,6 +1298,7 @@ fn failed_delivery_detail(
         provider: info.provider,
         runtime_state: runtime_state.to_string(),
         delivery_state: "failed".to_string(),
+        input_mode,
         error: Some(DeliveryErrorDetail {
             code: error_code.to_string(),
             message: error_message.into(),
@@ -1658,9 +1694,17 @@ mod tests {
             .unwrap()
             .insert("agent-1".to_string(), tx);
 
-        deliver_message_to_target(None, &state, "OpenCodeOne", "hello", None, None)
-            .await
-            .unwrap();
+        deliver_message_to_target(
+            None,
+            &state,
+            "OpenCodeOne",
+            "hello",
+            None,
+            MessageInputMode::Message,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
         assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
@@ -1871,9 +1915,17 @@ mod tests {
             .unwrap()
             .insert("agent-1".to_string(), tx);
 
-        deliver_message_to_target(None, &state, "CoderOne", "hello", None, None)
-            .await
-            .unwrap();
+        deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "hello",
+            None,
+            MessageInputMode::Message,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
         assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
@@ -1903,6 +1955,7 @@ mod tests {
             "CoderOne",
             "check this",
             None,
+            MessageInputMode::Message,
             Some(&wardian_core::control::MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -1915,6 +1968,51 @@ mod tests {
             b"From PlannerOne: check this".to_vec()
         );
         assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+    }
+
+    #[tokio::test]
+    async fn command_delivery_keeps_origin_unattributed_and_records_input_mode() {
+        let state = AppState::new();
+        insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let delivery = deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "/goal test",
+            None,
+            MessageInputMode::Command,
+            Some(&wardian_core::control::MessageOrigin::WardianAgent {
+                session_id: "source-1".to_string(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(rx.recv().await.unwrap(), b"/goal test".to_vec());
+        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+        assert_eq!(delivery[0].input_mode, MessageInputMode::Command);
+    }
+
+    #[test]
+    fn command_delivery_rejects_multi_target_selectors() {
+        let all =
+            validate_send_message_options("all", None, MessageInputMode::Command).unwrap_err();
+        let class = validate_send_message_options("class:Coder", None, MessageInputMode::Command)
+            .unwrap_err();
+
+        assert_eq!(all.code(), "not_supported");
+        assert_eq!(class.code(), "not_supported");
+        assert!(all
+            .to_string()
+            .contains("--as-command requires a single agent name or uuid"));
     }
 
     #[tokio::test]
@@ -1940,6 +2038,7 @@ mod tests {
             "CoderOne",
             "y",
             None,
+            MessageInputMode::Message,
             Some(&wardian_core::control::MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -1974,6 +2073,7 @@ mod tests {
             "CoderOne",
             "yes",
             None,
+            MessageInputMode::Message,
             Some(&wardian_core::control::MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -1989,9 +2089,17 @@ mod tests {
     async fn message_delivery_reports_missing_target_as_not_found() {
         let state = AppState::new();
 
-        let error = deliver_message_to_target(None, &state, "ghost", "hello", None, None)
-            .await
-            .unwrap_err();
+        let error = deliver_message_to_target(
+            None,
+            &state,
+            "ghost",
+            "hello",
+            None,
+            MessageInputMode::Message,
+            None,
+        )
+        .await
+        .unwrap_err();
 
         assert_eq!(error.code(), "not_found");
         assert!(error
@@ -2004,9 +2112,17 @@ mod tests {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
 
-        let error = deliver_message_to_target(None, &state, "agent-1", "hello", None, None)
-            .await
-            .unwrap_err();
+        let error = deliver_message_to_target(
+            None,
+            &state,
+            "agent-1",
+            "hello",
+            None,
+            MessageInputMode::Message,
+            None,
+        )
+        .await
+        .unwrap_err();
 
         assert_eq!(error.code(), "request_failed");
         assert!(error.to_string().contains("agent-1: no input channel"));
@@ -2032,9 +2148,17 @@ mod tests {
             .unwrap()
             .insert("agent-1".to_string(), tx);
 
-        let error = deliver_message_to_target(None, &state, "class:Coder", "hello", None, None)
-            .await
-            .unwrap_err();
+        let error = deliver_message_to_target(
+            None,
+            &state,
+            "class:Coder",
+            "hello",
+            None,
+            MessageInputMode::Message,
+            None,
+        )
+        .await
+        .unwrap_err();
 
         assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
         assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
@@ -2064,9 +2188,17 @@ mod tests {
             .unwrap()
             .insert("agent-1".to_string(), tx);
 
-        deliver_message_to_target(None, &state, "CoderOne", "hello", None, None)
-            .await
-            .unwrap();
+        deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "hello",
+            None,
+            MessageInputMode::Message,
+            None,
+        )
+        .await
+        .unwrap();
 
         assert!(rx.recv().await.is_some());
         let agents = state.agents.lock().await;


### PR DESCRIPTION
## Description
Adds an explicit `wardian send --as-command` mode for provider slash commands. Command sends keep the existing provider-aware submit path, but skip Wardian's `From <sender>:` attribution so `/goal`, `/status`, and similar commands remain the first input token.

The default `wardian send` behavior remains attributed. `--as-command` is limited to one explicit agent name or UUID, rejects `all`, `class:<ClassName>`, and `--thread` with `not_supported`, and exposes `input_mode: "command"` in CLI/control delivery output.

## Related Issues
Fixes #228

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `cargo test -p wardian-cli send_as_command`
- `cargo test -p wardian-core send_message`
- `cd src-tauri && cargo test command_delivery`
- `cargo test -p wardian-cli`
- `cargo test -p wardian-core`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- `rustfmt --edition 2021 --check crates/wardian-cli/src/args.rs crates/wardian-cli/src/live.rs crates/wardian-cli/src/main.rs crates/wardian-cli/tests/send_cli.rs crates/wardian-core/src/control.rs src-tauri/src/control.rs`
- `git diff --check`
- Secrets scan over changed files: no matches for API key, token, password, secret, or PEM markers

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable