### PR TITLE
Fix agent watch readable output defaults

### DIFF
--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -245,6 +245,8 @@ pub enum AgentCommand {
         until: Option<String>,
         #[arg(long)]
         include: Option<String>,
+        #[arg(long)]
+        raw: bool,
         #[arg(long = "tail")]
         tail: Option<usize>,
         #[arg(long, default_value = "10m")]
@@ -503,7 +505,7 @@ mod tests {
         };
         assert!(matches!(
             args.command,
-            Some(AgentCommand::Watch { ref target, ref since, ref until, ref include, tail, ref timeout, follow })
+            Some(AgentCommand::Watch { ref target, ref since, ref until, ref include, raw: false, tail, ref timeout, follow })
                 if target == "Wardian-Codex"
                     && since.as_deref() == Some("agent-1:0001")
                     && until.as_deref() == Some("output:OK")
@@ -511,6 +513,29 @@ mod tests {
                     && tail == Some(4096)
                     && timeout == "30s"
                     && !follow
+        ));
+    }
+
+    #[test]
+    fn parses_agent_watch_readable_and_raw_options() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "agent",
+            "watch",
+            "Wardian-Codex",
+            "--include",
+            "transcript,output,raw_output",
+            "--raw",
+        ])
+        .unwrap();
+
+        let Command::Agent(args) = cli.command else {
+            panic!("agent")
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Watch { ref include, raw: true, .. })
+                if include.as_deref() == Some("transcript,output,raw_output")
         ));
     }
 

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -619,6 +619,7 @@ fn send_message_and_watch_condition_with_output_echo_guard(
         None,
         vec![
             "status".to_string(),
+            "transcript".to_string(),
             "output".to_string(),
             "delivery".to_string(),
         ],
@@ -638,6 +639,7 @@ fn send_message_and_watch_condition_with_output_echo_guard(
         until: Some(request.condition),
         include: vec![
             "status".to_string(),
+            "transcript".to_string(),
             "output".to_string(),
             "delivery".to_string(),
         ],

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -164,17 +164,21 @@ fn handle_agent(args: AgentArgs) -> Result<String, CliError> {
             since,
             until,
             include,
+            raw,
             tail,
             timeout,
             follow,
         }) => handle_agent_watch(
             target,
-            since.as_deref(),
-            until.as_deref(),
-            include.as_deref(),
-            *tail,
-            timeout,
-            *follow,
+            AgentWatchCliOptions {
+                since: since.as_deref(),
+                until: until.as_deref(),
+                include: include.as_deref(),
+                raw: *raw,
+                tail: *tail,
+                timeout,
+                follow: *follow,
+            },
         ),
         Some(AgentCommand::Wait {
             target,
@@ -294,27 +298,40 @@ fn handle_agent_wait(
 
 fn handle_agent_watch(
     target: &str,
-    since: Option<&str>,
-    until: Option<&str>,
-    include: Option<&str>,
-    tail: Option<usize>,
-    timeout: &str,
-    follow: bool,
+    options: AgentWatchCliOptions<'_>,
 ) -> Result<String, CliError> {
-    if follow {
+    if options.follow {
         return Err(CliError::backend(
             ExitCode::Generic,
             "not_supported",
             "agent watch --follow is reserved for a future streaming implementation",
         ));
     }
-    let timeout = parse_timeout(timeout)?;
-    let include = parse_include(include);
-    let response = live::agent_watch(target, since, until, include, tail, follow, timeout)
-        .map_err(control_error)?;
+    let timeout = parse_timeout(options.timeout)?;
+    let include = parse_watch_include(options.include, options.raw);
+    let response = live::agent_watch(
+        target,
+        options.since,
+        options.until,
+        include,
+        options.tail,
+        options.follow,
+        timeout,
+    )
+    .map_err(control_error)?;
     serde_json::to_string_pretty(&response)
         .map(|json| format!("{json}\n"))
         .map_err(|e| CliError::generic(e.to_string()))
+}
+
+struct AgentWatchCliOptions<'a> {
+    since: Option<&'a str>,
+    until: Option<&'a str>,
+    include: Option<&'a str>,
+    raw: bool,
+    tail: Option<usize>,
+    timeout: &'a str,
+    follow: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -566,6 +583,7 @@ fn render_ask_response(
         "cursor": watch.cursor,
         "delivery": ask.delivery,
         "output": watch.output,
+        "transcript": watch.transcript,
         "events": watch.events,
     });
     serde_json::to_string_pretty(&response)
@@ -575,12 +593,20 @@ fn render_ask_response(
 
 fn parse_include(include: Option<&str>) -> Vec<String> {
     include
-        .unwrap_or("status,output,delivery")
+        .unwrap_or("status,transcript,output,delivery")
         .split(',')
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
         .collect()
+}
+
+fn parse_watch_include(include: Option<&str>, raw: bool) -> Vec<String> {
+    let mut values = parse_include(include);
+    if raw && !values.iter().any(|value| value == "raw_output") {
+        values.push("raw_output".to_string());
+    }
+    values
 }
 
 // ---------------------------------------------------------------------------
@@ -944,6 +970,8 @@ mod tests {
                     truncated: false,
                     omitted_bytes: 0,
                 },
+                transcript: None,
+                raw_output: None,
                 delivery: wardian_core::control::WatchDeliverySnapshot {
                     delivery: Vec::new(),
                 },
@@ -986,6 +1014,8 @@ mod tests {
                     truncated: false,
                     omitted_bytes: 0,
                 },
+                transcript: None,
+                raw_output: None,
                 delivery: wardian_core::control::WatchDeliverySnapshot {
                     delivery: Vec::new(),
                 },
@@ -1000,8 +1030,77 @@ mod tests {
     }
 
     #[test]
+    fn render_ask_response_includes_transcript_when_watch_has_it() {
+        let ask = live::AskAgentResponse {
+            request_id: None,
+            reply: None,
+            delivery: Vec::new(),
+            watch: wardian_core::control::AgentWatchResponse {
+                schema: 1,
+                agent: wardian_core::control::WatchAgentSnapshot {
+                    uuid: "agent-1".to_string(),
+                    name: "reviewer-a1".to_string(),
+                    provider: "gemini".to_string(),
+                    status: "idle".to_string(),
+                    last_status_at: None,
+                },
+                cursor: "agent-1:2".to_string(),
+                events: Vec::new(),
+                output: wardian_core::control::WatchOutput {
+                    cursor: "agent-1:2".to_string(),
+                    text: String::new(),
+                    truncated: false,
+                    omitted_bytes: 0,
+                },
+                transcript: Some(wardian_core::control::WatchTranscript {
+                    cursor: "agent-1:2".to_string(),
+                    messages: vec![wardian_core::control::WatchTranscriptMessage {
+                        role: "assistant".to_string(),
+                        text: "Gemini answer".to_string(),
+                        provider: "gemini".to_string(),
+                        turn_id: Some("m2".to_string()),
+                        source: Some("gemini_log".to_string()),
+                    }],
+                    latest_text: "Gemini answer".to_string(),
+                    truncated: false,
+                    omitted_bytes: 0,
+                }),
+                raw_output: None,
+                delivery: wardian_core::control::WatchDeliverySnapshot {
+                    delivery: Vec::new(),
+                },
+            },
+        };
+
+        let rendered = render_ask_response("reviewer-a1", "output:Gemini answer", ask).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(json["transcript"]["latest_text"], "Gemini answer");
+    }
+
+    #[test]
     fn normalize_ask_condition_keeps_structured_reply_mode() {
         assert_eq!(normalize_ask_condition("reply").unwrap(), "reply");
+    }
+
+    #[test]
+    fn parse_include_defaults_to_readable_watch_surfaces() {
+        assert_eq!(
+            parse_include(None),
+            vec![
+                "status".to_string(),
+                "transcript".to_string(),
+                "output".to_string(),
+                "delivery".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_include_adds_raw_output_when_raw_flag_is_set() {
+        assert_eq!(
+            parse_watch_include(Some("output"), true),
+            vec!["output".to_string(), "raw_output".to_string()]
+        );
     }
 
     #[test]

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -224,6 +224,26 @@ pub struct WatchOutput {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WatchTranscriptMessage {
+    pub role: String,
+    pub text: String,
+    pub provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WatchTranscript {
+    pub cursor: String,
+    pub messages: Vec<WatchTranscriptMessage>,
+    pub latest_text: String,
+    pub truncated: bool,
+    pub omitted_bytes: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct WatchDeliverySnapshot {
     pub delivery: Vec<DeliveryDetail>,
 }
@@ -244,6 +264,10 @@ pub struct AgentWatchResponse {
     pub cursor: String,
     pub events: Vec<WatchEvent>,
     pub output: WatchOutput,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript: Option<WatchTranscript>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_output: Option<WatchOutput>,
     pub delivery: WatchDeliverySnapshot,
 }
 
@@ -520,6 +544,88 @@ mod tests {
 
         assert!(json.contains(r#""output_echo_guard":"Say AUTO_TEST_2_DONE""#));
         assert_eq!(roundtrip, req);
+    }
+
+    #[test]
+    fn agent_watch_response_serializes_clean_output_without_raw_output_by_default() {
+        let response = AgentWatchResponse {
+            schema: CONTROL_SCHEMA,
+            agent: WatchAgentSnapshot {
+                uuid: "agent-1".to_string(),
+                name: "CoderOne".to_string(),
+                provider: "codex".to_string(),
+                status: "idle".to_string(),
+                last_status_at: None,
+            },
+            cursor: "agent-1:0000000000000002".to_string(),
+            events: Vec::new(),
+            output: WatchOutput {
+                cursor: "agent-1:0000000000000002".to_string(),
+                text: "clean answer".to_string(),
+                truncated: false,
+                omitted_bytes: 0,
+            },
+            transcript: Some(WatchTranscript {
+                cursor: "agent-1:0000000000000002".to_string(),
+                messages: vec![WatchTranscriptMessage {
+                    role: "assistant".to_string(),
+                    text: "clean answer".to_string(),
+                    provider: "codex".to_string(),
+                    turn_id: Some("turn-1".to_string()),
+                    source: Some("response_item".to_string()),
+                }],
+                latest_text: "clean answer".to_string(),
+                truncated: false,
+                omitted_bytes: 0,
+            }),
+            raw_output: None,
+            delivery: WatchDeliverySnapshot {
+                delivery: Vec::new(),
+            },
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(json["output"]["text"], "clean answer");
+        assert_eq!(json["transcript"]["latest_text"], "clean answer");
+        assert!(json.get("raw_output").is_none());
+    }
+
+    #[test]
+    fn agent_watch_response_serializes_raw_output_when_requested() {
+        let response = AgentWatchResponse {
+            schema: CONTROL_SCHEMA,
+            agent: WatchAgentSnapshot {
+                uuid: "agent-1".to_string(),
+                name: "CoderOne".to_string(),
+                provider: "codex".to_string(),
+                status: "idle".to_string(),
+                last_status_at: None,
+            },
+            cursor: "agent-1:0000000000000002".to_string(),
+            events: Vec::new(),
+            output: WatchOutput {
+                cursor: "agent-1:0000000000000002".to_string(),
+                text: "red".to_string(),
+                truncated: false,
+                omitted_bytes: 0,
+            },
+            transcript: None,
+            raw_output: Some(WatchOutput {
+                cursor: "agent-1:0000000000000002".to_string(),
+                text: "\u{1b}[31mred\u{1b}[0m".to_string(),
+                truncated: false,
+                omitted_bytes: 0,
+            }),
+            delivery: WatchDeliverySnapshot {
+                delivery: Vec::new(),
+            },
+        };
+
+        let json = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(json["output"]["text"], "red");
+        assert_eq!(json["raw_output"]["text"], "\u{1b}[31mred\u{1b}[0m");
     }
 
     #[test]

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -52,7 +52,8 @@ wardian agent worktree join <name-or-uuid> --worktree <absolute-worktree-path-or
 wardian agent worktree disable <name-or-uuid>
 wardian agent wait reviewer-a1 --until idle --timeout 10m
 wardian agent wait reviewer-a1 --until idle --next --timeout 10m
-wardian agent watch reviewer-a1 --until output:REVIEW_DONE --include status,output,delivery --timeout 10m
+wardian agent watch reviewer-a1 --until output:REVIEW_DONE --include transcript,output,delivery --timeout 10m
+wardian agent watch reviewer-a1 --include raw_output --raw
 wardian team list
 wardian team show <team-name-or-id>
 wardian watchlist list
@@ -89,10 +90,26 @@ Send a prompt to an existing agent and wait for the next Idle transition:
 wardian send --file prompt.md --to coder-a1 --wait-until idle --timeout 10m
 ```
 
-Watch retained output for a deterministic marker:
+Watch retained readable output for a deterministic marker:
 
 ```bash
-wardian agent watch coder-a1 --until output:READY_FOR_REVIEW --include status,output,delivery --timeout 10m
+wardian agent watch coder-a1 --until output:READY_FOR_REVIEW --include transcript,output,delivery --timeout 10m
+```
+
+Inspect provider-adapted transcript text, sanitized terminal fallback, or raw PTY evidence:
+
+```bash
+wardian agent watch Librarian --include transcript
+wardian agent watch Librarian --include output
+wardian agent watch Librarian --include raw_output --raw
+```
+
+PowerShell:
+
+```powershell
+wardian agent watch Librarian --include transcript
+wardian agent watch Librarian --include output
+wardian agent watch Librarian --include raw_output --raw
 ```
 
 Run a saved workflow through the app-owned backend:
@@ -114,7 +131,11 @@ Mutating commands use Wardian's local control endpoint and require the desktop a
 
 `agent wait <target> --until <status>` blocks inside the CLI process until a single agent name or UUID reaches a normalized status such as `idle`, `processing`, `action_required`, `off`, or `error`. Plain `wait` returns immediately when the target is already in the requested status. Add `--next` to wait for a newer matching observation. Use `--timeout` with `ms`, `s`, or `m` units.
 
-`agent watch <target>` returns a live snapshot with agent status, retained output, recent events, delivery details, and a cursor. Add `--until` to block until `status:<status>`, `output:<substring>`, `event:<kind>`, or `delivery:<state>` is observed. `watch` accepts only one name or UUID in this slice. `--follow` is reserved and returns `not_supported`.
+`agent watch <target>` returns a live snapshot with agent status, a provider-adapted `transcript`, sanitized retained terminal `output`, delivery details, and a cursor. Raw PTY text is not returned by default. Add `--raw` or `--include raw_output` only when debugging terminal rendering, ANSI/control sequences, or PTY transport behavior. `raw_output.text` may contain escape sequences and prompt repaint fragments.
+
+`transcript` is extracted from structured provider lines when Wardian has a provider adapter. This slice covers Codex, Claude, Gemini, OpenCode, and the mock provider. Gemini can backfill completed assistant text from Gemini chat logs, and OpenCode can backfill assistant text from its session database when the live TUI does not expose a clean structured line. Ambiguous provider lines fall back to sanitized terminal `output` until provider-specific transcript adapters are added. `output` is the compatibility surface for `--until output:<substring>` and is cleaned of common ANSI, OSC, cursor, and clear-line controls. Internally, marker matching also checks transcript text and the raw PTY tap so existing token-based automation keeps working without returning raw text by default.
+
+Add `--until` to block until `status:<status>`, `output:<substring>`, `event:<kind>`, or `delivery:<state>` is observed. `watch` accepts only one name or UUID in this slice. `--follow` is reserved and returns `not_supported`.
 
 `ask <target>` sends one prompt to one live Wardian-managed agent and creates a live structured request id. By default, Wardian appends reply instructions to the delivered prompt and waits for the target to answer with `wardian reply <request-id> --status done --stdin`. The JSON response includes `request_id`, `reply.status`, `reply.body`, delivery evidence, watch events, and retained output. `reply.status` can be `done`, `blocked`, or `failed`; timeout remains a separate `watch_timeout` error.
 

--- a/docs/specs/034-agent-watch-and-communication.md
+++ b/docs/specs/034-agent-watch-and-communication.md
@@ -34,7 +34,7 @@ Supported options:
 - `--since <cursor>`: return only events and output after a prior cursor.
 - `--until <condition>`: block until a condition is reached or timeout expires.
 - `--timeout <duration>`: maximum wait time, using the existing `ms`, `s`, and `m` syntax.
-- `--include <fields>`: comma-separated data classes. Initial values: `status`, `output`, `events`, `delivery`, `agent`.
+- `--include <fields>`: comma-separated data classes. Initial values: `status`, `transcript`, `output`, `events`, `delivery`, `agent`, `raw_output`.
 - `--tail <bytes>`: cap returned terminal output. Default should be conservative enough for model context.
 
 `watch` accepts only a single agent name or UUID in the first implementation. Selectors that can resolve to multiple agents, such as `class:<ClassName>` and `all`, return `not_supported` with a hint to choose a single target. This keeps the first response schema unambiguous and avoids hiding partial observation gaps behind a list response.
@@ -95,8 +95,23 @@ Non-following `watch` returns one JSON envelope:
       "status": "processing"
     }
   ],
+  "transcript": {
+    "cursor": "57244fa9-2b9c-4b45-ba32-6919d2786c29:0000000000000042",
+    "messages": [
+      {
+        "role": "assistant",
+        "text": "WARDIAN_PROBE_CODEX_OK",
+        "provider": "codex",
+        "turn_id": "turn-1",
+        "source": "response_item"
+      }
+    ],
+    "latest_text": "WARDIAN_PROBE_CODEX_OK",
+    "truncated": false,
+    "omitted_bytes": 0
+  },
   "output": {
-    "text": "WARDIAN_PROBE_CODEX_OK\r\n",
+    "text": "WARDIAN_PROBE_CODEX_OK\n",
     "truncated": false
   },
   "delivery": {
@@ -107,6 +122,8 @@ Non-following `watch` returns one JSON envelope:
 }
 ```
 
+`output.text` is a sanitized terminal fallback suitable for agents. Raw PTY text is available only through explicit `--include raw_output` or `--raw`; it may contain ANSI/control sequences and repaint fragments. `transcript` is provider-adapted and provider-neutral in shape. Issue #273 changed the default watch surface from raw terminal bytes to transcript plus sanitized output while retaining the internal raw PTY tap for debugging.
+
 Cursors are opaque strings. Callers must compare them only for equality or pass them back through `--since`.
 
 Cursor semantics:
@@ -115,7 +132,7 @@ Cursor semantics:
 - Events and output batches share one monotonically increasing cursor sequence per agent, so a cursor represents a total order across status, delivery, provider events, and output tap updates.
 - If `--since` is older than the retained event/output ring, the command fails with `cursor_expired` and includes the oldest available cursor in error details. Silent gaps are not allowed.
 - If retention is lost during a blocking `--until`, the command fails with `gap_detected` rather than continuing against incomplete evidence.
-- `--tail <bytes>` truncates on valid UTF-8 character boundaries after ANSI/control bytes are preserved as text. The response includes `truncated: true`, `omitted_bytes`, and `oldest_available_cursor` when output is trimmed.
+- `--tail <bytes>` truncates on valid UTF-8 character boundaries. Sanitized `output` reports truncation relative to the retained terminal bytes. Explicit `raw_output` preserves ANSI/control bytes as decoded text. The response includes `truncated: true`, `omitted_bytes`, and `oldest_available_cursor` when output is trimmed.
 
 ### Backend State Model
 
@@ -124,6 +141,7 @@ Extend `ActiveAgent` with live observation state:
 - `last_status_at`: timestamp updated whenever the normalized status changes.
 - `watch_events`: bounded in-memory event ring for status changes, delivery attempts, and provider parser events.
 - `output_tap`: bounded, non-draining terminal output ring independent from the UI's drain-on-read `output_buffer`.
+- `transcript`: bounded provider-neutral transcript messages extracted from structured provider output when an adapter exists.
 - `delivery_state`: latest structured delivery result per target session.
 
 The terminal reader writes to both:
@@ -243,10 +261,12 @@ The first slice is live-only. `watch` does not fall back to SQLite because persi
 
 Unit tests:
 
-- CLI argument parsing for `agent watch`, `--since`, `--until`, `--include`, and `--tail`.
+- CLI argument parsing for `agent watch`, `--since`, `--until`, `--include`, `--raw`, and `--tail`.
 - Reserved `--follow` behavior: the flag parses and returns `not_supported` until the streaming transport slice is implemented.
-- Watch response serialization in `wardian-core`.
+- Watch response serialization in `wardian-core`, including `transcript` and opt-in `raw_output`.
 - Event ring cursor behavior and truncation behavior.
+- Terminal sanitizer behavior for ANSI SGR, CSI cursor/clear controls, OSC titles, CRLF normalization, and UTF-8 tailing.
+- Provider transcript extraction for Codex, Claude, and mock output.
 - `agent wait` immediate readiness behavior when the target already starts in the requested status.
 - `agent wait --next` and `send --wait-until` behavior when the target begins in the desired status and later produces a newer completion event.
 - Provider-aware send byte sequences for Codex, Gemini, Claude, and mock.
@@ -256,6 +276,7 @@ Unit tests:
 Native E2E tests:
 
 - Mock provider: `send -> watch --until output:<token>` captures the response without relying on frontend terminal reads.
+- Mock provider: ANSI terminal output is removed from default `output.text`, provider transcript text is returned when requested, and `raw_output.text` preserves escape sequences only after explicit opt-in.
 - Mock provider: `send --wait-until idle` succeeds when the target starts idle and completes a fast turn.
 - Off target: `send` reports `target_off` or `no_input_channel` with per-target details.
 - Multi-target partial delivery: `class:<ClassName>` returns nonzero with stderr `details.delivery[]` when one target cannot receive input.

--- a/docs/specs/041-agent-watch-readable-output.md
+++ b/docs/specs/041-agent-watch-readable-output.md
@@ -1,0 +1,103 @@
+# Spec 041: Agent Watch Readable Output
+
+- **Status:** Implemented
+- **Date:** 2026-05-16
+- **Issue:** [#273](https://github.com/tangemicioglu/Wardian/issues/273)
+- **Decider:** Wardian Codex
+
+## Decision
+
+`wardian agent watch` returns agent-readable output by default. The default watch include set is `status,transcript,output,delivery`.
+
+- `transcript` is provider-adapted, provider-neutral answer text.
+- `output` is a sanitized terminal fallback with common ANSI, OSC, cursor, and clear-line controls removed.
+- `raw_output` is opt-in through `--include raw_output` or `--raw`.
+
+Wardian keeps the internal non-draining raw PTY tap. Raw terminal text remains required for PTY debugging, but it is no longer the default surface returned to agents.
+
+## Schema
+
+Default readable response:
+
+```json
+{
+  "schema": 1,
+  "agent": {
+    "uuid": "agent-1",
+    "name": "CoderOne",
+    "provider": "codex",
+    "status": "idle",
+    "last_status_at": "2026-05-16T12:00:00.000Z"
+  },
+  "cursor": "agent-1:0000000000000002",
+  "events": [],
+  "output": {
+    "cursor": "agent-1:0000000000000002",
+    "text": "Final answer\n",
+    "truncated": false,
+    "omitted_bytes": 0
+  },
+  "transcript": {
+    "cursor": "agent-1:0000000000000002",
+    "messages": [
+      {
+        "role": "assistant",
+        "text": "Final answer",
+        "provider": "codex",
+        "turn_id": "turn-1",
+        "source": "response_item"
+      }
+    ],
+    "latest_text": "Final answer",
+    "truncated": false,
+    "omitted_bytes": 0
+  },
+  "delivery": {
+    "delivery": []
+  }
+}
+```
+
+Raw opt-in response:
+
+```bash
+wardian agent watch CoderOne --include raw_output --raw
+```
+
+```json
+{
+  "schema": 1,
+  "agent": {
+    "uuid": "agent-1",
+    "name": "CoderOne",
+    "provider": "codex",
+    "status": "idle",
+    "last_status_at": "2026-05-16T12:00:00.000Z"
+  },
+  "cursor": "agent-1:0000000000000002",
+  "events": [],
+  "output": {
+    "cursor": "agent-1:0000000000000002",
+    "text": "",
+    "truncated": false,
+    "omitted_bytes": 0
+  },
+  "raw_output": {
+    "cursor": "agent-1:0000000000000002",
+    "text": "\u001b[31mFinal answer\u001b[0m\r\n",
+    "truncated": false,
+    "omitted_bytes": 0
+  },
+  "delivery": {
+    "delivery": []
+  }
+}
+```
+
+## Provider Coverage
+
+This slice extracts transcript messages for Codex, Claude, Gemini, OpenCode, and the mock provider. Gemini backfills completed assistant text from Gemini chat logs; OpenCode also backfills assistant text from the provider session database when the live TUI/log stream does not provide a clean structured transcript line. Ambiguous structured lines fall back to sanitized terminal `output`. `--until output:<token>` checks transcript text, sanitized output, and the internal raw PTY fallback so marker-based automation continues to work without exposing raw PTY text by default.
+
+## Compatibility
+
+The top-level `output` field remains present for existing consumers, but it now contains sanitized terminal text. Consumers that depended on ANSI/control sequences must opt in to `raw_output`. Existing cursor, `--since`, `--tail`, delivery, status, event, and output wait behavior are preserved.

--- a/e2e-native/tests/cli-shared-state-native.test.mjs
+++ b/e2e-native/tests/cli-shared-state-native.test.mjs
@@ -23,6 +23,7 @@ const CONTROL_SESSION_NAME = `E2E-CLI-CONTROL-${RUN_ID}`;
 const CONTROL_CLONE_NAME = `E2E-CLI-CONTROL-CLONE-${RUN_ID}`;
 const ASK_SESSION_NAME = `E2E-CLI-ASK-${RUN_ID}`;
 const ASK_ECHO_SESSION_NAME = `E2E-CLI-ASK-ECHO-${RUN_ID}`;
+const WATCH_READABLE_SESSION_NAME = `E2E-CLI-WATCH-READABLE-${RUN_ID}`;
 
 function commandName(name) {
   return process.platform === "win32" ? `${name}.exe` : name;
@@ -373,7 +374,7 @@ test("native CLI control commands operate through the running app", { timeout: 1
       "--until",
       "output:Action approved",
       "--include",
-      "status,output,delivery",
+      "status,events,output,delivery",
       "--timeout",
       "30s",
     ]);
@@ -609,6 +610,89 @@ test("native CLI ask output waits ignore the submitted prompt echo", { timeout: 
     assert.ok(Array.isArray(askJson.delivery));
     assert.equal(askJson.delivery[0].delivery_state, "submitted");
   });
+});
+
+test("native CLI watch returns readable output by default and raw output on opt-in", { timeout: 180000 }, async (t) => {
+  const harness = await createNativeHarness();
+  assert.ok(harness.appPath);
+
+  try {
+    if (!skipNativeBuild) {
+      ensureNativeAppBuilt(harness);
+    }
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  prepareIsolatedHome(harness);
+
+  const cliPath = buildCli(harness);
+  const workspacePath = path.join(harness.repoRoot, "e2e-native");
+
+  let session;
+  try {
+    session = await startNativeSession(harness);
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  t.after(async () => {
+    await session.close();
+  });
+
+  await waitForAppShell(session.driver, 20000);
+  await watchStep(harness, "Wardian app shell is ready for readable watch smoke");
+
+  const agent = await createMockAgent(session.driver, workspacePath, {
+    sessionId: `e2e-cli-watch-readable-${RUN_ID}`,
+    sessionName: WATCH_READABLE_SESSION_NAME,
+    isOff: true,
+  });
+
+  const seeded = await session.driver.executeAsyncScript((sessionId, done) => {
+    window.__TAURI_INTERNALS__.invoke("debug_push_agent_watch_output", {
+      sessionId,
+      output: "\u001b[31mANSI_TERMINAL_LINE\u001b[0m\r\n",
+      transcriptText: "ANSI readable answer.",
+      provider: "mock",
+    }).then(
+      () => done({ ok: true }),
+      (error) => done({ ok: false, error: String(error) }),
+    );
+  }, agent.session_id);
+  assert.equal(seeded.ok, true, `debug_push_agent_watch_output failed: ${seeded.error}`);
+
+  const readableResult = runCliOk(cliPath, harness, [
+    "agent",
+    "watch",
+    WATCH_READABLE_SESSION_NAME,
+    "--until",
+    "output:ANSI readable answer",
+    "--include",
+    "output,transcript",
+    "--timeout",
+    "30s",
+  ]);
+  const readable = JSON.parse(readableResult.stdout);
+  assert.doesNotMatch(readable.output.text, /\x1b/);
+  assert.match(readable.output.text, /ANSI_TERMINAL_LINE/);
+  assert.match(readable.transcript.latest_text, /ANSI readable answer/);
+  assert.equal(readable.raw_output, undefined);
+
+  const rawResult = runCliOk(cliPath, harness, [
+    "agent",
+    "watch",
+    WATCH_READABLE_SESSION_NAME,
+    "--include",
+    "raw_output",
+    "--raw",
+    "--timeout",
+    "30s",
+  ]);
+  const raw = JSON.parse(rawResult.stdout);
+  assert.match(raw.raw_output.text, /\x1b\[31mANSI_TERMINAL_LINE\x1b\[0m/);
 });
 
 test.skip("real Codex CLI send submits without leaving residual prompt text", () => {

--- a/scripts/mock-agent.cjs
+++ b/scripts/mock-agent.cjs
@@ -19,6 +19,7 @@
  *   multi_turn    — init → [user → generating → model_response → turn_completed] × 3
  *   interactive_multi_turn — init → action_required → stdin-driven responses × 2
  *   interactive_echo_then_response — init → action_required → prompt echo → response
+ *   ansi_output   — init → ANSI terminal output → model_response → turn_completed
  */
 
 "use strict";
@@ -209,6 +210,18 @@ async function runInteractiveEchoThenResponse() {
   emit(events.turnCompleted());
 }
 
+async function runAnsiOutput() {
+  emit(events.init());
+  await sleep(delay);
+  emit(events.user());
+  await sleep(delay);
+  process.stdout.write("\x1b[31mANSI_TERMINAL_LINE\x1b[0m\n");
+  await sleep(delay);
+  emit(events.modelResponse("ANSI readable answer."));
+  await sleep(delay);
+  emit(events.turnCompleted());
+}
+
 async function main() {
   // Headless mode: --print flag overrides scenario
   if (isPrint) {
@@ -226,6 +239,7 @@ async function main() {
     multi_turn: runMultiTurn,
     interactive_multi_turn: runInteractiveMultiTurn,
     interactive_echo_then_response: runInteractiveEchoThenResponse,
+    ansi_output: runAnsiOutput,
   };
 
   const runner = scenarios[scenario];

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -108,9 +108,13 @@ reaches a normalized status such as `idle`, `processing`, `action_required`,
 in the requested status. Use `--next` to wait for a newer matching observation.
 Use `--timeout` with `ms`, `s`, or `m` units.
 
-`agent watch <target>` returns status, retained output, events, delivery
-details, and a cursor. Use `--until output:<token>` when you need the response
-text itself. `--follow` is reserved and currently returns `not_supported`.
+`agent watch <target>` returns status, provider-adapted transcript text,
+sanitized terminal output, delivery details, and a cursor by default. Raw PTY
+text is opt-in with `--raw` or `--include raw_output`; use it only when you need
+terminal escape bytes or repaint evidence. Use `--until output:<token>` when you
+need output-substring compatibility; marker matching checks transcript text,
+sanitized output, and the internal raw PTY fallback. `--follow` is reserved and
+currently returns `not_supported`.
 
 `agent worktree` commands require the desktop app for the same `WARDIAN_HOME`.
 They route through Wardian's live control endpoint and reuse the GUI/backend

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -2789,6 +2789,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
     async fn full_agent_command_loads_saved_config_from_state() {
         let _lock = crate::utils::wardian_test_env_lock();
         let temp = tempfile::tempdir().expect("temp dir");

--- a/src-tauri/src/commands/debug.rs
+++ b/src-tauri/src/commands/debug.rs
@@ -17,3 +17,36 @@ pub async fn debug_remove_agent_input_sender(
     senders.remove(&session_id);
     Ok(())
 }
+
+#[tauri::command]
+pub async fn debug_push_agent_watch_output(
+    session_id: String,
+    output: String,
+    transcript_text: Option<String>,
+    provider: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    if !cfg!(debug_assertions) {
+        return Err("debug commands are disabled in production builds".to_string());
+    }
+
+    let agents = state.agents.lock().await;
+    let agent = agents
+        .get(&session_id)
+        .ok_or_else(|| format!("agent not found: {session_id}"))?;
+    let mut watch_state = agent
+        .watch_state
+        .lock()
+        .map_err(|_| "watch state lock poisoned".to_string())?;
+    watch_state.push_output(output.as_bytes());
+    if let Some(text) = transcript_text.filter(|text| !text.trim().is_empty()) {
+        watch_state.push_transcript(wardian_core::control::WatchTranscriptMessage {
+            role: "assistant".to_string(),
+            text,
+            provider: provider.unwrap_or_else(|| "mock".to_string()),
+            turn_id: Some("debug-seed".to_string()),
+            source: Some("debug".to_string()),
+        });
+    }
+    Ok(())
+}

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -153,7 +153,7 @@ pub async fn submit_prompt_to_agent(
     state: State<'_, AppState>,
     _app: AppHandle,
 ) -> Result<(), String> {
-    let (provider_name, config, tx) = {
+    let (provider_name, tx) = {
         let agents = state.agents.lock().await;
         let agent = agents
             .get(&session_id)
@@ -165,7 +165,7 @@ pub async fn submit_prompt_to_agent(
             .map_err(|_| "Input channel temporarily locked".to_string())?
             .get(&session_id)
             .cloned();
-        (config.provider.clone(), config, tx)
+        (config.provider.clone(), tx)
     };
 
     let tx = match tx {
@@ -175,96 +175,6 @@ pub async fn submit_prompt_to_agent(
 
     if provider_name == "opencode" {
         wait_for_opencode_terminal_ready(&session_id, &state, 15000).await?;
-
-        {
-            let agents = state.agents.lock().await;
-            if let Some(agent) = agents.get(&session_id) {
-                if manager::mark_agent_prompt_started(agent) {
-                    manager::set_agent_status(
-                        &_app,
-                        &session_id,
-                        &agent.current_status,
-                        "Processing...",
-                    );
-                }
-            }
-        }
-
-        let habitat_cwd = crate::utils::fs::get_wardian_home()
-            .map(|home| home.join("agents").join(&session_id).join("habitat"))
-            .filter(|path| path.exists())
-            .unwrap_or_else(|| crate::utils::fs::resolve_cwd(&config.folder, &session_id));
-
-        let result = match manager::run_headless_with_config(
-            &habitat_cwd,
-            &prompt,
-            &session_id,
-            "text",
-            &provider_name,
-            Some(&config),
-        )
-        .await
-        {
-            Ok(result) => result,
-            Err(error) => {
-                {
-                    let agents = state.agents.lock().await;
-                    if let Some(agent) = agents.get(&session_id) {
-                        manager::set_agent_status(
-                            &_app,
-                            &session_id,
-                            &agent.current_status,
-                            "Error",
-                        );
-                    }
-                }
-
-                return Err(error);
-            }
-        };
-
-        let response_text = result
-            .get("text")
-            .and_then(|value| value.as_str())
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("");
-
-        manager::log_debug(&format!(
-            "[Wardian] OpenCode headless submit response for session {}: {}",
-            session_id,
-            if response_text.is_empty() {
-                "<empty>"
-            } else {
-                response_text
-            }
-        ));
-
-        if !response_text.is_empty() {
-            let agents = state.agents.lock().await;
-            if let Some(agent) = agents.get(&session_id) {
-                if let Ok(mut buf) = agent.output_buffer.lock() {
-                    if !buf.is_empty() && !buf.ends_with('\n') {
-                        buf.push_str("\r\n");
-                    }
-                    buf.push_str(response_text);
-                    buf.push_str("\r\n");
-                }
-            }
-            let _ = _app.emit(
-                "agent-pty-output-ready",
-                serde_json::json!({ "session_id": session_id }),
-            );
-        }
-
-        {
-            let agents = state.agents.lock().await;
-            if let Some(agent) = agents.get(&session_id) {
-                manager::set_agent_status(&_app, &session_id, &agent.current_status, "Idle");
-            }
-        }
-
-        return Ok(());
     }
 
     {

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -282,7 +282,7 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             target,
             since,
             until,
-            include: _,
+            include,
             tail_bytes,
             follow,
             timeout_ms,
@@ -294,6 +294,7 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
                 AgentWatchControlOptions {
                     since,
                     until,
+                    include,
                     tail_bytes,
                     follow,
                     timeout_ms,
@@ -979,7 +980,16 @@ async fn handle_structured_ask(
         .map_err(control_error_from_watch_state)?;
     let agent = watch_agent_snapshot(&state, &target_uuid).await?;
 
-    let delivery_snapshot = delivery_snapshot_from_events(&snapshot.events);
+    let watch = build_agent_watch_response(
+        agent,
+        snapshot,
+        &WatchIncludes::from_values(&[
+            "events".to_string(),
+            "transcript".to_string(),
+            "output".to_string(),
+            "delivery".to_string(),
+        ]),
+    );
     ok_json(&AskResponse {
         schema: wardian_core::control::CONTROL_SCHEMA,
         ok: true,
@@ -987,14 +997,7 @@ async fn handle_structured_ask(
         target: target.to_string(),
         delivery,
         reply,
-        watch: AgentWatchResponse {
-            schema: wardian_core::control::CONTROL_SCHEMA,
-            agent,
-            cursor: snapshot.cursor,
-            events: snapshot.events,
-            output: snapshot.output,
-            delivery: delivery_snapshot,
-        },
+        watch,
     })
 }
 
@@ -1254,25 +1257,91 @@ async fn handle_agent_watch(
             .map_err(control_error_from_watch_state)?
     };
     let agent = watch_agent_snapshot(&state, &uuid).await?;
-    let delivery = delivery_snapshot_from_events(&snapshot.events);
+    let includes = WatchIncludes::from_values(&options.include);
 
-    ok_json(&AgentWatchResponse {
-        schema: wardian_core::control::CONTROL_SCHEMA,
-        agent,
-        cursor: snapshot.cursor,
-        events: snapshot.events,
-        output: snapshot.output,
-        delivery,
-    })
+    ok_json(&build_agent_watch_response(agent, snapshot, &includes))
 }
 
 struct AgentWatchControlOptions {
     since: Option<String>,
     until: Option<String>,
+    include: Vec<String>,
     tail_bytes: Option<usize>,
     follow: bool,
     timeout_ms: Option<u64>,
     output_echo_guard: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct WatchIncludes {
+    events: bool,
+    output: bool,
+    transcript: bool,
+    raw_output: bool,
+    delivery: bool,
+}
+
+impl WatchIncludes {
+    fn from_values(values: &[String]) -> Self {
+        let values = if values.is_empty() {
+            vec![
+                "status".to_string(),
+                "transcript".to_string(),
+                "output".to_string(),
+                "delivery".to_string(),
+            ]
+        } else {
+            values.to_vec()
+        };
+
+        Self {
+            events: values.iter().any(|value| value == "events"),
+            output: values.iter().any(|value| value == "output"),
+            transcript: values.iter().any(|value| value == "transcript"),
+            raw_output: values.iter().any(|value| value == "raw_output"),
+            delivery: values.iter().any(|value| value == "delivery"),
+        }
+    }
+}
+
+fn build_agent_watch_response(
+    agent: WatchAgentSnapshot,
+    snapshot: crate::state::agent_watch::WatchSnapshot,
+    includes: &WatchIncludes,
+) -> AgentWatchResponse {
+    let cursor = snapshot.cursor.clone();
+    let events = if includes.events {
+        snapshot.events.clone()
+    } else {
+        Vec::new()
+    };
+    let delivery = if includes.delivery {
+        delivery_snapshot_from_events(&snapshot.events)
+    } else {
+        WatchDeliverySnapshot {
+            delivery: Vec::new(),
+        }
+    };
+    let empty_output = || wardian_core::control::WatchOutput {
+        cursor: cursor.clone(),
+        text: String::new(),
+        truncated: false,
+        omitted_bytes: 0,
+    };
+    AgentWatchResponse {
+        schema: wardian_core::control::CONTROL_SCHEMA,
+        agent,
+        cursor: cursor.clone(),
+        events,
+        output: if includes.output {
+            snapshot.output
+        } else {
+            empty_output()
+        },
+        transcript: includes.transcript.then_some(snapshot.transcript),
+        raw_output: includes.raw_output.then_some(snapshot.raw_output),
+        delivery,
+    }
 }
 
 fn validate_watch_target(target: &str) -> Result<(), ControlError> {
@@ -1382,14 +1451,14 @@ fn watch_condition_matches(
                     .and_then(|value| value.as_str())
                     .is_some_and(|value| normalize_status(value) == *status)
         }),
-        WatchCondition::OutputContains(token) => {
-            snapshot.output.text.contains(token)
-                && !output_match_is_prompt_echo_only(
-                    token,
-                    &snapshot.output.text,
-                    output_echo_guard,
-                )
-        }
+        WatchCondition::OutputContains(token) => [
+            snapshot.transcript.latest_text.as_str(),
+            snapshot.output.text.as_str(),
+            snapshot.raw_output.text.as_str(),
+        ]
+        .into_iter()
+        .filter(|text| text.contains(token))
+        .any(|text| !output_match_is_prompt_echo_only(token, text, output_echo_guard)),
         WatchCondition::EventKind(kind) => snapshot.events.iter().any(|event| &event.kind == kind),
         WatchCondition::DeliveryState(state) => snapshot.events.iter().any(|event| {
             event.kind == "delivery"
@@ -2102,7 +2171,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
-        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+        assert_eq!(rx.recv().await.unwrap(), b"\x1b[13u".to_vec());
     }
 
     #[test]
@@ -2843,6 +2912,117 @@ mod tests {
         assert_eq!(error.code(), "not_supported");
     }
 
+    fn snapshot_with_output(cursor: &str, text: &str) -> crate::state::agent_watch::WatchSnapshot {
+        crate::state::agent_watch::WatchSnapshot {
+            cursor: cursor.to_string(),
+            events: Vec::new(),
+            output: wardian_core::control::WatchOutput {
+                cursor: cursor.to_string(),
+                text: text.to_string(),
+                truncated: false,
+                omitted_bytes: 0,
+            },
+            raw_output: wardian_core::control::WatchOutput {
+                cursor: cursor.to_string(),
+                text: text.to_string(),
+                truncated: false,
+                omitted_bytes: 0,
+            },
+            transcript: wardian_core::control::WatchTranscript {
+                cursor: cursor.to_string(),
+                messages: Vec::new(),
+                latest_text: String::new(),
+                truncated: false,
+                omitted_bytes: 0,
+            },
+        }
+    }
+
+    fn test_watch_agent() -> WatchAgentSnapshot {
+        WatchAgentSnapshot {
+            uuid: "agent-1".to_string(),
+            name: "CoderOne".to_string(),
+            provider: "mock".to_string(),
+            status: "idle".to_string(),
+            last_status_at: None,
+        }
+    }
+
+    #[test]
+    fn watch_response_default_includes_readable_output_without_raw_output() {
+        let mut state = crate::state::AgentWatchState::new("agent-1".to_string(), 16, 1024);
+        state.push_output("\u{1b}[31mreadable\u{1b}[0m".as_bytes());
+        let snapshot = state.snapshot_since(None, Some(1024)).unwrap();
+        let response = build_agent_watch_response(
+            test_watch_agent(),
+            snapshot,
+            &WatchIncludes::from_values(&[]),
+        );
+
+        assert_eq!(response.output.text, "readable");
+        assert!(response.raw_output.is_none());
+        assert!(response.transcript.is_some());
+    }
+
+    #[test]
+    fn watch_response_raw_include_preserves_raw_terminal_text() {
+        let mut state = crate::state::AgentWatchState::new("agent-1".to_string(), 16, 1024);
+        state.push_output("\u{1b}[31mreadable\u{1b}[0m".as_bytes());
+        let snapshot = state.snapshot_since(None, Some(1024)).unwrap();
+        let response = build_agent_watch_response(
+            test_watch_agent(),
+            snapshot,
+            &WatchIncludes::from_values(&["raw_output".to_string(), "output".to_string()]),
+        );
+
+        assert_eq!(response.output.text, "readable");
+        assert_eq!(
+            response.raw_output.as_ref().unwrap().text,
+            "\u{1b}[31mreadable\u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn output_condition_matches_transcript_clean_output_and_raw_fallback() {
+        let mut transcript_snapshot = snapshot_with_output("agent-1:1", "");
+        transcript_snapshot.transcript.latest_text = "Final REVIEW_DONE".to_string();
+        assert!(watch_condition_matches(
+            &WatchCondition::OutputContains("REVIEW_DONE".to_string()),
+            &transcript_snapshot,
+            None,
+        ));
+
+        let clean_snapshot = snapshot_with_output("agent-1:2", "Final REVIEW_DONE");
+        assert!(watch_condition_matches(
+            &WatchCondition::OutputContains("REVIEW_DONE".to_string()),
+            &clean_snapshot,
+            None,
+        ));
+
+        let mut raw_snapshot = snapshot_with_output("agent-1:3", "");
+        raw_snapshot.raw_output.text = "Final \u{1b}[31mREVIEW_DONE\u{1b}[0m".to_string();
+        assert!(watch_condition_matches(
+            &WatchCondition::OutputContains("REVIEW_DONE".to_string()),
+            &raw_snapshot,
+            None,
+        ));
+    }
+
+    #[test]
+    fn output_condition_checks_later_surfaces_after_echo_match() {
+        let mut snapshot = snapshot_with_output(
+            "agent-1:4",
+            "\u{1b}[1m›\u{1b}[22m Say REVIEW_DONE when finished\r\nActual response: REVIEW_DONE",
+        );
+        snapshot.transcript.latest_text = "Say REVIEW_DONE when finished".to_string();
+
+        assert!(watch_condition_matches(
+            &WatchCondition::OutputContains("REVIEW_DONE".to_string()),
+            &snapshot,
+            Some("Say REVIEW_DONE when finished"),
+        ));
+    }
+
     #[tokio::test]
     async fn blocking_watch_wakes_when_output_arrives() {
         let state = std::sync::Arc::new(std::sync::Mutex::new(crate::state::AgentWatchState::new(
@@ -2874,16 +3054,10 @@ mod tests {
 
     #[test]
     fn output_condition_with_ask_echo_guard_ignores_submitted_prompt_echo() {
-        let snapshot = crate::state::agent_watch::WatchSnapshot {
-            cursor: "agent-1:0000000000000001".to_string(),
-            events: Vec::new(),
-            output: wardian_core::control::WatchOutput {
-                cursor: "agent-1:0000000000000001".to_string(),
-                text: "\u{1b}[1m›\u{1b}[22m From Wardian-Arch: Say AUTO_TEST_2_DONE when finished\r\n  gpt-5.5 high · D:\\Development\\Wardian".to_string(),
-                truncated: false,
-                omitted_bytes: 0,
-            },
-        };
+        let snapshot = snapshot_with_output(
+            "agent-1:0000000000000001",
+            "\u{1b}[1m›\u{1b}[22m From Wardian-Arch: Say AUTO_TEST_2_DONE when finished\r\n  gpt-5.5 high · D:\\Development\\Wardian",
+        );
 
         assert!(!watch_condition_matches(
             &WatchCondition::OutputContains("AUTO_TEST_2_DONE".to_string()),
@@ -2894,16 +3068,10 @@ mod tests {
 
     #[test]
     fn output_condition_with_ask_echo_guard_matches_provider_response_after_echo() {
-        let snapshot = crate::state::agent_watch::WatchSnapshot {
-            cursor: "agent-1:0000000000000002".to_string(),
-            events: Vec::new(),
-            output: wardian_core::control::WatchOutput {
-                cursor: "agent-1:0000000000000002".to_string(),
-                text: "\u{1b}[1m›\u{1b}[22m Say AUTO_TEST_2_DONE when finished\r\nActual response: AUTO_TEST_2_DONE".to_string(),
-                truncated: false,
-                omitted_bytes: 0,
-            },
-        };
+        let snapshot = snapshot_with_output(
+            "agent-1:0000000000000002",
+            "\u{1b}[1m›\u{1b}[22m Say AUTO_TEST_2_DONE when finished\r\nActual response: AUTO_TEST_2_DONE",
+        );
 
         assert!(watch_condition_matches(
             &WatchCondition::OutputContains("AUTO_TEST_2_DONE".to_string()),
@@ -2914,16 +3082,10 @@ mod tests {
 
     #[test]
     fn output_condition_with_ask_echo_guard_ignores_codex_repaint_prompt_fragment() {
-        let snapshot = crate::state::agent_watch::WatchSnapshot {
-            cursor: "agent-1:0000000000000003".to_string(),
-            events: Vec::new(),
-            output: wardian_core::control::WatchOutput {
-                cursor: "agent-1:0000000000000003".to_string(),
-                text: "\u{1b}[2J\u{1b}[H\u{1b}[1m›\u{1b}[22m From Wardian-Arch: Capture the README demo GIF\r\n  and end exactly with DEMO_GIF_DONE  gpt-5.5 high · D:\\Development\\Wardian · 75% context left".to_string(),
-                truncated: false,
-                omitted_bytes: 0,
-            },
-        };
+        let snapshot = snapshot_with_output(
+            "agent-1:0000000000000003",
+            "\u{1b}[2J\u{1b}[H\u{1b}[1m›\u{1b}[22m From Wardian-Arch: Capture the README demo GIF\r\n  and end exactly with DEMO_GIF_DONE  gpt-5.5 high · D:\\Development\\Wardian · 75% context left",
+        );
 
         assert!(!watch_condition_matches(
             &WatchCondition::OutputContains("DEMO_GIF_DONE".to_string()),
@@ -2934,16 +3096,10 @@ mod tests {
 
     #[test]
     fn output_condition_with_ask_echo_guard_matches_response_after_codex_repaint_echo() {
-        let snapshot = crate::state::agent_watch::WatchSnapshot {
-            cursor: "agent-1:0000000000000004".to_string(),
-            events: Vec::new(),
-            output: wardian_core::control::WatchOutput {
-                cursor: "agent-1:0000000000000004".to_string(),
-                text: "\u{1b}[2J\u{1b}[H\u{1b}[1m›\u{1b}[22m From Wardian-Arch: Capture the README demo GIF\r\n  and end exactly with DEMO_GIF_DONE  gpt-5.5 high · D:\\Development\\Wardian · 75% context left\r\nFinal response: DEMO_GIF_DONE".to_string(),
-                truncated: false,
-                omitted_bytes: 0,
-            },
-        };
+        let snapshot = snapshot_with_output(
+            "agent-1:0000000000000004",
+            "\u{1b}[2J\u{1b}[H\u{1b}[1m›\u{1b}[22m From Wardian-Arch: Capture the README demo GIF\r\n  and end exactly with DEMO_GIF_DONE  gpt-5.5 high · D:\\Development\\Wardian · 75% context left\r\nFinal response: DEMO_GIF_DONE",
+        );
 
         assert!(watch_condition_matches(
             &WatchCondition::OutputContains("DEMO_GIF_DONE".to_string()),
@@ -2954,18 +3110,10 @@ mod tests {
 
     #[test]
     fn output_condition_with_ask_echo_guard_matches_exact_marker_response_after_echo() {
-        let snapshot = crate::state::agent_watch::WatchSnapshot {
-            cursor: "agent-1:0000000000000005".to_string(),
-            events: Vec::new(),
-            output: wardian_core::control::WatchOutput {
-                cursor: "agent-1:0000000000000005".to_string(),
-                text:
-                    "\u{1b}[1m›\u{1b}[22m Say AUTO_TEST_2_DONE when finished\r\n  AUTO_TEST_2_DONE"
-                        .to_string(),
-                truncated: false,
-                omitted_bytes: 0,
-            },
-        };
+        let snapshot = snapshot_with_output(
+            "agent-1:0000000000000005",
+            "\u{1b}[1m›\u{1b}[22m Say AUTO_TEST_2_DONE when finished\r\n  AUTO_TEST_2_DONE",
+        );
 
         assert!(watch_condition_matches(
             &WatchCondition::OutputContains("AUTO_TEST_2_DONE".to_string()),
@@ -2976,16 +3124,10 @@ mod tests {
 
     #[test]
     fn output_condition_with_ask_echo_guard_ignores_origin_prefixed_json_echo() {
-        let snapshot = crate::state::agent_watch::WatchSnapshot {
-            cursor: "agent-1:0000000000000006".to_string(),
-            events: Vec::new(),
-            output: wardian_core::control::WatchOutput {
-                cursor: "agent-1:0000000000000006".to_string(),
-                text: "From Wardian agent agent-1: AUTO_TEST_2_DONE\r\n{\"type\":\"model\",\"content\":\"From Wardian agent agent-1: AUTO_TEST_2_DONE\"}".to_string(),
-                truncated: false,
-                omitted_bytes: 0,
-            },
-        };
+        let snapshot = snapshot_with_output(
+            "agent-1:0000000000000006",
+            "From Wardian agent agent-1: AUTO_TEST_2_DONE\r\n{\"type\":\"model\",\"content\":\"From Wardian agent agent-1: AUTO_TEST_2_DONE\"}",
+        );
 
         assert!(!watch_condition_matches(
             &WatchCondition::OutputContains("AUTO_TEST_2_DONE".to_string()),
@@ -2996,16 +3138,10 @@ mod tests {
 
     #[test]
     fn output_condition_with_ask_echo_guard_matches_origin_prefixed_response_after_echo() {
-        let snapshot = crate::state::agent_watch::WatchSnapshot {
-            cursor: "agent-1:0000000000000007".to_string(),
-            events: Vec::new(),
-            output: wardian_core::control::WatchOutput {
-                cursor: "agent-1:0000000000000007".to_string(),
-                text: "From Wardian agent agent-1: AUTO_TEST_2_DONE\r\n{\"type\":\"model\",\"content\":\"From Wardian agent agent-1: AUTO_TEST_2_DONE\"}\r\nActual response after echo: From Wardian agent agent-1: AUTO_TEST_2_DONE".to_string(),
-                truncated: false,
-                omitted_bytes: 0,
-            },
-        };
+        let snapshot = snapshot_with_output(
+            "agent-1:0000000000000007",
+            "From Wardian agent agent-1: AUTO_TEST_2_DONE\r\n{\"type\":\"model\",\"content\":\"From Wardian agent agent-1: AUTO_TEST_2_DONE\"}\r\nActual response after echo: From Wardian agent agent-1: AUTO_TEST_2_DONE",
+        );
 
         assert!(watch_condition_matches(
             &WatchCondition::OutputContains("AUTO_TEST_2_DONE".to_string()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -273,6 +273,7 @@ pub fn run() {
             commands::agent::assign_agent_worktree,
             commands::agent::disable_agent_worktree,
             commands::debug::debug_remove_agent_input_sender,
+            commands::debug::debug_push_agent_watch_output,
             commands::terminal::send_input_to_agent,
             commands::terminal::submit_prompt_to_agent,
             commands::terminal::send_binary_input_to_agent,

--- a/src-tauri/src/manager/opencode.rs
+++ b/src-tauri/src/manager/opencode.rs
@@ -265,8 +265,7 @@ fn opencode_log_timestamp_to_rfc3339(timestamp: &str) -> Option<String> {
 ///
 /// Returns the file with the highest mtime among all qualifying candidates so
 /// that the server log (newer) wins over the parent log (older).
-#[cfg(test)]
-fn opencode_log_path_after(
+pub(crate) fn opencode_log_path_after(
     base: &std::path::Path,
     spawn_time: std::time::SystemTime,
 ) -> Option<std::path::PathBuf> {

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -1,4 +1,5 @@
 use crate::providers::claude::{classify_claude_user_event, ClaudeUserEventKind};
+use crate::providers::transcript::extract_transcript_message;
 use crate::providers::ProviderFactory;
 use crate::state::{ActiveAgent, AgentWatchState, AppState};
 use crate::utils::fs::*;
@@ -576,6 +577,14 @@ pub async fn spawn_agent(
                                 Some(Ok(parsed)) => {
                                     // Use provider to classify the raw JSON into an AgentEvent
                                     let raw_line = parsed.to_string();
+                                    if let Some(message) = extract_transcript_message(
+                                        &provider_name_for_pty,
+                                        &raw_line,
+                                    ) {
+                                        if let Ok(mut watch_state) = watch_state_clone.lock() {
+                                            watch_state.push_transcript(message);
+                                        }
+                                    }
                                     if let Some(event) = pty_provider.parse_output(&raw_line) {
                                         if let AgentEvent::Init {
                                             ref session_id,
@@ -678,6 +687,7 @@ pub async fn spawn_agent(
         let watcher_current_status = current_status.clone();
         let watcher_log_path = log_path.clone();
         let watcher_config = config_lock.clone();
+        let watcher_watch_state = watch_state.clone();
         let watcher_skip_existing_log = is_restored;
         let wardian_agent_dir = get_wardian_home()
             .map(|home| home.join("agents").join(&watcher_session))
@@ -764,6 +774,13 @@ pub async fn spawn_agent(
                                     serde_json::from_str::<serde_json::Value>(line.trim())
                                 {
                                     let raw_line = parsed.to_string();
+                                    if let Some(message) =
+                                        extract_transcript_message("codex", &raw_line)
+                                    {
+                                        if let Ok(mut watch_state) = watcher_watch_state.lock() {
+                                            watch_state.push_transcript(message);
+                                        }
+                                    }
                                     if let Some(event) = watcher_provider.parse_output(&raw_line) {
                                         apply_agent_event(
                                             &watcher_app,
@@ -794,6 +811,7 @@ pub async fn spawn_agent(
         let watcher_current_status = current_status.clone();
         let watcher_log_path = log_path.clone();
         let watcher_folder = expected_folder.clone();
+        let watcher_watch_state = watch_state.clone();
         let watcher_skip_existing_log = is_restored;
         let hook_event_log = claude_hook.as_ref().map(|hook| hook.event_log_path.clone());
         let waiting_for_permission = std::sync::Arc::new(std::sync::Mutex::new(false));
@@ -853,6 +871,13 @@ pub async fn spawn_agent(
                                     break;
                                 }
                                 offset += read as u64;
+                                if let Some(message) =
+                                    extract_transcript_message("claude", line.trim())
+                                {
+                                    if let Ok(mut watch_state) = watcher_watch_state.lock() {
+                                        watch_state.push_transcript(message);
+                                    }
+                                }
                                 if let Some(event) = watcher_provider.parse_output(line.trim()) {
                                     let mut waiting = log_waiting_for_permission
                                         .lock()

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -4,6 +4,8 @@ use std::collections::{BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
 use wardian_core::models::{AgentTelemetry, AppTelemetry};
 
+use crate::providers::transcript::extract_transcript_message;
+
 use super::claude::{claude_is_real_user_query, claude_project_dir_name, claude_status_from_log};
 use super::codex::{
     codex_log_lookup_session_id, codex_session_file_path, codex_status_from_log,
@@ -11,8 +13,9 @@ use super::codex::{
 };
 use super::display_log_path;
 use super::opencode::{
-    apply_opencode_log_metrics, opencode_log_dirs, opencode_log_path_in,
-    opencode_session_diff_path, opencode_should_fallback_to_idle,
+    apply_opencode_log_metrics, opencode_extract_created_session_id, opencode_last_assistant_text,
+    opencode_log_dirs, opencode_log_path_after, opencode_log_path_in, opencode_session_diff_path,
+    opencode_should_fallback_to_idle,
 };
 
 fn normalize_cpu_usage(raw_cpu_usage: f32, logical_cpu_count: usize) -> f32 {
@@ -206,6 +209,103 @@ fn set_snapshot_status_from_log(snap: &AgentSnapshot, next_status: &str, is_init
     set_snapshot_status(snap, next_status);
 }
 
+fn record_opencode_assistant_text(snap: &AgentSnapshot, session_id: &str, text: &str) {
+    let text = text.trim();
+    if text.is_empty() {
+        return;
+    }
+
+    if let Ok(mut watch_state) = snap.watch_state.lock() {
+        let latest = watch_state
+            .snapshot_since(None, Some(4096))
+            .ok()
+            .map(|snapshot| snapshot.transcript.latest_text)
+            .unwrap_or_default();
+        if latest == text {
+            return;
+        }
+        watch_state.push_output(format!("{text}\r\n").as_bytes());
+        watch_state.push_transcript(wardian_core::control::WatchTranscriptMessage {
+            role: "assistant".to_string(),
+            text: text.to_string(),
+            provider: "opencode".to_string(),
+            turn_id: Some(session_id.to_string()),
+            source: Some("opencode_db".to_string()),
+        });
+    }
+
+    if let Ok(mut stamp) = snap.last_output_at.lock() {
+        *stamp = Some(std::time::SystemTime::now());
+    }
+}
+
+fn record_latest_opencode_assistant_text(snap: &AgentSnapshot, session_id: &str) {
+    match opencode_last_assistant_text(session_id) {
+        Ok(Some(text)) => record_opencode_assistant_text(snap, session_id, &text),
+        Ok(None) => {}
+        Err(error) => crate::utils::logging::log_debug(&format!(
+            "[Wardian] Failed to read OpenCode assistant text for {session_id}: {error}"
+        )),
+    }
+}
+
+fn latest_gemini_assistant_message(
+    content: &str,
+) -> Option<wardian_core::control::WatchTranscriptMessage> {
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(content) {
+        if let Some(messages) = parsed.get("messages").and_then(|value| value.as_array()) {
+            return messages
+                .iter()
+                .rev()
+                .find_map(|message| extract_transcript_message("gemini", &message.to_string()));
+        }
+    }
+
+    content
+        .lines()
+        .rev()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            (!trimmed.is_empty()).then_some(trimmed)
+        })
+        .find_map(|line| extract_transcript_message("gemini", line))
+}
+
+fn record_latest_gemini_assistant_text(snap: &AgentSnapshot, content: &str) {
+    let Some(message) = latest_gemini_assistant_message(content) else {
+        return;
+    };
+
+    if let Ok(mut watch_state) = snap.watch_state.lock() {
+        let latest = watch_state
+            .snapshot_since(None, Some(4096))
+            .ok()
+            .and_then(|snapshot| snapshot.transcript.messages.last().cloned());
+        if latest.as_ref().is_some_and(|latest| {
+            latest.provider == message.provider
+                && latest.turn_id == message.turn_id
+                && latest.text == message.text
+        }) {
+            return;
+        }
+        watch_state.push_transcript(message);
+    }
+
+    if let Ok(mut stamp) = snap.last_output_at.lock() {
+        *stamp = Some(std::time::SystemTime::now());
+    }
+}
+
+fn timestamp_to_system_time(timestamp: Option<&str>) -> Option<std::time::SystemTime> {
+    let timestamp = timestamp?;
+    let parsed = chrono::DateTime::parse_from_rfc3339(timestamp).ok()?;
+    let millis = parsed.timestamp_millis();
+    if millis < 0 {
+        return None;
+    }
+    Some(std::time::UNIX_EPOCH + std::time::Duration::from_millis(millis as u64))
+}
+
 fn collect_descendant_pids(
     pid: u32,
     children_map: &HashMap<u32, Vec<u32>>,
@@ -382,6 +482,26 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                     if let Some(path) = opencode_log_path_in(dir, opencode_session_id) {
                         discovered_log = Some(path);
                         break;
+                    }
+                }
+                if discovered_log.is_none()
+                    && snap
+                        .resume_session
+                        .as_deref()
+                        .is_none_or(|value| !value.starts_with("ses_"))
+                {
+                    let spawn_time = snap
+                        .init_timestamp
+                        .lock()
+                        .ok()
+                        .and_then(|timestamp| timestamp_to_system_time(timestamp.as_deref()));
+                    if let Some(spawn_time) = spawn_time {
+                        for dir in &log_dirs {
+                            if let Some(path) = opencode_log_path_after(dir, spawn_time) {
+                                discovered_log = Some(path);
+                                break;
+                            }
+                        }
                     }
                 }
                 *log_path_lock = discovered_log
@@ -586,13 +706,22 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                             }
                             "opencode" => {
                                 let mut status = snap.current_status.lock().unwrap().clone();
+                                let effective_session_id =
+                                    opencode_extract_created_session_id(path)
+                                        .unwrap_or_else(|| opencode_session_id.to_string());
                                 apply_opencode_log_metrics(
                                     &content,
-                                    opencode_session_id,
+                                    &effective_session_id,
                                     &mut q_count,
                                     &mut i_ts,
                                     &mut status,
                                 );
+                                if wardian_core::identity::normalize_status(&status) == "idle" {
+                                    record_latest_opencode_assistant_text(
+                                        snap,
+                                        &effective_session_id,
+                                    );
+                                }
                                 set_snapshot_status_from_log(snap, &status, is_initial_log_replay);
                             }
                             _ => {
@@ -608,6 +737,9 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                     if let Some(start_time) = metrics.init_timestamp {
                                         i_ts = Some(start_time);
                                     }
+                                }
+                                if snap.provider == "gemini" {
+                                    record_latest_gemini_assistant_text(snap, &content);
                                 }
                             }
                         }
@@ -866,6 +998,55 @@ mod tests {
                 .get("status")
                 .and_then(|value| value.as_str()),
             Some("idle")
+        );
+    }
+
+    #[test]
+    fn opencode_assistant_text_records_watch_output_and_transcript() {
+        let snap = test_snapshot("Processing...");
+
+        super::record_opencode_assistant_text(&snap, "ses_test", "OC_DONE");
+
+        let snapshot = snap
+            .watch_state
+            .lock()
+            .unwrap()
+            .snapshot_since(None, Some(4096))
+            .unwrap();
+        assert!(snapshot.output.text.contains("OC_DONE"));
+        assert_eq!(snapshot.transcript.latest_text, "OC_DONE");
+        assert_eq!(snapshot.transcript.messages[0].provider, "opencode");
+        assert_eq!(
+            snapshot.transcript.messages[0].turn_id.as_deref(),
+            Some("ses_test")
+        );
+    }
+
+    #[test]
+    fn gemini_assistant_text_records_watch_transcript() {
+        let snap = test_snapshot("Processing...");
+        let content = concat!(
+            r#"{"sessionId":"gemini-session-1","projectHash":"project","startTime":"2026-05-14T12:00:00.000Z"}"#,
+            "\n",
+            r#"{"id":"m1","timestamp":"2026-05-14T12:00:01.000Z","type":"user","content":"hello"}"#,
+            "\n",
+            r#"{"id":"m2","timestamp":"2026-05-14T12:00:03.000Z","type":"model","content":"Gemini answer","tokens":{"input":10,"output":2,"total":12}}"#,
+            "\n"
+        );
+
+        super::record_latest_gemini_assistant_text(&snap, content);
+
+        let snapshot = snap
+            .watch_state
+            .lock()
+            .unwrap()
+            .snapshot_since(None, Some(4096))
+            .unwrap();
+        assert_eq!(snapshot.transcript.latest_text, "Gemini answer");
+        assert_eq!(snapshot.transcript.messages[0].provider, "gemini");
+        assert_eq!(
+            snapshot.transcript.messages[0].turn_id.as_deref(),
+            Some("m2")
         );
     }
 

--- a/src-tauri/src/providers/mock.rs
+++ b/src-tauri/src/providers/mock.rs
@@ -24,12 +24,23 @@ impl MockProvider {
             return None;
         }
 
-        Some(
-            std::fs::canonicalize(&path)
-                .unwrap_or(path)
-                .to_string_lossy()
-                .to_string(),
-        )
+        Some(Self::node_compatible_script_path(
+            std::fs::canonicalize(&path).unwrap_or(path),
+        ))
+    }
+
+    fn node_compatible_script_path(path: std::path::PathBuf) -> String {
+        let text = path.to_string_lossy();
+        #[cfg(windows)]
+        {
+            if let Some(stripped) = text.strip_prefix("\\\\?\\UNC\\") {
+                return format!("\\\\{stripped}");
+            }
+            if let Some(stripped) = text.strip_prefix("\\\\?\\") {
+                return stripped.to_string();
+            }
+        }
+        text.to_string()
     }
 
     /// Resolves the path to `scripts/mock-agent.cjs`.
@@ -216,10 +227,14 @@ mod tests {
         std::fs::write(&script, "console.log('mock');").expect("write script");
 
         let resolved = MockProvider::existing_script_path(script.clone()).unwrap();
+        let expected =
+            MockProvider::node_compatible_script_path(std::fs::canonicalize(script).unwrap());
 
-        assert_eq!(
-            std::path::PathBuf::from(resolved),
-            std::fs::canonicalize(script).expect("canonical script path")
+        assert_eq!(resolved, expected);
+        #[cfg(windows)]
+        assert!(
+            !resolved.starts_with(r"\\?\"),
+            "Node rejects verbatim Windows script paths: {resolved}"
         );
     }
 
@@ -239,11 +254,10 @@ mod tests {
         std::env::set_var("WARDIAN_MOCK_SCRIPT", &script);
 
         let resolved = MockProvider::resolve_mock_script_path();
+        let expected =
+            MockProvider::node_compatible_script_path(std::fs::canonicalize(&script).unwrap());
 
-        assert_eq!(
-            std::path::PathBuf::from(resolved),
-            std::fs::canonicalize(&script).expect("canonical script path")
-        );
+        assert_eq!(resolved, expected);
         std::env::remove_var("WARDIAN_MOCK_SCRIPT");
     }
 

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -4,6 +4,7 @@ pub mod factory;
 pub mod gemini;
 pub mod mock;
 pub mod opencode;
+pub mod transcript;
 pub use codex::CodexProvider;
 pub use factory::ProviderFactory;
 pub use gemini::GeminiProvider;

--- a/src-tauri/src/providers/transcript.rs
+++ b/src-tauri/src/providers/transcript.rs
@@ -1,0 +1,288 @@
+use wardian_core::control::WatchTranscriptMessage;
+
+pub fn extract_transcript_message(
+    provider_id: &str,
+    raw_line: &str,
+) -> Option<WatchTranscriptMessage> {
+    let provider = provider_id.trim().to_ascii_lowercase();
+    match provider.as_str() {
+        "codex" => extract_codex(raw_line),
+        "claude" => extract_claude(raw_line),
+        "gemini" => extract_gemini(raw_line),
+        "mock" => extract_mock(raw_line),
+        "opencode" => extract_opencode(raw_line),
+        _ => None,
+    }
+}
+
+fn extract_codex(raw_line: &str) -> Option<WatchTranscriptMessage> {
+    let parsed: serde_json::Value = serde_json::from_str(raw_line).ok()?;
+    let msg_type = parsed.get("type")?.as_str()?;
+    let (payload, source) = match msg_type {
+        "response_item" => (parsed.get("payload")?, "response_item"),
+        "event_msg" => (parsed.get("payload")?, "event_msg"),
+        "item.completed" => (parsed.get("item")?, "item.completed"),
+        _ => return None,
+    };
+    let payload_type = payload.get("type").and_then(|value| value.as_str())?;
+    let role = payload.get("role").and_then(|value| value.as_str());
+    let is_assistant = role == Some("assistant")
+        || matches!(
+            payload_type,
+            "agent_message" | "assistant_message" | "message"
+        );
+    if !is_assistant {
+        return None;
+    }
+    let text = extract_text(payload)?;
+    Some(WatchTranscriptMessage {
+        role: "assistant".to_string(),
+        text,
+        provider: "codex".to_string(),
+        turn_id: parsed
+            .get("turn_id")
+            .or_else(|| payload.get("turn_id"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        source: Some(source.to_string()),
+    })
+}
+
+fn extract_claude(raw_line: &str) -> Option<WatchTranscriptMessage> {
+    let parsed: serde_json::Value = serde_json::from_str(raw_line).ok()?;
+    if parsed.get("type").and_then(|value| value.as_str())? != "assistant" {
+        return None;
+    }
+    let message = parsed.get("message").unwrap_or(&parsed);
+    let text = extract_text(message)?;
+    Some(WatchTranscriptMessage {
+        role: "assistant".to_string(),
+        text,
+        provider: "claude".to_string(),
+        turn_id: message
+            .get("id")
+            .or_else(|| parsed.get("message_id"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        source: Some("stream_json".to_string()),
+    })
+}
+
+fn extract_mock(raw_line: &str) -> Option<WatchTranscriptMessage> {
+    let parsed: serde_json::Value = serde_json::from_str(raw_line).ok()?;
+    let msg_type = parsed.get("type")?.as_str()?;
+    if !matches!(msg_type, "model" | "message" | "info") {
+        return None;
+    }
+    if msg_type == "message" {
+        let role = parsed.get("role").and_then(|value| value.as_str());
+        if !matches!(role, Some("assistant" | "model")) {
+            return None;
+        }
+    }
+    let text = extract_text(&parsed)?;
+    Some(WatchTranscriptMessage {
+        role: "assistant".to_string(),
+        text,
+        provider: "mock".to_string(),
+        turn_id: parsed
+            .get("turn_id")
+            .or_else(|| parsed.get("id"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        source: Some(msg_type.to_string()),
+    })
+}
+
+fn extract_gemini(raw_line: &str) -> Option<WatchTranscriptMessage> {
+    let parsed: serde_json::Value = serde_json::from_str(raw_line).ok()?;
+    let msg_type = gemini_message_kind(&parsed)?;
+    match msg_type {
+        "gemini" | "assistant" | "model" if gemini_completed_message(&parsed) => {}
+        "message" => {
+            let role = parsed.get("role").and_then(|value| value.as_str());
+            if !matches!(role, Some("assistant" | "model")) {
+                return None;
+            }
+            if !gemini_completed_message(&parsed) {
+                return None;
+            }
+        }
+        _ => return None,
+    }
+
+    let text = extract_text(&parsed)?;
+    Some(WatchTranscriptMessage {
+        role: "assistant".to_string(),
+        text,
+        provider: "gemini".to_string(),
+        turn_id: parsed
+            .get("id")
+            .or_else(|| parsed.get("message_id"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        source: Some("gemini_log".to_string()),
+    })
+}
+
+fn extract_opencode(raw_line: &str) -> Option<WatchTranscriptMessage> {
+    let parsed: serde_json::Value = serde_json::from_str(raw_line).ok()?;
+    if parsed.get("type").and_then(|value| value.as_str())? != "text" {
+        return None;
+    }
+    let text = parsed
+        .get("part")
+        .and_then(extract_text)
+        .or_else(|| extract_text(&parsed))?;
+    Some(WatchTranscriptMessage {
+        role: "assistant".to_string(),
+        text,
+        provider: "opencode".to_string(),
+        turn_id: parsed
+            .get("sessionID")
+            .or_else(|| parsed.get("session_id"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        source: Some("stream_json".to_string()),
+    })
+}
+
+fn gemini_message_kind(value: &serde_json::Value) -> Option<&str> {
+    value
+        .get("type")
+        .and_then(|value| value.as_str())
+        .or_else(|| value.get("role").and_then(|value| value.as_str()))
+}
+
+fn gemini_completed_message(value: &serde_json::Value) -> bool {
+    value.get("tokens").is_some()
+        || value.get("usage").is_some()
+        || value.get("finishReason").is_some()
+        || value.get("finish_reason").is_some()
+}
+
+fn extract_text(value: &serde_json::Value) -> Option<String> {
+    let candidates = ["text", "content", "message", "summary"];
+    for key in candidates {
+        if let Some(text) = value.get(key).and_then(|value| value.as_str()) {
+            let trimmed = text.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+
+    if let Some(content) = value.get("content").and_then(|value| value.as_array()) {
+        let parts = content
+            .iter()
+            .filter_map(|item| {
+                item.get("text")
+                    .or_else(|| item.get("content"))
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|text| !text.is_empty())
+            })
+            .collect::<Vec<_>>();
+        if !parts.is_empty() {
+            return Some(parts.join("\n"));
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_response_item_message_extracts_assistant_text() {
+        let line = r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Codex answer"}]},"turn_id":"turn-1"}"#;
+
+        let message = extract_transcript_message("codex", line).unwrap();
+
+        assert_eq!(message.role, "assistant");
+        assert_eq!(message.text, "Codex answer");
+        assert_eq!(message.provider, "codex");
+        assert_eq!(message.turn_id.as_deref(), Some("turn-1"));
+    }
+
+    #[test]
+    fn claude_assistant_content_text_block_extracts_assistant_text() {
+        let line = r#"{"type":"assistant","message":{"id":"msg-1","content":[{"type":"text","text":"Claude answer"}]}}"#;
+
+        let message = extract_transcript_message("claude", line).unwrap();
+
+        assert_eq!(message.role, "assistant");
+        assert_eq!(message.text, "Claude answer");
+        assert_eq!(message.provider, "claude");
+        assert_eq!(message.turn_id.as_deref(), Some("msg-1"));
+    }
+
+    #[test]
+    fn mock_model_event_extracts_assistant_text() {
+        let line = r#"{"type":"model","content":"Mock answer","turn_id":"turn-7"}"#;
+
+        let message = extract_transcript_message("mock", line).unwrap();
+
+        assert_eq!(message.role, "assistant");
+        assert_eq!(message.text, "Mock answer");
+        assert_eq!(message.provider, "mock");
+        assert_eq!(message.turn_id.as_deref(), Some("turn-7"));
+    }
+
+    #[test]
+    fn opencode_text_part_extracts_assistant_text() {
+        let line = r#"{"type":"text","sessionID":"ses_test","part":{"type":"text","text":"OpenCode answer"}}"#;
+
+        let message = extract_transcript_message("opencode", line).unwrap();
+
+        assert_eq!(message.role, "assistant");
+        assert_eq!(message.text, "OpenCode answer");
+        assert_eq!(message.provider, "opencode");
+        assert_eq!(message.turn_id.as_deref(), Some("ses_test"));
+    }
+
+    #[test]
+    fn gemini_completed_model_record_extracts_assistant_text() {
+        let line = r#"{"id":"gem-msg-1","type":"model","content":"Gemini answer","tokens":{"input":10,"output":2,"total":12}}"#;
+
+        let message = extract_transcript_message("gemini", line).unwrap();
+
+        assert_eq!(message.role, "assistant");
+        assert_eq!(message.text, "Gemini answer");
+        assert_eq!(message.provider, "gemini");
+        assert_eq!(message.turn_id.as_deref(), Some("gem-msg-1"));
+    }
+
+    #[test]
+    fn gemini_partial_model_chunk_does_not_extract_transcript() {
+        for line in [
+            r#"{"id":"gem-msg-1","type":"model","content":"partial chunk"}"#,
+            r#"{"id":"gem-msg-2","type":"gemini","content":"partial chunk"}"#,
+            r#"{"id":"gem-msg-3","type":"assistant","content":"partial chunk"}"#,
+        ] {
+            assert!(extract_transcript_message("gemini", line).is_none());
+        }
+    }
+
+    #[test]
+    fn user_prompt_echo_and_tool_events_do_not_extract_transcript() {
+        assert!(
+            extract_transcript_message("mock", r#"{"type":"user","content":"hello"}"#).is_none()
+        );
+        assert!(extract_transcript_message(
+            "codex",
+            r#"{"type":"response_item","payload":{"type":"function_call","arguments":"{}"}}"#
+        )
+        .is_none());
+        assert!(extract_transcript_message(
+            "claude",
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}"#
+        )
+        .is_none());
+        assert!(
+            extract_transcript_message("gemini", r#"{"type":"user","content":"hello"}"#).is_none()
+        );
+    }
+}

--- a/src-tauri/src/state/agent_watch.rs
+++ b/src-tauri/src/state/agent_watch.rs
@@ -2,7 +2,9 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use tokio::sync::Notify;
-use wardian_core::control::{WatchEvent, WatchOutput};
+use wardian_core::control::{WatchEvent, WatchOutput, WatchTranscript, WatchTranscriptMessage};
+
+use super::terminal_text::strip_terminal_controls;
 
 #[derive(Debug)]
 pub struct AgentWatchState {
@@ -55,6 +57,10 @@ impl AgentWatchState {
         self.push_record(WatchRecordKind::Delivery { payload })
     }
 
+    pub fn push_transcript(&mut self, message: WatchTranscriptMessage) -> WatchCursor {
+        self.push_record(WatchRecordKind::Transcript { message })
+    }
+
     pub fn snapshot_since(
         &self,
         since: Option<&str>,
@@ -78,6 +84,7 @@ impl AgentWatchState {
             .filter(|record| record.sequence > since_sequence);
         let mut events = Vec::new();
         let mut output = Vec::new();
+        let mut transcript_messages = Vec::new();
         for record in records {
             match &record.kind {
                 WatchRecordKind::Event { kind, payload } => events.push(WatchEvent {
@@ -91,15 +98,53 @@ impl AgentWatchState {
                     payload: payload.clone(),
                 }),
                 WatchRecordKind::Output { bytes } => output.extend(bytes),
+                WatchRecordKind::Transcript { message } => {
+                    transcript_messages.push(message.clone());
+                }
             }
         }
 
-        let output = self.snapshot_output(output, tail_bytes);
+        let raw_output = self.snapshot_output(output.clone(), tail_bytes, false);
+        let output = self.snapshot_output(output, tail_bytes, true);
+        let transcript = self.snapshot_transcript(transcript_messages, tail_bytes);
         Ok(WatchSnapshot {
             cursor: self.latest_cursor(),
             events,
             output,
+            raw_output,
+            transcript,
         })
+    }
+
+    pub fn raw_snapshot_since(
+        &self,
+        since: Option<&str>,
+        tail_bytes: Option<usize>,
+    ) -> Result<WatchOutput, WatchStateError> {
+        let since_sequence = self.parse_since_sequence(since)?;
+        let oldest = self.oldest_available_sequence();
+        if since_sequence.saturating_add(1) < oldest {
+            return Err(WatchStateError::new(
+                "cursor_expired",
+                serde_json::json!({
+                    "oldest_available_cursor": self.oldest_available_cursor(),
+                    "requested_cursor": since,
+                }),
+            ));
+        }
+
+        let mut output = Vec::new();
+        for record in self
+            .records
+            .iter()
+            .filter(|record| record.sequence > since_sequence)
+        {
+            if let WatchRecordKind::Output { bytes } = &record.kind {
+                output.extend(bytes);
+            }
+        }
+
+        Ok(self.snapshot_output(output, tail_bytes, false))
     }
 
     fn push_record(&mut self, kind: WatchRecordKind) -> WatchCursor {
@@ -145,14 +190,69 @@ impl AgentWatchState {
             .sum()
     }
 
-    fn snapshot_output(&self, bytes: Vec<u8>, tail_bytes: Option<usize>) -> WatchOutput {
+    fn snapshot_output(
+        &self,
+        bytes: Vec<u8>,
+        tail_bytes: Option<usize>,
+        sanitize: bool,
+    ) -> WatchOutput {
         let limit = tail_bytes.unwrap_or(bytes.len()).min(bytes.len());
         let start = utf8_tail_start(&bytes, limit);
         let omitted_bytes = start;
         let text = String::from_utf8_lossy(&bytes[start..]).to_string();
+        let text = if sanitize {
+            strip_terminal_controls(&text)
+        } else {
+            text
+        };
         WatchOutput {
             cursor: self.latest_cursor(),
             text,
+            truncated: omitted_bytes > 0,
+            omitted_bytes,
+        }
+    }
+
+    fn snapshot_transcript(
+        &self,
+        messages: Vec<WatchTranscriptMessage>,
+        tail_bytes: Option<usize>,
+    ) -> WatchTranscript {
+        let limit = tail_bytes.unwrap_or(self.max_output_bytes);
+        let mut remaining = limit;
+        let mut omitted_bytes = 0usize;
+        let mut retained = Vec::new();
+
+        for mut message in messages.into_iter().rev() {
+            let bytes = message.text.as_bytes();
+            if bytes.len() <= remaining {
+                remaining = remaining.saturating_sub(bytes.len());
+                retained.push(message);
+                continue;
+            }
+
+            if remaining > 0 {
+                let start = utf8_tail_start(bytes, remaining);
+                omitted_bytes = omitted_bytes.saturating_add(start);
+                message.text = String::from_utf8_lossy(&bytes[start..]).to_string();
+                retained.push(message);
+                remaining = 0;
+            } else {
+                omitted_bytes = omitted_bytes.saturating_add(bytes.len());
+            }
+        }
+
+        retained.reverse();
+        let latest_text = retained
+            .iter()
+            .rev()
+            .find(|message| !message.text.trim().is_empty())
+            .map(|message| message.text.clone())
+            .unwrap_or_default();
+        WatchTranscript {
+            cursor: self.latest_cursor(),
+            messages: retained,
+            latest_text,
             truncated: omitted_bytes > 0,
             omitted_bytes,
         }
@@ -208,6 +308,8 @@ pub struct WatchSnapshot {
     pub cursor: String,
     pub events: Vec<WatchEvent>,
     pub output: WatchOutput,
+    pub raw_output: WatchOutput,
+    pub transcript: WatchTranscript,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -245,6 +347,9 @@ enum WatchRecordKind {
     Output {
         bytes: Vec<u8>,
     },
+    Transcript {
+        message: WatchTranscriptMessage,
+    },
     Delivery {
         payload: serde_json::Value,
     },
@@ -277,6 +382,72 @@ mod tests {
 
         assert_eq!(first.output.text, "hello");
         assert_eq!(second.output.text, "hello");
+    }
+
+    #[test]
+    fn watch_state_sanitizes_default_output_and_keeps_raw_snapshot_opt_in() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 16, 1024);
+        state.push_output("\u{1b}[31mred\u{1b}[0m".as_bytes());
+
+        let snapshot = state.snapshot_since(None, Some(1024)).unwrap();
+        let raw = state.raw_snapshot_since(None, Some(1024)).unwrap();
+
+        assert_eq!(snapshot.output.text, "red");
+        assert_eq!(raw.text, "\u{1b}[31mred\u{1b}[0m");
+    }
+
+    #[test]
+    fn watch_state_returns_transcript_messages_since_cursor() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 16, 1024);
+        let start = state.latest_cursor();
+        state.push_transcript(wardian_core::control::WatchTranscriptMessage {
+            role: "assistant".to_string(),
+            text: "final answer".to_string(),
+            provider: "mock".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            source: Some("model".to_string()),
+        });
+
+        let snapshot = state.snapshot_since(Some(&start), Some(1024)).unwrap();
+
+        assert_eq!(snapshot.transcript.messages.len(), 1);
+        assert_eq!(snapshot.transcript.latest_text, "final answer");
+    }
+
+    #[test]
+    fn watch_state_tail_bounds_transcript_text() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 16, 1024);
+        state.push_transcript(wardian_core::control::WatchTranscriptMessage {
+            role: "assistant".to_string(),
+            text: "alpha beta gamma".to_string(),
+            provider: "mock".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            source: Some("model".to_string()),
+        });
+
+        let snapshot = state.snapshot_since(None, Some(5)).unwrap();
+
+        assert_eq!(snapshot.transcript.messages.len(), 1);
+        assert_eq!(snapshot.transcript.latest_text, "gamma");
+        assert!(snapshot.transcript.truncated);
+        assert!(snapshot.transcript.omitted_bytes > 0);
+    }
+
+    #[test]
+    fn watch_state_default_transcript_uses_retention_byte_limit() {
+        let mut state = AgentWatchState::new("agent-1".to_string(), 16, 6);
+        state.push_transcript(wardian_core::control::WatchTranscriptMessage {
+            role: "assistant".to_string(),
+            text: "alpha beta".to_string(),
+            provider: "mock".to_string(),
+            turn_id: Some("turn-1".to_string()),
+            source: Some("model".to_string()),
+        });
+
+        let snapshot = state.snapshot_since(None, None).unwrap();
+
+        assert_eq!(snapshot.transcript.latest_text, "a beta");
+        assert!(snapshot.transcript.truncated);
     }
 
     #[test]
@@ -320,10 +491,18 @@ mod tests {
 
         let status = state.push_event("status", serde_json::json!({"status":"processing"}));
         let output = state.push_output("hello".as_bytes());
+        let transcript = state.push_transcript(wardian_core::control::WatchTranscriptMessage {
+            role: "assistant".to_string(),
+            text: "hello".to_string(),
+            provider: "mock".to_string(),
+            turn_id: None,
+            source: None,
+        });
         let delivery = state.push_delivery(serde_json::json!({"delivery_state":"submitted"}));
 
         assert!(status.sequence() < output.sequence());
-        assert!(output.sequence() < delivery.sequence());
+        assert!(output.sequence() < transcript.sequence());
+        assert!(transcript.sequence() < delivery.sequence());
     }
 
     #[test]

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -1,6 +1,7 @@
 pub mod active_agent;
 pub mod agent_watch;
 pub mod app_state;
+pub mod terminal_text;
 pub mod user_terminal;
 
 pub use active_agent::ActiveAgent;

--- a/src-tauri/src/state/terminal_text.rs
+++ b/src-tauri/src/state/terminal_text.rs
@@ -1,0 +1,91 @@
+pub fn strip_terminal_controls(input: &str) -> String {
+    let normalized = input.replace("\r\n", "\n").replace('\r', "\n");
+    let mut output = String::with_capacity(normalized.len());
+    let mut chars = normalized.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch != '\u{1b}' {
+            output.push(ch);
+            continue;
+        }
+
+        match chars.peek().copied() {
+            Some('[') => {
+                chars.next();
+                for code in chars.by_ref() {
+                    if ('@'..='~').contains(&code) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                chars.next();
+                while let Some(code) = chars.next() {
+                    if code == '\u{7}' {
+                        break;
+                    }
+                    if code == '\u{1b}' && chars.peek() == Some(&'\\') {
+                        chars.next();
+                        break;
+                    }
+                }
+            }
+            Some('(' | ')' | '*' | '+' | '-' | '.' | '/') => {
+                chars.next();
+                let _ = chars.next();
+            }
+            Some(_) => {
+                let _ = chars.next();
+            }
+            None => {}
+        }
+    }
+
+    output
+        .lines()
+        .map(|line| line.trim_end_matches('\u{8}'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_terminal_controls_removes_sgr_color() {
+        assert_eq!(strip_terminal_controls("\u{1b}[31mred\u{1b}[0m"), "red");
+    }
+
+    #[test]
+    fn strip_terminal_controls_removes_csi_cursor_and_clear_controls() {
+        assert_eq!(
+            strip_terminal_controls("\u{1b}[2J\u{1b}[Hanswer\u{1b}[K"),
+            "answer"
+        );
+    }
+
+    #[test]
+    fn strip_terminal_controls_removes_osc_title() {
+        assert_eq!(
+            strip_terminal_controls("\u{1b}]0;Wardian\u{7}ready"),
+            "ready"
+        );
+    }
+
+    #[test]
+    fn strip_terminal_controls_normalizes_crlf_and_cr() {
+        assert_eq!(strip_terminal_controls("a\r\nb\rc"), "a\nb\nc");
+    }
+
+    #[test]
+    fn strip_terminal_controls_makes_bibtex_sample_readable() {
+        let sample = "\u{1b}[2J\u{1b}[H\u{1b}[1m@article{smith2026,\u{1b}[0m\r\n  title={Wardian},\u{1b}[K\r\n}";
+
+        let cleaned = strip_terminal_controls(sample);
+
+        assert!(!cleaned.contains('\u{1b}'));
+        assert!(cleaned.contains("@article{smith2026,"));
+        assert!(cleaned.contains("title={Wardian}"));
+    }
+}

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -924,11 +924,10 @@ fn is_windows_cmd_shim(program: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        CodexRuntimePolicy, ShellOption, ShellSettings,
         build_interactive_shell_launch_with_settings, build_program_launch_with_settings,
         build_shell_cd_command, build_shell_command_with_settings, default_shell_args,
         load_shell_settings_from_path, save_shell_settings_to_path, shell_id_from_executable,
-        shell_option,
+        shell_option, CodexRuntimePolicy, ShellOption, ShellSettings,
     };
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;

--- a/src-tauri/src/utils/terminal_input.rs
+++ b/src-tauri/src/utils/terminal_input.rs
@@ -1,7 +1,8 @@
-use tokio::sync::mpsc::Sender;
-
 const TERMINAL_SUBMIT_DELAY_MS: u64 = 1000;
 const TERMINAL_SUBMIT_KEY: &[u8] = b"\r";
+const OPENCODE_SUBMIT_KEY: &[u8] = b"\x1b[13u";
+
+use tokio::sync::mpsc::Sender;
 
 pub fn normalize_prompt_for_terminal_submit(prompt: &str) -> String {
     prompt
@@ -11,13 +12,18 @@ pub fn normalize_prompt_for_terminal_submit(prompt: &str) -> String {
         .to_string()
 }
 
-pub fn provider_submit_chunks(_provider_name: &str, prompt: &str) -> Result<Vec<Vec<u8>>, String> {
+pub fn provider_submit_chunks(provider_name: &str, prompt: &str) -> Result<Vec<Vec<u8>>, String> {
     let normalized = normalize_prompt_for_terminal_submit(prompt);
     if normalized.is_empty() {
         return Ok(Vec::new());
     }
 
-    Ok(vec![normalized.into_bytes(), TERMINAL_SUBMIT_KEY.to_vec()])
+    let submit_key = if provider_name.eq_ignore_ascii_case("opencode") {
+        OPENCODE_SUBMIT_KEY
+    } else {
+        TERMINAL_SUBMIT_KEY
+    };
+    Ok(vec![normalized.into_bytes(), submit_key.to_vec()])
 }
 
 pub async fn submit_prompt_chunks_via_sender(
@@ -58,7 +64,9 @@ pub async fn submit_prompt_via_sender(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_prompt_for_terminal_submit, submit_prompt_via_sender};
+    use super::{
+        normalize_prompt_for_terminal_submit, provider_submit_chunks, submit_prompt_via_sender,
+    };
 
     #[test]
     fn normalize_prompt_flattens_newlines_and_trims() {
@@ -81,5 +89,12 @@ mod tests {
 
         assert_eq!(String::from_utf8(first).expect("utf8"), "hello world");
         assert_eq!(second, b"\r".to_vec());
+    }
+
+    #[test]
+    fn opencode_submit_uses_kitty_protocol_return_key() {
+        let chunks = provider_submit_chunks("opencode", "hello").expect("chunks");
+
+        assert_eq!(chunks, vec![b"hello".to_vec(), b"\x1b[13u".to_vec()]);
     }
 }

--- a/src-tauri/tests/mock_provider_e2e.rs
+++ b/src-tauri/tests/mock_provider_e2e.rs
@@ -163,6 +163,29 @@ fn long_output_scenario_emits_many_lines() {
 }
 
 #[test]
+fn ansi_output_scenario_preserves_terminal_escape_bytes() {
+    let script = mock_script_path();
+
+    let output = Command::new("node")
+        .arg(&script)
+        .env("WARDIAN_MOCK_SCENARIO", "ansi_output")
+        .env("WARDIAN_MOCK_DELAY_MS", "0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("Failed to spawn mock-agent.cjs");
+
+    assert!(
+        output.status.success(),
+        "mock agent should exit successfully"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("\u{1b}[31mANSI_TERMINAL_LINE\u{1b}[0m"));
+    assert!(stdout.contains("ANSI readable answer."));
+}
+
+#[test]
 fn interactive_multi_turn_echoes_each_submitted_input() {
     let script = mock_script_path();
 


### PR DESCRIPTION
## Description
- Makes `wardian agent watch` return agent-readable surfaces by default: provider transcript, sanitized terminal output, delivery/status metadata, and cursor.
- Keeps raw PTY bytes available through explicit `--raw` / `raw_output` opt-in for terminal debugging.
- Adds transcript adapters and fallback coverage for Codex, Claude, Gemini, OpenCode, and mock, including Gemini log-backed assistant text and OpenCode DB-backed assistant text for live visible TUI sessions.
- Removes OpenCode prompt submission from the headless path for active sessions; live control now submits through the real PTY with the provider-specific Kitty Return sequence.
- Documents issue #273 behavior and compatibility expectations in the CLI guide, specs, and bundled Wardian CLI skill.

## Related Issues
Fixes #273

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] Independent code review requested twice. First review found no Critical issues and Important findings on transcript tailing, output echo matching, and OpenCode headless submit; those were fixed. Follow-up review found Gemini partial chunk handling and transcript-only ask visibility issues; those were fixed and the final focused re-review found no Critical, Important, or Minor findings.
- [x] `cd src-tauri && cargo fmt --check`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cd src-tauri && cargo test` (490 Rust tests plus 7 mock-provider E2E tests)
- [x] `cargo test -p wardian-cli` (70 main CLI tests plus integration suites)
- [x] `npm run lint`
- [x] `npm run test` (62 files / 614 tests; existing React act warnings still print)
- [x] `npm run tauri -- build --debug --no-bundle`
- [x] `npm run test:e2e:native:fast -- e2e-native/tests/cli-shared-state-native.test.mjs` (6 passed, 1 real-provider-only skip)
- [x] `git diff --check`
- [x] Real OpenCode live visible TUI smoke: `wardian ask` delivered through PTY and produced readable DB-backed transcript/output marker.

Provider coverage / compatibility notes:
- Codex, Claude, Gemini, OpenCode, and mock have transcript adapter coverage in this slice.
- Ambiguous/unknown provider lines intentionally fall back to sanitized terminal `output`.
- Gemini completed assistant text is backfilled from Gemini chat logs when available; partial assistant-like chunks without completion markers are ignored to avoid treating streaming fragments as final transcript messages.
- Raw PTY output remains available but is no longer returned by default.
- The native readable/raw watch test uses debug-seeded mock output to prove response shaping; real OpenCode was separately smoke-tested for PTY delivery and DB-backed output.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable