### PR TITLE
chore(release): clarify install assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,7 @@ jobs:
           tagName: ${{ github.ref_name }}
           releaseDraft: true
           includeUpdaterJson: ${{ needs.create-release.outputs.is_prerelease == 'false' }}
+          uploadUpdaterSignatures: false
           updaterJsonPreferNsis: true
           args: --config src-tauri/tauri.updater.conf.json ${{ matrix.platform.args || '' }}
 
@@ -213,6 +214,7 @@ jobs:
           tagName: ${{ inputs.release_tag }}
           releaseDraft: true
           includeUpdaterJson: ${{ needs.resolve-release.outputs.is_prerelease == 'false' }}
+          uploadUpdaterSignatures: false
           updaterJsonPreferNsis: true
           args: --config src-tauri/tauri.updater.conf.json ${{ matrix.platform.args || '' }}
 
@@ -224,6 +226,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
+          uploadUpdaterSignatures: false
           args: --config src-tauri/tauri.updater.conf.json ${{ matrix.platform.args || '' }}
 
       - name: Upload dry-run artifacts

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ Wardian is an **Integrated Agent Environment** — a local, app-first governance
 
 Pre-built binaries for Windows, macOS (Apple Silicon + Intel), and Linux are available from the [Releases page](https://github.com/tangemicioglu/Wardian/releases).
 
+Choose the asset for your operating system and CPU:
+
+| System | Download asset | Notes |
+| :--- | :--- | :--- |
+| Windows x64 | `Wardian_X.Y.Z_x64-setup.exe` | Standard Windows installer. |
+| macOS Apple Silicon | `Wardian_X.Y.Z_aarch64.dmg` | For M-series Macs such as M1, M2, M3, or M4. |
+| macOS Intel | `Wardian_X.Y.Z_x64.dmg` | For older Intel Macs. |
+| Linux Debian/Ubuntu x64 | `Wardian_X.Y.Z_amd64.deb` | Installable Debian package. |
+| Linux other x64 | `Wardian_X.Y.Z_amd64.AppImage` | Portable Linux app. |
+
+`x64` and `amd64` both mean 64-bit Intel/AMD CPUs. On macOS, Apple Silicon uses `aarch64`, not `x64`. Ignore updater-only assets such as `latest.json`, `.app.tar.gz`, or `.sig` files when installing manually.
+
 > **Note:** Wardian binaries are currently unsigned. On first launch:
 > - **Windows:** SmartScreen will show a warning. Click "More info" → "Run anyway."
 > - **macOS:** Gatekeeper will refuse to open the app. Right-click the app and choose "Open," or run `xattr -cr /Applications/Wardian.app` from Terminal.

--- a/docs/developer/release-updates.md
+++ b/docs/developer/release-updates.md
@@ -49,7 +49,7 @@ Official stable release builds opt into updater checks with the compile-time mar
 
 ## Release Workflow
 
-The release workflow builds platform installers, signs update artifacts, uploads `latest.json`, validates updater metadata, and only then publishes the release.
+The release workflow builds platform installers, signs update artifacts, uploads `latest.json`, validates updater metadata, and only then publishes the release. Standalone `.sig` assets are not uploaded to GitHub Releases; Tauri embeds the signature content that the app needs inside `latest.json`.
 
 Local `npm run tauri build` creates an installable bundle without updater artifacts, so it does not require `TAURI_SIGNING_PRIVATE_KEY`. Release builds opt into updater artifact generation by passing `--config src-tauri/tauri.updater.conf.json` to Tauri. That overlay sets `bundle.createUpdaterArtifacts` to `true` only inside release infrastructure.
 
@@ -62,7 +62,7 @@ Stable tag-push and stable manual backfill builds set `WARDIAN_UPDATE_CHANNEL=st
 - `darwin-aarch64`
 - `darwin-x86_64`
 
-Each platform entry must include a URL and signature. The metadata version must match the release tag without the leading `v`, and each platform URL must be a canonical GitHub release download URL for that tag whose filename matches an uploaded release asset. This filename-based validation is intentional: GitHub draft releases expose asset URLs under an `untagged-...` placeholder until publish time, while updater metadata must already point at the final tag URL. A missing, incomplete, wrong-version, or wrong-release `latest.json` should leave the release as a draft.
+Each platform entry must include a URL and inline signature. The metadata version must match the release tag without the leading `v`, and each platform URL must be a canonical GitHub release download URL for that tag whose filename matches an uploaded release asset. This filename-based validation is intentional: GitHub draft releases expose asset URLs under an `untagged-...` placeholder until publish time, while updater metadata must already point at the final tag URL. A missing, incomplete, wrong-version, or wrong-release `latest.json` should leave the release as a draft.
 
 Manual backfill runs must target an explicit `release_tag`. Backfill is draft-only unless the workflow is deliberately changed to support published-release mutation. If the target release is already published, the workflow should fail instead of rewriting updater metadata.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -8,6 +8,18 @@ If any first-run step fails, use [First-Run Troubleshooting](./first-run-trouble
 
 Download the latest installer or app bundle from the [Wardian releases page](https://github.com/tangemicioglu/Wardian/releases/latest), then launch Wardian from your operating system.
 
+Choose the asset for your operating system and CPU:
+
+| System | Download asset | Notes |
+| :--- | :--- | :--- |
+| Windows x64 | `Wardian_X.Y.Z_x64-setup.exe` | Standard Windows installer. |
+| macOS Apple Silicon | `Wardian_X.Y.Z_aarch64.dmg` | For M-series Macs such as M1, M2, M3, or M4. |
+| macOS Intel | `Wardian_X.Y.Z_x64.dmg` | For older Intel Macs. |
+| Linux Debian/Ubuntu x64 | `Wardian_X.Y.Z_amd64.deb` | Installable Debian package. |
+| Linux other x64 | `Wardian_X.Y.Z_amd64.AppImage` | Portable Linux app. |
+
+`x64` and `amd64` both mean 64-bit Intel/AMD CPUs. On macOS, Apple Silicon uses `aarch64`, not `x64`. Ignore updater-only assets such as `latest.json`, `.app.tar.gz`, or `.sig` files when installing manually.
+
 Wardian binaries are currently unsigned:
 
 - **Windows:** SmartScreen can show a warning. Choose **More info**, then **Run anyway**.

--- a/docs/specs/2026-05-19-in-app-updates.md
+++ b/docs/specs/2026-05-19-in-app-updates.md
@@ -38,7 +38,7 @@ Wardian configures:
 - Tauri process restart permission in `src-tauri/capabilities/default.json`.
 - Windows updater install mode `passive`.
 
-The release workflow signs update artifacts with `TAURI_SIGNING_PRIVATE_KEY` and optional `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets, uploads updater signatures, and publishes `latest.json` only as part of successful release builds. The public key is committed in `tauri.conf.json`; the private key never appears in the repository or documentation beyond secret-name references.
+The release workflow signs update artifacts with `TAURI_SIGNING_PRIVATE_KEY` and optional `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets, embeds updater signatures in `latest.json`, and publishes `latest.json` only as part of successful release builds. Standalone `.sig` files are not uploaded as GitHub Release assets because the updater consumes inline signatures from `latest.json`, not separate signature URLs. The public key is committed in `tauri.conf.json`; the private key never appears in the repository or documentation beyond secret-name references.
 
 The app exposes update eligibility through a backend command rather than letting Settings infer it from frontend runtime details. Official stable tag-push and stable manual backfill release builds set `WARDIAN_UPDATE_CHANNEL=stable` at compile time. Prerelease, debug, and unmarked release builds return disabled eligibility, and the backend skips updater/process plugin registration for those builds. This keeps local builds and prereleases from replacing themselves with public stable installer releases and keeps updater IPC unavailable outside official stable builds.
 

--- a/docs/specs/2026-05-20-release-asset-cleanup.md
+++ b/docs/specs/2026-05-20-release-asset-cleanup.md
@@ -1,0 +1,36 @@
+# Release Asset Cleanup
+
+- **Status:** Accepted
+- **Date:** 2026-05-20
+- **Decider:** Wardian Codex and user
+
+## Context
+
+The v0.3.6 GitHub Release exposed installer assets, updater bundles,
+`latest.json`, and standalone `.sig` files in one flat asset list. This made the
+human download path confusing, especially for macOS users choosing between
+Apple Silicon and Intel builds.
+
+Wardian still needs signed updater metadata for in-app updates, but Tauri's
+static updater JSON embeds the signature content directly in `latest.json`.
+The app does not need separate `.sig` release assets.
+
+## Decision
+
+The release workflow keeps generating updater signatures and `latest.json`, but
+sets `uploadUpdaterSignatures: false` for Tauri Action. GitHub Releases should
+show user-installable packages, updater bundles referenced by `latest.json`, and
+`latest.json` itself, without loose `.sig` files.
+
+Package-manager metadata continues to use the installer assets and GitHub's
+SHA-256 release asset digests. It must not depend on standalone `.sig` files.
+
+## Consequences
+
+- **Positive:** The release asset list is easier for users to scan.
+- **Positive:** In-app updates keep signature verification through
+  `latest.json`.
+- **Positive:** The package-manager manifest workflow remains based on
+  canonical installer assets and SHA-256 digests.
+- **Negative:** Maintainers inspecting updater signatures must read
+  `latest.json` instead of downloading adjacent `.sig` files from the release.

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -72,6 +72,8 @@ describe("release workflow contract", () => {
     expect(releaseWorkflow).toContain("includeUpdaterJson: ${{ needs.create-release.outputs.is_prerelease == 'false' }}");
     expect(releaseWorkflow).toContain("includeUpdaterJson: ${{ needs.resolve-release.outputs.is_prerelease == 'false' }}");
     expect(releaseWorkflow).not.toContain("uploadUpdaterJson:");
+    expect(releaseWorkflow).toContain("uploadUpdaterSignatures: false");
+    expect(releaseWorkflow.match(/uploadUpdaterSignatures: false/g)).toHaveLength(3);
     expect(releaseWorkflow).toContain("updaterJsonPreferNsis: true");
     expect(releaseWorkflow).toContain("Build (dry run)");
     expect(releaseWorkflow).toContain("ref: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true' && inputs.release_tag || github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag || github.ref }}");


### PR DESCRIPTION
## Description
Clarifies the release download path and reduces release asset noise:

- stops uploading standalone Tauri updater `.sig` files while preserving `latest.json` inline signatures
- adds consistent OS/CPU release asset selection tables to the README and first-run guide
- records the release asset cleanup decision in a spec and updates updater release docs

## Related Issues
Fixes #328
Refs #326

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run docs:build`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo clippy`
- [x] `cd src-tauri && cargo test`
- [x] targeted secrets scan on changed release/doc files

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable