### PR TITLE
fix(release): update updater signing configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           tagName: ${{ github.ref_name }}
           releaseDraft: true
-          uploadUpdaterJson: ${{ needs.create-release.outputs.is_prerelease == 'false' }}
+          includeUpdaterJson: ${{ needs.create-release.outputs.is_prerelease == 'false' }}
           updaterJsonPreferNsis: true
           args: --config src-tauri/tauri.updater.conf.json ${{ matrix.platform.args || '' }}
 
@@ -212,7 +212,7 @@ jobs:
           releaseId: ${{ needs.resolve-release.outputs.release_id }}
           tagName: ${{ inputs.release_tag }}
           releaseDraft: true
-          uploadUpdaterJson: ${{ needs.resolve-release.outputs.is_prerelease == 'false' }}
+          includeUpdaterJson: ${{ needs.resolve-release.outputs.is_prerelease == 'false' }}
           updaterJsonPreferNsis: true
           args: --config src-tauri/tauri.updater.conf.json ${{ matrix.platform.args || '' }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Wardian"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -5253,7 +5253,7 @@ dependencies = [
 
 [[package]]
 name = "wardian-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "rusqlite",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "wardian-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "dirs 5.0.1",

--- a/docs/developer/release-updates.md
+++ b/docs/developer/release-updates.md
@@ -27,6 +27,10 @@ Configure GitHub Actions secrets:
 - `TAURI_SIGNING_PRIVATE_KEY`: the private key content, or use `TAURI_SIGNING_PRIVATE_KEY_PATH` in a controlled runner environment.
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: optional, only when the private key was generated with a password.
 
+For this repository's GitHub Actions workflow, store the private key file content in `TAURI_SIGNING_PRIVATE_KEY`. Do not store the public `.pub` file, the committed `plugins.updater.pubkey`, or a local filesystem path. The generated private key file is base64 text; when decoded it starts with `untrusted comment:` and contains `secret key`.
+
+If GitHub Actions reports `Missing comment in secret key`, replace `TAURI_SIGNING_PRIVATE_KEY` with the contents of the generated private key file and confirm `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` matches the password used when generating it. If the key was generated with a Tauri CLI version between `2.9.3` and `2.10.0` and no password, regenerate it with the current repository CLI before using it for the first updater-capable release.
+
 If the private key or password is lost, existing updater-enabled installs cannot verify future update packages. Recovery requires a manual installer release with a new public key. If the key is compromised, revoke use of the old key, generate a new pair, publish a manual recovery installer, and document the incident in release notes.
 
 ## Stable Channel

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENBQUQ3NkRBNzBDMTc3RDkKUldUWmQ4RncybmF0eWtadWFpNURLNUVONDN3UXdPYm9OZE8vbS9ISjJzUWxVTy91U3RzZ1FOcnkK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk2MjA4NDc3ODFFQUYxRjMKUldUejhlcUJkNFFnbHNXT21UUFFVcjQwc2d4VldqZEU4bVdhYjJOK3dZb0ZZQ2R3RDVEeFJscVUK",
       "endpoints": [
         "https://github.com/tangemicioglu/Wardian/releases/latest/download/latest.json"
       ],

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -69,8 +69,9 @@ describe("release workflow contract", () => {
     expect(releaseWorkflow).toContain("tagName: ${{ inputs.release_tag }}");
     expect(releaseWorkflow).toContain("WARDIAN_UPDATE_CHANNEL: ${{ needs.create-release.outputs.is_prerelease == 'false' && 'stable' || '' }}");
     expect(releaseWorkflow).toContain("WARDIAN_UPDATE_CHANNEL: ${{ needs.resolve-release.outputs.is_prerelease == 'false' && 'stable' || '' }}");
-    expect(releaseWorkflow).toContain("uploadUpdaterJson: ${{ needs.create-release.outputs.is_prerelease == 'false' }}");
-    expect(releaseWorkflow).toContain("uploadUpdaterJson: ${{ needs.resolve-release.outputs.is_prerelease == 'false' }}");
+    expect(releaseWorkflow).toContain("includeUpdaterJson: ${{ needs.create-release.outputs.is_prerelease == 'false' }}");
+    expect(releaseWorkflow).toContain("includeUpdaterJson: ${{ needs.resolve-release.outputs.is_prerelease == 'false' }}");
+    expect(releaseWorkflow).not.toContain("uploadUpdaterJson:");
     expect(releaseWorkflow).toContain("updaterJsonPreferNsis: true");
     expect(releaseWorkflow).toContain("Build (dry run)");
     expect(releaseWorkflow).toContain("ref: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true' && inputs.release_tag || github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag || github.ref }}");


### PR DESCRIPTION
## Description
- Switches the Tauri Action updater metadata input from ignored `uploadUpdaterJson` to supported `includeUpdaterJson`.
- Updates the committed Tauri updater public key to match the newly stored GitHub Actions private signing key.
- Documents the GitHub Actions signing secret shape and the `Missing comment in secret key` failure mode.
- Syncs `Cargo.lock` package versions to the 0.3.6 workspace manifests after cargo verification updated them.

## Related Issues
Fixes #319

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run test -- src/config/releaseWorkflow.test.ts`
- `npm run docs:build`
- `cargo check`
- Earlier branch verification before the public-key follow-up: `npm run lint`, `npm run test`, `npm run build`, `cd src-tauri && cargo clippy`, `cd src-tauri && cargo test`, `cd src-tauri && cargo check`.
- Secrets scan: `rg -n "wardian-updater\.key|TAURI_SIGNING_PRIVATE_KEY|BEGIN|PRIVATE KEY|\\.env|password" .` found no private key material.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
