### PR TITLE
fix(gemini): handle empty restarts and patch paths

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1324,6 +1324,20 @@ pub(crate) fn prepare_restored_config_for_spawn(config: &mut AgentConfig) -> Res
     prepare_resume_config(config)
 }
 
+fn prepare_resume_config_for_runtime(
+    config: &mut AgentConfig,
+    query_count: usize,
+) -> Result<(), String> {
+    if config.provider == "gemini" && query_count == 0 && !config.is_off {
+        config.is_off = false;
+        config.resume_session = None;
+        config.fresh_provider_session_id = Some(uuid::Uuid::new_v4().to_string());
+        return Ok(());
+    }
+
+    prepare_resume_config(config)
+}
+
 fn prepare_clear_config(config: &mut AgentConfig) -> Result<(), String> {
     config.is_off = false;
     config.resume_session = None;
@@ -1943,7 +1957,7 @@ pub async fn resume_agent(
     };
 
     let mut config = snapshot.config;
-    prepare_resume_config(&mut config)?;
+    prepare_resume_config_for_runtime(&mut config, snapshot.query_count)?;
     let mut new_active = manager::spawn_agent(
         app.clone(),
         config.clone(),
@@ -2658,7 +2672,7 @@ mod tests {
         flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
         mark_agent_paused_off, normalize_clone_folder_override, normalize_spawn_folder,
         persisted_resume_session_for_provider, prepare_clear_config,
-        prepare_restored_config_for_spawn, prepare_resume_config,
+        prepare_restored_config_for_spawn, prepare_resume_config, prepare_resume_config_for_runtime,
         promote_fresh_provider_session_after_resume, provider_needs_obtain_session_id_on_clear,
         provider_uses_generated_session_id, reserve_spawn_session_name,
         resolve_agent_worktree_branch_name, resolve_agent_worktree_path,
@@ -4888,6 +4902,62 @@ mod tests {
             Some("wardian-agent-id")
         );
         assert!(config.fresh_provider_session_id.is_some());
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn gemini_empty_runtime_resume_starts_fresh_session() {
+        let (_guard, _temp) = use_isolated_resume_setting();
+        let mut config = AgentConfig {
+            provider: "gemini".to_string(),
+            session_id: "wardian-agent-id".to_string(),
+            resume_session: Some("gemini-provider-session".to_string()),
+            is_off: false,
+            ..Default::default()
+        };
+
+        prepare_resume_config_for_runtime(&mut config, 0).expect("prepare resume config");
+
+        assert_eq!(config.session_id, "wardian-agent-id");
+        assert_eq!(config.resume_session, None);
+        assert_ne!(
+            config.fresh_provider_session_id.as_deref(),
+            Some("wardian-agent-id")
+        );
+        assert_ne!(
+            config.fresh_provider_session_id.as_deref(),
+            Some("gemini-provider-session")
+        );
+        assert!(config.fresh_provider_session_id.is_some());
+        let args = GeminiProvider::new().get_spawn_args(&config, false);
+        assert!(args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"--resume".to_string()));
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn off_gemini_runtime_resume_with_unknown_query_count_keeps_resume_session() {
+        let (_guard, _temp) = use_isolated_resume_setting();
+        let mut config = AgentConfig {
+            provider: "gemini".to_string(),
+            session_id: "wardian-agent-id".to_string(),
+            resume_session: Some("gemini-provider-session".to_string()),
+            is_off: true,
+            ..Default::default()
+        };
+
+        prepare_resume_config_for_runtime(&mut config, 0).expect("prepare resume config");
+
+        assert_eq!(
+            config.resume_session.as_deref(),
+            Some("gemini-provider-session")
+        );
+        assert_eq!(config.fresh_provider_session_id, None);
+        assert!(!config.is_off);
+        let args = GeminiProvider::new().get_spawn_args(&config, true);
+        assert!(args.contains(&"--resume".to_string()));
+        assert!(args.contains(&"gemini-provider-session".to_string()));
+        assert!(!args.contains(&"--session-id".to_string()));
         std::env::remove_var("WARDIAN_HOME");
     }
 

--- a/src-tauri/src/commands/patch.rs
+++ b/src-tauri/src/commands/patch.rs
@@ -1,6 +1,22 @@
 use crate::manager::log_debug;
+use std::path::PathBuf;
 use std::process::Command;
 use tauri::{AppHandle, Manager};
+
+fn node_entrypoint_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let raw = path.as_os_str().to_string_lossy();
+        if let Some(rest) = raw.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{}", rest));
+        }
+        if let Some(rest) = raw.strip_prefix(r"\\?\") {
+            return PathBuf::from(rest);
+        }
+    }
+
+    path
+}
 
 #[tauri::command]
 pub async fn run_gemini_patch(app: AppHandle) -> Result<String, String> {
@@ -51,9 +67,11 @@ pub async fn run_gemini_patch(app: AppHandle) -> Result<String, String> {
         resource_path
     ));
 
+    let node_resource_path = node_entrypoint_path(resource_path);
+
     #[allow(unused_mut)]
     let mut cmd = Command::new("node");
-    cmd.arg(&resource_path);
+    cmd.arg(&node_resource_path);
 
     #[cfg(windows)]
     {
@@ -77,5 +95,40 @@ pub async fn run_gemini_patch(app: AppHandle) -> Result<String, String> {
             "Script exited with status: {}. Stderr: {}",
             output.status, stderr
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::node_entrypoint_path;
+    use std::path::PathBuf;
+
+    #[test]
+    #[cfg(windows)]
+    fn node_entrypoint_path_removes_windows_verbatim_prefix() {
+        let path = PathBuf::from(r"\\?\D:\Development\Wardian\scripts\gemini-patch-skills.cjs");
+
+        assert_eq!(
+            node_entrypoint_path(path),
+            PathBuf::from(r"D:\Development\Wardian\scripts\gemini-patch-skills.cjs")
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn node_entrypoint_path_removes_windows_verbatim_unc_prefix() {
+        let path = PathBuf::from(r"\\?\UNC\server\share\scripts\gemini-patch-skills.cjs");
+
+        assert_eq!(
+            node_entrypoint_path(path),
+            PathBuf::from(r"\\server\share\scripts\gemini-patch-skills.cjs")
+        );
+    }
+
+    #[test]
+    fn node_entrypoint_path_keeps_regular_paths() {
+        let path = PathBuf::from("scripts/gemini-patch-skills.cjs");
+
+        assert_eq!(node_entrypoint_path(path.clone()), path);
     }
 }


### PR DESCRIPTION
## Description
Fixes two Gemini-specific runtime issues:

- Normalizes Windows verbatim resource paths before invoking Node for the Gemini patch script, avoiding Node v24 treating `\\?\D:\...` as an invalid directory lookup.
- Treats active Gemini runtime restarts with zero recorded queries as fresh provider sessions, matching other providers' empty-session behavior.
- Preserves off/restored Gemini sessions that have a saved provider `resume_session`, including a regression test for that case from subagent review.

## Related Issues
Fixes #308

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `git diff --check`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test -- --test-threads=1` (503 unit tests, plus mock provider E2E and doctests)
- `cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- `npm run lint`
- `npm run test` (65 files, 621 tests; existing React `act(...)` warnings still present)
- `npm run build` (passes; existing Vite chunk-size warning still present)
- `npm run test:e2e:native:fast -- e2e-native/tests/terminal-rendering-native.test.mjs` with temporary Vite server on `127.0.0.1:1420`; passes with existing Node `DEP0190` warning from the native test runner

Subagent review found a high-risk edge case where an off/restored Gemini session with unknown query count could be mistaken for an active empty session. The runtime predicate now excludes off/restored sessions, and the PR includes a regression test for that preservation path.

Docs maintenance checked: no docs updates are needed because this is an internal provider-runtime bugfix with no public commands, UI text, setup flow, or documented workflow changes.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, or docs are not applicable
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable

