### PR TITLE
feat(release): add OS package manager manifests

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: 💬 GitHub Discussions
-    url: https://github.com/tangemicioglu/Wardian/discussions
+    url: https://github.com/wardian-app/Wardian/discussions
     about: Ask questions and share ideas with the community.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We would love to accept your patches and contributions! Wardian is a community-d
 
 ## 🚀 Getting Started
 
-1.  **Find an Issue**: Browse our [GitHub Issues](https://github.com/tangemicioglu/Wardian/issues). We use labels like `help-wanted` and `complexity-low` for new contributors.
+1.  **Find an Issue**: Browse our [GitHub Issues](https://github.com/wardian-app/Wardian/issues). We use labels like `help-wanted` and `complexity-low` for new contributors.
 2.  **Fork & Branch**: Fork the repository and create a new branch for your feature or bug fix.
     ```bash
     git checkout -b feat/your-feature-name

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.3.6"
 edition = "2021"
 authors = ["Tan Gemicioglu"]
 license = "MIT"
-repository = "https://github.com/tangemicioglu/Wardian"
-homepage = "https://github.com/tangemicioglu/Wardian"
+repository = "https://github.com/wardian-app/Wardian"
+homepage = "https://wardian.org"
 
 [workspace.dependencies]
 chrono = "0.4.38"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 **Local command center for multi-agent CLI workflows** — see every session, collect completed work in a queue, and give agents a CLI surface for coordinating and controlling Wardian.
 
-[![CI](https://github.com/tangemicioglu/Wardian/actions/workflows/ci.yml/badge.svg)](https://github.com/tangemicioglu/Wardian/actions/workflows/ci.yml)
-[![Frontend Coverage](https://codecov.io/gh/tangemicioglu/Wardian/branch/main/graph/badge.svg?flag=frontend&label=frontend%20coverage)](https://codecov.io/gh/tangemicioglu/Wardian)
-[![Backend Coverage](https://codecov.io/gh/tangemicioglu/Wardian/branch/main/graph/badge.svg?flag=backend&label=backend%20coverage)](https://codecov.io/gh/tangemicioglu/Wardian)
-[![Release](https://img.shields.io/github/v/release/tangemicioglu/Wardian?label=release)](https://github.com/tangemicioglu/Wardian/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/tangemicioglu/Wardian/total?label=downloads)](https://github.com/tangemicioglu/Wardian/releases)
+[![CI](https://github.com/wardian-app/Wardian/actions/workflows/ci.yml/badge.svg)](https://github.com/wardian-app/Wardian/actions/workflows/ci.yml)
+[![Frontend Coverage](https://codecov.io/gh/wardian-app/Wardian/branch/main/graph/badge.svg?flag=frontend&label=frontend%20coverage)](https://codecov.io/gh/wardian-app/Wardian)
+[![Backend Coverage](https://codecov.io/gh/wardian-app/Wardian/branch/main/graph/badge.svg?flag=backend&label=backend%20coverage)](https://codecov.io/gh/wardian-app/Wardian)
+[![Release](https://img.shields.io/github/v/release/wardian-app/Wardian?label=release)](https://github.com/wardian-app/Wardian/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/wardian-app/Wardian/total?label=downloads)](https://github.com/wardian-app/Wardian/releases)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-555)
 
 [![Wardian Demo](public/demo.gif)](public/demo.gif)
@@ -19,7 +19,7 @@
 
 ---
 
-> 🚧 **Early development.** Wardian is under active construction. Expect rough edges: APIs, on-disk formats, and UI layouts can change between releases without notice. Pin a version if you depend on it, and please [file an issue](https://github.com/tangemicioglu/Wardian/issues) when something breaks.
+> 🚧 **Early development.** Wardian is under active construction. Expect rough edges: APIs, on-disk formats, and UI layouts can change between releases without notice. Pin a version if you depend on it, and please [file an issue](https://github.com/wardian-app/Wardian/issues) when something breaks.
 
 Wardian is an **Integrated Agent Environment** — a local, app-first governance layer for AI orchestration. It centralizes PTY management, live telemetry, completion queues, workflow execution, and shared context into a unified desktop Command Center for developers managing many long-running agent sessions across multiple projects. The bundled `wardian` CLI gives agents a textual control surface for discovering their own identity, coordinating peers, and controlling Wardian without driving the graphical app.
 
@@ -27,7 +27,7 @@ Wardian is an **Integrated Agent Environment** — a local, app-first governance
 
 ## Download
 
-Pre-built binaries for Windows, macOS (Apple Silicon + Intel), and Linux are available from the [Releases page](https://github.com/tangemicioglu/Wardian/releases).
+Pre-built binaries for Windows, macOS (Apple Silicon + Intel), and Linux are available from the [Releases page](https://github.com/wardian-app/Wardian/releases).
 
 Choose the asset for your operating system and CPU:
 
@@ -44,7 +44,7 @@ Choose the asset for your operating system and CPU:
 > **Note:** Wardian binaries are currently unsigned. On first launch:
 > - **Windows:** SmartScreen will show a warning. Click "More info" → "Run anyway."
 > - **macOS:** Gatekeeper will refuse to open the app. Right-click the app and choose "Open," or run `xattr -cr /Applications/Wardian.app` from Terminal.
-> - **Linux:** `.AppImage` is portable (`chmod +x` and run); `.deb` installs via `sudo dpkg -i wardian_*.deb`.
+> - **Linux:** `.AppImage` is portable (`chmod +x` and run); `.deb` installs via `sudo apt install ./Wardian_*.deb`.
 
 ---
 
@@ -75,7 +75,7 @@ That guide covers download, launch, provider CLI setup, authentication, the firs
 For local development, clone the repository and run the dev app:
 
 ```bash
-git clone https://github.com/tangemicioglu/Wardian.git
+git clone https://github.com/wardian-app/Wardian.git
 cd Wardian
 npm install
 npm run dev
@@ -220,7 +220,7 @@ Wardian is built with a focus on modularity, thread safety, and separation of co
 3. **Agent CLIs**: Install at least one supported provider CLI before spawning agents: [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`@google/gemini-cli`), [Claude Code](https://github.com/anthropics/claude-code) (`@anthropic-ai/claude-code`), [Codex](https://github.com/openai/codex) (`@openai/codex`), or [OpenCode](https://github.com/anomalyco/opencode) (`opencode` command, commonly installed from `opencode-ai`). Ensure each provider is authenticated successfully in your terminal first.
 4. **Clone & Install**:
    ```bash
-   git clone https://github.com/tangemicioglu/Wardian.git
+   git clone https://github.com/wardian-app/Wardian.git
    cd Wardian
    npm install
    ```

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -106,6 +106,7 @@ export default defineConfig({
             { text: "Provider Runtimes", link: "/developer/provider-runtimes" },
             { text: "PTY Lifecycle", link: "/developer/pty-lifecycle" },
             { text: "Native E2E", link: "/developer/native-e2e" },
+            { text: "Package Manager Distribution", link: "/developer/package-manager-distribution" },
             { text: "Docs Maintenance", link: "/developer/docs-maintenance" },
             { text: "Theming", link: "/developer/theming" },
             { text: "Screenshot Documentation", link: "/developer/screenshot-documentation" },

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -28,6 +28,7 @@ Use this index when implementing or debugging Wardian internals.
 
 - [Developer Setup](./setup.md)
 - [Release Updates](./release-updates.md)
+- [Package Manager Distribution](./package-manager-distribution.md)
 - [Documentation Maintenance](./docs-maintenance.md)
 - [Public Docs Site](./docs-site.md)
 - [Native E2E Harness](./native-e2e.md)

--- a/docs/developer/package-manager-distribution.md
+++ b/docs/developer/package-manager-distribution.md
@@ -1,0 +1,113 @@
+# Package Manager Distribution
+
+Wardian's package-manager metadata is generated from stable GitHub Release
+assets. GitHub Releases stay canonical; package managers are discovery and
+install surfaces that reuse the same desktop installers.
+
+## Scope
+
+Phase 1 covers:
+
+- winget for Windows, using the NSIS `.exe`.
+- Homebrew Cask for macOS, using the Apple Silicon and Intel `.dmg` files.
+- Linux direct-install docs for `.deb` and AppImage artifacts.
+
+npm bootstrap, standalone CLI-only distribution, signed APT repositories,
+Flathub, and Snap are out of scope for Phase 1. Linux package-manager publishing
+is tracked in [#324](https://github.com/tangemicioglu/Wardian/issues/324).
+The Phase 1 implementation is tracked in
+[#325](https://github.com/tangemicioglu/Wardian/issues/325).
+
+## Generate Manifests
+
+Run this only after the stable release workflow has published the GitHub
+Release and validated updater metadata.
+
+```bash
+mkdir -p dist/package-managers/v0.3.6
+gh release view v0.3.6 --json tagName,assets > dist/package-managers/v0.3.6/assets.json
+npm run release:package-manifests -- --release-assets dist/package-managers/v0.3.6/assets.json --out dist/package-managers/v0.3.6
+```
+
+PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force dist/package-managers/v0.3.6 | Out-Null
+gh release view v0.3.6 --json tagName,assets > dist/package-managers/v0.3.6/assets.json
+npm run release:package-manifests -- --release-assets dist/package-managers/v0.3.6/assets.json --out dist/package-managers/v0.3.6
+```
+
+Generated files:
+
+- `dist/package-managers/v0.3.6/winget/Tangemicioglu.Wardian.yaml`
+- `dist/package-managers/v0.3.6/winget/Tangemicioglu.Wardian.locale.en-US.yaml`
+- `dist/package-managers/v0.3.6/winget/Tangemicioglu.Wardian.installer.yaml`
+- `dist/package-managers/v0.3.6/homebrew/wardian.rb`
+- `dist/package-managers/v0.3.6/linux/install.md`
+
+The generator fails if a required asset is missing, lacks a SHA-256 digest, or
+does not point at the requested release tag.
+
+## winget
+
+Copy the generated winget files into a local clone of
+`microsoft/winget-pkgs` under:
+
+```text
+manifests/t/Tangemicioglu/Wardian/0.3.6/
+```
+
+Validate before submitting:
+
+```bash
+winget validate manifests/t/Tangemicioglu/Wardian/0.3.6
+```
+
+PowerShell:
+
+```powershell
+winget validate manifests\t\Tangemicioglu\Wardian\0.3.6
+```
+
+Submit through the normal `microsoft/winget-pkgs` PR flow or with
+`wingetcreate submit` after reviewing the generated YAML.
+
+## Homebrew
+
+Copy `dist/package-managers/v0.3.6/homebrew/wardian.rb` into the Wardian tap or
+the target Cask repository.
+
+Validate locally:
+
+```bash
+brew audit --cask wardian
+brew install --cask --verbose ./wardian.rb
+```
+
+Homebrew metadata declares `auto_updates true` because Wardian has its own
+Tauri updater. Package-manager updates may lag behind the in-app updater, but
+they must never point at prerelease or draft artifacts.
+
+## Linux Direct Install
+
+Use `dist/package-managers/v0.3.6/linux/install.md` as the hash-verified Linux
+install snippet for release notes and documentation. Do not present it as an
+APT, Flatpak, Snap, or AppImageUpdate channel. Those choices belong to the
+Phase 2 Linux package-manager work.
+
+## Verification
+
+For generator changes, run:
+
+```bash
+npm run test -- src/config/packageManagerManifestGenerator.test.ts
+npm run lint
+```
+
+Before submitting generated package-manager metadata for a release, run the
+ecosystem validators for the generated output:
+
+```bash
+winget validate <winget-manifest-directory>
+brew audit --cask wardian
+```

--- a/docs/developer/package-manager-distribution.md
+++ b/docs/developer/package-manager-distribution.md
@@ -14,9 +14,9 @@ Phase 1 covers:
 
 npm bootstrap, standalone CLI-only distribution, signed APT repositories,
 Flathub, and Snap are out of scope for Phase 1. Linux package-manager publishing
-is tracked in [#324](https://github.com/tangemicioglu/Wardian/issues/324).
+is tracked in [#324](https://github.com/wardian-app/Wardian/issues/324).
 The Phase 1 implementation is tracked in
-[#325](https://github.com/tangemicioglu/Wardian/issues/325).
+[#325](https://github.com/wardian-app/Wardian/issues/325).
 
 ## Generate Manifests
 
@@ -39,9 +39,9 @@ npm run release:package-manifests -- --release-assets dist/package-managers/v0.3
 
 Generated files:
 
-- `dist/package-managers/v0.3.6/winget/Tangemicioglu.Wardian.yaml`
-- `dist/package-managers/v0.3.6/winget/Tangemicioglu.Wardian.locale.en-US.yaml`
-- `dist/package-managers/v0.3.6/winget/Tangemicioglu.Wardian.installer.yaml`
+- `dist/package-managers/v0.3.6/winget/WardianApp.Wardian.yaml`
+- `dist/package-managers/v0.3.6/winget/WardianApp.Wardian.locale.en-US.yaml`
+- `dist/package-managers/v0.3.6/winget/WardianApp.Wardian.installer.yaml`
 - `dist/package-managers/v0.3.6/homebrew/wardian.rb`
 - `dist/package-managers/v0.3.6/linux/install.md`
 
@@ -54,19 +54,19 @@ Copy the generated winget files into a local clone of
 `microsoft/winget-pkgs` under:
 
 ```text
-manifests/t/Tangemicioglu/Wardian/0.3.6/
+manifests/w/WardianApp/Wardian/0.3.6/
 ```
 
 Validate before submitting:
 
 ```bash
-winget validate manifests/t/Tangemicioglu/Wardian/0.3.6
+winget validate manifests/w/WardianApp/Wardian/0.3.6
 ```
 
 PowerShell:
 
 ```powershell
-winget validate manifests\t\Tangemicioglu\Wardian\0.3.6
+winget validate manifests\w\WardianApp\Wardian\0.3.6
 ```
 
 Submit through the normal `microsoft/winget-pkgs` PR flow or with

--- a/docs/developer/release-updates.md
+++ b/docs/developer/release-updates.md
@@ -55,6 +55,13 @@ Local `npm run tauri build` creates an installable bundle without updater artifa
 
 Stable tag-push and stable manual backfill builds set `WARDIAN_UPDATE_CHANNEL=stable` before invoking `tauri-apps/tauri-action`. Prerelease builds intentionally omit the marker and do not upload stable updater metadata. Do not set that marker for ordinary local builds unless you are deliberately producing an official stable release artifact.
 
+After a stable release is published, generate winget, Homebrew, and Linux
+direct-install metadata from the published release assets. See
+[Package Manager Distribution](./package-manager-distribution.md) for the
+post-release package-manager workflow. Package-manager metadata must consume the
+published release asset URLs and SHA-256 digests; it must not depend on release
+titles.
+
 `latest.json` must contain all stable platform keys:
 
 - `windows-x86_64`

--- a/docs/developer/release-updates.md
+++ b/docs/developer/release-updates.md
@@ -38,7 +38,7 @@ If the private key or password is lost, existing updater-enabled installs cannot
 The first implementation uses only the stable channel:
 
 ```text
-https://github.com/tangemicioglu/Wardian/releases/latest/download/latest.json
+https://github.com/wardian-app/Wardian/releases/latest/download/latest.json
 ```
 
 Stable builds must not consume prerelease metadata. Hyphenated version tags such as preview, alpha, beta, rc, or nightly are treated as prereleases and must not publish stable updater metadata. Preview, beta, nightly, staged rollout, or rollback behavior should use a separate channel manifest or a dynamic update endpoint rather than overloading GitHub's stable latest release.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -6,7 +6,7 @@ If any first-run step fails, use [First-Run Troubleshooting](./first-run-trouble
 
 ## 1. Download and Launch Wardian
 
-Download the latest installer or app bundle from the [Wardian releases page](https://github.com/tangemicioglu/Wardian/releases/latest), then launch Wardian from your operating system.
+Download the latest installer or app bundle from the [Wardian releases page](https://github.com/tangemicioglu/Wardian/releases/latest), then launch Wardian from your operating system. GitHub Releases are the canonical install source; package-manager listings may lag behind the newest stable release.
 
 Choose the asset for your operating system and CPU:
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -6,7 +6,7 @@ If any first-run step fails, use [First-Run Troubleshooting](./first-run-trouble
 
 ## 1. Download and Launch Wardian
 
-Download the latest installer or app bundle from the [Wardian releases page](https://github.com/tangemicioglu/Wardian/releases/latest), then launch Wardian from your operating system. GitHub Releases are the canonical install source; package-manager listings may lag behind the newest stable release.
+Download the latest installer or app bundle from the [Wardian releases page](https://github.com/wardian-app/Wardian/releases/latest), then launch Wardian from your operating system. GitHub Releases are the canonical install source; package-manager listings may lag behind the newest stable release.
 
 Choose the asset for your operating system and CPU:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ This folder contains the public Wardian user guides, workflow references, and de
 - [Workflow Engine](./developer/workflow-engine.md)
 - [Visual Builder](./developer/visual-builder.md)
 - [Native E2E Harness](./developer/native-e2e.md)
+- [Package Manager Distribution](./developer/package-manager-distribution.md)
 - [Theming](./developer/theming.md)
 - [Screenshot Documentation](./developer/screenshot-documentation.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,5 +55,5 @@ This folder contains the public Wardian user guides, workflow references, and de
 
 ## Project Context
 
-- [Design Context](https://github.com/tangemicioglu/Wardian/blob/main/DESIGN.md)
+- [Design Context](https://github.com/wardian-app/Wardian/blob/main/DESIGN.md)
 - [OS Support](./os-support.md)

--- a/docs/os-support.md
+++ b/docs/os-support.md
@@ -30,7 +30,7 @@ Wardian is fully supported on Linux.
 
 - **Implementation**: Standard Unix PTY via `portable-pty`.
 - **Status**: Stable. Core features verified on Linux. Distribution-specific shell environments are handled via the runtime shell selection feature.
-- **Packages**: `.AppImage` (portable, `chmod +x` and run) and `.deb` (install via `sudo dpkg -i wardian_*.deb`) are available from the Releases page.
+- **Packages**: `.AppImage` (portable, `chmod +x` and run) and `.deb` (install via `sudo apt install ./Wardian_*.deb`) are available from the Releases page. A Linux package-manager channel is tracked separately in [#324](https://github.com/tangemicioglu/Wardian/issues/324).
 
 ---
 

--- a/docs/os-support.md
+++ b/docs/os-support.md
@@ -30,7 +30,7 @@ Wardian is fully supported on Linux.
 
 - **Implementation**: Standard Unix PTY via `portable-pty`.
 - **Status**: Stable. Core features verified on Linux. Distribution-specific shell environments are handled via the runtime shell selection feature.
-- **Packages**: `.AppImage` (portable, `chmod +x` and run) and `.deb` (install via `sudo apt install ./Wardian_*.deb`) are available from the Releases page. A Linux package-manager channel is tracked separately in [#324](https://github.com/tangemicioglu/Wardian/issues/324).
+- **Packages**: `.AppImage` (portable, `chmod +x` and run) and `.deb` (install via `sudo apt install ./Wardian_*.deb`) are available from the Releases page. A Linux package-manager channel is tracked separately in [#324](https://github.com/wardian-app/Wardian/issues/324).
 
 ---
 

--- a/docs/specs/2026-04-01-automated-testing-harness.md
+++ b/docs/specs/2026-04-01-automated-testing-harness.md
@@ -7,7 +7,7 @@
 ## Context and Problem Statement
 Wardian still depends heavily on manual verification for agent orchestration, workflow execution, PTY behavior, and provider-specific runtime behavior. That is slow, expensive, and risky because the current runtime shares the user's real `~/.wardian` state, real providers, and real agent sessions.
 
-Issue [#95](https://github.com/tangemicioglu/Wardian/issues/95) is not just about CI coverage. The more important requirement is that live agents must be able to verify their own changes during execution without interfering with production agents or hallucinating success.
+Issue [#95](https://github.com/wardian-app/Wardian/issues/95) is not just about CI coverage. The more important requirement is that live agents must be able to verify their own changes during execution without interfering with production agents or hallucinating success.
 
 The testing problem has three separate layers that must not be conflated:
 

--- a/docs/specs/2026-05-18-agent-watch-readable-output.md
+++ b/docs/specs/2026-05-18-agent-watch-readable-output.md
@@ -2,7 +2,7 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-16
-- **Issue:** [#273](https://github.com/tangemicioglu/Wardian/issues/273)
+- **Issue:** [#273](https://github.com/wardian-app/Wardian/issues/273)
 - **Decider:** Wardian Codex
 
 ## Decision

--- a/docs/specs/2026-05-19-in-app-updates.md
+++ b/docs/specs/2026-05-19-in-app-updates.md
@@ -33,7 +33,7 @@ Wardian configures:
 - `@tauri-apps/plugin-updater` in the frontend.
 - `@tauri-apps/plugin-process` for relaunch.
 - `bundle.createUpdaterArtifacts: true` in the release-only Tauri config overlay (`src-tauri/tauri.updater.conf.json`).
-- A stable endpoint at `https://github.com/tangemicioglu/Wardian/releases/latest/download/latest.json`.
+- A stable endpoint at `https://github.com/wardian-app/Wardian/releases/latest/download/latest.json`.
 - Tauri updater permissions in `src-tauri/capabilities/default.json`.
 - Tauri process restart permission in `src-tauri/capabilities/default.json`.
 - Windows updater install mode `passive`.

--- a/docs/specs/2026-05-20-os-package-managers-phase-1.md
+++ b/docs/specs/2026-05-20-os-package-managers-phase-1.md
@@ -3,8 +3,8 @@
 - **Status:** Accepted
 - **Date:** 2026-05-20
 - **Decider:** Wardian Codex and user
-- **Issue:** [#325](https://github.com/tangemicioglu/Wardian/issues/325)
-- **Follow-up:** Linux package-manager publishing is tracked in [#324](https://github.com/tangemicioglu/Wardian/issues/324).
+- **Issue:** [#325](https://github.com/wardian-app/Wardian/issues/325)
+- **Follow-up:** Linux package-manager publishing is tracked in [#324](https://github.com/wardian-app/Wardian/issues/324).
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-20-os-package-managers-phase-1.md
+++ b/docs/specs/2026-05-20-os-package-managers-phase-1.md
@@ -1,0 +1,80 @@
+# OS Package Managers Phase 1
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Decider:** Wardian Codex and user
+- **Issue:** [#325](https://github.com/tangemicioglu/Wardian/issues/325)
+- **Follow-up:** Linux package-manager publishing is tracked in [#324](https://github.com/tangemicioglu/Wardian/issues/324).
+
+## Context and Problem Statement
+
+Wardian now publishes signed updater artifacts and unified desktop installers
+through GitHub Releases. The next distribution step should improve install
+discovery through conventional desktop package managers without creating a
+separate npm or CLI-only channel.
+
+npm is deferred. Wardian is currently desktop-first, and the npm package would
+only be a bootstrapper that redirects to GitHub Releases. That can be revisited
+when Wardian has a web, headless, or standalone CLI runtime that maps naturally
+to `npx wardian`.
+
+Linux package-manager publishing is also deferred. Wardian already emits `.deb`
+and AppImage artifacts, but a real Linux package-manager channel requires a
+choice between a signed APT repository, Flathub, Snap, or another ecosystem.
+That decision has enough policy, hosting, and sandbox implications to deserve
+its own follow-up.
+
+## Decision
+
+Phase 1 adds release-support automation and documentation for:
+
+- **Windows:** winget manifests that reuse the release NSIS installer.
+- **macOS:** a Homebrew Cask that reuses the release DMG files.
+- **Linux:** direct GitHub Release installation instructions for `.deb` and
+  AppImage artifacts, including SHA-256 verification.
+
+GitHub Releases remain canonical. Package-manager metadata must be generated
+from a published stable release after asset validation succeeds. Package-manager
+automation must key on tag names, asset names, URLs, and hashes, never on the
+GitHub release title.
+
+## Artifact Contract
+
+For a stable release tag `vX.Y.Z`, Phase 1 expects these release assets:
+
+- `Wardian_X.Y.Z_x64-setup.exe`
+- `Wardian_X.Y.Z_aarch64.dmg`
+- `Wardian_X.Y.Z_x64.dmg`
+- `Wardian_X.Y.Z_amd64.deb`
+- `Wardian_X.Y.Z_amd64.AppImage`
+
+The package-manager generator consumes the GitHub release asset JSON, including
+GitHub's SHA-256 `digest` field, and fails if any required asset is missing,
+missing a hash, or points at a different release tag.
+
+## Workflow
+
+After a stable release is published:
+
+1. Export the GitHub Release asset JSON with `gh release view`.
+2. Run `npm run release:package-manifests` with the asset JSON and an ignored
+   output directory under `dist/`.
+3. Validate the winget directory with `winget validate`.
+4. Submit the winget manifests to `microsoft/winget-pkgs`.
+5. Copy the generated Homebrew Cask into the Wardian tap or a Homebrew Cask PR
+   and run Homebrew audit/install validation.
+6. Use the generated Linux install markdown as the source for release notes or
+   documentation until the Linux package-manager follow-up lands.
+
+## Consequences
+
+- **Positive:** Windows and macOS package-manager metadata is repeatable and
+  derived from release assets instead of hand-copied hashes.
+- **Positive:** The workflow preserves GitHub Releases and Tauri updater
+  artifacts as the trust anchor.
+- **Positive:** Linux users get hash-verified direct-install instructions now,
+  while the package-manager choice stays explicit in #324.
+- **Negative:** Phase 1 still requires maintainer action after publishing a
+  release. Fully automated external repository PRs are deferred.
+- **Negative:** Homebrew distribution still needs a tap or upstream Cask
+  submission target outside this repository.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "stage-cli": "node scripts/stage-cli.mjs",
+    "release:package-manifests": "node scripts/package-managers/generate-manifests.mjs",
     "lint": "tsc --noEmit",
     "check:frontend-screenshot": "node scripts/verify-frontend-screenshot.mjs",
     "docs:dev": "vitepress dev docs",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tangemicioglu/Wardian.git"
+    "url": "https://github.com/wardian-app/Wardian.git"
   },
-  "homepage": "https://github.com/tangemicioglu/Wardian#readme",
+  "homepage": "https://wardian.org",
   "bugs": {
-    "url": "https://github.com/tangemicioglu/Wardian/issues"
+    "url": "https://github.com/wardian-app/Wardian/issues"
   },
   "scripts": {
     "start": "tauri dev",

--- a/scripts/package-managers/generate-manifests.mjs
+++ b/scripts/package-managers/generate-manifests.mjs
@@ -4,9 +4,9 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
-const packageIdentifier = "Tangemicioglu.Wardian";
-const repositoryUrl = "https://github.com/tangemicioglu/Wardian";
-const publisher = "Tangemicioglu";
+const packageIdentifier = "WardianApp.Wardian";
+const homepageUrl = "https://wardian.org";
+const publisher = "Wardian App";
 const description = "Local command center for multi-agent CLI workflows.";
 
 function parseArgs(argv) {
@@ -122,11 +122,11 @@ function writeWingetManifests(outDir, release, assets) {
       `PackageVersion: ${release.version}`,
       "PackageLocale: en-US",
       `Publisher: ${publisher}`,
-      "PublisherUrl: https://github.com/tangemicioglu",
-      "PublisherSupportUrl: https://github.com/tangemicioglu/Wardian/issues",
-      "Author: Tangemicioglu",
+      `PublisherUrl: ${homepageUrl}`,
+      "PublisherSupportUrl: https://github.com/wardian-app/Wardian/issues",
+      "Author: Wardian App",
       "PackageName: Wardian",
-      `PackageUrl: ${repositoryUrl}`,
+      `PackageUrl: ${homepageUrl}`,
       "License: MIT",
       `Description: ${description}`,
       "ShortDescription: Local command center for multi-agent CLI workflows.",
@@ -191,7 +191,7 @@ function writeHomebrewCask(outDir, release, assets) {
       "",
       '  name "Wardian"',
       `  desc "${description}"`,
-      `  homepage "${repositoryUrl}"`,
+      `  homepage "${homepageUrl}"`,
       "",
       "  livecheck do",
       "    url :url",

--- a/scripts/package-managers/generate-manifests.mjs
+++ b/scripts/package-managers/generate-manifests.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+const packageIdentifier = "Tangemicioglu.Wardian";
+const repositoryUrl = "https://github.com/tangemicioglu/Wardian";
+const publisher = "Tangemicioglu";
+const description = "Local command center for multi-agent CLI workflows.";
+
+function parseArgs(argv) {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || !value || value.startsWith("--")) {
+      throw new Error(`Expected --key value argument pair near ${key ?? "<end>"}`);
+    }
+    args.set(key, value);
+  }
+
+  const releaseAssets = args.get("--release-assets");
+  const out = args.get("--out") ?? "dist/package-managers";
+  if (!releaseAssets) {
+    throw new Error("--release-assets is required");
+  }
+
+  return { releaseAssets, out };
+}
+
+function normalizeSha256(asset) {
+  const raw = asset.digest ?? asset.sha256 ?? asset.InstallerSha256;
+  if (typeof raw !== "string") {
+    throw new Error(`Release asset ${asset.name ?? "<unknown>"} is missing a sha256 digest`);
+  }
+
+  const digest = raw.replace(/^sha256:/i, "").trim();
+  if (!/^[a-f0-9]{64}$/i.test(digest)) {
+    throw new Error(`Release asset ${asset.name ?? "<unknown>"} has invalid sha256 digest ${raw}`);
+  }
+
+  return digest.toLowerCase();
+}
+
+function normalizeUrl(asset) {
+  const url = asset.browser_download_url ?? asset.browserDownloadUrl ?? asset.url;
+  if (typeof url !== "string" || !url.startsWith("https://")) {
+    throw new Error(`Release asset ${asset.name ?? "<unknown>"} is missing an HTTPS download URL`);
+  }
+
+  return url;
+}
+
+function loadReleaseManifest(path) {
+  const raw = JSON.parse(readFileSync(path, "utf8"));
+  const tag = raw.tagName ?? raw.tag_name ?? raw.tag;
+  if (typeof tag !== "string" || !/^v\d+\.\d+\.\d+/.test(tag)) {
+    throw new Error("Release manifest must include tagName, tag_name, or tag like v0.3.6");
+  }
+
+  const assets = Array.isArray(raw.assets) ? raw.assets : [];
+  const version = tag.replace(/^v/, "");
+  return {
+    tag,
+    version,
+    assets: assets.map((asset) => ({
+      name: asset.name,
+      url: normalizeUrl(asset),
+      sha256: normalizeSha256(asset),
+    })),
+  };
+}
+
+function findAsset(release, kind, expectedName) {
+  const asset = release.assets.find((candidate) => candidate.name === expectedName);
+  if (!asset) {
+    throw new Error(`Missing required release asset for ${kind}: ${expectedName}`);
+  }
+
+  if (!asset.url.includes(`/releases/download/${release.tag}/`)) {
+    throw new Error(`${expectedName} URL must target ${release.tag}: ${asset.url}`);
+  }
+
+  return asset;
+}
+
+function resolvePhaseOneAssets(release) {
+  const version = release.version;
+  return {
+    windowsX64: findAsset(release, "winget x64 installer", `Wardian_${version}_x64-setup.exe`),
+    macArm64: findAsset(release, "Homebrew Apple Silicon DMG", `Wardian_${version}_aarch64.dmg`),
+    macX64: findAsset(release, "Homebrew Intel DMG", `Wardian_${version}_x64.dmg`),
+    linuxDeb: findAsset(release, "Linux Debian package", `Wardian_${version}_amd64.deb`),
+    linuxAppImage: findAsset(release, "Linux AppImage", `Wardian_${version}_amd64.AppImage`),
+  };
+}
+
+function writeWingetManifests(outDir, release, assets) {
+  const dir = join(outDir, "winget");
+  mkdirSync(dir, { recursive: true });
+
+  writeFileSync(
+    join(dir, `${packageIdentifier}.yaml`),
+    [
+      "# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json",
+      `PackageIdentifier: ${packageIdentifier}`,
+      `PackageVersion: ${release.version}`,
+      "DefaultLocale: en-US",
+      "ManifestType: version",
+      "ManifestVersion: 1.10.0",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  writeFileSync(
+    join(dir, `${packageIdentifier}.locale.en-US.yaml`),
+    [
+      "# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json",
+      `PackageIdentifier: ${packageIdentifier}`,
+      `PackageVersion: ${release.version}`,
+      "PackageLocale: en-US",
+      `Publisher: ${publisher}`,
+      "PublisherUrl: https://github.com/tangemicioglu",
+      "PublisherSupportUrl: https://github.com/tangemicioglu/Wardian/issues",
+      "Author: Tangemicioglu",
+      "PackageName: Wardian",
+      `PackageUrl: ${repositoryUrl}`,
+      "License: MIT",
+      `Description: ${description}`,
+      "ShortDescription: Local command center for multi-agent CLI workflows.",
+      "Tags:",
+      "- ai",
+      "- agents",
+      "- cli",
+      "- tauri",
+      "ManifestType: defaultLocale",
+      "ManifestVersion: 1.10.0",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  writeFileSync(
+    join(dir, `${packageIdentifier}.installer.yaml`),
+    [
+      "# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json",
+      `PackageIdentifier: ${packageIdentifier}`,
+      `PackageVersion: ${release.version}`,
+      "InstallerLocale: en-US",
+      "InstallerType: nullsoft",
+      "InstallModes:",
+      "- interactive",
+      "- silent",
+      "InstallerSwitches:",
+      "  Silent: /S",
+      "  SilentWithProgress: /S",
+      "UpgradeBehavior: install",
+      "Installers:",
+      "- Architecture: x64",
+      `  InstallerUrl: ${assets.windowsX64.url}`,
+      `  InstallerSha256: ${assets.windowsX64.sha256}`,
+      "ManifestType: installer",
+      "ManifestVersion: 1.10.0",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeHomebrewCask(outDir, release, assets) {
+  const dir = join(outDir, "homebrew");
+  mkdirSync(dir, { recursive: true });
+
+  writeFileSync(
+    join(dir, "wardian.rb"),
+    [
+      'cask "wardian" do',
+      `  version "${release.version}"`,
+      "",
+      "  on_arm do",
+      `    url "${assets.macArm64.url}"`,
+      `    sha256 "${assets.macArm64.sha256}"`,
+      "  end",
+      "",
+      "  on_intel do",
+      `    url "${assets.macX64.url}"`,
+      `    sha256 "${assets.macX64.sha256}"`,
+      "  end",
+      "",
+      '  name "Wardian"',
+      `  desc "${description}"`,
+      `  homepage "${repositoryUrl}"`,
+      "",
+      "  livecheck do",
+      "    url :url",
+      "    strategy :github_latest",
+      "  end",
+      "",
+      "  auto_updates true",
+      "",
+      '  app "Wardian.app"',
+      "",
+      "  zap trash: [",
+      '    "~/Library/Application Support/org.wardian.desktop",',
+      '    "~/Library/Logs/org.wardian.desktop",',
+      '    "~/Library/Preferences/org.wardian.desktop.plist",',
+      "  ]",
+      "end",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function writeLinuxInstallDoc(outDir, release, assets) {
+  const dir = join(outDir, "linux");
+  mkdirSync(dir, { recursive: true });
+
+  writeFileSync(
+    join(dir, "install.md"),
+    [
+      `# Wardian ${release.version} Linux Install`,
+      "",
+      "GitHub Releases remain the canonical source for Linux Phase 1. Verify the",
+      "downloaded artifact hash before installing.",
+      "",
+      "## Debian/Ubuntu",
+      "",
+      "```bash",
+      `curl -L -o ${assets.linuxDeb.name} ${assets.linuxDeb.url}`,
+      `echo "${assets.linuxDeb.sha256}  ${assets.linuxDeb.name}" | sha256sum -c -`,
+      `sudo apt install ./${assets.linuxDeb.name}`,
+      "```",
+      "",
+      `sha256sum: ${assets.linuxDeb.sha256}`,
+      "",
+      "## AppImage",
+      "",
+      "```bash",
+      `curl -L -o ${assets.linuxAppImage.name} ${assets.linuxAppImage.url}`,
+      `echo "${assets.linuxAppImage.sha256}  ${assets.linuxAppImage.name}" | sha256sum -c -`,
+      `chmod +x ${assets.linuxAppImage.name}`,
+      `./${assets.linuxAppImage.name}`,
+      "```",
+      "",
+      `sha256sum: ${assets.linuxAppImage.sha256}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+export function generatePackageManagerManifests(options) {
+  const release = loadReleaseManifest(options.releaseAssets);
+  const assets = resolvePhaseOneAssets(release);
+  const outDir = options.out;
+  writeWingetManifests(outDir, release, assets);
+  writeHomebrewCask(outDir, release, assets);
+  writeLinuxInstallDoc(outDir, release, assets);
+  return outDir;
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const outDir = generatePackageManagerManifests(parseArgs(process.argv.slice(2)));
+    console.log(`Generated package-manager files in ${outDir}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Tan Gemicioglu"]
 edition = "2021"
 build = "build.rs"
 license = "MIT"
-repository = "https://github.com/tangemicioglu/Wardian"
-homepage = "https://github.com/tangemicioglu/Wardian"
+repository = "https://github.com/wardian-app/Wardian"
+homepage = "https://wardian.org"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,7 +53,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDk2MjA4NDc3ODFFQUYxRjMKUldUejhlcUJkNFFnbHNXT21UUFFVcjQwc2d4VldqZEU4bVdhYjJOK3dZb0ZZQ2R3RDVEeFJscVUK",
       "endpoints": [
-        "https://github.com/tangemicioglu/Wardian/releases/latest/download/latest.json"
+        "https://github.com/wardian-app/Wardian/releases/latest/download/latest.json"
       ],
       "windows": {
         "installMode": "passive"

--- a/src/config/packageManagerManifestGenerator.test.ts
+++ b/src/config/packageManagerManifestGenerator.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const script = "scripts/package-managers/generate-manifests.mjs";
+
+function hash(ch: string): string {
+  return ch.repeat(64);
+}
+
+function writeReleaseFixture(dir: string): string {
+  const fixture = {
+    tagName: "v0.3.6",
+    assets: [
+      {
+        name: "Wardian_0.3.6_x64-setup.exe",
+        browser_download_url:
+          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64-setup.exe",
+        digest: `sha256:${hash("a")}`,
+      },
+      {
+        name: "Wardian_0.3.6_aarch64.dmg",
+        browser_download_url:
+          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_aarch64.dmg",
+        digest: `sha256:${hash("b")}`,
+      },
+      {
+        name: "Wardian_0.3.6_x64.dmg",
+        browser_download_url:
+          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64.dmg",
+        digest: `sha256:${hash("c")}`,
+      },
+      {
+        name: "Wardian_0.3.6_amd64.deb",
+        browser_download_url:
+          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_amd64.deb",
+        digest: `sha256:${hash("d")}`,
+      },
+      {
+        name: "Wardian_0.3.6_amd64.AppImage",
+        browser_download_url:
+          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_amd64.AppImage",
+        digest: `sha256:${hash("e")}`,
+      },
+    ],
+  };
+  const fixturePath = join(dir, "release-assets.json");
+  writeFileSync(fixturePath, `${JSON.stringify(fixture, null, 2)}\n`, "utf8");
+  return fixturePath;
+}
+
+describe("package-manager manifest generator", () => {
+  it("generates winget, Homebrew, and Linux direct-install release files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wardian-package-manifests-"));
+    try {
+      const fixturePath = writeReleaseFixture(dir);
+      const outDir = join(dir, "out");
+
+      execFileSync("node", [script, "--release-assets", fixturePath, "--out", outDir], {
+        cwd: process.cwd(),
+        stdio: "pipe",
+      });
+
+      const wingetInstaller = readFileSync(
+        join(outDir, "winget", "Tangemicioglu.Wardian.installer.yaml"),
+        "utf8",
+      );
+      expect(wingetInstaller).toContain("PackageIdentifier: Tangemicioglu.Wardian");
+      expect(wingetInstaller).toContain("PackageVersion: 0.3.6");
+      expect(wingetInstaller).toContain("InstallerType: nullsoft");
+      expect(wingetInstaller).toContain("Silent: /S");
+      expect(wingetInstaller).toContain("Architecture: x64");
+      expect(wingetInstaller).toContain(`InstallerSha256: ${hash("a")}`);
+
+      const cask = readFileSync(join(outDir, "homebrew", "wardian.rb"), "utf8");
+      expect(cask).toContain('cask "wardian" do');
+      expect(cask).toContain('version "0.3.6"');
+      expect(cask).toContain("on_arm do");
+      expect(cask).toContain(`sha256 "${hash("b")}"`);
+      expect(cask).toContain("on_intel do");
+      expect(cask).toContain(`sha256 "${hash("c")}"`);
+      expect(cask).toContain('app "Wardian.app"');
+      expect(cask).toContain("auto_updates true");
+
+      const linuxInstall = readFileSync(join(outDir, "linux", "install.md"), "utf8");
+      expect(linuxInstall).toContain("# Wardian 0.3.6 Linux Install");
+      expect(linuxInstall).toContain("Wardian_0.3.6_amd64.deb");
+      expect(linuxInstall).toContain(`sha256sum: ${hash("d")}`);
+      expect(linuxInstall).toContain("Wardian_0.3.6_amd64.AppImage");
+      expect(linuxInstall).toContain(`sha256sum: ${hash("e")}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails before writing manifests when a required Phase 1 asset is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "wardian-package-manifests-"));
+    try {
+      const fixturePath = join(dir, "release-assets.json");
+      writeFileSync(
+        fixturePath,
+        JSON.stringify({
+          tagName: "v0.3.6",
+          assets: [
+            {
+              name: "Wardian_0.3.6_x64-setup.exe",
+              browser_download_url:
+                "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64-setup.exe",
+              digest: `sha256:${hash("a")}`,
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      expect(() =>
+        execFileSync("node", [script, "--release-assets", fixturePath, "--out", join(dir, "out")], {
+          cwd: process.cwd(),
+          stdio: "pipe",
+        }),
+      ).toThrow(/Missing required release asset/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/config/packageManagerManifestGenerator.test.ts
+++ b/src/config/packageManagerManifestGenerator.test.ts
@@ -17,31 +17,31 @@ function writeReleaseFixture(dir: string): string {
       {
         name: "Wardian_0.3.6_x64-setup.exe",
         browser_download_url:
-          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64-setup.exe",
+          "https://github.com/wardian-app/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64-setup.exe",
         digest: `sha256:${hash("a")}`,
       },
       {
         name: "Wardian_0.3.6_aarch64.dmg",
         browser_download_url:
-          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_aarch64.dmg",
+          "https://github.com/wardian-app/Wardian/releases/download/v0.3.6/Wardian_0.3.6_aarch64.dmg",
         digest: `sha256:${hash("b")}`,
       },
       {
         name: "Wardian_0.3.6_x64.dmg",
         browser_download_url:
-          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64.dmg",
+          "https://github.com/wardian-app/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64.dmg",
         digest: `sha256:${hash("c")}`,
       },
       {
         name: "Wardian_0.3.6_amd64.deb",
         browser_download_url:
-          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_amd64.deb",
+          "https://github.com/wardian-app/Wardian/releases/download/v0.3.6/Wardian_0.3.6_amd64.deb",
         digest: `sha256:${hash("d")}`,
       },
       {
         name: "Wardian_0.3.6_amd64.AppImage",
         browser_download_url:
-          "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_amd64.AppImage",
+          "https://github.com/wardian-app/Wardian/releases/download/v0.3.6/Wardian_0.3.6_amd64.AppImage",
         digest: `sha256:${hash("e")}`,
       },
     ],
@@ -64,10 +64,10 @@ describe("package-manager manifest generator", () => {
       });
 
       const wingetInstaller = readFileSync(
-        join(outDir, "winget", "Tangemicioglu.Wardian.installer.yaml"),
+        join(outDir, "winget", "WardianApp.Wardian.installer.yaml"),
         "utf8",
       );
-      expect(wingetInstaller).toContain("PackageIdentifier: Tangemicioglu.Wardian");
+      expect(wingetInstaller).toContain("PackageIdentifier: WardianApp.Wardian");
       expect(wingetInstaller).toContain("PackageVersion: 0.3.6");
       expect(wingetInstaller).toContain("InstallerType: nullsoft");
       expect(wingetInstaller).toContain("Silent: /S");
@@ -107,7 +107,7 @@ describe("package-manager manifest generator", () => {
             {
               name: "Wardian_0.3.6_x64-setup.exe",
               browser_download_url:
-                "https://github.com/tangemicioglu/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64-setup.exe",
+                "https://github.com/wardian-app/Wardian/releases/download/v0.3.6/Wardian_0.3.6_x64-setup.exe",
               digest: `sha256:${hash("a")}`,
             },
           ],


### PR DESCRIPTION
## Description
Adds Phase 1 package-manager distribution support for existing Wardian desktop release artifacts:

- adds a release manifest generator for winget YAML, Homebrew Cask, and Linux direct-install markdown
- documents the package-manager workflow and records the Phase 1 distribution decision in a spec
- keeps npm/bootstrap and Linux package-manager publishing deferred
- updates repository, updater, docs, and generated manifest metadata for the `wardian-app/Wardian` GitHub org migration
- uses `WardianApp.Wardian` as the winget package identifier to avoid tying package-manager listings to a personal namespace

## Related Issues
Fixes #325
Refs #324

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run test -- src/config/packageManagerManifestGenerator.test.ts`
- `npm run release:package-manifests -- --release-assets dist/package-managers/v0.3.6/assets.json --out dist/package-managers/v0.3.6`
- `winget validate dist\package-managers\v0.3.6\winget`
- `npm run lint`
- `npm run test`
- `npm run docs:build`
- `npm run build`
- `cd src-tauri && cargo clippy`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo check`

Post-rebase smoke checks also passed:

- `npm run test -- src/config/packageManagerManifestGenerator.test.ts`
- `npm run lint`
- `npm run docs:build`

Homebrew validation was not run locally because `brew` is not available on this Windows machine.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable