### PR TITLE
docs: add provider readiness guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
           text: "First-Time Setup",
           items: [
             { text: "Getting Started", link: "/guide/getting-started" },
+            { text: "Provider Readiness", link: "/guide/provider-readiness" },
             { text: "UI Overview", link: "/guide/ui-overview" },
           ],
         },

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,6 +9,8 @@ Wardian is an integrated habitat for managing multiple autonomous agents. This g
 
 Authenticate each provider in a normal terminal before spawning it through Wardian.
 
+Before the first spawn, verify the provider command, authentication, and shell `PATH` using [Provider Readiness](./provider-readiness.md).
+
 ## 2. Understanding Blueprints
 Before spawning an agent, you must understand **Classes**. A Class is a "Blueprint" that defines an agent's base instructions and capabilities.
 1. Click **LIBRARY** in the top bar view-switcher.
@@ -66,5 +68,6 @@ Click **GRID** in the top bar to see all active agents in a high-density termina
 - Triage completed work in the [Queue](./queue.md).
 - Manage per-agent Git operations in [Source Control](./source-control.md).
 - Configure runtime behavior and shell defaults in [Settings](./settings.md).
+- Verify provider commands and authentication in [Provider Readiness](./provider-readiness.md).
 - Compare provider runtime behavior in [Provider Runtimes](../providers.md).
 - Automate complex tasks with [Visual Workflows](./workflows.md).

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -5,6 +5,7 @@ Use this index to find user-facing documentation by task.
 ## First-Time Setup
 
 - [Getting Started](./getting-started.md)
+- [Provider Readiness](./provider-readiness.md)
 - [UI Overview](./ui-overview.md)
 
 ## Agent Operations

--- a/docs/guide/provider-readiness.md
+++ b/docs/guide/provider-readiness.md
@@ -1,0 +1,174 @@
+# Provider Readiness
+
+Wardian launches provider CLIs that are already installed and authenticated on your machine. Before spawning your first agent, verify at least one supported provider in a normal terminal.
+
+Use this guide when a provider does not appear to start, opens an unexpected sign-in prompt, or works in one shell but not inside Wardian.
+
+## What Wardian Detects
+
+Wardian can detect and launch supported provider commands when they are visible from the Wardian app process environment. For desktop launches, that usually means the provider command must be on the user or system `PATH` before Wardian starts.
+
+Wardian does not install provider accounts, complete browser sign-in, create provider billing, or repair shell startup files. Do those steps in a normal terminal before spawning an agent.
+
+## Basic Workflow
+
+1. Install one provider CLI.
+2. Confirm the command is on `PATH`.
+3. Run the provider once in a normal terminal and complete its authentication flow.
+4. Restart Wardian after changing `PATH` so the app process can see the provider command.
+5. Return to [Getting Started](./getting-started.md) and spawn an agent with that provider.
+
+## Shared Checks
+
+Most supported providers are distributed through Node.js packages. Check Node and npm first:
+
+```bash
+node --version
+npm --version
+```
+
+Confirm provider commands are visible:
+
+```bash
+command -v gemini
+command -v claude
+command -v codex
+command -v opencode
+```
+
+PowerShell:
+
+```powershell
+node --version
+npm --version
+Get-Command gemini, claude, codex, opencode -ErrorAction SilentlyContinue
+```
+
+If a command appears only after a shell startup script modifies `PATH`, make that path available to the app process as well. The agent default shell setting controls shell-hosted commands; interactive provider spawning resolves the provider executable before that shell runs.
+
+## Gemini CLI
+
+Install:
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+Verify:
+
+```bash
+gemini --version
+gemini
+```
+
+Complete the Gemini CLI sign-in or API-key flow in the terminal. After it reaches the interactive prompt, exit and spawn a Gemini agent from Wardian.
+
+## Claude Code
+
+Install:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Verify:
+
+```bash
+claude --version
+claude
+```
+
+Complete Claude Code authentication in the terminal. If Claude opens a browser or prompts for a plan/account, finish that setup before using Wardian.
+
+## Codex
+
+Install:
+
+```bash
+npm install -g @openai/codex
+```
+
+Verify:
+
+```bash
+codex --version
+codex
+```
+
+Complete the OpenAI sign-in or credential setup requested by Codex. If Codex asks to trust a workspace, answer that prompt in a normal terminal for the workspace you plan to use.
+
+## OpenCode
+
+OpenCode's official install script is the simplest POSIX path:
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+The Node.js package is also available:
+
+```bash
+npm install -g opencode-ai
+```
+
+Verify:
+
+```bash
+opencode --version
+opencode
+```
+
+In the OpenCode TUI, run `/connect` and configure the LLM provider you want OpenCode to use. On Windows, OpenCode's own documentation recommends WSL for the best terminal compatibility; npm, Chocolatey, Scoop, and binary installs are also available.
+
+## Troubleshooting
+
+### Provider Not Found
+
+If Wardian reports that a provider command is missing, first check whether a newly opened terminal can see the command:
+
+```bash
+command -v <provider-command>
+```
+
+PowerShell:
+
+```powershell
+Get-Command <provider-command>
+```
+
+If the command exists in a terminal but Wardian still cannot find it, update the user or system `PATH` that the desktop app inherits, then fully restart Wardian. Changing the agent **Default Shell** can help shell-hosted workflow commands, but it does not by itself make an interactive provider executable visible to the Wardian app process.
+
+### Authentication Prompt Appears in the Agent Terminal
+
+Stop the agent, open a normal terminal, and run the provider command directly. Complete browser sign-in, device-code login, API-key entry, billing setup, workspace trust, or provider-specific first-run prompts there. Then spawn the Wardian agent again.
+
+### PATH Mismatch
+
+Global npm installs often land in a user-level bin directory. If your login shell adds that directory but the desktop app was launched before the change, Wardian may not see the provider command.
+
+Prefer one of these fixes:
+
+- Install the provider in a location already visible to all shells you use.
+- Add the package-manager bin directory to the user or system `PATH`.
+- Fully restart Wardian after changing `PATH`.
+- Verify the command from a newly opened terminal that did not inherit a temporary one-session path edit.
+
+### Shell Mismatch
+
+Provider shims can behave differently in bash, zsh, PowerShell, cmd, Git Bash, WSL, and package-manager shells. Wardian resolves the interactive provider executable from the app process, then may wrap some Windows shims for compatibility. Use the agent **Default Shell** in [Settings](./settings.md) for shell-hosted commands and workflow command nodes, but fix provider-not-found errors by making the provider command visible to the app process `PATH`.
+
+### Provider-Specific Startup Failure
+
+When the command is found but startup still fails:
+
+- Run the provider directly in the target workspace and read its first error.
+- Check whether the provider requires project trust, API credits, model access, or a newer Node.js version.
+- For OpenCode on Windows, try WSL if the native terminal path fails.
+- For Gemini skill discovery issues, run the Gemini patch from Settings before changing project files.
+- For deeper runtime differences, compare the provider behavior in [Provider Runtimes](../providers.md).
+
+## Related Links
+
+- [Getting Started](./getting-started.md)
+- [Settings](./settings.md)
+- [Provider Runtimes](../providers.md)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -85,5 +85,6 @@ If OpenCode misses instructions or skills, inspect the generated `OPENCODE_CONFI
 ## Related References
 
 - [Developer Provider Runtime Notes](./developer/provider-runtimes.md)
+- [Provider Readiness](./guide/provider-readiness.md)
 - [Settings](./guide/settings.md)
 - [Agent Roles and Responsibilities](./agents/roles.md)


### PR DESCRIPTION
## Description
Adds a Provider Readiness guide for first-run setup. The new page covers Gemini CLI, Claude Code, Codex, and OpenCode installation/authentication expectations, POSIX-first verification commands with labeled PowerShell equivalents, what Wardian can detect automatically, and troubleshooting for provider lookup, auth prompts, PATH mismatch, shell mismatch, and provider-specific startup failures.

The first-run guide now links to Provider Readiness before the first spawn step, and Provider Runtimes links back to it for setup-oriented checks.

## Related Issues
Fixes #279
Part of #274

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run docs:build`
- `npm run lint`
- `npm run test`
- `npm run build`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo clippy`
- `git diff --check`
- Changed-file secret/local-path scan with `rg`
- Subagent review by Singer; blocking PATH/app-process guidance was fixed before commit

Notes: `npm run test` still emits existing React `act(...)` warnings in unrelated Watchlist/App tests. `npm run build` and `npm run docs:build` still emit the existing Vite large-chunk warning.

## Screenshots
<!-- Non-UI documentation-only change. -->

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable