### PR TITLE
fix(release): sync Rust workspace versions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,46 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        with:
+          fetch-depth: 0
+      - name: Sync release PR Cargo lockfile
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          release_branch="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state open \
+              --base main \
+              --label "autorelease: pending" \
+              --json headRefName \
+              --jq '.[0].headRefName'
+          )"
+
+          if [ -z "$release_branch" ] || [ "$release_branch" = "null" ]; then
+            echo "No pending Release Please PR branch found."
+            exit 1
+          fi
+
+          git fetch origin "$release_branch"
+          git checkout -B "$release_branch" "origin/$release_branch"
+          cargo metadata --format-version 1 --no-deps > /dev/null
+
+          if git diff --quiet -- Cargo.lock; then
+            echo "Cargo.lock already matches release manifests."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git commit -m "chore: sync release Cargo.lock"
+          git push origin "HEAD:$release_branch"
       - name: Dispatch asset build
         if: ${{ steps.release.outputs.release_created == 'true' }}
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Wardian"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "wardian-cli"
-version = "0.3.3"
+version = "0.3.5"
 dependencies = [
  "clap",
  "rusqlite",
@@ -5002,7 +5002,7 @@ dependencies = [
 
 [[package]]
 name = "wardian-core"
-version = "0.3.3"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.5"
 edition = "2021"
 authors = ["Tan Gemicioglu"]
 license = "MIT"

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -16,6 +16,28 @@ use wardian_core::models::WorkflowDefinition;
 const CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
 const CONTROL_MUTATION_TIMEOUT: Duration = Duration::from_secs(30);
 
+struct AgentWatchRequest<'a> {
+    target: &'a str,
+    since: Option<&'a str>,
+    until: Option<&'a str>,
+    include: Vec<String>,
+    tail_bytes: Option<usize>,
+    follow: bool,
+    timeout: Duration,
+    output_echo_guard: Option<&'a str>,
+}
+
+struct SendAndWatchRequest<'a> {
+    target: &'a str,
+    message: &'a str,
+    thread: Option<&'a str>,
+    input_mode: MessageInputMode,
+    condition: &'a str,
+    tail_bytes: Option<usize>,
+    timeout: Duration,
+    output_echo_guard: Option<&'a str>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ControlOperation {
     AgentList,
@@ -430,38 +452,38 @@ pub fn agent_watch(
     follow: bool,
     timeout: Duration,
 ) -> io::Result<AgentWatchResponse> {
-    agent_watch_with_output_echo_guard(
-        target, since, until, include, tail_bytes, follow, timeout, None,
-    )
+    agent_watch_with_output_echo_guard(AgentWatchRequest {
+        target,
+        since,
+        until,
+        include,
+        tail_bytes,
+        follow,
+        timeout,
+        output_echo_guard: None,
+    })
 }
 
 fn agent_watch_with_output_echo_guard(
-    target: &str,
-    since: Option<&str>,
-    until: Option<&str>,
-    include: Vec<String>,
-    tail_bytes: Option<usize>,
-    follow: bool,
-    timeout: Duration,
-    output_echo_guard: Option<&str>,
+    request: AgentWatchRequest<'_>,
 ) -> io::Result<AgentWatchResponse> {
     let runtime = build_runtime()?;
     let value = timeout_block(
         &runtime,
         ControlOperation::AgentWatch {
-            requested: timeout,
-            target: target.to_string(),
-            until: until.unwrap_or("snapshot").to_string(),
+            requested: request.timeout,
+            target: request.target.to_string(),
+            until: request.until.unwrap_or("snapshot").to_string(),
         },
         send_request(ControlRequest::AgentWatch {
-            target: target.to_string(),
-            since: since.map(str::to_string),
-            until: until.map(str::to_string),
-            include,
-            tail_bytes,
-            follow,
-            timeout_ms: Some(timeout.as_millis().try_into().unwrap_or(u64::MAX)),
-            output_echo_guard: output_echo_guard.map(str::to_string),
+            target: request.target.to_string(),
+            since: request.since.map(str::to_string),
+            until: request.until.map(str::to_string),
+            include: request.include,
+            tail_bytes: request.tail_bytes,
+            follow: request.follow,
+            timeout_ms: Some(request.timeout.as_millis().try_into().unwrap_or(u64::MAX)),
+            output_echo_guard: request.output_echo_guard.map(str::to_string),
         }),
     )?;
     serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
@@ -522,16 +544,16 @@ pub fn ask_agent(
     if condition == "reply" {
         return ask_agent_structured(target, message, thread, tail_bytes, timeout);
     }
-    send_message_and_watch_condition_with_output_echo_guard(
+    send_message_and_watch_condition_with_output_echo_guard(SendAndWatchRequest {
         target,
         message,
         thread,
-        MessageInputMode::Message,
+        input_mode: MessageInputMode::Message,
         condition,
         tail_bytes,
         timeout,
-        ask_prompt_echo_guard(condition, message),
-    )
+        output_echo_guard: ask_prompt_echo_guard(condition, message),
+    })
 }
 
 fn ask_agent_structured(
@@ -576,23 +598,23 @@ pub fn send_message_and_watch_condition(
     tail_bytes: Option<usize>,
     timeout: Duration,
 ) -> io::Result<AskAgentResponse> {
-    send_message_and_watch_condition_with_output_echo_guard(
-        target, message, thread, input_mode, condition, tail_bytes, timeout, None,
-    )
+    send_message_and_watch_condition_with_output_echo_guard(SendAndWatchRequest {
+        target,
+        message,
+        thread,
+        input_mode,
+        condition,
+        tail_bytes,
+        timeout,
+        output_echo_guard: None,
+    })
 }
 
 fn send_message_and_watch_condition_with_output_echo_guard(
-    target: &str,
-    message: &str,
-    thread: Option<&str>,
-    input_mode: MessageInputMode,
-    condition: &str,
-    tail_bytes: Option<usize>,
-    timeout: Duration,
-    output_echo_guard: Option<&str>,
+    request: SendAndWatchRequest<'_>,
 ) -> io::Result<AskAgentResponse> {
     let initial = agent_watch(
-        target,
+        request.target,
         None,
         None,
         vec![
@@ -600,25 +622,30 @@ fn send_message_and_watch_condition_with_output_echo_guard(
             "output".to_string(),
             "delivery".to_string(),
         ],
-        tail_bytes.or(Some(4096)),
+        request.tail_bytes.or(Some(4096)),
         false,
         Duration::from_secs(5),
     )?;
-    let sent = send_message_with_input_mode(target, message, thread, input_mode)?;
-    let watch = agent_watch_with_output_echo_guard(
-        target,
-        Some(&initial.cursor),
-        Some(condition),
-        vec![
+    let sent = send_message_with_input_mode(
+        request.target,
+        request.message,
+        request.thread,
+        request.input_mode,
+    )?;
+    let watch = agent_watch_with_output_echo_guard(AgentWatchRequest {
+        target: request.target,
+        since: Some(&initial.cursor),
+        until: Some(request.condition),
+        include: vec![
             "status".to_string(),
             "output".to_string(),
             "delivery".to_string(),
         ],
-        tail_bytes,
-        false,
-        timeout,
-        output_echo_guard,
-    )?;
+        tail_bytes: request.tail_bytes,
+        follow: false,
+        timeout: request.timeout,
+        output_echo_guard: request.output_echo_guard,
+    })?;
     Ok(AskAgentResponse {
         request_id: None,
         reply: None,

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -531,9 +531,8 @@ fn validate_send_command_thread(thread: Option<&str>) -> Result<(), CliError> {
 }
 
 fn normalize_ask_condition(until: &str) -> Result<String, CliError> {
-    if until == "reply" {
-        Ok(until.to_string())
-    } else if until.starts_with("status:")
+    if until == "reply"
+        || until.starts_with("status:")
         || until.starts_with("output:")
         || until.starts_with("event:")
         || until.starts_with("delivery:")

--- a/docs/specs/021-release-system.md
+++ b/docs/specs/021-release-system.md
@@ -18,7 +18,7 @@ The system must also be forward-compatible with a planned CLI companion (`wardia
 
 **In scope:**
 
-- Synchronized version bumps across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`.
+- Synchronized version bumps across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and the root `Cargo.toml` workspace package version used by `wardian-core` and `wardian-cli`.
 - Automated CHANGELOG.md generation from Conventional Commits, via release-please.
 - GitHub Actions workflow that builds unsigned multi-OS bundles on tag push and publishes them to a GitHub Release.
 - Stable and Preview release channels, both manually cut.
@@ -37,7 +37,8 @@ The system must also be forward-compatible with a planned CLI companion (`wardia
 
 **Files introduced at repo root:**
 
-- `release-please-config.json` — configures Wardian as a single-package manifest release, enables CHANGELOG generation with Keep-a-Changelog section taxonomy (Features, Bug Fixes, Performance, Documentation, Miscellaneous), and uses `extra-files` to keep `src-tauri/tauri.conf.json` and `src-tauri/Cargo.toml` in sync with `package.json`.
+- `release-please-config.json` — configures Wardian as a single-package manifest release, enables CHANGELOG generation with Keep-a-Changelog section taxonomy (Features, Bug Fixes, Performance, Documentation, Miscellaneous), and uses `extra-files` to keep `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and the root Rust workspace version in sync with `package.json`.
+- `.github/workflows/release-please.yml` — after Release Please creates or updates the release PR, the workflow checks out the pending release branch, runs `cargo metadata --format-version 1 --no-deps`, and commits `Cargo.lock` if Cargo regenerated local workspace crate versions.
 - `.release-please-manifest.json` — tracks the current version (`0.2.1`).
 - `CHANGELOG.md` — Keep-a-Changelog format, seeded with the `[0.2.1]` entry so release-please has a known anchor.
 
@@ -112,7 +113,7 @@ The Tauri bundle configuration (`src-tauri/tauri.conf.json` → `bundle.resource
 ### Testing & Rollout Plan
 
 1. **Dry-run build** via `workflow_dispatch` on `feat/release-system` branch. Download each artifact, install on each host OS, confirm the app launches and basic UI renders.
-2. **Dry-run release-please** by merging synthetic `feat:` and `fix:` commits and observing the Release PR output. Verify all three version files bump together and CHANGELOG renders as expected.
+2. **Dry-run release-please** by merging synthetic `feat:` and `fix:` commits and observing the Release PR output. Verify the frontend package, Tauri app, and Rust workspace version files bump together and CHANGELOG renders as expected.
 3. **First real release**: cut `v0.2.2` from the next trivial patch to validate the tag-triggered build + publish path with low stakes.
 4. **First preview release**: cut `v0.3.0-preview.1` shortly after to validate the prerelease marking path.
 
@@ -129,7 +130,7 @@ The Tauri bundle configuration (`src-tauri/tauri.conf.json` → `bundle.resource
 ## Consequences
 
 - **Positive:** users can download installable Wardian builds from GitHub Releases on all three major OSes without cloning the repo.
-- **Positive:** versions cannot drift across `package.json`, `tauri.conf.json`, and `Cargo.toml` — release-please syncs all three.
+- **Positive:** versions cannot drift across `package.json`, `tauri.conf.json`, the Tauri crate manifest, and the root Rust workspace manifest — release-please syncs all release-bearing manifests.
 - **Positive:** CHANGELOG stays curated with minimal maintainer effort; commit discipline (Conventional Commits) is the only ongoing cost.
 - **Positive:** pipeline is sized to accept code signing, auto-updates, OS package managers, and the CLI without restructuring.
 - **Negative:** Windows users see a SmartScreen warning on first install; macOS users must right-click → Open or `xattr -cr` the app. Acceptable for a 0.x developer-audience project, unacceptable long-term.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,6 +31,11 @@
           "type": "toml",
           "path": "src-tauri/Cargo.toml",
           "jsonpath": "$.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
         }
       ]
     }

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -18,6 +18,22 @@ describe("release workflow contract", () => {
     expect(releasePleaseWorkflow).toContain("steps.release.outputs.tag_name");
   });
 
+  it("keeps Rust workspace crate versions in the Release Please bump set", () => {
+    expect(releasePleaseConfig.packages["."]["extra-files"]).toContainEqual({
+      type: "toml",
+      path: "Cargo.toml",
+      jsonpath: "$.workspace.package.version",
+    });
+    expect(releasePleaseWorkflow).toContain("Sync release PR Cargo lockfile");
+    expect(releasePleaseWorkflow).toContain("steps.release.outputs.prs_created == 'true'");
+    expect(releasePleaseWorkflow).toContain("actions/checkout@v4");
+    expect(releasePleaseWorkflow).toContain("fetch-depth: 0");
+    expect(releasePleaseWorkflow).toContain("--label \"autorelease: pending\"");
+    expect(releasePleaseWorkflow).toContain("cargo metadata --format-version 1 --no-deps");
+    expect(releasePleaseWorkflow).toContain("git add Cargo.lock");
+    expect(releasePleaseWorkflow).toContain("chore: sync release Cargo.lock");
+  });
+
   it("keeps the artifact release workflow responsible for tag releases", () => {
     expect(releaseWorkflow).toContain("tags:");
     expect(releaseWorkflow).toContain('- "v*"');


### PR DESCRIPTION
## Description
- Adds the root Rust workspace version to Release Please so `wardian-core` and `wardian-cli` inherit the released app version.
- Updates the Release Please workflow to refresh and commit `Cargo.lock` on the pending release PR branch after version bumps.
- Updates release docs and adds a release workflow contract test; also cleans up existing wardian-cli clippy warnings so `cargo clippy -- -D warnings` is green.

## Related Issues
Fixes #260

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test` (555 passed; existing React `act(...)` warnings still print)
- [x] `npm run build` (passes; existing Vite large-chunk warning still prints)
- [x] `cargo check`
- [x] `cargo metadata --locked --format-version 1 --no-deps`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `git diff --check` (no whitespace errors; Git warns `Cargo.lock` will be converted LF to CRLF on next touch)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable