### PR TITLE
fix(runtime): harden agent update telemetry

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,9 @@ use crate::state::AppState;
 use tauri::{Emitter, Manager};
 use wardian_core::models::AgentConfig;
 
+const TELEMETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+const TELEMETRY_TICK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 pub async fn reconcile_headless_agents() -> std::result::Result<(), Box<dyn std::error::Error>> {
     use sysinfo::System;
 
@@ -55,6 +58,41 @@ pub async fn reconcile_headless_agents() -> std::result::Result<(), Box<dyn std:
         }
     }
     Ok(())
+}
+
+async fn emit_metrics_tick(metrics_handle: tauri::AppHandle) {
+    let state = metrics_handle.state::<AppState>();
+    let metrics = manager::get_all_metrics(&state).await;
+    let app_metrics = manager::get_app_metrics(&state).await;
+    let _ = metrics_handle.emit("agent-metrics", &metrics);
+    let _ = metrics_handle.emit("app-metrics", &app_metrics);
+}
+
+fn start_metrics_supervisor(metrics_handle: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            tokio::time::sleep(TELEMETRY_INTERVAL).await;
+            let tick_handle = metrics_handle.clone();
+            let mut tick = tauri::async_runtime::spawn(async move {
+                emit_metrics_tick(tick_handle).await;
+            });
+            match tokio::time::timeout(TELEMETRY_TICK_TIMEOUT, &mut tick).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    crate::utils::logging::log_debug(&format!(
+                        "[Wardian] Telemetry tick failed; continuing metrics supervisor: {error}"
+                    ));
+                }
+                Err(_) => {
+                    tick.abort();
+                    crate::utils::logging::log_debug(&format!(
+                        "[Wardian] Telemetry tick exceeded {}s; continuing metrics supervisor while timed-out work finishes in background",
+                        TELEMETRY_TICK_TIMEOUT.as_secs()
+                    ));
+                }
+            }
+        }
+    });
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -108,17 +146,7 @@ pub fn run() {
             control::spawn_control_server(app_handle.clone());
             manager::init_agent_classes(&app_handle);
 
-            let metrics_handle = app.handle().clone();
-            tauri::async_runtime::spawn(async move {
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    let state = metrics_handle.state::<AppState>();
-                    let metrics = manager::get_all_metrics(&state).await;
-                    let app_metrics = manager::get_app_metrics(&state).await;
-                    let _ = metrics_handle.emit("agent-metrics", &metrics);
-                    let _ = metrics_handle.emit("app-metrics", &app_metrics);
-                }
-            });
+            start_metrics_supervisor(app.handle().clone());
 
             tauri::async_runtime::spawn(async move {
                 let state = app_handle.state::<AppState>();

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -22,6 +22,58 @@ use super::{
 };
 use crate::providers::gemini::gemini_status_from_title;
 
+const OUTPUT_READY_EMIT_MIN_INTERVAL: std::time::Duration = std::time::Duration::from_millis(33);
+
+#[derive(Default)]
+struct OutputReadyEmitGate {
+    last_emit_at: Option<std::time::Instant>,
+    delayed_emit_scheduled: bool,
+}
+
+impl OutputReadyEmitGate {
+    fn after_buffer_append(&mut self, now: std::time::Instant) -> OutputReadyEmitAction {
+        let elapsed = self
+            .last_emit_at
+            .map(|last_emit_at| now.saturating_duration_since(last_emit_at));
+        if elapsed.is_none_or(|elapsed| elapsed >= OUTPUT_READY_EMIT_MIN_INTERVAL) {
+            self.last_emit_at = Some(now);
+            self.delayed_emit_scheduled = false;
+            return OutputReadyEmitAction::EmitNow;
+        }
+
+        if self.delayed_emit_scheduled {
+            return OutputReadyEmitAction::Suppress;
+        }
+
+        self.delayed_emit_scheduled = true;
+        OutputReadyEmitAction::ScheduleAfter(OUTPUT_READY_EMIT_MIN_INTERVAL - elapsed.unwrap())
+    }
+
+    fn finish_delayed_emit(&mut self, buffer_has_output: bool, now: std::time::Instant) -> bool {
+        self.delayed_emit_scheduled = false;
+        if !buffer_has_output {
+            return false;
+        }
+
+        let elapsed = self
+            .last_emit_at
+            .map(|last_emit_at| now.saturating_duration_since(last_emit_at));
+        if elapsed.is_none_or(|elapsed| elapsed >= OUTPUT_READY_EMIT_MIN_INTERVAL) {
+            self.last_emit_at = Some(now);
+            return true;
+        }
+
+        false
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum OutputReadyEmitAction {
+    EmitNow,
+    ScheduleAfter(std::time::Duration),
+    Suppress,
+}
+
 fn codex_cleared_provider_sessions(config: &AgentConfig) -> Vec<String> {
     config.codex_config().cleared_provider_sessions
 }
@@ -378,6 +430,8 @@ pub async fn spawn_agent(
         let mut had_pty_output = false;
         let mut opencode_chunks_logged = 0usize;
         let mut pty_decoder = PtyUtf8Decoder::new();
+        let output_ready_emit_gate =
+            std::sync::Arc::new(std::sync::Mutex::new(OutputReadyEmitGate::default()));
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => {
@@ -555,18 +609,50 @@ pub async fn spawn_agent(
                             }
                         }
                     }
-                    let should_emit_output_ready = if let Ok(mut h) = output_buffer_clone.lock() {
-                        let was_empty = h.is_empty();
+                    let output_ready_action = if let Ok(mut h) = output_buffer_clone.lock() {
                         h.push_str(&text);
-                        was_empty
+                        output_ready_emit_gate
+                            .lock()
+                            .map(|mut gate| gate.after_buffer_append(std::time::Instant::now()))
+                            .unwrap_or(OutputReadyEmitAction::Suppress)
                     } else {
-                        false
+                        OutputReadyEmitAction::Suppress
                     };
-                    if should_emit_output_ready {
-                        let _ = pty_emit_app.emit(
-                            "agent-pty-output-ready",
-                            serde_json::json!({ "session_id": sid_for_pty }),
-                        );
+                    match output_ready_action {
+                        OutputReadyEmitAction::EmitNow => {
+                            let _ = pty_emit_app.emit(
+                                "agent-pty-output-ready",
+                                serde_json::json!({ "session_id": sid_for_pty }),
+                            );
+                        }
+                        OutputReadyEmitAction::ScheduleAfter(delay) => {
+                            let delayed_app = pty_emit_app.clone();
+                            let delayed_session_id = sid_for_pty.clone();
+                            let delayed_buffer = output_buffer_clone.clone();
+                            let delayed_gate = output_ready_emit_gate.clone();
+                            tauri::async_runtime::spawn(async move {
+                                tokio::time::sleep(delay).await;
+                                let should_emit = match delayed_buffer.lock() {
+                                    Ok(buffer) => delayed_gate
+                                        .lock()
+                                        .map(|mut gate| {
+                                            gate.finish_delayed_emit(
+                                                !buffer.is_empty(),
+                                                std::time::Instant::now(),
+                                            )
+                                        })
+                                        .unwrap_or(false),
+                                    Err(_) => false,
+                                };
+                                if should_emit {
+                                    let _ = delayed_app.emit(
+                                        "agent-pty-output-ready",
+                                        serde_json::json!({ "session_id": delayed_session_id }),
+                                    );
+                                }
+                            });
+                        }
+                        OutputReadyEmitAction::Suppress => {}
                     }
                     current_line.push_str(&text);
                     loop {
@@ -1163,5 +1249,25 @@ mod tests {
     fn restored_spawns_skip_stale_process_scan() {
         assert!(!should_cleanup_stale_session_processes_before_spawn(true));
         assert!(should_cleanup_stale_session_processes_before_spawn(false));
+    }
+
+    #[test]
+    fn output_ready_emit_gate_coalesces_repeats_after_throttle() {
+        let mut gate = OutputReadyEmitGate::default();
+        let start = std::time::Instant::now();
+
+        assert_eq!(
+            gate.after_buffer_append(start),
+            OutputReadyEmitAction::EmitNow
+        );
+        assert_eq!(
+            gate.after_buffer_append(start + OUTPUT_READY_EMIT_MIN_INTERVAL / 2),
+            OutputReadyEmitAction::ScheduleAfter(OUTPUT_READY_EMIT_MIN_INTERVAL / 2)
+        );
+        assert_eq!(
+            gate.after_buffer_append(start + OUTPUT_READY_EMIT_MIN_INTERVAL / 2),
+            OutputReadyEmitAction::Suppress
+        );
+        assert!(gate.finish_delayed_emit(true, start + OUTPUT_READY_EMIT_MIN_INTERVAL));
     }
 }

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -1,6 +1,7 @@
 use crate::state::AppState;
 use crate::utils::fs::get_wardian_home;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::OnceLock;
 use std::sync::{Arc, Mutex};
 use wardian_core::models::{AgentTelemetry, AppTelemetry};
 
@@ -17,6 +18,10 @@ use super::opencode::{
     opencode_log_dirs, opencode_log_path_after, opencode_log_path_in, opencode_session_diff_path,
     opencode_should_fallback_to_idle,
 };
+
+const TELEMETRY_SLOW_PASS_THRESHOLD: std::time::Duration = std::time::Duration::from_millis(500);
+
+static TELEMETRY_AGENT_WORK_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
 fn normalize_cpu_usage(raw_cpu_usage: f32, logical_cpu_count: usize) -> f32 {
     let divisor = logical_cpu_count.max(1) as f32;
@@ -176,6 +181,135 @@ struct AgentSnapshot {
     last_output_at: Arc<Mutex<Option<std::time::SystemTime>>>,
     log_path: Arc<Mutex<Option<std::path::PathBuf>>>,
     log_last_modified: Arc<Mutex<Option<std::time::SystemTime>>>,
+}
+
+#[derive(Debug, Clone)]
+struct ProcessSample {
+    cpu_usage: f32,
+    memory: u64,
+    run_time: u64,
+}
+
+#[derive(Debug, Clone)]
+struct SystemProcessSnapshot {
+    logical_cpu_count: usize,
+    children_map: HashMap<u32, Vec<u32>>,
+    processes: HashMap<u32, ProcessSample>,
+    sys_refresh: std::time::Duration,
+}
+
+struct TelemetryAgentWorkGuard {
+    session_id: String,
+}
+
+impl Drop for TelemetryAgentWorkGuard {
+    fn drop(&mut self) {
+        let in_flight = TELEMETRY_AGENT_WORK_IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()));
+        if let Ok(mut in_flight) = in_flight.lock() {
+            in_flight.remove(&self.session_id);
+        }
+    }
+}
+
+fn try_begin_agent_telemetry_work(session_id: &str) -> Option<TelemetryAgentWorkGuard> {
+    let in_flight = TELEMETRY_AGENT_WORK_IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()));
+    let mut in_flight = in_flight.lock().ok()?;
+    if !in_flight.insert(session_id.to_string()) {
+        return None;
+    }
+    Some(TelemetryAgentWorkGuard {
+        session_id: session_id.to_string(),
+    })
+}
+
+fn refresh_system_process_snapshot(
+    sys_metrics: &tokio::sync::Mutex<sysinfo::System>,
+) -> Option<SystemProcessSnapshot> {
+    let mut sys = match sys_metrics.try_lock() {
+        Ok(sys) => sys,
+        Err(_) => {
+            crate::utils::logging::log_debug(
+                "[Wardian] Telemetry skipped system sampling because previous refresh is still running",
+            );
+            return None;
+        }
+    };
+    let sys_refresh_started = std::time::Instant::now();
+    sys.refresh_all();
+    let sys_refresh = sys_refresh_started.elapsed();
+    let logical_cpu_count = sys.cpus().len();
+    let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut processes = HashMap::new();
+
+    for (pid, process) in sys.processes() {
+        let pid = pid.as_u32();
+        if let Some(parent) = process.parent() {
+            children_map.entry(parent.as_u32()).or_default().push(pid);
+        }
+        processes.insert(
+            pid,
+            ProcessSample {
+                cpu_usage: process.cpu_usage(),
+                memory: process.memory(),
+                run_time: process.run_time(),
+            },
+        );
+    }
+
+    Some(SystemProcessSnapshot {
+        logical_cpu_count,
+        children_map,
+        processes,
+        sys_refresh,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct TelemetrySlowAgent {
+    session_id: String,
+    provider: String,
+    duration: std::time::Duration,
+}
+
+#[derive(Debug, Clone)]
+struct TelemetryPassTimings {
+    total: std::time::Duration,
+    sys_refresh: std::time::Duration,
+    agent_count: usize,
+    slow_agents: Vec<TelemetrySlowAgent>,
+}
+
+impl TelemetryPassTimings {
+    fn slow_log_message(&self, threshold: std::time::Duration) -> Option<String> {
+        if self.total < threshold && self.sys_refresh < threshold && self.slow_agents.is_empty() {
+            return None;
+        }
+
+        let slow_agents = if self.slow_agents.is_empty() {
+            "none".to_string()
+        } else {
+            self.slow_agents
+                .iter()
+                .map(|agent| {
+                    format!(
+                        "{}:{}:{}ms",
+                        agent.session_id,
+                        agent.provider,
+                        agent.duration.as_millis()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+
+        Some(format!(
+            "[Wardian] Slow telemetry pass total_ms={} sys_refresh_ms={} agent_count={} slow_agents={}",
+            self.total.as_millis(),
+            self.sys_refresh.as_millis(),
+            self.agent_count,
+            slow_agents
+        ))
+    }
 }
 
 fn set_snapshot_status(snap: &AgentSnapshot, next_status: &str) {
@@ -383,28 +517,19 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
 
     let sys_metrics = state.system_metrics.clone();
     tokio::task::spawn_blocking(move || {
+        let pass_started = std::time::Instant::now();
         let mut results = Vec::new();
-        let mut sys = sys_metrics.blocking_lock();
-        sys.refresh_all();
-        let logical_cpu_count = sys.cpus().len();
-
-        let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
-        for (pid, process) in sys.processes() {
-            if let Some(parent) = process.parent() {
-                children_map
-                    .entry(parent.as_u32())
-                    .or_default()
-                    .push(pid.as_u32());
-            }
-        }
+        let system_snapshot = refresh_system_process_snapshot(&sys_metrics);
+        let mut slow_agents = Vec::new();
 
         for snap in &snapshots {
+            let agent_started = std::time::Instant::now();
             let mut cpu = 0.0;
             let mut mem = 0.0;
             let mut uptime = 0;
             let mut related_process_ids = BTreeSet::new();
 
-            if let Some(pid) = snap.process_id {
+            if let (Some(system_snapshot), Some(pid)) = (&system_snapshot, snap.process_id) {
                 #[cfg(windows)]
                 let discovered_roots = crate::utils::process::find_wardian_session_process_roots(
                     &snap.session_id,
@@ -413,18 +538,21 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                 #[cfg(not(windows))]
                 let discovered_roots = Vec::new();
 
-                related_process_ids =
-                    collect_related_pids(Some(pid), &discovered_roots, &children_map);
+                related_process_ids = collect_related_pids(
+                    Some(pid),
+                    &discovered_roots,
+                    &system_snapshot.children_map,
+                );
                 let mut raw_cpu = 0.0;
                 let mut memory_bytes = 0_u64;
                 for pid in &related_process_ids {
-                    if let Some(process) = sys.process(sysinfo::Pid::from_u32(*pid)) {
-                        raw_cpu += process.cpu_usage();
-                        memory_bytes = memory_bytes.saturating_add(process.memory());
-                        uptime = std::cmp::max(uptime, process.run_time());
+                    if let Some(process) = system_snapshot.processes.get(pid) {
+                        raw_cpu += process.cpu_usage;
+                        memory_bytes = memory_bytes.saturating_add(process.memory);
+                        uptime = std::cmp::max(uptime, process.run_time);
                     }
                 }
-                cpu = normalize_cpu_usage(raw_cpu, logical_cpu_count);
+                cpu = normalize_cpu_usage(raw_cpu, system_snapshot.logical_cpu_count);
                 mem = bytes_to_mib(memory_bytes);
 
                 // Phase 3: Uptime Alignment
@@ -445,14 +573,21 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                 }
             }
 
-            // Detect whether the agent process is still alive
-            let process_alive = related_process_ids
-                .iter()
-                .any(|pid| sys.process(sysinfo::Pid::from_u32(*pid)).is_some());
+            // Detect whether the agent process is still alive. If system sampling
+            // is skipped, liveness is unknown and must not force a status change.
+            let process_alive = system_snapshot.as_ref().map(|system_snapshot| {
+                related_process_ids
+                    .iter()
+                    .any(|pid| system_snapshot.processes.contains_key(pid))
+            });
 
             let mut q_count = *snap.query_count.lock().unwrap();
             let mut i_ts = snap.init_timestamp.lock().unwrap().clone();
-            let mut log_path_lock = snap.log_path.lock().unwrap_or_else(|e| e.into_inner());
+            let mut log_path_display = snap
+                .log_path
+                .try_lock()
+                .ok()
+                .and_then(|path| path.as_ref().map(|p| display_log_path(p)));
             let opencode_session_id = snap
                 .resume_session
                 .as_deref()
@@ -460,242 +595,199 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                 .unwrap_or(&snap.session_id);
             let gemini_session_id = snap.resume_session.as_deref().unwrap_or(&snap.session_id);
 
-            if snap.provider == "gemini" {
-                let stale_gemini_log = log_path_lock.as_ref().is_some_and(|path| {
-                    std::fs::read_to_string(path).ok().is_none_or(|content| {
-                        !gemini_log_matches_session(&content, gemini_session_id)
-                    })
-                });
-                if stale_gemini_log {
-                    *log_path_lock = None;
-                    if let Ok(mut last_modified) = snap.log_last_modified.lock() {
-                        *last_modified = None;
-                    }
-                }
-            }
+            if let Some(_agent_work_guard) = try_begin_agent_telemetry_work(&snap.session_id) {
+                let mut log_path_lock = snap.log_path.lock().unwrap_or_else(|e| e.into_inner());
 
-            // Provider-aware log discovery
-            if snap.provider == "opencode" {
-                let mut discovered_log = None;
-                let log_dirs = opencode_log_dirs();
-                for dir in &log_dirs {
-                    if let Some(path) = opencode_log_path_in(dir, opencode_session_id) {
-                        discovered_log = Some(path);
-                        break;
-                    }
-                }
-                if discovered_log.is_none()
-                    && snap
-                        .resume_session
-                        .as_deref()
-                        .is_none_or(|value| !value.starts_with("ses_"))
-                {
-                    let spawn_time = snap
-                        .init_timestamp
-                        .lock()
-                        .ok()
-                        .and_then(|timestamp| timestamp_to_system_time(timestamp.as_deref()));
-                    if let Some(spawn_time) = spawn_time {
-                        for dir in &log_dirs {
-                            if let Some(path) = opencode_log_path_after(dir, spawn_time) {
-                                discovered_log = Some(path);
-                                break;
-                            }
+                if snap.provider == "gemini" {
+                    let stale_gemini_log = log_path_lock.as_ref().is_some_and(|path| {
+                        std::fs::read_to_string(path).ok().is_none_or(|content| {
+                            !gemini_log_matches_session(&content, gemini_session_id)
+                        })
+                    });
+                    if stale_gemini_log {
+                        *log_path_lock = None;
+                        if let Ok(mut last_modified) = snap.log_last_modified.lock() {
+                            *last_modified = None;
                         }
                     }
                 }
-                *log_path_lock = discovered_log
-                    .or_else(|| Some(opencode_session_diff_path(opencode_session_id)));
-            } else if snap.provider == "claude" && snap.resume_session.is_some() {
-                // For Claude, if we have a resume_session (Conversation ID), always re-verify
-                // the path so it updates immediately after a Clear rotation.
-                if let Some(home) = dirs::home_dir() {
-                    let project_dir = claude_project_dir_name(&snap.folder);
-                    let session_id_to_find = snap.resume_session.as_deref().unwrap();
-                    let candidate = home
-                        .join(".claude")
-                        .join("projects")
-                        .join(&project_dir)
-                        .join(format!("{}.jsonl", session_id_to_find));
-                    if candidate.exists() {
-                        *log_path_lock = Some(candidate);
+
+                // Provider-aware log discovery
+                if snap.provider == "opencode" {
+                    let mut discovered_log = None;
+                    let log_dirs = opencode_log_dirs();
+                    for dir in &log_dirs {
+                        if let Some(path) = opencode_log_path_in(dir, opencode_session_id) {
+                            discovered_log = Some(path);
+                            break;
+                        }
                     }
-                }
-            } else if log_path_lock.is_none() {
-                match snap.provider.as_str() {
-                    "codex" => {
-                        let agent_home = get_wardian_home()
-                            .map(|home| home.join("agents").join(&snap.session_id))
-                            .filter(|path| path.exists())
-                            .map(|path| path.to_string_lossy().to_string());
-                        let codex_session_id =
-                            codex_log_lookup_session_id(snap.resume_session.as_deref())
-                                .map(str::to_string)
-                                .or_else(|| {
-                                    latest_codex_session_index_entry(&snap.session_id)
-                                        .ok()
-                                        .flatten()
-                                        .map(|(session_id, _updated_at)| session_id)
-                                });
-                        if let Some(codex_session_id) = codex_session_id {
-                            if let Some(path) =
-                                codex_session_file_path(&codex_session_id, agent_home.as_deref())
-                            {
-                                *log_path_lock = Some(path);
+                    if discovered_log.is_none()
+                        && snap
+                            .resume_session
+                            .as_deref()
+                            .is_none_or(|value| !value.starts_with("ses_"))
+                    {
+                        let spawn_time =
+                            snap.init_timestamp.lock().ok().and_then(|timestamp| {
+                                timestamp_to_system_time(timestamp.as_deref())
+                            });
+                        if let Some(spawn_time) = spawn_time {
+                            for dir in &log_dirs {
+                                if let Some(path) = opencode_log_path_after(dir, spawn_time) {
+                                    discovered_log = Some(path);
+                                    break;
+                                }
                             }
                         }
                     }
-                    "claude" => {
-                        // Fallback for initial spawn where resume_session might not be set yet
-                        if let Some(home) = dirs::home_dir() {
-                            let project_dir = claude_project_dir_name(&snap.folder);
-                            let candidate = home
-                                .join(".claude")
-                                .join("projects")
-                                .join(&project_dir)
-                                .join(format!("{}.jsonl", snap.session_id));
-                            if candidate.exists() {
-                                *log_path_lock = Some(candidate);
-                            }
+                    *log_path_lock = discovered_log
+                        .or_else(|| Some(opencode_session_diff_path(opencode_session_id)));
+                } else if snap.provider == "claude" && snap.resume_session.is_some() {
+                    // For Claude, if we have a resume_session (Conversation ID), always re-verify
+                    // the path so it updates immediately after a Clear rotation.
+                    if let Some(home) = dirs::home_dir() {
+                        let project_dir = claude_project_dir_name(&snap.folder);
+                        let session_id_to_find = snap.resume_session.as_deref().unwrap();
+                        let candidate = home
+                            .join(".claude")
+                            .join("projects")
+                            .join(&project_dir)
+                            .join(format!("{}.jsonl", session_id_to_find));
+                        if candidate.exists() {
+                            *log_path_lock = Some(candidate);
                         }
                     }
-                    _ => {
-                        // Gemini: scan ~/.gemini/tmp for chat log files
-                        if let Some(home) = dirs::home_dir() {
-                            let tmp_dir = home.join(".gemini").join("tmp");
-                            if let Ok(entries) = std::fs::read_dir(tmp_dir) {
-                                for entry in entries.flatten() {
-                                    let chat_dir = entry.path().join("chats");
-                                    if let Ok(chat_files) = std::fs::read_dir(chat_dir) {
-                                        for chat_file in chat_files.flatten() {
-                                            if let Ok(content) =
-                                                std::fs::read_to_string(chat_file.path())
-                                            {
-                                                if gemini_log_matches_session(
-                                                    &content,
-                                                    gemini_session_id,
-                                                ) {
-                                                    *log_path_lock = Some(chat_file.path());
-                                                    break;
+                } else if log_path_lock.is_none() {
+                    match snap.provider.as_str() {
+                        "codex" => {
+                            let agent_home = get_wardian_home()
+                                .map(|home| home.join("agents").join(&snap.session_id))
+                                .filter(|path| path.exists())
+                                .map(|path| path.to_string_lossy().to_string());
+                            let codex_session_id =
+                                codex_log_lookup_session_id(snap.resume_session.as_deref())
+                                    .map(str::to_string)
+                                    .or_else(|| {
+                                        latest_codex_session_index_entry(&snap.session_id)
+                                            .ok()
+                                            .flatten()
+                                            .map(|(session_id, _updated_at)| session_id)
+                                    });
+                            if let Some(codex_session_id) = codex_session_id {
+                                if let Some(path) = codex_session_file_path(
+                                    &codex_session_id,
+                                    agent_home.as_deref(),
+                                ) {
+                                    *log_path_lock = Some(path);
+                                }
+                            }
+                        }
+                        "claude" => {
+                            // Fallback for initial spawn where resume_session might not be set yet
+                            if let Some(home) = dirs::home_dir() {
+                                let project_dir = claude_project_dir_name(&snap.folder);
+                                let candidate = home
+                                    .join(".claude")
+                                    .join("projects")
+                                    .join(&project_dir)
+                                    .join(format!("{}.jsonl", snap.session_id));
+                                if candidate.exists() {
+                                    *log_path_lock = Some(candidate);
+                                }
+                            }
+                        }
+                        _ => {
+                            // Gemini: scan ~/.gemini/tmp for chat log files
+                            if let Some(home) = dirs::home_dir() {
+                                let tmp_dir = home.join(".gemini").join("tmp");
+                                if let Ok(entries) = std::fs::read_dir(tmp_dir) {
+                                    for entry in entries.flatten() {
+                                        let chat_dir = entry.path().join("chats");
+                                        if let Ok(chat_files) = std::fs::read_dir(chat_dir) {
+                                            for chat_file in chat_files.flatten() {
+                                                if let Ok(content) =
+                                                    std::fs::read_to_string(chat_file.path())
+                                                {
+                                                    if gemini_log_matches_session(
+                                                        &content,
+                                                        gemini_session_id,
+                                                    ) {
+                                                        *log_path_lock = Some(chat_file.path());
+                                                        break;
+                                                    }
                                                 }
                                             }
                                         }
-                                    }
-                                    if log_path_lock.is_some() {
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Provider-aware log parsing for status/query enrichment
-            if let Some(ref path) = *log_path_lock {
-                let mut should_parse = true;
-                let mut new_mtime = None;
-                let mut is_initial_log_replay = snap
-                    .log_last_modified
-                    .lock()
-                    .map(|last| last.is_none())
-                    .unwrap_or(false);
-                if let Ok(metadata) = std::fs::metadata(path) {
-                    if let Ok(modified) = metadata.modified() {
-                        let last_mod = *snap.log_last_modified.lock().unwrap();
-                        if last_mod == Some(modified) {
-                            should_parse = false;
-                        } else {
-                            is_initial_log_replay = last_mod.is_none();
-                            new_mtime = Some(modified);
-                        }
-                    }
-                }
-
-                if should_parse {
-                    if let Ok(content) = std::fs::read_to_string(path) {
-                        if let Some(mtime) = new_mtime {
-                            *snap.log_last_modified.lock().unwrap() = Some(mtime);
-                        }
-                        match snap.provider.as_str() {
-                            "codex" => {
-                                let lines: Vec<serde_json::Value> = content
-                                    .lines()
-                                    .filter_map(|l| serde_json::from_str(l).ok())
-                                    .collect();
-
-                                q_count = lines
-                                    .iter()
-                                    .filter(|l| {
-                                        l.get("type").and_then(|v| v.as_str()) == Some("event_msg")
-                                            && l.get("payload")
-                                                .and_then(|v| v.get("type"))
-                                                .and_then(|v| v.as_str())
-                                                == Some("user_message")
-                                    })
-                                    .count();
-
-                                if let Some(meta) = lines.iter().find(|l| {
-                                    l.get("type").and_then(|v| v.as_str()) == Some("session_meta")
-                                }) {
-                                    if let Some(ts) = meta
-                                        .get("payload")
-                                        .and_then(|v| v.get("timestamp"))
-                                        .and_then(|v| v.as_str())
-                                    {
-                                        i_ts = Some(ts.to_string());
-                                    }
-                                }
-
-                                if let Some(status) = codex_status_from_log(&lines) {
-                                    set_snapshot_status_from_log(
-                                        snap,
-                                        &status,
-                                        is_initial_log_replay,
-                                    );
-                                }
-                            }
-                            "claude" => {
-                                // Claude logs are JSONL — one JSON object per line
-                                let lines: Vec<serde_json::Value> = content
-                                    .lines()
-                                    .filter_map(|l| serde_json::from_str(l).ok())
-                                    .collect();
-
-                                q_count = lines
-                                    .iter()
-                                    .filter(|l| {
-                                        l.get("type").and_then(|v| v.as_str()) == Some("user")
-                                            && claude_is_real_user_query(l)
-                                    })
-                                    .count();
-
-                                if let Some(first) = lines.first() {
-                                    if let Some(ts) =
-                                        first.get("timestamp").and_then(|v| v.as_str())
-                                    {
-                                        i_ts = Some(ts.to_string());
-                                    } else if let Some(ts_num) =
-                                        first.get("timestamp").and_then(|v| v.as_i64())
-                                    {
-                                        // Fallback if timestamp is an epoch number
-                                        if let Some(dt) =
-                                            chrono::DateTime::from_timestamp_millis(ts_num)
-                                        {
-                                            i_ts = Some(dt.to_rfc3339_opts(
-                                                chrono::SecondsFormat::Millis,
-                                                true,
-                                            ));
+                                        if log_path_lock.is_some() {
+                                            break;
                                         }
                                     }
                                 }
+                            }
+                        }
+                    }
+                }
 
-                                let current_status_snap =
-                                    snap.current_status.lock().unwrap().clone();
-                                if !current_status_snap.starts_with("Action Required")
-                                    && !current_status_snap.starts_with("Action Needed")
-                                {
-                                    if let Some(status) = claude_status_from_log(&lines) {
+                // Provider-aware log parsing for status/query enrichment
+                if let Some(ref path) = *log_path_lock {
+                    let mut should_parse = true;
+                    let mut new_mtime = None;
+                    let mut is_initial_log_replay = snap
+                        .log_last_modified
+                        .lock()
+                        .map(|last| last.is_none())
+                        .unwrap_or(false);
+                    if let Ok(metadata) = std::fs::metadata(path) {
+                        if let Ok(modified) = metadata.modified() {
+                            let last_mod = *snap.log_last_modified.lock().unwrap();
+                            if last_mod == Some(modified) {
+                                should_parse = false;
+                            } else {
+                                is_initial_log_replay = last_mod.is_none();
+                                new_mtime = Some(modified);
+                            }
+                        }
+                    }
+
+                    if should_parse {
+                        if let Ok(content) = std::fs::read_to_string(path) {
+                            if let Some(mtime) = new_mtime {
+                                *snap.log_last_modified.lock().unwrap() = Some(mtime);
+                            }
+                            match snap.provider.as_str() {
+                                "codex" => {
+                                    let lines: Vec<serde_json::Value> = content
+                                        .lines()
+                                        .filter_map(|l| serde_json::from_str(l).ok())
+                                        .collect();
+
+                                    q_count = lines
+                                        .iter()
+                                        .filter(|l| {
+                                            l.get("type").and_then(|v| v.as_str())
+                                                == Some("event_msg")
+                                                && l.get("payload")
+                                                    .and_then(|v| v.get("type"))
+                                                    .and_then(|v| v.as_str())
+                                                    == Some("user_message")
+                                        })
+                                        .count();
+
+                                    if let Some(meta) = lines.iter().find(|l| {
+                                        l.get("type").and_then(|v| v.as_str())
+                                            == Some("session_meta")
+                                    }) {
+                                        if let Some(ts) = meta
+                                            .get("payload")
+                                            .and_then(|v| v.get("timestamp"))
+                                            .and_then(|v| v.as_str())
+                                        {
+                                            i_ts = Some(ts.to_string());
+                                        }
+                                    }
+
+                                    if let Some(status) = codex_status_from_log(&lines) {
                                         set_snapshot_status_from_log(
                                             snap,
                                             &status,
@@ -703,58 +795,119 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                         );
                                     }
                                 }
-                            }
-                            "opencode" => {
-                                let mut status = snap.current_status.lock().unwrap().clone();
-                                let effective_session_id =
-                                    opencode_extract_created_session_id(path)
-                                        .unwrap_or_else(|| opencode_session_id.to_string());
-                                apply_opencode_log_metrics(
-                                    &content,
-                                    &effective_session_id,
-                                    &mut q_count,
-                                    &mut i_ts,
-                                    &mut status,
-                                );
-                                if wardian_core::identity::normalize_status(&status) == "idle" {
-                                    record_latest_opencode_assistant_text(
-                                        snap,
-                                        &effective_session_id,
-                                    );
+                                "claude" => {
+                                    // Claude logs are JSONL — one JSON object per line
+                                    let lines: Vec<serde_json::Value> = content
+                                        .lines()
+                                        .filter_map(|l| serde_json::from_str(l).ok())
+                                        .collect();
+
+                                    q_count = lines
+                                        .iter()
+                                        .filter(|l| {
+                                            l.get("type").and_then(|v| v.as_str()) == Some("user")
+                                                && claude_is_real_user_query(l)
+                                        })
+                                        .count();
+
+                                    if let Some(first) = lines.first() {
+                                        if let Some(ts) =
+                                            first.get("timestamp").and_then(|v| v.as_str())
+                                        {
+                                            i_ts = Some(ts.to_string());
+                                        } else if let Some(ts_num) =
+                                            first.get("timestamp").and_then(|v| v.as_i64())
+                                        {
+                                            // Fallback if timestamp is an epoch number
+                                            if let Some(dt) =
+                                                chrono::DateTime::from_timestamp_millis(ts_num)
+                                            {
+                                                i_ts = Some(dt.to_rfc3339_opts(
+                                                    chrono::SecondsFormat::Millis,
+                                                    true,
+                                                ));
+                                            }
+                                        }
+                                    }
+
+                                    let current_status_snap =
+                                        snap.current_status.lock().unwrap().clone();
+                                    if !current_status_snap.starts_with("Action Required")
+                                        && !current_status_snap.starts_with("Action Needed")
+                                    {
+                                        if let Some(status) = claude_status_from_log(&lines) {
+                                            set_snapshot_status_from_log(
+                                                snap,
+                                                &status,
+                                                is_initial_log_replay,
+                                            );
+                                        }
+                                    }
                                 }
-                                set_snapshot_status_from_log(snap, &status, is_initial_log_replay);
-                            }
-                            _ => {
-                                if let Some(metrics) = parse_gemini_log_metrics(&content) {
-                                    q_count = metrics.query_count;
-                                    if let Some(status) = metrics.status {
-                                        set_snapshot_status_from_log(
+                                "opencode" => {
+                                    let mut status = snap.current_status.lock().unwrap().clone();
+                                    let effective_session_id =
+                                        opencode_extract_created_session_id(path)
+                                            .unwrap_or_else(|| opencode_session_id.to_string());
+                                    apply_opencode_log_metrics(
+                                        &content,
+                                        &effective_session_id,
+                                        &mut q_count,
+                                        &mut i_ts,
+                                        &mut status,
+                                    );
+                                    if wardian_core::identity::normalize_status(&status) == "idle" {
+                                        record_latest_opencode_assistant_text(
                                             snap,
-                                            status,
-                                            is_initial_log_replay,
+                                            &effective_session_id,
                                         );
                                     }
-                                    if let Some(start_time) = metrics.init_timestamp {
-                                        i_ts = Some(start_time);
-                                    }
+                                    set_snapshot_status_from_log(
+                                        snap,
+                                        &status,
+                                        is_initial_log_replay,
+                                    );
                                 }
-                                if snap.provider == "gemini" {
-                                    record_latest_gemini_assistant_text(snap, &content);
+                                _ => {
+                                    if let Some(metrics) = parse_gemini_log_metrics(&content) {
+                                        q_count = metrics.query_count;
+                                        if let Some(status) = metrics.status {
+                                            set_snapshot_status_from_log(
+                                                snap,
+                                                status,
+                                                is_initial_log_replay,
+                                            );
+                                        }
+                                        if let Some(start_time) = metrics.init_timestamp {
+                                            i_ts = Some(start_time);
+                                        }
+                                    }
+                                    if snap.provider == "gemini" {
+                                        record_latest_gemini_assistant_text(snap, &content);
+                                    }
                                 }
                             }
                         }
                     }
                 }
+
+                if q_count > 0 {
+                    *snap.query_count.lock().unwrap() = q_count;
+                }
+                if let Some(ts) = i_ts {
+                    *snap.init_timestamp.lock().unwrap() = Some(ts);
+                }
+                log_path_display = log_path_lock.as_ref().map(|p| display_log_path(p));
+            } else {
+                crate::utils::logging::log_debug(&format!(
+                    "[Wardian] Skipped overlapping telemetry log work for {}",
+                    snap.session_id
+                ));
             }
 
-            if q_count > 0 {
-                *snap.query_count.lock().unwrap() = q_count;
-            }
-            if let Some(ts) = i_ts {
-                *snap.init_timestamp.lock().unwrap() = Some(ts);
-            }
-
-            if snap.provider == "opencode" || snap.provider == "claude" {
+            if (snap.provider == "opencode" || snap.provider == "claude")
+                && (snap.process_id.is_none() || process_alive == Some(true))
+            {
                 let current_status = snap.current_status.lock().unwrap().clone();
                 let last_output_at = *snap.last_output_at.lock().unwrap();
                 if opencode_should_fallback_to_idle(
@@ -768,7 +921,7 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
 
             // If the process has terminated, force status to "Off" so the UI
             // doesn't stay stuck on "Processing..." or "Action Needed".
-            if !process_alive && snap.process_id.is_some() {
+            if process_alive == Some(false) && snap.process_id.is_some() {
                 set_snapshot_status(snap, "Off");
             }
 
@@ -780,8 +933,28 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                 query_count: *snap.query_count.lock().unwrap(),
                 init_timestamp: snap.init_timestamp.lock().unwrap().clone(),
                 current_status: snap.current_status.lock().unwrap().clone(),
-                log_path: log_path_lock.as_ref().map(|p| display_log_path(p)),
+                log_path: log_path_display,
             });
+            let agent_duration = agent_started.elapsed();
+            if agent_duration >= TELEMETRY_SLOW_PASS_THRESHOLD {
+                slow_agents.push(TelemetrySlowAgent {
+                    session_id: snap.session_id.clone(),
+                    provider: snap.provider.clone(),
+                    duration: agent_duration,
+                });
+            }
+        }
+        let timings = TelemetryPassTimings {
+            total: pass_started.elapsed(),
+            sys_refresh: system_snapshot
+                .as_ref()
+                .map(|snapshot| snapshot.sys_refresh)
+                .unwrap_or_default(),
+            agent_count: snapshots.len(),
+            slow_agents,
+        };
+        if let Some(message) = timings.slow_log_message(TELEMETRY_SLOW_PASS_THRESHOLD) {
+            crate::utils::logging::log_debug(&message);
         }
         results
     })
@@ -805,7 +978,15 @@ pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
     tokio::task::spawn_blocking(move || {
         // Reuse the snapshot refreshed by get_all_metrics in the telemetry loop.
         // Refreshing again immediately would reset sysinfo's CPU deltas.
-        let sys = sys_metrics.blocking_lock();
+        let Ok(sys) = sys_metrics.try_lock() else {
+            crate::utils::logging::log_debug(
+                "[Wardian] App telemetry skipped because system sampling is still running",
+            );
+            return AppTelemetry {
+                cpu_usage: 0.0,
+                memory_mb: 0.0,
+            };
+        };
         let logical_cpu_count = sys.cpus().len();
 
         let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
@@ -857,7 +1038,7 @@ pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
 
 #[cfg(test)]
 mod tests {
-    use super::AgentSnapshot;
+    use super::{AgentSnapshot, TelemetryPassTimings, TelemetrySlowAgent};
     use std::collections::{BTreeSet, HashMap};
     use std::sync::{Arc, Mutex};
 
@@ -958,6 +1139,36 @@ mod tests {
             .snapshot_since(None, None)
             .unwrap();
         assert!(snapshot.events.is_empty());
+    }
+
+    #[test]
+    fn slow_telemetry_report_only_formats_slow_passes() {
+        let report = TelemetryPassTimings {
+            total: std::time::Duration::from_millis(750),
+            sys_refresh: std::time::Duration::from_millis(25),
+            agent_count: 3,
+            slow_agents: vec![TelemetrySlowAgent {
+                session_id: "agent-1".to_string(),
+                provider: "codex".to_string(),
+                duration: std::time::Duration::from_millis(620),
+            }],
+        };
+
+        let message = report.slow_log_message(std::time::Duration::from_millis(500));
+
+        assert!(message.is_some_and(|message| {
+            message.contains("total_ms=750")
+                && message.contains("agent_count=3")
+                && message.contains("agent-1:codex:620ms")
+        }));
+        assert!(TelemetryPassTimings {
+            total: std::time::Duration::from_millis(250),
+            sys_refresh: std::time::Duration::from_millis(25),
+            agent_count: 1,
+            slow_agents: Vec::new(),
+        }
+        .slow_log_message(std::time::Duration::from_millis(500))
+        .is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Description

Harden the backend paths that can make all agents appear stuck when a telemetry tick or PTY output notification path stalls.

- Supervise periodic telemetry ticks and log slow/timed-out passes without stopping the metrics loop.
- Avoid global telemetry stalls by using nonblocking system sampling and per-agent log-work guards.
- Coalesce `agent-pty-output-ready` events while preserving delayed wakeups for drained buffers.
- Add slow-pass diagnostics for identifying expensive agents/providers.

## Related Issues

Fixes #302

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Backend verification on Windows:

```text
cd src-tauri && cargo fmt --check
cd src-tauri && cargo check
cd src-tauri && cargo test
cd src-tauri && cargo clippy -- -D warnings
git diff --check
```

After rebasing onto latest `origin/main`, reran:

```text
cd src-tauri && cargo check
cd src-tauri && cargo test output_ready_emit_gate_coalesces_repeats_after_throttle
cd src-tauri && cargo test slow_telemetry_report_only_formats_slow_passes
git diff --check HEAD~1 HEAD
```

Subagent review reported no blocking findings after the final fixes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes