### PR TITLE
fix(gemini): align manual session lifecycle

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -736,12 +736,16 @@ fn persisted_resume_session_for_provider(
     session_id: &str,
 ) -> Option<String> {
     actual_resume.or_else(|| {
-        if provider_name == "claude" && !session_id.trim().is_empty() {
+        if provider_uses_manual_session_id(provider_name) && !session_id.trim().is_empty() {
             Some(session_id.to_string())
         } else {
             None
         }
     })
+}
+
+fn provider_uses_manual_session_id(provider_name: &str) -> bool {
+    matches!(provider_name, "claude" | "gemini")
 }
 
 fn provider_uses_generated_session_id(provider_name: &str) -> bool {
@@ -776,13 +780,27 @@ fn promote_fresh_provider_session_after_resume(
     provider: &str,
     new_active: &mut crate::state::ActiveAgent,
 ) {
-    if provider != "claude" {
+    if !provider_uses_manual_session_id(provider) {
         return;
     }
 
-    let mut new_config = new_active.config.lock().unwrap();
-    if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take() {
-        new_config.resume_session = Some(fresh_provider_session_id);
+    let promoted = {
+        let mut new_config = new_active.config.lock().unwrap();
+        if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take() {
+            new_config.resume_session = Some(fresh_provider_session_id);
+            true
+        } else {
+            false
+        }
+    };
+
+    if promoted {
+        if let Ok(mut log_path) = new_active.log_path.lock() {
+            *log_path = None;
+        }
+        if let Ok(mut log_last_modified) = new_active.log_last_modified.lock() {
+            *log_last_modified = None;
+        }
     }
 }
 
@@ -1239,7 +1257,7 @@ fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
     config.fresh_provider_session_id = None;
     if resolved_persistence == AgentSessionPersistence::Fresh {
         config.resume_session = None;
-        if config.provider == "claude" {
+        if provider_uses_manual_session_id(&config.provider) {
             config.fresh_provider_session_id = Some(uuid::Uuid::new_v4().to_string());
         }
         return Ok(());
@@ -1287,7 +1305,7 @@ fn prepare_resume_config(config: &mut AgentConfig) -> Result<(), String> {
     if config.resume_session.is_none() {
         let should_fallback = match config.provider.as_str() {
             "opencode" => config.session_id.starts_with("ses_"),
-            "codex" | "gemini" => false,
+            "codex" => false,
             _ => true,
         };
         if should_fallback {
@@ -1303,7 +1321,7 @@ fn prepare_clear_config(config: &mut AgentConfig) -> Result<(), String> {
     config.resume_session = None;
     config.fresh_provider_session_id = None;
     clear_codex_cleared_provider_sessions(config);
-    if config.provider == "claude" {
+    if provider_uses_manual_session_id(&config.provider) {
         config.fresh_provider_session_id = Some(uuid::Uuid::new_v4().to_string());
     }
     Ok(())
@@ -2074,7 +2092,7 @@ pub async fn clear_agent_session(
         {
             let mut new_config = new_active.config.lock().unwrap();
             let mut old_config = agent.config.lock().unwrap();
-            if old_config.provider == "claude" {
+            if provider_uses_manual_session_id(&old_config.provider) {
                 if let Some(fresh_provider_session_id) = new_config.fresh_provider_session_id.take()
                 {
                     new_config.resume_session = Some(fresh_provider_session_id);
@@ -2618,7 +2636,6 @@ pub async fn reorder_agents(
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentOrderPlacement, CloneProfileCopyPlan, CloneProfileSelection,
         agent_status_update_payload, assign_worktree_config,
         build_agent_cli_command_for_session_id_with_shells, build_agent_cli_command_with_shells,
         build_agent_clone_preview, capture_opencode_pause_resume_session,
@@ -2637,13 +2654,16 @@ mod tests {
         provider_uses_generated_session_id, reserve_spawn_session_name,
         resolve_agent_worktree_branch_name, resolve_agent_worktree_path,
         resolve_requested_spawn_session_name, restore_runtime_state_snapshot_after_resume,
-        sync_resumed_input_sender, terminal_cleared_payload,
+        sync_resumed_input_sender, terminal_cleared_payload, AgentOrderPlacement,
+        CloneProfileCopyPlan, CloneProfileSelection,
     };
+    use crate::providers::GeminiProvider;
     use crate::state::{ActiveAgent, AppState};
     use crate::utils::fs::create_directory_link;
     use crate::utils::{ShellOption, ShellSettings};
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
+    use wardian_core::models::provider::AgentProvider;
     use wardian_core::models::{
         AgentConfig, AgentSessionPersistenceOverride, ClaudeProviderConfig, CodexProviderConfig,
         DeployedSkillRef, GeminiProviderConfig, OpenCodeProviderConfig, ProviderConfig,
@@ -2899,13 +2919,11 @@ mod tests {
             preview.default_selected_files,
             vec!["AGENTS.md".to_string()]
         );
-        assert!(
-            preview
-                .files
-                .children
-                .iter()
-                .any(|node| node.path() == "notes.md")
-        );
+        assert!(preview
+            .files
+            .children
+            .iter()
+            .any(|node| node.path() == "notes.md"));
     }
 
     #[test]
@@ -3017,14 +3035,12 @@ mod tests {
         )
         .expect("permission log");
 
-        assert!(
-            clone_validate_selected_profile_files(
-                home,
-                "source-agent",
-                &["claude/permission-requests.jsonl".to_string()]
-            )
-            .is_err()
-        );
+        assert!(clone_validate_selected_profile_files(
+            home,
+            "source-agent",
+            &["claude/permission-requests.jsonl".to_string()]
+        )
+        .is_err());
     }
 
     #[test]
@@ -3081,22 +3097,18 @@ mod tests {
         std::fs::create_dir_all(&source).expect("source");
         std::fs::write(source.join("AGENTS.md"), "# Agent\n").expect("agents");
 
-        assert!(
-            clone_validate_selected_profile_files(
-                home,
-                "source-agent",
-                &["../secret.md".to_string()]
-            )
-            .is_err()
-        );
-        assert!(
-            clone_validate_selected_profile_files(
-                home,
-                "source-agent",
-                &["C:/secret.md".to_string()]
-            )
-            .is_err()
-        );
+        assert!(clone_validate_selected_profile_files(
+            home,
+            "source-agent",
+            &["../secret.md".to_string()]
+        )
+        .is_err());
+        assert!(clone_validate_selected_profile_files(
+            home,
+            "source-agent",
+            &["C:/secret.md".to_string()]
+        )
+        .is_err());
     }
 
     #[test]
@@ -3115,14 +3127,12 @@ mod tests {
             return;
         }
 
-        assert!(
-            clone_validate_selected_profile_files(
-                home,
-                "source-agent",
-                &["linked/secret.md".to_string()]
-            )
-            .is_err()
-        );
+        assert!(clone_validate_selected_profile_files(
+            home,
+            "source-agent",
+            &["linked/secret.md".to_string()]
+        )
+        .is_err());
     }
 
     #[test]
@@ -3164,17 +3174,14 @@ mod tests {
         )
         .expect("copy selected skills");
 
-        assert!(
-            temp.path()
-                .join("agents/dest-agent/.agents/skills/planner/SKILL.md")
-                .is_file()
-        );
-        assert!(
-            !temp
-                .path()
-                .join("agents/dest-agent/.agents/skills/ignored")
-                .exists()
-        );
+        assert!(temp
+            .path()
+            .join("agents/dest-agent/.agents/skills/planner/SKILL.md")
+            .is_file());
+        assert!(!temp
+            .path()
+            .join("agents/dest-agent/.agents/skills/ignored")
+            .exists());
     }
 
     #[test]
@@ -4018,12 +4025,10 @@ mod tests {
             "# Skill\n"
         );
         assert!(!dest.join("habitat").exists());
-        assert!(
-            !dest
-                .join("claude")
-                .join("permission-requests.jsonl")
-                .exists()
-        );
+        assert!(!dest
+            .join("claude")
+            .join("permission-requests.jsonl")
+            .exists());
     }
 
     #[test]
@@ -4144,26 +4149,30 @@ mod tests {
     }
 
     #[test]
-    fn claude_resume_promotes_fresh_provider_session_to_resume_session() {
+    fn manual_session_provider_resume_promotes_fresh_provider_session_to_resume_session() {
         let mut new_active = make_test_agent();
         {
             let mut config = new_active.config.lock().unwrap();
-            config.fresh_provider_session_id = Some("claude-fresh-session".to_string());
+            config.fresh_provider_session_id = Some("gemini-fresh-session".to_string());
             config.resume_session = None;
         }
+        *new_active.log_path.lock().unwrap() = Some(std::path::PathBuf::from("C:/tmp/old.jsonl"));
+        *new_active.log_last_modified.lock().unwrap() = Some(std::time::SystemTime::now());
 
-        promote_fresh_provider_session_after_resume("claude", &mut new_active);
+        promote_fresh_provider_session_after_resume("gemini", &mut new_active);
 
         let config = new_active.config.lock().unwrap();
         assert_eq!(
             config.resume_session.as_deref(),
-            Some("claude-fresh-session")
+            Some("gemini-fresh-session")
         );
         assert_eq!(config.fresh_provider_session_id, None);
+        assert_eq!(*new_active.log_path.lock().unwrap(), None);
+        assert_eq!(*new_active.log_last_modified.lock().unwrap(), None);
     }
 
     #[test]
-    fn non_claude_resume_keeps_fresh_provider_session_field() {
+    fn non_manual_session_provider_resume_keeps_fresh_provider_session_field() {
         let mut new_active = make_test_agent();
         {
             let mut config = new_active.config.lock().unwrap();
@@ -4308,7 +4317,15 @@ mod tests {
     }
 
     #[test]
-    fn non_claude_providers_leave_resume_session_unchanged() {
+    fn gemini_persists_resume_session_after_initial_spawn() {
+        assert_eq!(
+            persisted_resume_session_for_provider("gemini", None, "gemini-session-1"),
+            Some("gemini-session-1".to_string())
+        );
+    }
+
+    #[test]
+    fn non_manual_session_providers_leave_resume_session_unchanged() {
         assert_eq!(
             persisted_resume_session_for_provider("codex", None, "codex-session-1"),
             None
@@ -4386,6 +4403,24 @@ mod tests {
         prepare_resume_config(&mut config).expect("prepare resume config");
 
         assert_eq!(config.resume_session.as_deref(), Some("claude-session"));
+        assert!(!config.is_off);
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn gemini_resume_without_recorded_resume_session_uses_manual_session_id() {
+        let (_guard, _temp) = use_isolated_resume_setting();
+        let mut config = AgentConfig {
+            provider: "gemini".to_string(),
+            session_id: "gemini-session".to_string(),
+            resume_session: None,
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_resume_config(&mut config).expect("prepare resume config");
+
+        assert_eq!(config.resume_session.as_deref(), Some("gemini-session"));
         assert!(!config.is_off);
         std::env::remove_var("WARDIAN_HOME");
     }
@@ -4756,6 +4791,58 @@ mod tests {
     }
 
     #[test]
+    fn gemini_pause_resume_config_builds_resume_spawn_args() {
+        let (_guard, _temp) = use_isolated_resume_setting();
+        let mut config = AgentConfig {
+            provider: "gemini".to_string(),
+            session_id: "gemini-session".to_string(),
+            resume_session: None,
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_resume_config(&mut config).expect("prepare resume config");
+
+        assert_eq!(config.resume_session.as_deref(), Some("gemini-session"));
+        let args = GeminiProvider::new().get_spawn_args(&config, true);
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(args.contains(&"gemini-session".to_string()));
+        assert!(!args.contains(&"--session-id".to_string()));
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn gemini_fresh_resume_uses_new_provider_session_without_changing_wardian_id() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::env::set_var("WARDIAN_HOME", temp.path());
+        crate::utils::save_shell_settings(&crate::utils::ShellSettings {
+            agent_session_persistence: wardian_core::models::AgentSessionPersistence::Fresh,
+            ..Default::default()
+        })
+        .expect("save shell settings");
+
+        let mut config = AgentConfig {
+            provider: "gemini".to_string(),
+            session_id: "wardian-agent-id".to_string(),
+            resume_session: Some("old-gemini-session".to_string()),
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_resume_config(&mut config).expect("prepare resume config");
+
+        assert_eq!(config.session_id, "wardian-agent-id");
+        assert_eq!(config.resume_session, None);
+        assert_ne!(
+            config.fresh_provider_session_id.as_deref(),
+            Some("wardian-agent-id")
+        );
+        assert!(config.fresh_provider_session_id.is_some());
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
     fn prepare_clear_config_forces_fresh_resume_and_clears_runtime_fields() {
         let mut config = AgentConfig {
             provider: "claude".to_string(),
@@ -4797,6 +4884,7 @@ mod tests {
         assert_eq!(config.gemini_config().sandbox, Some(true));
         assert!(matches!(config.provider_config, ProviderConfig::Gemini(_)));
         assert_eq!(config.resume_session, None);
+        assert!(config.fresh_provider_session_id.is_some());
         assert!(!config.is_off);
     }
 }

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -24,6 +24,141 @@ fn bytes_to_mib(bytes: u64) -> f64 {
     bytes as f64 / 1_048_576.0
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct GeminiLogMetrics {
+    query_count: usize,
+    init_timestamp: Option<String>,
+    status: Option<&'static str>,
+}
+
+fn gemini_message_kind(value: &serde_json::Value) -> Option<&str> {
+    value
+        .get("type")
+        .and_then(|v| v.as_str())
+        .or_else(|| value.get("role").and_then(|v| v.as_str()))
+}
+
+fn gemini_status_from_last_kind(kind: Option<&str>) -> Option<&'static str> {
+    match kind {
+        Some("user") => Some("Processing..."),
+        Some("gemini") | Some("assistant") | Some("model") => Some("Idle"),
+        _ => None,
+    }
+}
+
+fn gemini_jsonl_completed_message(value: &serde_json::Value) -> bool {
+    value.get("tokens").is_some()
+        || value.get("usage").is_some()
+        || value.get("finishReason").is_some()
+        || value.get("finish_reason").is_some()
+}
+
+fn gemini_jsonl_record_status(value: &serde_json::Value) -> Option<&'static str> {
+    match gemini_message_kind(value) {
+        Some("user") => Some("Processing..."),
+        Some("result") => Some("Idle"),
+        Some("gemini") | Some("assistant") | Some("model")
+            if gemini_jsonl_completed_message(value) =>
+        {
+            Some("Idle")
+        }
+        _ => None,
+    }
+}
+
+fn gemini_log_matches_session(content: &str, target_id: &str) -> bool {
+    let target_id = target_id.trim();
+    if target_id.is_empty() {
+        return false;
+    }
+
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(content) {
+        if parsed.get("sessionId").and_then(|v| v.as_str()) == Some(target_id) {
+            return true;
+        }
+    }
+
+    content.lines().any(|line| {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+        serde_json::from_str::<serde_json::Value>(trimmed)
+            .ok()
+            .is_some_and(|value| value.get("sessionId").and_then(|v| v.as_str()) == Some(target_id))
+    })
+}
+
+fn parse_gemini_log_metrics(content: &str) -> Option<GeminiLogMetrics> {
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(content) {
+        if let Some(messages) = parsed.get("messages").and_then(|v| v.as_array()) {
+            let query_count = messages
+                .iter()
+                .filter(|message| gemini_message_kind(message) == Some("user"))
+                .count();
+            let status =
+                gemini_status_from_last_kind(messages.last().and_then(gemini_message_kind));
+            return Some(GeminiLogMetrics {
+                query_count,
+                init_timestamp: parsed
+                    .get("startTime")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string),
+                status,
+            });
+        }
+    }
+
+    let mut query_count = 0usize;
+    let mut init_timestamp = None;
+    let mut status = None;
+    let mut saw_gemini_record = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+
+        if init_timestamp.is_none() {
+            init_timestamp = record
+                .get("startTime")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+        }
+
+        if let Some(kind) = gemini_message_kind(&record) {
+            match kind {
+                "user" => {
+                    query_count += 1;
+                    status = Some("Processing...");
+                    saw_gemini_record = true;
+                }
+                "gemini" | "assistant" | "model" | "result" => {
+                    if let Some(record_status) = gemini_jsonl_record_status(&record) {
+                        status = Some(record_status);
+                    }
+                    saw_gemini_record = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if !saw_gemini_record && init_timestamp.is_none() {
+        return None;
+    }
+
+    Some(GeminiLogMetrics {
+        query_count,
+        init_timestamp,
+        status,
+    })
+}
+
 struct AgentSnapshot {
     session_id: String,
     provider: String,
@@ -223,6 +358,21 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                 .as_deref()
                 .filter(|value| value.starts_with("ses_"))
                 .unwrap_or(&snap.session_id);
+            let gemini_session_id = snap.resume_session.as_deref().unwrap_or(&snap.session_id);
+
+            if snap.provider == "gemini" {
+                let stale_gemini_log = log_path_lock.as_ref().is_some_and(|path| {
+                    std::fs::read_to_string(path).ok().is_none_or(|content| {
+                        !gemini_log_matches_session(&content, gemini_session_id)
+                    })
+                });
+                if stale_gemini_log {
+                    *log_path_lock = None;
+                    if let Ok(mut last_modified) = snap.log_last_modified.lock() {
+                        *last_modified = None;
+                    }
+                }
+            }
 
             // Provider-aware log discovery
             if snap.provider == "opencode" {
@@ -301,21 +451,12 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                             if let Ok(content) =
                                                 std::fs::read_to_string(chat_file.path())
                                             {
-                                                if let Ok(p) =
-                                                    serde_json::from_str::<serde_json::Value>(
-                                                        &content,
-                                                    )
-                                                {
-                                                    let target_id = snap
-                                                        .resume_session
-                                                        .as_deref()
-                                                        .unwrap_or(&snap.session_id);
-                                                    if p.get("sessionId").and_then(|v| v.as_str())
-                                                        == Some(target_id)
-                                                    {
-                                                        *log_path_lock = Some(chat_file.path());
-                                                        break;
-                                                    }
+                                                if gemini_log_matches_session(
+                                                    &content,
+                                                    gemini_session_id,
+                                                ) {
+                                                    *log_path_lock = Some(chat_file.path());
+                                                    break;
                                                 }
                                             }
                                         }
@@ -455,46 +596,17 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                 set_snapshot_status_from_log(snap, &status, is_initial_log_replay);
                             }
                             _ => {
-                                // Gemini logs are a single JSON object with a messages array
-                                if let Ok(p) = serde_json::from_str::<serde_json::Value>(&content) {
-                                    if let Some(msgs) = p.get("messages").and_then(|v| v.as_array())
-                                    {
-                                        q_count = msgs
-                                            .iter()
-                                            .filter(|m| {
-                                                m.get("type").and_then(|v| v.as_str())
-                                                    == Some("user")
-                                                    || m.get("role").and_then(|v| v.as_str())
-                                                        == Some("user")
-                                            })
-                                            .count();
-
-                                        if let Some(last_msg) = msgs.last() {
-                                            let msg_type = last_msg
-                                                .get("type")
-                                                .and_then(|v| v.as_str())
-                                                .or_else(|| {
-                                                    last_msg.get("role").and_then(|v| v.as_str())
-                                                });
-                                            if msg_type == Some("user") {
-                                                set_snapshot_status_from_log(
-                                                    snap,
-                                                    "Processing...",
-                                                    is_initial_log_replay,
-                                                );
-                                            } else if msg_type == Some("gemini")
-                                                || msg_type == Some("assistant")
-                                            {
-                                                set_snapshot_status_from_log(
-                                                    snap,
-                                                    "Idle",
-                                                    is_initial_log_replay,
-                                                );
-                                            }
-                                        }
+                                if let Some(metrics) = parse_gemini_log_metrics(&content) {
+                                    q_count = metrics.query_count;
+                                    if let Some(status) = metrics.status {
+                                        set_snapshot_status_from_log(
+                                            snap,
+                                            status,
+                                            is_initial_log_replay,
+                                        );
                                     }
-                                    if let Some(st) = p.get("startTime").and_then(|v| v.as_str()) {
-                                        i_ts = Some(st.to_string());
+                                    if let Some(start_time) = metrics.init_timestamp {
+                                        i_ts = Some(start_time);
                                     }
                                 }
                             }
@@ -755,5 +867,130 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("idle")
         );
+    }
+
+    #[test]
+    fn gemini_log_matches_legacy_json_session_id() {
+        let content = r#"{
+          "sessionId": "gemini-session-1",
+          "messages": []
+        }"#;
+
+        assert!(super::gemini_log_matches_session(
+            content,
+            "gemini-session-1"
+        ));
+        assert!(!super::gemini_log_matches_session(content, "other-session"));
+    }
+
+    #[test]
+    fn gemini_log_matches_jsonl_metadata_session_id() {
+        let content = concat!(
+            r#"{"sessionId":"gemini-session-1","projectHash":"project","startTime":"2026-05-14T12:00:00.000Z"}"#,
+            "\n",
+            r#"{"id":"m1","timestamp":"2026-05-14T12:00:01.000Z","type":"user","content":"hello"}"#,
+            "\n"
+        );
+
+        assert!(super::gemini_log_matches_session(
+            content,
+            "gemini-session-1"
+        ));
+        assert!(!super::gemini_log_matches_session(content, "other-session"));
+    }
+
+    #[test]
+    fn gemini_log_metrics_parse_legacy_json() {
+        let content = r#"{
+          "sessionId": "gemini-session-1",
+          "startTime": "2026-05-14T12:00:00.000Z",
+          "messages": [
+            { "type": "user", "content": "hello" },
+            { "type": "gemini", "content": "hi" }
+          ]
+        }"#;
+
+        let metrics = super::parse_gemini_log_metrics(content).expect("metrics");
+
+        assert_eq!(metrics.query_count, 1);
+        assert_eq!(
+            metrics.init_timestamp.as_deref(),
+            Some("2026-05-14T12:00:00.000Z")
+        );
+        assert_eq!(metrics.status, Some("Idle"));
+    }
+
+    #[test]
+    fn gemini_log_metrics_parse_jsonl_completed_message_record() {
+        let content = concat!(
+            r#"{"sessionId":"gemini-session-1","projectHash":"project","startTime":"2026-05-14T12:00:00.000Z"}"#,
+            "\n",
+            r#"{"id":"m1","timestamp":"2026-05-14T12:00:01.000Z","type":"user","content":"hello"}"#,
+            "\n",
+            r#"{"$set":{"lastUpdated":"2026-05-14T12:00:02.000Z"}}"#,
+            "\n",
+            r#"{"id":"m2","timestamp":"2026-05-14T12:00:03.000Z","type":"gemini","content":"hi","tokens":{"input":10,"output":1,"total":11}}"#,
+            "\n"
+        );
+
+        let metrics = super::parse_gemini_log_metrics(content).expect("metrics");
+
+        assert_eq!(metrics.query_count, 1);
+        assert_eq!(
+            metrics.init_timestamp.as_deref(),
+            Some("2026-05-14T12:00:00.000Z")
+        );
+        assert_eq!(metrics.status, Some("Idle"));
+    }
+
+    #[test]
+    fn gemini_log_metrics_jsonl_model_chunk_without_completion_stays_processing() {
+        let content = concat!(
+            r#"{"sessionId":"gemini-session-1","projectHash":"project","startTime":"2026-05-14T12:00:00.000Z"}"#,
+            "\n",
+            r#"{"id":"m1","timestamp":"2026-05-14T12:00:01.000Z","type":"user","content":"hello"}"#,
+            "\n",
+            r#"{"id":"m2","timestamp":"2026-05-14T12:00:03.000Z","type":"model","content":"partial"}"#,
+            "\n"
+        );
+
+        let metrics = super::parse_gemini_log_metrics(content).expect("metrics");
+
+        assert_eq!(metrics.query_count, 1);
+        assert_eq!(metrics.status, Some("Processing..."));
+    }
+
+    #[test]
+    fn gemini_log_metrics_jsonl_result_marks_idle() {
+        let content = concat!(
+            r#"{"sessionId":"gemini-session-1","projectHash":"project","startTime":"2026-05-14T12:00:00.000Z"}"#,
+            "\n",
+            r#"{"id":"m1","timestamp":"2026-05-14T12:00:01.000Z","type":"user","content":"hello"}"#,
+            "\n",
+            r#"{"id":"m2","timestamp":"2026-05-14T12:00:03.000Z","type":"model","content":"partial"}"#,
+            "\n",
+            r#"{"type":"result"}"#,
+            "\n"
+        );
+
+        let metrics = super::parse_gemini_log_metrics(content).expect("metrics");
+
+        assert_eq!(metrics.query_count, 1);
+        assert_eq!(metrics.status, Some("Idle"));
+    }
+
+    #[test]
+    fn gemini_log_metrics_jsonl_last_user_is_processing() {
+        let content = concat!(
+            r#"{"sessionId":"gemini-session-1","projectHash":"project","startTime":"2026-05-14T12:00:00.000Z"}"#,
+            "\n",
+            r#"{"id":"m1","timestamp":"2026-05-14T12:00:01.000Z","type":"user","content":"hello"}"#,
+            "\n"
+        );
+
+        let metrics = super::parse_gemini_log_metrics(content).expect("metrics");
+
+        assert_eq!(metrics.query_count, 1);
+        assert_eq!(metrics.status, Some("Processing..."));
     }
 }

--- a/src-tauri/src/providers/gemini.rs
+++ b/src-tauri/src/providers/gemini.rs
@@ -173,6 +173,16 @@ impl AgentProvider for GeminiProvider {
         if is_resume && !resume_id.is_empty() {
             args.push("--resume".into());
             args.push(resume_id.to_string());
+        } else {
+            let session_id = config
+                .fresh_provider_session_id
+                .as_deref()
+                .unwrap_or(config.session_id.as_str())
+                .trim();
+            if !session_id.is_empty() {
+                args.push("--session-id".into());
+                args.push(session_id.to_string());
+            }
         }
 
         args
@@ -332,6 +342,53 @@ mod tests {
         let args_resume = p.get_spawn_args(&config, true);
         assert!(args_resume.contains(&"--resume".to_string()));
         assert!(args_resume.contains(&"session-abc".to_string()));
+    }
+
+    #[test]
+    fn fresh_spawn_uses_explicit_session_id() {
+        let p = make_provider();
+        let config = AgentConfig {
+            session_id: "wardian-session".into(),
+            ..Default::default()
+        };
+
+        let args = p.get_spawn_args(&config, false);
+
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(args.contains(&"wardian-session".to_string()));
+    }
+
+    #[test]
+    fn fresh_spawn_prefers_transient_provider_session_id() {
+        let p = make_provider();
+        let config = AgentConfig {
+            session_id: "wardian-session".into(),
+            fresh_provider_session_id: Some("fresh-gemini-session".into()),
+            ..Default::default()
+        };
+
+        let args = p.get_spawn_args(&config, false);
+
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(args.contains(&"fresh-gemini-session".to_string()));
+        assert!(!args.contains(&"wardian-session".to_string()));
+    }
+
+    #[test]
+    fn resume_spawn_omits_manual_session_id() {
+        let p = make_provider();
+        let config = AgentConfig {
+            session_id: "wardian-session".into(),
+            resume_session: Some("provider-session".into()),
+            ..Default::default()
+        };
+
+        let args = p.get_spawn_args(&config, true);
+
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(args.contains(&"provider-session".to_string()));
+        assert!(!args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"wardian-session".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Description
Align Gemini interactive agents with Wardian's manual session lifecycle:

- Fresh Gemini spawns now pass a deterministic `--session-id`, while resumed Gemini spawns use `--resume <session>` and omit fresh session ids.
- Gemini resume-session persistence now follows the same manual-session policy as Claude without changing codex/opencode behavior.
- Gemini telemetry now discovers/parses Gemini CLI 0.42 JSONL chat logs as well as legacy JSON logs, and revalidates cached Gemini log paths against the active provider session.
- Added regression coverage for Gemini spawn args, pause/resume config, fresh-session log clearing, and JSONL telemetry status parsing.

## Related Issues
Fixes #266

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Requested Wardian code review from `Wardian-Gemini-Review`; initial review found two Important issues, both fixed. Focused re-review reported no remaining Critical or Important blockers.
- `cd src-tauri && cargo test -p Wardian --lib commands::agent::tests::gemini` passed, 6 tests.
- `cd src-tauri && cargo test -p Wardian --lib manager::telemetry::tests::gemini_log_metrics` passed, 5 tests.
- `cd src-tauri && cargo test -p Wardian --lib providers::gemini::tests` passed, 25 tests.
- `cd src-tauri && cargo check` passed.
- `cd src-tauri && cargo clippy` passed with no warnings.
- `cd src-tauri && cargo test` passed, 463 lib tests + 6 mock provider e2e tests.
- `git diff --check -- src-tauri/src/commands/agent.rs src-tauri/src/manager/telemetry.rs src-tauri/src/providers/gemini.rs` passed.
- Secret scan on touched files found only literal test fixture names/fields (`secret.md`, `tokens`), no credentials.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, or none were needed for this backend fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable