### PR TITLE
docs: refresh provider runtime references

### DIFF
--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -11,7 +11,7 @@ Wardian is built as a **High-Performance Hybrid Environment**, using **Rust (Tau
 - **PTY Management**: Uses `portable-pty` for cross-platform PTY handles. On Windows, it leverages `win32job` to ensure child processes are strictly terminated when the agent session ends.
 - **Provider Adapters**: Agent CLIs are integrated behind a Rust provider layer so session spawn, headless execution, and telemetry enrichment can support Gemini, Claude, Codex, and OpenCode without rewriting the rest of the backend.
   See [Provider Runtime Notes](./provider-runtimes.md) for the provider-specific working-root, skill, and session rules that sit behind this abstraction.
-- **Provider Context Projection**: The backend adapts Wardian instructions and skills to each provider's native discovery model without mutating the user repository. Gemini and Claude run in the real workspace with provider-native instruction/include paths, Codex runs against the real workspace via `--cd` while keeping per-agent `CODEX_HOME` habitat state, and OpenCode runs in the real workspace with generated runtime config and config-directory skill projection.
+- **Habitat Projection**: For providers that cannot natively discover Wardian instructions and skills from external include roots, the backend materializes a neutral per-session `habitat` directory. That habitat links the real workspace, projects a scoped `AGENTS.md`, and exposes provider-native skill layouts without mutating the user repository. OpenCode is an explicit exception: it stays in the real workspace and receives class/skill scope through injected runtime config instead of a projected workspace.
 - **State Management**: `AppState` holds `Mutex`-protected maps of active agents, metrics, and background triggers.
 - **Worker Threads**:
   - **Heartbeat (Scheduler)**: Handles periodic tasks and cron triggers.
@@ -30,7 +30,7 @@ Wardian is built as a **High-Performance Hybrid Environment**, using **Rust (Tau
 - **Continuity vs Memory**: Provider-native resume state is not the same thing as long-term memory. Session IDs, PTY ownership, approval hooks, and provider trust remain runtime concerns.
 - **Evidence-First Memory**: Wardian's memory direction is to preserve raw evidence, index it for retrieval, and build prompt context selectively rather than replaying prior sessions wholesale.
 - **Promoted Knowledge**: Curated atoms remain useful, but as promoted knowledge with provenance back to retrieved evidence rather than as the primary memory substrate.
-- See [2026-04-17 Evidence First Memory](../specs/2026-04-17-evidence-first-memory.md) for the target architecture.
+- See [Evidence-First Memory](../specs/2026-04-17-evidence-first-memory.md) for the target architecture.
 
 ### 3. The UI Layer (React Frontend)
 

--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -21,7 +21,7 @@ This document captures the practical runtime differences between Wardian's suppo
 | Gemini | Real target workspace | `GEMINI.md` | Patched CLI can discover skills from include directories | Discovered from provider output |
 | Claude | Real target workspace | `CLAUDE.md` | `.claude/skills` points at Wardian's `.agents/skills` | Wardian assigns `--session-id` up front |
 | Codex | Real target workspace via `--cd` | `AGENTS.md` | Per-agent `CODEX_HOME/skills` under habitat | Discovered from provider output, then adopted |
-| OpenCode | Real target workspace | `AGENTS.md` plus injected runtime config | `OPENCODE_CONFIG_DIR` skill projection built from Wardian include roots | Discovered from provider output |
+| OpenCode | Real target workspace | `AGENTS.md` plus injected runtime config | `skills.paths` built from Wardian include roots | Discovered from provider output |
 
 ## Gemini
 
@@ -75,19 +75,12 @@ Claude also runs directly in the real target workspace. Wardian does not use a p
 
 - Claude depends heavily on the permission-hook path being writable and stable.
 - Bugs here are usually about hook setup, `CLAUDE.md` discovery, or resume/session flags.
-- On Windows, Claude sessions may invoke tools through either PowerShell/cmd semantics or a Git Bash-compatible `bash`. Wardian prepends its managed CLI `bin` directory to Claude child process `PATH` and installs both `wardian.cmd` and an extensionless POSIX shell launcher so `wardian` resolves in both shell families.
-- To smoke-test the launcher pair on Windows, use an isolated `WARDIAN_HOME`, launch Wardian once so the CLI is installed, then verify both shells:
-
-```bash
-command -v wardian
-wardian --version
-```
-
-PowerShell:
+- On Windows, Claude may invoke both PowerShell and bash-family tool shells during one Wardian-managed session. Wardian therefore installs both `%USERPROFILE%\.wardian\bin\wardian.cmd` and `%USERPROFILE%\.wardian\bin\wardian`, then prepends the active Wardian `bin` directory to the managed provider process PATH. Verify shell parity from inside the managed runtime, not only from the parent Wardian process.
+- Windows manual smoke:
 
 ```powershell
-(Get-Command wardian).Source
-wardian --version
+powershell -NoProfile -Command "wardian --version"
+bash -lc "wardian --version"
 ```
 
 ## Codex
@@ -184,10 +177,10 @@ OpenCode runs directly in the real target workspace. Wardian does not use a proj
 ### Instruction and skill discovery
 
 - OpenCode reads `AGENTS.md` natively when it exists in the working tree.
-- Wardian also injects runtime configuration through generated `OPENCODE_CONFIG` and `OPENCODE_CONFIG_DIR` paths.
+- Wardian also injects runtime configuration through `OPENCODE_CONFIG_CONTENT`.
 - That injected config adds:
   - extra `AGENTS.md` files from Wardian include roots to `instructions`
-  - linked skills from Wardian include roots into the generated config directory
+  - extra `.agents/skills` directories from Wardian include roots to `skills.paths`
 
 This is how OpenCode sees Wardian-managed class and agent context without forcing those files into the user repository.
 
@@ -201,7 +194,7 @@ This is how OpenCode sees Wardian-managed class and agent context without forcin
 
 - OpenCode is closer to Gemini than Codex on workspace handling: it wants the real repo as `cwd`.
 - OpenCode is closer to Codex than Gemini on instruction naming: it consumes `AGENTS.md` directly.
-- If OpenCode stops seeing Wardian skills or class instructions, inspect the generated `OPENCODE_CONFIG` file and `OPENCODE_CONFIG_DIR` first.
+- If OpenCode stops seeing Wardian skills or class instructions, inspect the generated `OPENCODE_CONFIG_CONTENT` first.
 - If interactive spawn works but telemetry is thin, that is expected today; OpenCode does not expose one stable per-session JSONL path the way Claude and Codex do.
 - On Windows, Wardian should prefer a native `opencode.exe` or packaged OpenCode binary over `.cmd`/script shims during PATH resolution. If only a shim exists, interactive launch must wrap it through `cmd /d /c ...` because direct PTY spawning does not get shell dispatch semantics.
 
@@ -212,7 +205,7 @@ When provider behavior breaks, start with the provider-specific seam instead of 
 - Gemini problems: inspect patching, include directories, and JSON event parsing.
 - Claude problems: inspect `CLAUDE.md` discovery, permission hooks, and explicit session flags.
 - Codex problems: inspect `CODEX_HOME`, `--cd`, bootstrap migration, and sandbox approval transitions.
-- OpenCode problems: inspect `OPENCODE_CONFIG`, `OPENCODE_CONFIG_DIR`, real-workspace `cwd`, and JSON session parsing.
+- OpenCode problems: inspect `OPENCODE_CONFIG_CONTENT`, real-workspace `cwd`, and JSON session parsing.
 
 ## Related Research
 

--- a/docs/developer/screenshot-documentation.md
+++ b/docs/developer/screenshot-documentation.md
@@ -83,4 +83,4 @@ For screenshots that require Tauri IPC, PTY behavior, or provider runtime behavi
 
 Use [Core Feature Screenshot Capture Plan](./screenshot-capture-plan.md) to decide which screenshots belong in the first documentation pass.
 
-See [2026-05-12 Core Feature Screenshot Documentation](../specs/2026-05-12-core-feature-screenshot-documentation.md) for the architectural decision.
+See [Core Feature Screenshot Documentation](../specs/2026-05-12-core-feature-screenshot-documentation.md) for the architectural decision.

--- a/docs/features.md
+++ b/docs/features.md
@@ -59,7 +59,7 @@ Related docs:
 Related docs:
 
 - [Source Control](./guide/source-control.md)
-- [2026-04-17 Source Control Panel](./specs/2026-04-17-source-control-panel.md)
+- [Source Control Panel](./specs/2026-04-17-source-control-panel.md)
 
 ## Workflow Builder and Runtime
 
@@ -92,13 +92,13 @@ Related docs:
 
 - Default shell selection (`auto`, discovered shell, or custom executable)
 - Per-installation regular-agent session persistence policy (`resume` vs `fresh`)
-- Provider-specific runtime utilities, including Gemini skill patching, Codex runtime policy, and OpenCode theme sync
+- Theme sync support and Gemini patch actions from settings
 
 Related docs:
 
 - [Settings](./guide/settings.md)
-- [2026-03-30 Runtime Shell Selection](./specs/2026-03-30-runtime-shell-selection.md)
-- [2026-04-17 Session Persistence Policy](./specs/2026-04-17-session-persistence-policy.md)
+- [Runtime Shell Selection](./specs/2026-03-30-runtime-shell-selection.md)
+- [Session Persistence Policy](./specs/2026-04-17-session-persistence-policy.md)
 
 ## Provider-Aware Orchestration
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -12,7 +12,7 @@ The desktop app copies the bundled CLI on startup:
 - macOS/Linux command: `$HOME/.wardian/bin/wardian`
 - macOS/Linux implementation binary: `$HOME/.wardian/bin/wardian-cli`
 
-Wardian also attempts to add that `bin` directory to the user PATH. Restart the terminal after first launch if `wardian` is not found.
+Wardian also attempts to add that `bin` directory to the user PATH. On Windows, Wardian installs both a `.cmd` launcher for PowerShell/cmd and an extensionless launcher for bash-family shells such as Git Bash. Managed agent processes receive the Wardian `bin` directory at the front of their runtime PATH so Claude can run `wardian` from either PowerShell or bash commands. Restart ordinary terminals after first launch if `wardian` is not found.
 
 On Windows, Wardian installs both a `wardian.cmd` launcher for PowerShell/cmd and an extensionless POSIX shell launcher for Git Bash, MSYS2, or provider shell tools that execute `bash`. Wardian-managed agent processes also receive the active Wardian `bin` directory at the front of `PATH`, so shell tools inside Claude sessions can resolve `wardian` without depending on the user's global shell startup files.
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-The Settings tab controls theme behavior, runtime shell selection, session policy defaults, and provider-specific runtime utilities.
+The Settings tab controls theme behavior, runtime shell selection, session policy defaults, and Gemini patch utilities.
 
 ![Wardian Settings tab showing theme, session persistence, and shell selection controls](../assets/screenshots/settings/runtime-settings.png)
 
@@ -12,7 +12,7 @@ Theme options:
 - **Dark**
 - **Light**
 
-Wardian applies the selected mode to the app UI. For OpenCode agents, Wardian also syncs the provider theme preference through backend settings.
+Wardian applies the selected mode to the app UI and syncs the OpenCode theme preference through backend settings.
 
 ## Agent Runtime: Regular Agent Sessions
 
@@ -41,15 +41,6 @@ Typical uses:
 
 After changing shell settings, use **Save Shell**.
 
-## Provider Runtime Utilities
-
-Provider-specific settings apply only to providers that need them:
-
-- **Gemini**: skill discovery patch controls.
-- **Codex**: runtime policy controls for sandbox mode, approval policy, and full-auto behavior.
-- **OpenCode**: theme preference sync.
-- **Claude**: permission and session behavior are configured per agent rather than from this global settings panel.
-
 ## Advanced: Gemini Patch
 
 Controls:
@@ -57,19 +48,17 @@ Controls:
 - **Auto-patch Gemini CLI** toggle
 - **Run Patch Now** button
 
-Use this when Gemini skill discovery requires Wardian's patch flow. Other providers use their own discovery paths; see [Provider Runtimes](../providers.md) for the full comparison.
+Use this when Gemini skill discovery requires Wardian's patch flow.
 
 ## Troubleshooting
 
 - If shell options are empty, verify shell binaries are installed and visible in your OS PATH.
 - If resume behavior is not what you expect, verify both the global runtime policy and any per-agent override.
-- If Gemini skills are missing, run the Gemini patch manually and restart the app session.
-- If OpenCode skills or instructions are missing, inspect the generated provider config and config directory described in Provider Runtimes.
-- If Codex skills are missing, inspect the agent habitat skill projection before changing repository files.
+- If Gemini skills are missing, run patch manually and restart the app session.
 
 ## Related References
 
 - [UI Overview](./ui-overview.md)
 - [Provider Runtimes](../providers.md)
-- [2026-03-30 Runtime Shell Selection](../specs/2026-03-30-runtime-shell-selection.md)
-- [2026-04-17 Session Persistence Policy](../specs/2026-04-17-session-persistence-policy.md)
+- [Runtime Shell Selection](../specs/2026-03-30-runtime-shell-selection.md)
+- [Session Persistence Policy](../specs/2026-04-17-session-persistence-policy.md)

--- a/docs/guide/source-control.md
+++ b/docs/guide/source-control.md
@@ -84,4 +84,4 @@ wardian agent worktree disable <agent-name-or-id>
 
 - [Explorer](./explorer.md)
 - [Watchlists](./watchlists.md)
-- [2026-04-17 Source Control Panel](../specs/2026-04-17-source-control-panel.md)
+- [Source Control Panel](../specs/2026-04-17-source-control-panel.md)

--- a/docs/specs/2026-03-15-kts-milestone-1.md
+++ b/docs/specs/2026-03-15-kts-milestone-1.md
@@ -4,7 +4,7 @@
 * **Date:** 2026-03-15
 * **Decider:** Architect
 
-> Note: This proposal is partially superseded by [2026-04-17 Evidence First Memory](./2026-04-17-evidence-first-memory.md). KTS remains valid as a promoted knowledge layer, but it is no longer the recommended base memory substrate.
+> Note: This proposal is partially superseded by [Evidence-First Memory](./2026-04-17-evidence-first-memory.md). KTS remains valid as a promoted knowledge layer, but it is no longer the recommended base memory substrate.
 
 ## Context and Problem Statement
 Wardian needs a way for agents to store and retrieve "Atoms" of knowledge (tasks, facts, project metadata) that is both human-readable (for Git versioning) and high-performance (for agent indexing). Current session logs are too bloated and unstructured for long-term "Self-Improvement" workflows.
@@ -29,7 +29,7 @@ We will implement the **Knowledge Task System (KTS)** as a curated knowledge lay
 3. **Rust Atom Parser**: A new module `src-tauri/src/kts/` using `serde_yaml` and `pulldown-cmark` to perform CRUD operations.
 4. **Projection Layer**: On startup, the Rust backend will parse all atoms and project them into a **Global SQLite Cache** (using `rusqlite`) for rapid SQL/semantic search without reading all files into memory every time.
 
-Under [2026-04-17 Evidence First Memory](./2026-04-17-evidence-first-memory.md), this projection should consume both promoted atoms and raw evidence, with atoms serving as higher-confidence curated records rather than the first ingestion layer.
+Under [Evidence-First Memory](./2026-04-17-evidence-first-memory.md), this projection should consume both promoted atoms and raw evidence, with atoms serving as higher-confidence curated records rather than the first ingestion layer.
 
 ## Consequences
 * **Positive**: Human-readable, Git-friendly, and extremely fast for agent retrieval.

--- a/docs/specs/2026-03-15-scheduler.md
+++ b/docs/specs/2026-03-15-scheduler.md
@@ -40,7 +40,7 @@ The Workflow Sidebar will be refactored to handle two primary tabs:
 
 ### 4. Implementation (Rust)
 
-The **Internal Heartbeat Thread** (from the original 2026-03-15 Scheduler) will remain the driver, but it will now query a `scheduled_runs.json` store instead of individual workflow files.
+The **Internal Heartbeat Thread** (from the original scheduler spec) will remain the driver, but it will now query a `scheduled_runs.json` store instead of individual workflow files.
 
 ## Consequences
 

--- a/docs/specs/2026-04-17-session-persistence-policy.md
+++ b/docs/specs/2026-04-17-session-persistence-policy.md
@@ -169,7 +169,7 @@ Update user-facing workflow docs to explain:
 
 Update developer docs to preserve the key invariant: provider-native resume state is runtime state, not Wardian memory.
 
-Memory read/write behavior is intentionally out of scope for this spec except for one boundary: `inherit_fresh` may read source-agent scoped memory, but it should write workflow artifacts only. Promotion into source-agent memory belongs to [2026-04-17 Evidence First Memory](./2026-04-17-evidence-first-memory.md).
+Memory read/write behavior is intentionally out of scope for this spec except for one boundary: `inherit_fresh` may read source-agent scoped memory, but it should write workflow artifacts only. Promotion into source-agent memory belongs to [Evidence-First Memory](./2026-04-17-evidence-first-memory.md).
 
 ## Consequences
 

--- a/docs/specs/2026-04-21-wardian-cli-and-agent-command.md
+++ b/docs/specs/2026-04-21-wardian-cli-and-agent-command.md
@@ -8,7 +8,7 @@
 
 Wardian has no command-line interface. Every interaction — spawning agents, inspecting state, running workflows — goes through the Tauri GUI. This forces a specific problem: the primary users of Wardian are *agents*, not humans, and agents cannot usefully drive a graphical app. They need a textual surface to introspect themselves, discover peers, and (eventually) act on the system they live inside.
 
-2026-04-20 Agent Identity and Status Tracking already lays the groundwork for this by making the Rust backend the source of truth for agent identity and status via `~/.wardian/state.db`, and by injecting `WARDIAN_SESSION_ID` into every spawned agent's environment. 2026-04-19 Release System reserves a slot for a `wardian-cli` binary in the release pipeline and documents its intended bundle location. What is missing is the CLI itself.
+[Agent Identity and Status Tracking](./2026-04-20-agent-identity-and-status-tracking.md) already lays the groundwork for this by making the Rust backend the source of truth for agent identity and status via `~/.wardian/state.db`, and by injecting `WARDIAN_SESSION_ID` into every spawned agent's environment. [Release System](./2026-04-19-release-system.md) reserves a slot for a `wardian-cli` binary in the release pipeline and documents its intended bundle location. What is missing is the CLI itself.
 
 This spec defines the first slice: a `wardian` command distributed alongside the GUI, sharing Rust code with the Tauri app through a workspace refactor, always on the user's `PATH`, and exposing one noun — `wardian agent` — for self- and peer-introspection. Mutating commands (`spawn`, `send`, `kill`), auto-update, and distribution wrappers (npm/pip/cargo) are explicitly deferred to follow-up specs. The command surface is designed so those follow-ups slot in without restructuring.
 
@@ -61,14 +61,14 @@ The refactor is mechanical: move files, adjust `use` paths, update `Cargo.toml` 
 
 ### Component 2 — Binary, Distribution, Install
 
-**Binary names:** the implementation binary is `wardian-cli` / `wardian-cli.exe` so it can coexist with the desktop app's `Wardian.exe` on Windows. The user-facing command remains `wardian`: macOS/Linux install a `wardian` shell launcher, and Windows installs both `wardian.cmd` and an extensionless `wardian` POSIX shell launcher, all delegating to the adjacent `wardian-cli` binary.
+**Binary names:** the implementation binary is `wardian-cli` / `wardian-cli.exe` so it can coexist with the desktop app's `Wardian.exe` on Windows. The user-facing command remains `wardian`: macOS/Linux install a `wardian` shell launcher, and Windows installs `wardian.cmd`, both delegating to the adjacent `wardian-cli` binary.
 
 **Build outputs:**
 
-- Bundled inside the Tauri app under `resources/bin/wardian-cli[.exe]` via `src-tauri/tauri.conf.json` -> `bundle.resources`. 2026-04-19 Release System already reserves this slot.
-- Per-platform release assets on GitHub Releases: `wardian-cli-{arch}-{os}[.exe]`. 2026-04-19 Release System's stubbed CLI matrix job is enabled as part of this spec.
+- Bundled inside the Tauri app under `resources/bin/wardian-cli[.exe]` via `src-tauri/tauri.conf.json` -> `bundle.resources`. [Release System](./2026-04-19-release-system.md) already reserves this slot.
+- Per-platform release assets on GitHub Releases: `wardian-cli-{arch}-{os}[.exe]`. The [Release System](./2026-04-19-release-system.md) stubbed CLI matrix job is enabled as part of this spec.
 
-**Install location:** `~/.wardian/bin/wardian` on macOS/Linux; `%USERPROFILE%\.wardian\bin\wardian.cmd`, `%USERPROFILE%\.wardian\bin\wardian`, and `%USERPROFILE%\.wardian\bin\wardian-cli.exe` on Windows. Per-user, no elevation required, inside the Wardian-owned tree alongside `state.db`, `agents/`, `classes/`.
+**Install location:** `~/.wardian/bin/wardian` on macOS/Linux, `%USERPROFILE%\.wardian\bin\wardian.cmd` on Windows, with the implementation binary beside it. Per-user, no elevation required, inside the Wardian-owned tree alongside `state.db`, `agents/`, `classes/`.
 
 **Install-time behavior:**
 
@@ -78,7 +78,7 @@ The refactor is mechanical: move files, adjust `use` paths, update `Cargo.toml` 
 2. If either step fails (read-only FS, no profile file, etc.), the GUI surfaces a dismissible notification with a copy-pasteable fallback command. The app continues to function; only the CLI is unreachable from user shells.
 3. The binary inside the app bundle is a *source* artifact. The live binary is whatever is in `~/.wardian/bin/`. This separation is deliberate: the forthcoming updater swaps the live binary, not the bundled one, so GUI and CLI update paths decouple cleanly.
 
-**Agent subterminal guarantee:** user shells normally find `wardian` because `~/.wardian/bin` is on the user's real `PATH`. On Windows, Wardian also prepends the managed CLI `bin` directory to managed provider processes so agent shell tools are not dependent on global shell startup propagation. This is especially important for Claude tools that may run through either PowerShell/cmd semantics or Git Bash-compatible POSIX shell lookup.
+**Agent subterminal guarantee:** because `~/.wardian/bin` is on the user's real `PATH`, any shell an agent spawns — including nested shells, tmux panes, and provider-invoked subprocesses — finds `wardian` without needing environment injection. The CLI is reliably available, not dependent on the parent process propagating env correctly.
 
 ### Component 3 — State Access Model
 
@@ -90,7 +90,7 @@ The live control endpoint is not Tauri command IPC. It is a local OS endpoint ke
 
 ### Component 4 — Self-Resolution via `WARDIAN_SESSION_ID`
 
-2026-04-20 Agent Identity and Status Tracking injects `WARDIAN_SESSION_ID=<uuid>` into the environment of every spawned agent. The CLI uses this as its "who am I?" signal:
+[Agent Identity and Status Tracking](./2026-04-20-agent-identity-and-status-tracking.md) injects `WARDIAN_SESSION_ID=<uuid>` into the environment of every spawned agent. The CLI uses this as its "who am I?" signal:
 
 1. `wardian agent` (no args) reads `$WARDIAN_SESSION_ID`.
 2. If set, looks up the matching row in `state.db` and returns it.

--- a/docs/specs/2026-05-07-agent-watch-and-communication.md
+++ b/docs/specs/2026-05-07-agent-watch-and-communication.md
@@ -6,7 +6,7 @@
 
 ## Context and Problem Statement
 
-2026-04-21 Wardian CLI and Agent Command gave agents a CLI surface for introspection, and 2026-05-07 CLI Agent Control added live control commands such as `wardian send` and `wardian agent wait`. That first control slice is useful, but it is still too narrow for reliable agent-to-agent work.
+[Wardian CLI and `wardian agent` Command](./2026-04-21-wardian-cli-and-agent-command.md) gave agents a CLI surface for introspection, and [CLI Agent Control and Communication](./2026-05-07-cli-agent-control.md) added live control commands such as `wardian send` and `wardian agent wait`. That first control slice is useful, but it is still too narrow for reliable agent-to-agent work.
 
 The current communication path is mostly a one-way PTY injection. A caller can send text and optionally wait for a target status, but it cannot directly observe what the target saw, whether output changed, whether a response was produced, or why a delivery path was unavailable. This makes failures ambiguous. During provider probes on 2026-05-07:
 
@@ -235,7 +235,7 @@ Delivery responses should report per-target details:
 }
 ```
 
-CLI output follows the existing 2026-04-21 Wardian CLI and Agent Command error contract. If any matched target fails, the command exits nonzero, stdout is empty, and stderr contains the standard error envelope with `details.delivery[]`. If every matched target is submitted successfully, stdout contains the success envelope with `delivery[]` and stderr is empty.
+CLI output follows the existing [Wardian CLI and `wardian agent` Command](./2026-04-21-wardian-cli-and-agent-command.md) error contract. If any matched target fails, the command exits nonzero, stdout is empty, and stderr contains the standard error envelope with `details.delivery[]`. If every matched target is submitted successfully, stdout contains the success envelope with `delivery[]` and stderr is empty.
 
 ### Error Semantics
 

--- a/docs/specs/2026-05-07-cli-agent-control.md
+++ b/docs/specs/2026-05-07-cli-agent-control.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-2026-04-21 Wardian CLI and Agent Command introduced the `wardian` CLI as a read-oriented agent introspection surface and explicitly deferred mutating commands. The next slice adds the control-plane commands agents need to act on Wardian state: lifecycle commands, workflow operations, and PTY message delivery.
+[Wardian CLI and `wardian agent` Command](./2026-04-21-wardian-cli-and-agent-command.md) introduced the `wardian` CLI as a read-oriented agent introspection surface and explicitly deferred mutating commands. The next slice adds the control-plane commands agents need to act on Wardian state: lifecycle commands, workflow operations, and PTY message delivery.
 
 ## Decision
 
@@ -40,7 +40,7 @@ The CLI preserves `not_found` and `not_supported` for app-reported control error
 
 ## State Access
 
-2026-04-21 Wardian CLI and Agent Command described read-only SQLite fallback for the original introspection commands. The current implementation opens the database normally and runs migrations before reading so older Wardian homes remain queryable from the CLI. This is a deliberate compatibility tradeoff: the CLI may upgrade schema metadata during reads, but it does not mutate agent lifecycle state through SQLite.
+[Wardian CLI and `wardian agent` Command](./2026-04-21-wardian-cli-and-agent-command.md) described read-only SQLite fallback for the original introspection commands. The current implementation opens the database normally and runs migrations before reading so older Wardian homes remain queryable from the CLI. This is a deliberate compatibility tradeoff: the CLI may upgrade schema metadata during reads, but it does not mutate agent lifecycle state through SQLite.
 
 ## Follow-Ups
 

--- a/docs/specs/2026-05-12-core-feature-screenshot-documentation.md
+++ b/docs/specs/2026-05-12-core-feature-screenshot-documentation.md
@@ -8,7 +8,7 @@
 
 Wardian has user guides for the core windows and feature areas, but most pages describe the interface only in text. Clean screenshots would make the documentation easier to scan, especially for readers learning the Grid, Dashboard, Library, Workflows, Explorer, Command Panel, Source Control, Settings, and Watchlist surfaces.
 
-2026-04-26 Testing Coverage and Screenshot Docs already defines local PR screenshot evidence under `e2e/screenshots/<feature>/<timestamp>/`. That path is intentionally ignored by git and should remain a temporary evidence location. Reader-facing documentation screenshots need a committed, stable home that does not mix with local test artifacts.
+[Testing Coverage and Screenshot Documentation](./2026-04-26-testing-coverage-and-screenshot-docs.md) already defines local PR screenshot evidence under `e2e/screenshots/<feature>/<timestamp>/`. That path is intentionally ignored by git and should remain a temporary evidence location. Reader-facing documentation screenshots need a committed, stable home that does not mix with local test artifacts.
 
 ## Proposed Decision
 

--- a/docs/specs/template.md
+++ b/docs/specs/template.md
@@ -1,10 +1,10 @@
 # [Title]
 
+Filename: `YYYY-MM-DD-short-slug.md`
+
 - **Status:** Proposed | Implemented | Deprecated
 - **Date:** [YYYY-MM-DD]
 - **Decider:** [Role/User]
-
-Filename: `YYYY-MM-DD-short-slug.md`
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
## Description
Refreshes provider runtime documentation references and related docs links so the current provider runtime guidance is consistent across developer docs, guides, and specs. This is a docs-only follow-up split out from the local remnants on the Gemini resume branch.

## Related Issues
Fixes #306

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `git diff --check origin/main..HEAD`
- `npm run lint`
- `npm run test` - passed; existing React `act(...)` warnings still appear in watchlist/App tests.
- `npm run build` - passed; existing Vite large chunk warning still appears.
- `npm run docs:build` - passed; existing Vite large chunk warning still appears.
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo clippy`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable