### PR TITLE
ci: move backend coverage to linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   backend-windows:
-    name: Backend (Windows - Full Test)
+    name: Backend (Windows - Lint, Test & Check)
     runs-on: windows-latest
     if: github.event_name == 'pull_request'
     steps:
@@ -74,25 +74,15 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
       - name: Clippy
         working-directory: src-tauri
         run: cargo clippy -- -D warnings
-      - name: Test with Coverage
+      - name: Test
         working-directory: src-tauri
-        run: |
-          mkdir -p ../coverage
-          cargo llvm-cov --lcov --output-path ../coverage/rust-lcov.info
-      - name: Upload Backend Coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage/rust-lcov.info
-          flags: backend
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
+        run: cargo test
+      - name: Check Compilation
+        working-directory: src-tauri
+        run: cargo check
 
   e2e-smoke:
     name: E2E Smoke Tests (Windows)
@@ -126,8 +116,8 @@ jobs:
           name: e2e-results
           path: e2e/test-results/
 
-  backend-linux-check:
-    name: Backend (Linux - Compile Check)
+  backend-linux-coverage:
+    name: Backend (Linux - Test & Coverage)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
@@ -144,10 +134,25 @@ jobs:
           echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
-      - name: Check Compilation
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Test with Coverage
         working-directory: src-tauri
-        run: cargo check
+        run: |
+          mkdir -p ../coverage
+          cargo llvm-cov --lcov --output-path ../coverage/rust-lcov.info
+      - name: Upload Backend Coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage/rust-lcov.info
+          flags: backend
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -1103,16 +1103,17 @@ mod tests {
 
         assert_eq!(spec.executable, "C:/Program Files/Git/bin/bash.exe");
         assert_eq!(spec.args[0], "-lc");
+        assert_eq!(spec.args[1], "exec \"$@\"");
+        assert_eq!(spec.args[2], "wardian-shell");
         if cfg!(windows) {
-            assert_eq!(spec.args[1], "exec \"$@\"");
-            assert_eq!(spec.args[2], "wardian-shell");
             assert_eq!(spec.args[3], "cmd.exe");
             assert_eq!(spec.args[4], "/d");
             assert_eq!(spec.args[5], "/c");
             assert_eq!(spec.args[6], "claude.cmd");
             assert_eq!(spec.args[7], "--verbose");
         } else {
-            assert!(spec.args[1].starts_with("exec 'claude.cmd'"));
+            assert_eq!(spec.args[3], "claude.cmd");
+            assert_eq!(spec.args[4], "--verbose");
         }
     }
 


### PR DESCRIPTION
## Description
Recreates the intent of PR #147 cleanly against current `origin/main` to speed up backend PR feedback.

This splits backend PR responsibilities by runner:
- Windows backend CI keeps correctness coverage with `cargo clippy -- -D warnings`, plain `cargo test`, and `cargo check`.
- Windows no longer installs or runs `cargo llvm-cov`, avoiding coverage instrumentation and duplicate full recompiles on `windows-latest`.
- Linux backend CI now owns `cargo llvm-cov` and uploads `coverage/rust-lcov.info` to Codecov using the existing `backend` flag.

Follow-up after CI:
- The first PR run exposed a stale Linux test assertion in `utils::shell::tests::windows_cmd_shims_are_wrapped_for_posix_hosts` because Linux now runs Rust tests for coverage instead of only `cargo check`.
- The test expectation now matches the existing positional-forwarding behavior for POSIX shells; no production launch behavior changed.

Reviewer results:
- Initial CI workflow review: Wardian-Reviewer found no Critical, Important, or Minor issues and assessed the workflow split as production-ready.
- Incremental CI-failure fix review: Wardian-Reviewer found no issues and assessed the test-only fix as production-ready.

## Related Issues
Fixes #254

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] CI / workflow maintenance

## How Has This Been Tested?
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text()); print('YAML_OK')"` -> `YAML_OK`
- `git diff --check`
- `npm run check:frontend-screenshot -- origin/main HEAD` -> no frontend changes detected; screenshot evidence is not required
- `$env:CARGO_TARGET_DIR = "$env:TEMP\wardian-ci-fast-target"; cargo test -p Wardian --lib utils::shell::tests::windows_cmd_shims_are_wrapped_for_posix_hosts -- --nocapture` -> passed
- `$env:CARGO_TARGET_DIR = "$env:TEMP\wardian-ci-fast-target"; cargo test -p Wardian --lib` -> 431 passed
- `$env:CARGO_TARGET_DIR = "$env:TEMP\wardian-ci-fast-target"; cargo check` -> passed
- `$env:CARGO_TARGET_DIR = "$env:TEMP\wardian-ci-fast-target"; cargo clippy -- -D warnings` -> passed
- Checked for local workflow validation tooling/actionlint; none was available locally
- Manual workflow inspection of the backend Windows/Linux job split
- Wardian-Reviewer review of `origin/main..HEAD` and the incremental CI-failure fix
- GitHub Actions rerun on this PR:
  - Backend (Linux - Test & Coverage) -> passed in 6m14s
  - Backend (Windows - Lint, Test & Check) -> passed in 10m18s
  - Frontend (Lint & Test) -> passed
  - Security & Dependency Audit -> passed
  - `codecov/patch` -> passed

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable