### PR TITLE
docs: define docs maintenance workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ Please describe the tests that you ran to verify your changes.
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
+- [ ] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -96,6 +96,7 @@ export default defineConfig({
             { text: "Provider Runtimes", link: "/developer/provider-runtimes" },
             { text: "PTY Lifecycle", link: "/developer/pty-lifecycle" },
             { text: "Native E2E", link: "/developer/native-e2e" },
+            { text: "Docs Maintenance", link: "/developer/docs-maintenance" },
             { text: "Theming", link: "/developer/theming" },
             { text: "Screenshot Documentation", link: "/developer/screenshot-documentation" },
           ],

--- a/docs/developer/docs-maintenance.md
+++ b/docs/developer/docs-maintenance.md
@@ -1,0 +1,66 @@
+# Documentation Maintenance
+
+Wardian documentation is part of the product surface. Feature PRs should update the public docs in the same branch when the change affects what users install, see, configure, run, troubleshoot, or automate.
+
+## When a PR Must Update User Docs
+
+Update user-facing docs when a change affects any of these surfaces:
+
+- first-run setup, provider installation, app launch, or troubleshooting
+- visible UI behavior, labels, navigation, status indicators, settings, or empty states
+- CLI commands, arguments, output fields, exit behavior, or live-control requirements
+- workflow authoring, node behavior, scheduling, Queue behavior, or agent assignment
+- provider runtime behavior, shell behavior, permissions, sandboxing, session persistence, or filesystem expectations
+- release, installation, platform support, or upgrade behavior
+- error messages or recovery paths that users are expected to act on
+
+Internal-only changes do not need user docs when they leave the public workflow unchanged. In that case, state that docs are not applicable in the PR checklist or test plan.
+
+## Where to Update
+
+Choose the smallest docs surface that matches the change:
+
+- `docs/guide/` for user workflows and task-oriented feature guides
+- `docs/workflows/` for workflow concepts, node behavior, and execution semantics
+- `docs/providers.md` and `docs/developer/provider-runtimes.md` for provider runtime behavior
+- `docs/developer/` for implementation, testing, publishing, and contributor workflows
+- `docs/specs/` for strategic decisions or behavior that needs design history
+- `README.md` only when the public overview, installation path, or top-level links change
+
+Keep cross-platform examples POSIX-first with a labeled PowerShell variant when commands differ. Use placeholders such as `<absolute-workspace-path>` instead of personal paths.
+
+## Screenshot Refresh Rules
+
+Refresh screenshots when a PR changes a user-visible state that an existing screenshot documents, or when a new guide needs visual evidence to be understandable.
+
+Use the existing screenshot rules:
+
+- Committed reader-facing screenshots live under `docs/assets/screenshots/<feature-or-window>/`.
+- Follow [Screenshot Documentation](./screenshot-documentation.md) for naming, placement, alt text, and capture hygiene.
+- Use `npm run docs:screenshots` for browser-capturable seeded UI states.
+- Use native E2E evidence for screenshots that require real Tauri IPC, PTY behavior, provider spawning, or filesystem effects.
+- Do not commit `e2e/screenshots/`; that path is for temporary PR evidence and local audit captures.
+
+Frontend PRs that change behavior or visuals must also embed representative screenshot evidence in the PR body using an HTTPS image URL. A local path alone is not enough.
+
+## Release Notes and Public Docs Checklist
+
+Before merging user-facing work, check:
+
+- The owning guide or reference page explains the new behavior.
+- Any affected screenshots were refreshed or intentionally left unchanged.
+- The PR body links the issue and lists verification evidence.
+- Release-impacting changes use a Conventional Commit type and scope that Release Please can place in `CHANGELOG.md`.
+- Public overview links in `README.md` and `docs/index.md` still point to the right guide pages.
+- `npm run docs:build` passes after docs changes.
+
+## Docs Publication Policy
+
+Wardian currently publishes docs from `main`, not from release tags.
+
+- Pull requests that touch docs, package metadata, or the docs workflow run the `Wardian Docs` build for validation.
+- Merges to `main` that touch those paths build and deploy `docs/.vitepress/dist` to GitHub Pages.
+- Maintainers can also run the workflow manually with `workflow_dispatch` to rebuild the current `main` docs site.
+- Release tags do not trigger a separate docs publication. This is an explicit deferral until Wardian needs versioned or release-frozen documentation.
+
+See [Public Docs Site](./docs-site.md) for the publishing workflow and base-path details.

--- a/docs/developer/docs-site.md
+++ b/docs/developer/docs-site.md
@@ -34,6 +34,10 @@ PowerShell uses the same commands.
 
 The `Wardian Docs` GitHub Actions workflow builds the site on pushes to `main` that touch docs, package metadata, or the docs workflow. It deploys `docs/.vitepress/dist` to GitHub Pages.
 
+Pull requests that touch those same paths run the docs build without deploying. Maintainers can also run the workflow manually with `workflow_dispatch` to rebuild the current `main` site.
+
+Wardian does not publish docs from release tags today. Release documentation is expected to merge to `main` before or with the release; versioned or release-frozen docs are explicitly deferred until the release cadence needs them.
+
 The workflow sets `DOCS_BASE=/` because the Wardian repository uses the custom GitHub Pages domain `docs.wardian.org`. If the site falls back to the default project URL, update the workflow environment to use `DOCS_BASE=/Wardian/`.
 
 ## Content Rules
@@ -42,4 +46,5 @@ The workflow sets `DOCS_BASE=/` because the Wardian repository uses the custom G
 - Prefer plain Markdown and relative links so pages remain readable on GitHub.
 - Use placeholders such as `<absolute-workspace-path>` instead of local machine paths.
 - Put user-facing screenshots under `docs/assets/screenshots/` and follow [Screenshot Documentation](./screenshot-documentation.md).
+- Follow [Documentation Maintenance](./docs-maintenance.md) when a feature PR changes user-facing behavior, release notes, screenshots, or public docs links.
 - Avoid VitePress-only Vue components unless the page genuinely needs an interactive docs feature.

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -27,6 +27,7 @@ Use this index when implementing or debugging Wardian internals.
 ## Testing and Verification
 
 - [Developer Setup](./setup.md)
+- [Documentation Maintenance](./docs-maintenance.md)
 - [Public Docs Site](./docs-site.md)
 - [Native E2E Harness](./native-e2e.md)
 - [Screenshot Documentation](./screenshot-documentation.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,7 @@ This folder contains user guides, workflow references, developer architecture no
 ## Developer Guides
 
 - [Developer Index](./developer/index.md)
+- [Documentation Maintenance](./developer/docs-maintenance.md)
 - [Public Docs Site](./developer/docs-site.md)
 - [Architecture](./developer/architecture.md)
 - [State Management](./developer/state-management.md)


### PR DESCRIPTION
## Description
Defines the contributor-facing documentation maintenance workflow for Wardian onboarding and public docs. The new guide explains when feature PRs must update user docs, how screenshot refreshes should be handled, what release notes/public links to check, and how docs publication works today.

## Related Issues
Fixes #282
Part of #274

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run docs:build`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `cargo check` in `src-tauri`
- [x] `cargo test` in `src-tauri`
- [x] `cargo clippy` in `src-tauri`
- [x] `git diff --check`
- [x] Secret/local path scan on changed files
- [x] Subagent review: no findings

Notes: the docs/frontend builds still emit the existing Vite chunk-size warning, and frontend tests still emit existing React `act(...)` warnings in watchlist/App tests.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable