### PR TITLE
docs: improve remote access guidance

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -74,6 +74,8 @@ export default defineConfig({
           text: "Configure and Automate",
           items: [
             { text: "Settings", link: "/guide/settings" },
+            { text: "Remote Control", link: "/guide/remote-control" },
+            { text: "Remote Access With Tailscale", link: "/guide/remote-access-tailscale" },
             { text: "Workflow View", link: "/guide/workflows" },
             { text: "Workflow Reference", link: "/workflows/" },
           ],

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -33,5 +33,6 @@ Use this index to find the guide that matches the task you are trying to finish.
 
 - [Settings](./settings.md): tune shell, provider, session, and theme behavior.
 - [Remote Control](./remote-control.md): pair a phone with the Wardian desktop over Tailscale HTTPS.
+- [Remote Access With Tailscale](./remote-access-tailscale.md): set up private tailnet access, Tailscale SSH, Serve, and temporary Funnel demos.
 - [Workflow View](./workflows.md): build and run visual automations from the app.
 - [Workflow Reference](../workflows/index.md): learn workflow triggers, nodes, scheduling, and troubleshooting.

--- a/docs/guide/remote-access-tailscale.md
+++ b/docs/guide/remote-access-tailscale.md
@@ -1,0 +1,236 @@
+# Remote Access With Tailscale
+
+Wardian is local-first: agent workspaces, terminal sessions, logs, and Markdown state live on the machine running Wardian. Remote access should preserve that model. Prefer a private tailnet over opening Wardian, shell ports, or development servers to the public internet.
+
+Use this guide when you want to check Wardian from another laptop, tablet, or phone while the host machine keeps the actual worktree, provider credentials, and terminal environment.
+
+## Recommended Shape
+
+Run Wardian on a trusted host, join that host and your client device to the same Tailscale tailnet, and access only the service you need:
+
+1. Use Tailscale device-to-device connectivity for private network reachability.
+2. Use MagicDNS names instead of hard-coded IP addresses when possible.
+3. Use Tailscale SSH for host shell access on supported destination devices.
+4. Use Tailscale Serve for a private web surface inside the tailnet.
+5. Use Tailscale Funnel only for temporary public demos, never for normal operations.
+
+Do not expose provider tokens, workspace paths, Wardian state directories, development servers, or terminal ports directly to the public internet.
+
+## Prerequisites
+
+- A Wardian host machine with the desktop app or development server running.
+- Tailscale installed on the Wardian host and on each client device.
+- A tailnet where you can manage device names, access rules, and HTTPS settings.
+- Local OS accounts and filesystem permissions already set up on the Wardian host.
+
+Install Tailscale using the official platform-specific installer, then sign in on each device. On Linux hosts, the initial CLI connection commonly needs elevated privileges unless operator permissions are configured:
+
+```sh
+sudo tailscale up
+tailscale status
+```
+
+On macOS or other systems where the Tailscale CLI can manage state without elevation, omit `sudo`.
+
+PowerShell:
+
+```powershell
+tailscale up
+tailscale status
+```
+
+For unattended hosts, prefer a tagged device and a scoped auth key rather than signing in with a personal browser session. Keep key expiry enabled unless you have a documented operational reason to turn it off.
+
+## Name The Wardian Host
+
+Give the host a stable Tailscale machine name such as `wardian-host`. With MagicDNS enabled, clients can use the short name:
+
+```sh
+tailscale ping wardian-host
+```
+
+PowerShell:
+
+```powershell
+tailscale ping wardian-host
+```
+
+If MagicDNS is unavailable, use the host's Tailscale IP from `tailscale status`. Avoid writing that IP into shared docs; use `<wardian-host-tailnet-name>` or `<wardian-host-tailscale-ip>` placeholders.
+
+## Private Shell Access
+
+Use SSH over the tailnet when you need to inspect the host, run the Wardian CLI, or restart a dev process.
+
+For Linux hosts, and for macOS hosts using the open source `tailscale` and `tailscaled` CLI variant, Tailscale SSH can manage SSH authentication and authorization:
+
+```sh
+sudo tailscale up --ssh
+ssh <host-user>@wardian-host
+```
+
+PowerShell client:
+
+```powershell
+ssh <host-user>@wardian-host
+```
+
+Tailscale SSH access depends on the tailnet policy file. Keep the default self-device policy for personal use, or create a narrower SSH rule for shared Wardian hosts. Avoid rules that let broad groups SSH as arbitrary non-root users on tagged hosts.
+
+For Windows hosts, use the normal Windows OpenSSH Server or remote desktop tooling over the Tailscale network instead of assuming Tailscale SSH can run on the destination. Keep Windows Firewall scoped to the Tailscale interface or the tailnet address range where possible.
+
+## Private Web Access
+
+If Wardian exposes a local web surface on the host, bind it to localhost and publish it privately with Tailscale Serve. This keeps access inside the tailnet and lets Tailscale access rules still apply.
+
+Example for a local service on port `3000`:
+
+```sh
+tailscale serve 3000
+```
+
+PowerShell:
+
+```powershell
+tailscale serve 3000
+```
+
+The command prints a tailnet HTTPS URL such as:
+
+```text
+https://<wardian-host>.<tailnet-name>.ts.net
+```
+
+Use that URL from another device signed in to the same tailnet. If the command prompts you to enable HTTPS certificates for the tailnet, complete that consent flow in the Tailscale admin console.
+
+Stop serving when the remote session is over:
+
+```sh
+tailscale serve reset
+```
+
+PowerShell:
+
+```powershell
+tailscale serve reset
+```
+
+## Temporary Public Demo Access
+
+Tailscale Funnel makes a local service reachable from the public internet. Use it only for short-lived demos where every stakeholder understands that the URL is public.
+
+Before using Funnel:
+
+- Confirm the surface has its own authentication and does not reveal provider credentials, terminals, logs, or workspace file contents.
+- Confirm you are comfortable using Funnel as a beta Tailscale feature.
+- Confirm the tailnet policy allows Funnel only for the operators who need it.
+- Prefer a disposable demo workspace and a mock provider.
+- Set a time box and reset Funnel immediately after the demo.
+
+Funnel requires the tailnet's HTTPS and Funnel policy prerequisites. If the CLI opens an admin consent flow, inspect the resulting tailnet policy before the demo. Do not leave a broad default such as `autogroup:member` with the `funnel` node attribute if only a smaller operator group should be allowed to publish public URLs.
+
+Do not configure Serve and Funnel on the same tailnet URL port at the same time. Tailscale treats the most recent Serve or Funnel command for that port as authoritative, so accidentally rerunning `tailscale funnel` can make a previously private Serve endpoint public.
+
+Example for a public demo of a local service on port `3000`:
+
+```sh
+tailscale funnel 3000
+```
+
+PowerShell:
+
+```powershell
+tailscale funnel 3000
+```
+
+Reset when finished:
+
+```sh
+tailscale funnel reset
+```
+
+PowerShell:
+
+```powershell
+tailscale funnel reset
+```
+
+Do not use Funnel for routine remote control of active Wardian agent sessions.
+
+## CLI And Shared State
+
+When testing the desktop app and CLI together from a remote shell, both processes must use the same `WARDIAN_HOME`.
+
+POSIX shell:
+
+```sh
+export WARDIAN_HOME="<absolute-wardian-home-path>"
+npm run dev
+```
+
+Second shell on the same host:
+
+```sh
+export WARDIAN_HOME="<absolute-wardian-home-path>"
+cargo run -p wardian-cli -- agent list --scope all
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_HOME = "<absolute-wardian-home-path>"
+npm run dev
+```
+
+Second PowerShell on the same host:
+
+```powershell
+$env:WARDIAN_HOME = "<absolute-wardian-home-path>"
+cargo run -p wardian-cli -- agent list --scope all
+```
+
+Do not point a remote client at a production `WARDIAN_HOME` while running experiments. Use an isolated state directory for testing:
+
+```sh
+WARDIAN_HOME="$(mktemp -d)" npm run tauri dev
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_HOME = Join-Path $PWD ".tmp/wardian-remote-test"
+npm run tauri dev
+```
+
+## Access Control Checklist
+
+Before relying on remote access:
+
+- Confirm `tailscale status` shows the expected host and client devices.
+- Confirm `tailscale ping <wardian-host>` succeeds from the client.
+- Confirm the Wardian service is reachable only through the tailnet path you intended.
+- Confirm the host firewall does not expose the same service on a public interface.
+- Confirm tailnet ACLs restrict access to the smallest practical user or group set.
+- Confirm SSH access rules do not grant broad access to shared host accounts.
+- Confirm no `.env`, provider token, or credential file is served through a web surface.
+- Confirm Serve or Funnel has been reset when it is no longer needed.
+
+## Troubleshooting
+
+If a client cannot reach the host:
+
+1. Run `tailscale status` on both devices and confirm both are signed in.
+2. Run `tailscale ping <wardian-host>` to check tailnet connectivity.
+3. Try the host's full MagicDNS name if the short name does not resolve.
+4. Check the tailnet access rules for device-to-device, SSH, Serve, or Funnel restrictions.
+5. Check the host firewall and whether the Wardian service is bound to `127.0.0.1` or another interface.
+6. Reset stale Serve or Funnel state, then publish the intended service again.
+
+If remote CLI state looks wrong, verify that the desktop app and CLI share the same `WARDIAN_HOME`. A remote shell that defaults to another home directory can read a different state database than the running app.
+
+## References
+
+- Tailscale install guide: <https://tailscale.com/docs/install>
+- Tailscale MagicDNS: <https://tailscale.com/docs/features/magicdns/>
+- Tailscale SSH: <https://tailscale.com/docs/features/tailscale-ssh>
+- Tailscale Serve: <https://tailscale.com/docs/features/tailscale-serve>
+- Tailscale Funnel: <https://tailscale.com/docs/features/tailscale-funnel>

--- a/docs/guide/remote-control.md
+++ b/docs/guide/remote-control.md
@@ -11,6 +11,10 @@ workflows, filesystem access, provider CLIs, PTYs, and telemetry.
 - A trusted HTTPS origin such as `https://<machine>.<tailnet>.ts.net`.
 - Remote access configured to bind only to the Wardian loopback gateway.
 
+For Tailscale setup, MagicDNS naming, Tailscale Serve, Tailscale SSH, and the
+difference between private Serve and public Funnel access, see
+[Remote Access With Tailscale](./remote-access-tailscale.md).
+
 ## Enable Remote Access
 
 1. Open Settings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,8 @@ This folder contains the public Wardian user guides, workflow references, and de
 - [Queue](./guide/queue.md)
 - [Source Control](./guide/source-control.md)
 - [Settings](./guide/settings.md)
+- [Remote Control](./guide/remote-control.md)
+- [Remote Access With Tailscale](./guide/remote-access-tailscale.md)
 
 ## Workflow Guides
 

--- a/docs/specs/2026-05-22-remote-access-guidelines.md
+++ b/docs/specs/2026-05-22-remote-access-guidelines.md
@@ -1,0 +1,39 @@
+# Remote Access Guidelines
+
+## Status
+
+Accepted.
+
+## Context
+
+Wardian's operating model is local-first. The desktop app, CLI, agent sessions, worktrees, telemetry, and Markdown state are safest when they remain on a trusted host machine. Remote operation is still useful for checking agent progress, restarting a process, or reviewing a local web surface from another device.
+
+The documentation previously had scattered references to shared `WARDIAN_HOME` state and remote testing, but it did not give operators a clear policy for private network access, Tailscale setup, or when public exposure is acceptable.
+
+## Decision
+
+Wardian remote access guidance will prefer a private Tailscale tailnet:
+
+- Tailscale device connectivity and MagicDNS are the default remote access layer.
+- Tailscale SSH is recommended for supported Linux and macOS destination hosts when shell access is needed.
+- Standard SSH or platform-native remote desktop over Tailscale is recommended for Windows destination hosts.
+- Tailscale Serve is the preferred way to expose a localhost web service privately to the tailnet.
+- Tailscale Funnel is documented only as a temporary public demo mechanism and must be reset after use.
+
+The guide avoids machine-specific paths and uses placeholders such as `<absolute-wardian-home-path>`, `<wardian-host>`, and `<tailnet-name>` so it remains cross-OS and cross-computer by default.
+
+## Consequences
+
+Operators get a single guide for remote Wardian access without weakening the local-first security posture. The tradeoff is that public sharing requires an explicit extra step and stronger warnings instead of being treated as the normal path.
+
+Future docs that mention remote Wardian use should link to `docs/guide/remote-access-tailscale.md` rather than repeating Tailscale setup details.
+
+## Verification
+
+This is a documentation-only decision. Review should confirm:
+
+- The guide includes POSIX shell examples before PowerShell equivalents where commands differ.
+- The guide uses placeholders instead of local machine paths.
+- The guide distinguishes Tailscale Serve from Funnel.
+- The guide does not recommend public exposure for routine Wardian operation.
+- The guide preserves `WARDIAN_HOME` shared-state guidance for app and CLI testing.


### PR DESCRIPTION
## Description
Adds operational documentation for Wardian remote access over Tailscale. The guide covers MagicDNS naming, Tailscale SSH platform boundaries, private Tailscale Serve access, temporary public Funnel demos, shared `WARDIAN_HOME` usage, access-control checks, and troubleshooting. The PR also links the new page from the public docs index, guide index, remote-control guide, and VitePress sidebar.

## Related Issues
Fixes #349

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run docs:build`
- [x] `npm run lint`
- [x] `npm run test` (82 files / 789 tests passed; existing React act/provider-readiness stderr warnings)
- [x] `npm run build` (passed; existing Vite chunk-size warning)
- [x] `cd src-tauri && cargo clippy`
- [x] `cd src-tauri && cargo test` (645 unit tests plus 7 mock provider E2E tests passed)
- [x] `cd src-tauri && cargo check`
- [x] `npm run check:frontend-screenshot` (no frontend changes detected; screenshot evidence not required)
- [x] `git diff --check`
- [x] Secrets check scoped to changed files; only warning text mentions provider tokens, no credentials added

### Review
- Wardian subagent review: Bacon, 2026-05-22
- Result: no findings; reviewer confirmed the diff is remote-access-only and that agent review handoff material is absent from the origin/main-facing diff.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings beyond existing local test/build warnings noted above
- [x] I have added tests that prove my fix is effective or that my feature works, or this documentation-only change is covered by docs build/navigation validation
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable