### PR TITLE
feat(cli): add provider-aware queued delivery

### DIFF
--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -96,6 +96,14 @@ pub struct SendArgs {
     #[arg(long = "as-command")]
     pub as_command: bool,
 
+    /// Queue policy to use when the target is not safe for live delivery
+    #[arg(long = "queue-policy", value_enum, default_value = "queue-if-busy")]
+    pub queue_policy: QueuePolicyArg,
+
+    /// Send an explicit approval action instead of a normal message
+    #[arg(long, value_enum, conflicts_with = "as_command")]
+    pub approval: Option<ApprovalArg>,
+
     /// Wait until the target reaches this status after sending
     #[arg(long = "wait-until")]
     pub wait_until: Option<String>,
@@ -103,6 +111,19 @@ pub struct SendArgs {
     /// Maximum time to wait, e.g. 30s, 10m, or 1000ms
     #[arg(long, default_value = "10m")]
     pub timeout: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum QueuePolicyArg {
+    QueueIfBusy,
+    LiveOnly,
+    MailboxOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ApprovalArg {
+    Accept,
+    Reject,
 }
 
 // ---------------------------------------------------------------------------
@@ -312,6 +333,55 @@ mod tests {
         assert!(args.as_command);
         assert_eq!(args.to, "Wardian-Codex");
         assert_eq!(args.message.as_deref(), Some("/goal test"));
+    }
+
+    #[test]
+    fn parses_send_queue_policy() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "send",
+            "hello",
+            "--to",
+            "agent-1",
+            "--queue-policy",
+            "live-only",
+        ])
+        .unwrap();
+        let Command::Send(args) = cli.command else {
+            panic!("expected Send command")
+        };
+
+        assert_eq!(args.queue_policy, QueuePolicyArg::LiveOnly);
+    }
+
+    #[test]
+    fn parses_send_approval_action() {
+        let cli =
+            Cli::try_parse_from(["wardian", "send", "--approval", "accept", "--to", "agent-1"])
+                .unwrap();
+        let Command::Send(args) = cli.command else {
+            panic!("expected Send command")
+        };
+
+        assert_eq!(args.approval, Some(ApprovalArg::Accept));
+        assert_eq!(args.message, None);
+    }
+
+    #[test]
+    fn send_approval_conflicts_with_as_command() {
+        let err = Cli::try_parse_from([
+            "wardian",
+            "send",
+            "--approval",
+            "accept",
+            "--to",
+            "agent-1",
+            "--as-command",
+            "/status",
+        ])
+        .unwrap_err();
+
+        assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -6,9 +6,10 @@ use std::{
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
     AgentListResponse, AgentResponse, AgentWatchResponse, AgentWorktreeListResponse,
-    AgentWorktreeMutationResponse, AgentWorktreeSummary, AskResponse, ControlRequest,
-    DeliveryDetail, MessageInputMode, MessageOrigin, ReplyResponse, ReplyStatus,
-    SendMessageResponse, StructuredReply, WorkflowListResponse, WorkflowResponse, WorkflowSummary,
+    AgentWorktreeMutationResponse, AgentWorktreeSummary, ApprovalAction, AskResponse,
+    ControlRequest, DeliveryDetail, MessageInputMode, MessageOrigin, QueuePolicy, ReplyResponse,
+    ReplyStatus, SendMessageResponse, StructuredReply, WatchEvent, WatchEvidenceError,
+    WorkflowListResponse, WorkflowResponse, WorkflowSummary,
 };
 use wardian_core::identity::AgentIdentity;
 use wardian_core::models::WorkflowDefinition;
@@ -32,10 +33,31 @@ struct SendAndWatchRequest<'a> {
     message: &'a str,
     thread: Option<&'a str>,
     input_mode: MessageInputMode,
+    queue_policy: QueuePolicy,
+    approval_action: Option<ApprovalAction>,
     condition: &'a str,
     tail_bytes: Option<usize>,
     timeout: Duration,
     output_echo_guard: Option<&'a str>,
+}
+
+pub struct SendMessageAndWatchOptions<'a> {
+    pub thread: Option<&'a str>,
+    pub input_mode: MessageInputMode,
+    pub queue_policy: QueuePolicy,
+    pub approval_action: Option<ApprovalAction>,
+    pub until: &'a str,
+    pub timeout: Duration,
+}
+
+pub struct SendMessageAndWatchConditionOptions<'a> {
+    pub thread: Option<&'a str>,
+    pub input_mode: MessageInputMode,
+    pub queue_policy: QueuePolicy,
+    pub approval_action: Option<ApprovalAction>,
+    pub condition: &'a str,
+    pub tail_bytes: Option<usize>,
+    pub timeout: Duration,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -195,6 +217,7 @@ pub struct AskAgentResponse {
     pub request_id: Option<String>,
     pub reply: Option<StructuredReply>,
     pub delivery: Vec<DeliveryDetail>,
+    pub watch_error: Option<WatchEvidenceError>,
     pub watch: AgentWatchResponse,
 }
 
@@ -405,6 +428,24 @@ pub fn send_message_with_input_mode(
     thread: Option<&str>,
     input_mode: MessageInputMode,
 ) -> io::Result<SendMessageResponse> {
+    send_message_with_delivery_options(
+        target,
+        message,
+        thread,
+        input_mode,
+        QueuePolicy::QueueIfBusy,
+        None,
+    )
+}
+
+pub fn send_message_with_delivery_options(
+    target: &str,
+    message: &str,
+    thread: Option<&str>,
+    input_mode: MessageInputMode,
+    queue_policy: QueuePolicy,
+    approval_action: Option<ApprovalAction>,
+) -> io::Result<SendMessageResponse> {
     let runtime = build_runtime()?;
     let value = timeout_block(
         &runtime,
@@ -414,6 +455,8 @@ pub fn send_message_with_input_mode(
             message: message.to_string(),
             thread: thread.map(str::to_string),
             input_mode,
+            queue_policy,
+            approval_action,
             origin: current_message_origin(),
         }),
     )?;
@@ -517,19 +560,20 @@ pub fn wait_agent_until_next(
 pub fn send_message_and_watch(
     target: &str,
     message: &str,
-    thread: Option<&str>,
-    input_mode: MessageInputMode,
-    until: &str,
-    timeout: Duration,
+    options: SendMessageAndWatchOptions<'_>,
 ) -> io::Result<AskAgentResponse> {
     send_message_and_watch_condition(
         target,
         message,
-        thread,
-        input_mode,
-        &format!("status:{until}"),
-        Some(4096),
-        timeout,
+        SendMessageAndWatchConditionOptions {
+            thread: options.thread,
+            input_mode: options.input_mode,
+            queue_policy: options.queue_policy,
+            approval_action: options.approval_action,
+            condition: &format!("status:{}", options.until),
+            tail_bytes: Some(4096),
+            timeout: options.timeout,
+        },
     )
 }
 
@@ -549,6 +593,8 @@ pub fn ask_agent(
         message,
         thread,
         input_mode: MessageInputMode::Message,
+        queue_policy: QueuePolicy::QueueIfBusy,
+        approval_action: None,
         condition,
         tail_bytes,
         timeout,
@@ -585,27 +631,26 @@ fn ask_agent_structured(
         request_id: Some(response.request_id),
         reply: Some(response.reply),
         delivery: response.delivery,
+        watch_error: response.watch_error,
         watch: response.watch,
     })
 }
 
-pub fn send_message_and_watch_condition(
+fn send_message_and_watch_condition(
     target: &str,
     message: &str,
-    thread: Option<&str>,
-    input_mode: MessageInputMode,
-    condition: &str,
-    tail_bytes: Option<usize>,
-    timeout: Duration,
+    options: SendMessageAndWatchConditionOptions<'_>,
 ) -> io::Result<AskAgentResponse> {
     send_message_and_watch_condition_with_output_echo_guard(SendAndWatchRequest {
         target,
         message,
-        thread,
-        input_mode,
-        condition,
-        tail_bytes,
-        timeout,
+        thread: options.thread,
+        input_mode: options.input_mode,
+        queue_policy: options.queue_policy,
+        approval_action: options.approval_action,
+        condition: options.condition,
+        tail_bytes: options.tail_bytes,
+        timeout: options.timeout,
         output_echo_guard: None,
     })
 }
@@ -627,15 +672,37 @@ fn send_message_and_watch_condition_with_output_echo_guard(
         false,
         Duration::from_secs(5),
     )?;
-    let sent = send_message_with_input_mode(
+    let sent = send_message_with_delivery_options(
         request.target,
         request.message,
         request.thread,
         request.input_mode,
+        request.queue_policy,
+        request.approval_action,
     )?;
+    let started_at = Instant::now();
+    let queued_message_ids = queued_delivery_message_ids(&sent.delivery);
+    let condition_since = if !queued_message_ids.is_empty()
+        && condition_requires_queued_delivery_submission(request.condition)
+    {
+        wait_for_queued_delivery_submission(
+            request.target,
+            &initial.cursor,
+            &queued_message_ids,
+            request.tail_bytes,
+            remaining_watch_timeout(
+                request.timeout,
+                started_at,
+                request.target,
+                request.condition,
+            )?,
+        )?
+    } else {
+        initial.cursor.clone()
+    };
     let watch = agent_watch_with_output_echo_guard(AgentWatchRequest {
         target: request.target,
-        since: Some(&initial.cursor),
+        since: Some(&condition_since),
         until: Some(request.condition),
         include: vec![
             "status".to_string(),
@@ -645,13 +712,19 @@ fn send_message_and_watch_condition_with_output_echo_guard(
         ],
         tail_bytes: request.tail_bytes,
         follow: false,
-        timeout: request.timeout,
+        timeout: remaining_watch_timeout(
+            request.timeout,
+            started_at,
+            request.target,
+            request.condition,
+        )?,
         output_echo_guard: request.output_echo_guard,
     })?;
     Ok(AskAgentResponse {
         request_id: None,
         reply: None,
         delivery: sent.delivery,
+        watch_error: None,
         watch,
     })
 }
@@ -731,6 +804,100 @@ fn current_message_origin() -> Option<MessageOrigin> {
 fn ask_prompt_echo_guard<'a>(condition: &str, message: &'a str) -> Option<&'a str> {
     let token = condition.strip_prefix("output:")?;
     (!token.is_empty() && message.contains(token)).then_some(message)
+}
+
+fn queued_delivery_message_ids(delivery: &[DeliveryDetail]) -> Vec<String> {
+    delivery
+        .iter()
+        .filter(|detail| detail.delivery_state == "queued")
+        .filter_map(|detail| detail.message_id.clone())
+        .collect()
+}
+
+fn condition_requires_queued_delivery_submission(condition: &str) -> bool {
+    condition.starts_with("output:") || condition.starts_with("status:")
+}
+
+fn wait_for_queued_delivery_submission(
+    target: &str,
+    since: &str,
+    message_ids: &[String],
+    tail_bytes: Option<usize>,
+    timeout: Duration,
+) -> io::Result<String> {
+    let started_at = Instant::now();
+    let mut since_cursor = since.to_string();
+
+    loop {
+        let watch = agent_watch_with_output_echo_guard(AgentWatchRequest {
+            target,
+            since: Some(&since_cursor),
+            until: Some("delivery:submit_started"),
+            include: vec![
+                "status".to_string(),
+                "transcript".to_string(),
+                "output".to_string(),
+                "delivery".to_string(),
+                "events".to_string(),
+            ],
+            tail_bytes,
+            follow: false,
+            timeout: remaining_watch_timeout(
+                timeout,
+                started_at,
+                target,
+                "delivery:submit_started",
+            )?,
+            output_echo_guard: None,
+        })?;
+
+        if let Some(cursor) = matching_delivery_event_cursor(&watch.events, message_ids) {
+            return Ok(cursor);
+        }
+        if watch
+            .delivery
+            .delivery
+            .iter()
+            .any(|detail| delivery_matches_submit(detail, message_ids))
+        {
+            return Ok(watch.cursor);
+        }
+        since_cursor = watch.cursor;
+    }
+}
+
+fn matching_delivery_event_cursor(events: &[WatchEvent], message_ids: &[String]) -> Option<String> {
+    events.iter().find_map(|event| {
+        if event.kind != "delivery" {
+            return None;
+        }
+        let detail = serde_json::from_value::<DeliveryDetail>(event.payload.clone()).ok()?;
+        delivery_matches_submit(&detail, message_ids).then(|| event.cursor.clone())
+    })
+}
+
+fn delivery_matches_submit(detail: &DeliveryDetail, message_ids: &[String]) -> bool {
+    detail.delivery_state == "submit_started"
+        && detail
+            .message_id
+            .as_ref()
+            .is_some_and(|id| message_ids.iter().any(|queued_id| queued_id == id))
+}
+
+fn remaining_watch_timeout(
+    timeout: Duration,
+    started_at: Instant,
+    target: &str,
+    condition: &str,
+) -> io::Result<Duration> {
+    let elapsed = started_at.elapsed();
+    if elapsed >= timeout {
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            WatchTimeoutError::new(target, condition, "unknown"),
+        ));
+    }
+    Ok(timeout - elapsed)
 }
 
 fn wait_agent_until_after_snapshot(
@@ -992,6 +1159,71 @@ mod tests {
             Some("Say AUTO_TEST_2_DONE")
         );
         assert_eq!(ask_prompt_echo_guard("status:idle", "Say DONE"), None);
+    }
+
+    fn delivery_detail(state: &str, message_id: Option<&str>) -> DeliveryDetail {
+        DeliveryDetail {
+            uuid: "agent-1".to_string(),
+            name: "reviewer-a1".to_string(),
+            provider: "mock".to_string(),
+            runtime_state: "target_action_required".to_string(),
+            delivery_state: state.to_string(),
+            input_mode: MessageInputMode::Message,
+            queue_policy: QueuePolicy::QueueIfBusy,
+            message_id: message_id.map(str::to_string),
+            delivery_phase: None,
+            observed_state: None,
+            reason: None,
+            profile: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn queued_delivery_message_ids_only_returns_queued_ids_with_ids() {
+        let delivery = vec![
+            delivery_detail("queued", Some("msg_1")),
+            delivery_detail("submit_started", Some("msg_2")),
+            delivery_detail("queued", None),
+        ];
+
+        assert_eq!(queued_delivery_message_ids(&delivery), vec!["msg_1"]);
+    }
+
+    #[test]
+    fn matching_delivery_event_cursor_uses_same_message_id_and_state() {
+        let events = vec![
+            wardian_core::control::WatchEvent {
+                cursor: "agent-1:1".to_string(),
+                kind: "delivery".to_string(),
+                payload: serde_json::json!(delivery_detail("submit_started", Some("msg_other"))),
+            },
+            wardian_core::control::WatchEvent {
+                cursor: "agent-1:2".to_string(),
+                kind: "delivery".to_string(),
+                payload: serde_json::json!(delivery_detail("submit_started", Some("msg_1"))),
+            },
+        ];
+
+        assert_eq!(
+            matching_delivery_event_cursor(&events, &["msg_1".to_string()]).as_deref(),
+            Some("agent-1:2")
+        );
+    }
+
+    #[test]
+    fn queued_submission_prewait_applies_only_to_output_and_status_conditions() {
+        assert!(condition_requires_queued_delivery_submission("output:DONE"));
+        assert!(condition_requires_queued_delivery_submission("status:idle"));
+        assert!(!condition_requires_queued_delivery_submission(
+            "delivery:submit_sent_unverified"
+        ));
+        assert!(!condition_requires_queued_delivery_submission(
+            "delivery:queued"
+        ));
+        assert!(!condition_requires_queued_delivery_submission(
+            "event:custom"
+        ));
     }
 
     #[test]

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -7,14 +7,14 @@ mod output;
 use std::{io::Read as _, time::Duration};
 
 use args::{
-    AgentArgs, AgentCommand, AgentWorktreeCommand, AskArgs, Cli, Command, ReplyArgs,
-    ReplyStatusArg, SendArgs, TeamArgs, TeamCommand, WatchlistArgs, WatchlistCommand, WorkflowArgs,
-    WorkflowCommand,
+    AgentArgs, AgentCommand, AgentWorktreeCommand, ApprovalArg, AskArgs, Cli, Command,
+    QueuePolicyArg, ReplyArgs, ReplyStatusArg, SendArgs, TeamArgs, TeamCommand, WatchlistArgs,
+    WatchlistCommand, WorkflowArgs, WorkflowCommand,
 };
 use clap::Parser;
 use errors::{CliError, ExitCode};
 use output::{render_list, render_show, RenderOptions};
-use wardian_core::control::MessageInputMode;
+use wardian_core::control::{ApprovalAction, MessageInputMode, QueuePolicy};
 use wardian_core::identity::{self, ListFilters, Scope};
 
 fn main() {
@@ -296,10 +296,7 @@ fn handle_agent_wait(
     render_show(&agent, &render_options(args))
 }
 
-fn handle_agent_watch(
-    target: &str,
-    options: AgentWatchCliOptions<'_>,
-) -> Result<String, CliError> {
+fn handle_agent_watch(target: &str, options: AgentWatchCliOptions<'_>) -> Result<String, CliError> {
     if options.follow {
         return Err(CliError::backend(
             ExitCode::Generic,
@@ -392,8 +389,17 @@ fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
 // ---------------------------------------------------------------------------
 
 fn handle_send(args: SendArgs) -> Result<String, CliError> {
-    let message = read_message_input(args.message.as_deref(), args.stdin, args.file.as_deref())?;
-    let input_mode = if args.as_command {
+    let approval_action = args.approval.map(approval_arg_to_control);
+    let message = read_send_message_input(
+        args.message.as_deref(),
+        args.stdin,
+        args.file.as_deref(),
+        args.approval,
+    )?;
+    let queue_policy = queue_policy_arg_to_control(args.queue_policy);
+    let input_mode = if approval_action.is_some() {
+        MessageInputMode::ApprovalAction
+    } else if args.as_command {
         validate_single_agent_target(&args.to, "send --as-command")?;
         validate_send_command_thread(args.thread.as_deref())?;
         MessageInputMode::Command
@@ -407,10 +413,14 @@ fn handle_send(args: SendArgs) -> Result<String, CliError> {
         let response = live::send_message_and_watch(
             &args.to,
             &message,
-            args.thread.as_deref(),
-            input_mode,
-            until,
-            timeout,
+            live::SendMessageAndWatchOptions {
+                thread: args.thread.as_deref(),
+                input_mode,
+                queue_policy,
+                approval_action,
+                until,
+                timeout,
+            },
         )
         .map_err(control_error)?;
         let watch = response.watch;
@@ -424,14 +434,19 @@ fn handle_send(args: SendArgs) -> Result<String, CliError> {
             "cursor": watch.cursor,
         })
     } else {
-        let sent = if input_mode == MessageInputMode::Message {
+        let sent = if input_mode == MessageInputMode::Message
+            && queue_policy == QueuePolicy::QueueIfBusy
+            && approval_action.is_none()
+        {
             live::send_message(&args.to, &message, args.thread.as_deref())
         } else {
-            live::send_message_with_input_mode(
+            live::send_message_with_delivery_options(
                 &args.to,
                 &message,
                 args.thread.as_deref(),
                 input_mode,
+                queue_policy,
+                approval_action,
             )
         }
         .map_err(control_error)?;
@@ -491,6 +506,43 @@ fn reply_status_arg_to_control(status: ReplyStatusArg) -> wardian_core::control:
         ReplyStatusArg::Done => wardian_core::control::ReplyStatus::Done,
         ReplyStatusArg::Blocked => wardian_core::control::ReplyStatus::Blocked,
         ReplyStatusArg::Failed => wardian_core::control::ReplyStatus::Failed,
+    }
+}
+
+fn queue_policy_arg_to_control(policy: QueuePolicyArg) -> QueuePolicy {
+    match policy {
+        QueuePolicyArg::QueueIfBusy => QueuePolicy::QueueIfBusy,
+        QueuePolicyArg::LiveOnly => QueuePolicy::LiveOnly,
+        QueuePolicyArg::MailboxOnly => QueuePolicy::MailboxOnly,
+    }
+}
+
+fn approval_arg_to_control(approval: ApprovalArg) -> ApprovalAction {
+    match approval {
+        ApprovalArg::Accept => ApprovalAction::Accept,
+        ApprovalArg::Reject => ApprovalAction::Reject,
+    }
+}
+
+fn approval_arg_default_message(approval: ApprovalArg) -> &'static str {
+    match approval {
+        ApprovalArg::Accept => "accept",
+        ApprovalArg::Reject => "reject",
+    }
+}
+
+fn read_send_message_input(
+    message: Option<&str>,
+    stdin: bool,
+    file: Option<&str>,
+    approval: Option<ApprovalArg>,
+) -> Result<String, CliError> {
+    match read_message_input(message, stdin, file) {
+        Ok(message) => Ok(message),
+        Err(_) if approval.is_some() && message.is_none() && !stdin && file.is_none() => {
+            Ok(approval_arg_default_message(approval.unwrap()).to_string())
+        }
+        Err(error) => Err(error),
     }
 }
 
@@ -579,6 +631,7 @@ fn render_ask_response(
         "condition": condition,
         "request_id": ask.request_id,
         "reply": ask.reply,
+        "watch_error": ask.watch_error,
         "agent": watch.agent,
         "cursor": watch.cursor,
         "delivery": ask.delivery,
@@ -951,8 +1004,15 @@ mod tests {
                 runtime_state: "live_pty_available".to_string(),
                 delivery_state: "submitted".to_string(),
                 input_mode: MessageInputMode::Message,
+                queue_policy: wardian_core::control::QueuePolicy::QueueIfBusy,
+                message_id: None,
+                delivery_phase: None,
+                observed_state: None,
+                reason: None,
+                profile: None,
                 error: None,
             }],
+            watch_error: None,
             watch: wardian_core::control::AgentWatchResponse {
                 schema: 1,
                 agent: wardian_core::control::WatchAgentSnapshot {
@@ -997,6 +1057,7 @@ mod tests {
                 replied_at: "2026-05-13T00:00:00.000Z".to_string(),
             }),
             delivery: Vec::new(),
+            watch_error: None,
             watch: wardian_core::control::AgentWatchResponse {
                 schema: 1,
                 agent: wardian_core::control::WatchAgentSnapshot {
@@ -1030,11 +1091,56 @@ mod tests {
     }
 
     #[test]
+    fn render_ask_response_includes_watch_error_when_present() {
+        let ask = live::AskAgentResponse {
+            request_id: None,
+            reply: None,
+            delivery: Vec::new(),
+            watch_error: Some(wardian_core::control::WatchEvidenceError {
+                code: "gap_detected".to_string(),
+                message: "watch cursor expired while waiting".to_string(),
+            }),
+            watch: wardian_core::control::AgentWatchResponse {
+                schema: 1,
+                agent: wardian_core::control::WatchAgentSnapshot {
+                    uuid: "agent-1".to_string(),
+                    name: "reviewer-a1".to_string(),
+                    provider: "mock".to_string(),
+                    status: "idle".to_string(),
+                    last_status_at: None,
+                },
+                cursor: "agent-1:2".to_string(),
+                events: Vec::new(),
+                output: wardian_core::control::WatchOutput {
+                    cursor: "agent-1:2".to_string(),
+                    text: String::new(),
+                    truncated: false,
+                    omitted_bytes: 0,
+                },
+                transcript: None,
+                raw_output: None,
+                delivery: wardian_core::control::WatchDeliverySnapshot {
+                    delivery: Vec::new(),
+                },
+            },
+        };
+
+        let rendered = render_ask_response("reviewer-a1", "reply", ask).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(json["watch_error"]["code"], "gap_detected");
+        assert_eq!(
+            json["watch_error"]["message"],
+            "watch cursor expired while waiting"
+        );
+    }
+
+    #[test]
     fn render_ask_response_includes_transcript_when_watch_has_it() {
         let ask = live::AskAgentResponse {
             request_id: None,
             reply: None,
             delivery: Vec::new(),
+            watch_error: None,
             watch: wardian_core::control::AgentWatchResponse {
                 schema: 1,
                 agent: wardian_core::control::WatchAgentSnapshot {

--- a/crates/wardian-cli/tests/send_cli.rs
+++ b/crates/wardian-cli/tests/send_cli.rs
@@ -161,3 +161,25 @@ fn send_as_command_rejects_thread_before_app_lookup() {
     assert!(stderr.contains(r#""code":"not_supported""#));
     assert!(stderr.contains("--as-command cannot be combined with --thread"));
 }
+
+#[test]
+fn send_approval_rejects_as_command_conflict() {
+    let home = TempDir::new().unwrap();
+    let output = Command::new(bin())
+        .args([
+            "send",
+            "--to",
+            "coder-a1",
+            "--approval",
+            "accept",
+            "--as-command",
+            "/status",
+        ])
+        .env("WARDIAN_HOME", home.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(r#""code":"generic""#));
+}

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -56,6 +56,10 @@ pub enum ControlRequest {
         thread: Option<String>,
         #[serde(default, skip_serializing_if = "MessageInputMode::is_message")]
         input_mode: MessageInputMode,
+        #[serde(default, skip_serializing_if = "QueuePolicy::is_queue_if_busy")]
+        queue_policy: QueuePolicy,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        approval_action: Option<ApprovalAction>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         origin: Option<MessageOrigin>,
     },
@@ -100,12 +104,37 @@ pub enum MessageInputMode {
     #[default]
     Message,
     Command,
+    ApprovalAction,
 }
 
 impl MessageInputMode {
     pub fn is_message(&self) -> bool {
         matches!(self, Self::Message)
     }
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QueuePolicy {
+    #[default]
+    QueueIfBusy,
+    LiveOnly,
+    MailboxOnly,
+}
+
+impl QueuePolicy {
+    pub fn is_queue_if_busy(&self) -> bool {
+        matches!(self, Self::QueueIfBusy)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum ApprovalAction {
+    Accept,
+    Reject,
+    Select { option: String },
+    FreeText { text: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -159,6 +188,18 @@ pub struct DeliveryDetail {
     pub delivery_state: String,
     #[serde(default)]
     pub input_mode: MessageInputMode,
+    #[serde(default, skip_serializing_if = "QueuePolicy::is_queue_if_busy")]
+    pub queue_policy: QueuePolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivery_phase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<DeliveryErrorDetail>,
 }
@@ -198,6 +239,14 @@ pub struct AskResponse {
     pub delivery: Vec<DeliveryDetail>,
     pub reply: StructuredReply,
     pub watch: AgentWatchResponse,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watch_error: Option<WatchEvidenceError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WatchEvidenceError {
+    pub code: String,
+    pub message: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -444,6 +493,8 @@ mod tests {
             message: "hello".to_string(),
             thread: None,
             input_mode: MessageInputMode::Message,
+            queue_policy: QueuePolicy::QueueIfBusy,
+            approval_action: None,
             origin: None,
         };
         let json = serde_json::to_string(&req).unwrap();
@@ -459,6 +510,8 @@ mod tests {
             message: "hello".to_string(),
             thread: None,
             input_mode: MessageInputMode::Message,
+            queue_policy: QueuePolicy::QueueIfBusy,
+            approval_action: None,
             origin: Some(MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -478,6 +531,8 @@ mod tests {
             message: "/goal test".to_string(),
             thread: None,
             input_mode: MessageInputMode::Command,
+            queue_policy: QueuePolicy::QueueIfBusy,
+            approval_action: None,
             origin: Some(MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -486,6 +541,30 @@ mod tests {
         let json = serde_json::to_string(&req).unwrap();
 
         assert!(json.contains(r#""input_mode":"command""#));
+    }
+
+    #[test]
+    fn send_message_request_serializes_queue_policy_and_approval_action() {
+        let req = ControlRequest::SendMessage {
+            target: "CoderOne".to_string(),
+            message: "approve".to_string(),
+            thread: None,
+            input_mode: MessageInputMode::ApprovalAction,
+            queue_policy: QueuePolicy::LiveOnly,
+            approval_action: Some(ApprovalAction::Select {
+                option: "allow_once".to_string(),
+            }),
+            origin: None,
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        let roundtrip: ControlRequest = serde_json::from_str(&json).unwrap();
+
+        assert!(json.contains(r#""input_mode":"approval_action""#));
+        assert!(json.contains(r#""queue_policy":"live_only""#));
+        assert!(json.contains(r#""action":"select""#));
+        assert!(json.contains(r#""option":"allow_once""#));
+        assert_eq!(roundtrip, req);
     }
 
     #[test]
@@ -500,6 +579,8 @@ mod tests {
                 message: "hello".to_string(),
                 thread: None,
                 input_mode: MessageInputMode::Message,
+                queue_policy: QueuePolicy::QueueIfBusy,
+                approval_action: None,
                 origin: None,
             }
         );
@@ -653,6 +734,65 @@ mod tests {
     }
 
     #[test]
+    fn ask_response_serializes_additive_watch_error() {
+        let response = AskResponse {
+            schema: CONTROL_SCHEMA,
+            ok: true,
+            request_id: "ask_0123456789abcdef".to_string(),
+            target: "reviewer-a1".to_string(),
+            delivery: Vec::new(),
+            reply: StructuredReply {
+                request_id: "ask_0123456789abcdef".to_string(),
+                status: ReplyStatus::Done,
+                body: "finished".to_string(),
+                target_session_id: "agent-1".to_string(),
+                source_session_id: Some("agent-1".to_string()),
+                replied_at: "2026-05-22T00:00:00.000Z".to_string(),
+            },
+            watch: AgentWatchResponse {
+                schema: CONTROL_SCHEMA,
+                agent: WatchAgentSnapshot {
+                    uuid: "agent-1".to_string(),
+                    name: "reviewer-a1".to_string(),
+                    provider: "codex".to_string(),
+                    status: "idle".to_string(),
+                    last_status_at: None,
+                },
+                cursor: "agent-1:0000000000000001".to_string(),
+                events: Vec::new(),
+                output: WatchOutput {
+                    cursor: "agent-1:0000000000000001".to_string(),
+                    text: String::new(),
+                    truncated: false,
+                    omitted_bytes: 0,
+                },
+                transcript: None,
+                raw_output: None,
+                delivery: WatchDeliverySnapshot {
+                    delivery: Vec::new(),
+                },
+            },
+            watch_error: Some(WatchEvidenceError {
+                code: "cursor_expired".to_string(),
+                message: "watch state error".to_string(),
+            }),
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        let roundtrip: AskResponse = serde_json::from_str(&json).unwrap();
+
+        assert!(json.contains(r#""watch_error""#));
+        assert_eq!(
+            roundtrip
+                .watch_error
+                .as_ref()
+                .map(|error| error.code.as_str()),
+            Some("cursor_expired")
+        );
+        assert_eq!(roundtrip.reply.body, "finished");
+    }
+
+    #[test]
     fn submit_reply_request_serializes_status_and_body() {
         let req = ControlRequest::SubmitReply {
             request_id: "ask_0123456789abcdef".to_string(),
@@ -753,6 +893,12 @@ mod tests {
             runtime_state: "live_pty_available".to_string(),
             delivery_state: "submitted".to_string(),
             input_mode: MessageInputMode::Message,
+            queue_policy: QueuePolicy::QueueIfBusy,
+            message_id: None,
+            delivery_phase: None,
+            observed_state: None,
+            reason: None,
+            profile: None,
             error: None,
         };
 
@@ -760,6 +906,34 @@ mod tests {
 
         assert!(json.contains(r#""runtime_state":"live_pty_available""#));
         assert!(json.contains(r#""delivery_state":"submitted""#));
+    }
+
+    #[test]
+    fn delivery_detail_serializes_rich_delivery_fields() {
+        let detail = DeliveryDetail {
+            uuid: "agent-1".to_string(),
+            name: "CoderOne".to_string(),
+            provider: "codex".to_string(),
+            runtime_state: "live_pty_available".to_string(),
+            delivery_state: "submitted".to_string(),
+            input_mode: MessageInputMode::ApprovalAction,
+            queue_policy: QueuePolicy::MailboxOnly,
+            message_id: Some("msg_1".to_string()),
+            delivery_phase: Some("submit".to_string()),
+            observed_state: Some("submitted_observed".to_string()),
+            reason: Some("target_processing".to_string()),
+            profile: Some("codex".to_string()),
+            error: None,
+        };
+
+        let json = serde_json::to_string(&detail).unwrap();
+
+        assert!(json.contains(r#""queue_policy":"mailbox_only""#));
+        assert!(json.contains(r#""message_id":"msg_1""#));
+        assert!(json.contains(r#""delivery_phase":"submit""#));
+        assert!(json.contains(r#""observed_state":"submitted_observed""#));
+        assert!(json.contains(r#""reason":"target_processing""#));
+        assert!(json.contains(r#""profile":"codex""#));
     }
 
     #[test]
@@ -774,6 +948,12 @@ mod tests {
                 runtime_state: "live_pty_available".to_string(),
                 delivery_state: "submitted".to_string(),
                 input_mode: MessageInputMode::Command,
+                queue_policy: QueuePolicy::QueueIfBusy,
+                message_id: None,
+                delivery_phase: None,
+                observed_state: None,
+                reason: None,
+                profile: None,
                 error: None,
             }],
         };

--- a/crates/wardian-core/src/models/agent_config.rs
+++ b/crates/wardian-core/src/models/agent_config.rs
@@ -149,7 +149,12 @@ pub struct OpenCodeProviderConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(default)]
-pub struct MockProviderConfig {}
+pub struct MockProviderConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scenario: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delay_ms: Option<u64>,
+}
 
 impl ProviderConfig {
     pub fn type_name(&self) -> &str {
@@ -215,8 +220,9 @@ impl ProviderConfig {
             "claude" => serde_json::from_value::<ClaudeProviderConfig>(value).map(Self::Claude),
             "gemini" => serde_json::from_value::<GeminiProviderConfig>(value).map(Self::Gemini),
             "codex" => serde_json::from_value::<CodexProviderConfig>(value).map(Self::Codex),
-            "antigravity" => serde_json::from_value::<AntigravityProviderConfig>(value)
-                .map(Self::Antigravity),
+            "antigravity" => {
+                serde_json::from_value::<AntigravityProviderConfig>(value).map(Self::Antigravity)
+            }
             "opencode" => {
                 serde_json::from_value::<OpenCodeProviderConfig>(value).map(Self::OpenCode)
             }
@@ -1169,17 +1175,23 @@ mod tests {
     fn mock_provider_config_roundtrips() {
         let config = AgentConfig {
             provider: "mock".into(),
-            provider_config: ProviderConfig::Mock(MockProviderConfig::default()),
+            provider_config: ProviderConfig::Mock(MockProviderConfig {
+                scenario: Some("interactive_echo_then_response".to_string()),
+                delay_ms: Some(700),
+            }),
             ..Default::default()
         };
 
         let serialized = serde_json::to_string(&config).unwrap();
         let deserialized: AgentConfig = serde_json::from_str(&serialized).unwrap();
 
-        assert!(matches!(
+        assert_eq!(
             deserialized.provider_config,
-            ProviderConfig::Mock(_)
-        ));
+            ProviderConfig::Mock(MockProviderConfig {
+                scenario: Some("interactive_echo_then_response".to_string()),
+                delay_ms: Some(700),
+            })
+        );
     }
 
     #[test]
@@ -1198,7 +1210,10 @@ mod tests {
 
         assert_eq!(value["provider_config"]["type"], "antigravity");
         assert_eq!(value["provider_config"]["sandbox"], true);
-        assert_eq!(value["provider_config"]["dangerously_skip_permissions"], true);
+        assert_eq!(
+            value["provider_config"]["dangerously_skip_permissions"],
+            true
+        );
         assert_eq!(value["provider_config"]["print_timeout"], "2m");
 
         let deserialized: AgentConfig = serde_json::from_value(value).unwrap();

--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -13,6 +13,9 @@ This document captures the practical runtime differences between Wardian's suppo
 - Workflow-spawned fresh runs skip interactive startup prompts. The workflow node prompt is the first provider input.
 - Regular visible agents use the global `Regular agent sessions` setting unless the agent config sets `session_persistence` to `fresh` or `resume`. The agent-level `default` value inherits the global setting.
 - The regular-agent context menu `Clear` action forces a fresh provider launch for that one action and clears both the backend PTY output buffer and frontend terminal scrollback cache.
+- Provider delivery profiles are responsible for translating Wardian input into the provider's native submit behavior, including short prompts, pasted multiline prompts, long prompts, slash-command-shaped text, and inputs that already end with a newline.
+- Delivery recognizers must fail closed. If Wardian cannot recognize that a provider prompt is ready, that a paste bracket has settled, or that a command was submitted, it should avoid sending more input instead of guessing and corrupting the provider TUI state.
+- Approval prompt state must be fresh. A stale recognizer hit, old transcript event, or previous terminal buffer line must not keep an agent in `action_required` or trigger a delivery retry for a new turn.
 
 ## Quick Comparison
 

--- a/docs/guide/provider-readiness.md
+++ b/docs/guide/provider-readiness.md
@@ -24,6 +24,46 @@ Wardian does not install provider accounts, complete browser sign-in, create pro
 
 You can choose a preferred launch provider in [Settings](./settings.md). `Auto` keeps the Claude-first default when Claude is installed, then falls back to the first installed supported provider.
 
+## Opt-In Delivery Validation
+
+Maintainers can run the real-provider delivery matrix after all provider CLIs are installed, authenticated, and trusted for the target workspace. This validation is opt-in because it can send prompts to live provider accounts.
+
+The full delivery matrix includes Codex, Claude, Gemini, OpenCode, and Antigravity:
+
+```bash
+WARDIAN_E2E_REAL_DELIVERY=1 WARDIAN_E2E_DELIVERY_PROVIDERS=codex,claude,gemini,opencode,antigravity npm run test:e2e:native:fast -- e2e-native/tests/provider-delivery-real-native.test.mjs
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_E2E_REAL_DELIVERY = "1"
+$env:WARDIAN_E2E_DELIVERY_PROVIDERS = "codex,claude,gemini,opencode,antigravity"
+npm run test:e2e:native:fast -- e2e-native/tests/provider-delivery-real-native.test.mjs
+Remove-Item Env:\WARDIAN_E2E_REAL_DELIVERY
+Remove-Item Env:\WARDIAN_E2E_DELIVERY_PROVIDERS
+```
+
+To limit a local run while debugging one provider, set `WARDIAN_E2E_DELIVERY_PROVIDERS` and explicitly allow a partial matrix:
+
+```bash
+WARDIAN_E2E_REAL_DELIVERY=1 WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL=1 WARDIAN_E2E_DELIVERY_PROVIDERS=codex,claude npm run test:e2e:native:fast -- e2e-native/tests/provider-delivery-real-native.test.mjs
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_E2E_REAL_DELIVERY = "1"
+$env:WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL = "1"
+$env:WARDIAN_E2E_DELIVERY_PROVIDERS = "codex,claude"
+npm run test:e2e:native:fast -- e2e-native/tests/provider-delivery-real-native.test.mjs
+Remove-Item Env:\WARDIAN_E2E_REAL_DELIVERY
+Remove-Item Env:\WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL
+Remove-Item Env:\WARDIAN_E2E_DELIVERY_PROVIDERS
+```
+
+When `WARDIAN_E2E_REAL_DELIVERY=1` is set, unknown provider names fail the test. Antigravity is required in the matrix unless `WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL=1` is also set.
+
 ## Shared Checks
 
 Most supported providers are distributed through Node.js packages. Check Node and npm first:

--- a/docs/specs/2026-05-22-agent-delivery-transport.md
+++ b/docs/specs/2026-05-22-agent-delivery-transport.md
@@ -1,0 +1,402 @@
+# Agent Delivery Transport
+
+- **Status:** Proposed
+- **Date:** 2026-05-22
+- **Decider:** Product/Engineering
+
+## Context and Problem Statement
+
+Wardian currently sends live agent messages by writing prompt text into a
+provider terminal, sleeping for a fixed delay, and sending the provider submit
+key. This preserves the visible interactive provider session, but it has three
+reliability problems:
+
+- Provider TUIs can treat a fast submit key as a literal newline or swallow it
+  during paste-burst suppression.
+- Wardian currently treats a successful PTY write as delivery even when the
+  provider has not visibly accepted or submitted the input.
+- Sending into a target that is `processing` or stuck in an unknown
+  `action_required` prompt can corrupt the provider composer or answer the
+  wrong prompt.
+
+The CLI also has an adjacent reliability problem: `wardian ask` can receive a
+structured reply, then fail while collecting watch evidence because the watch
+cursor has expired. The structured reply store must be the source of truth for
+ask completion; watch output is supporting evidence only.
+
+Wardian needs faster and more reliable agent communication without creating a
+separate headless provider turn. The live provider session remains the user
+visible session of record.
+
+## Goals
+
+- Preserve Wardian's visible live provider sessions.
+- Reduce unnecessary fixed submit delay while keeping provider-specific safety.
+- Avoid direct PTY injection when the target is not ready for input.
+- Make delivery results explicit enough for CLI automation and UI display.
+- Support a Wardian-owned queue for messages that cannot be safely submitted
+  immediately. In this implementation slice, the queue is live in-memory state;
+  durable persistence is future work.
+- Treat approval/action-required prompts as provider-specific structured UI,
+  not as generic free text.
+- Add deterministic fake-TUI and opt-in real-provider tests for Codex, Claude,
+  Gemini, OpenCode, and Antigravity.
+
+## Non-Goals
+
+- Replacing `portable-pty` or ConPTY with tmux as the primary backend.
+- Driving a separate headless provider turn for normal inter-agent messages.
+- Implementing provider-native protocol adapters in this slice.
+- Inferring approval intent from arbitrary message text such as `yes`.
+- Guaranteeing real-provider behavior without opt-in authenticated provider
+  test runs.
+
+## Decision
+
+Add a provider-aware delivery transport with two lanes:
+
+1. **Live submit lane** for targets that are freshly observed as input-ready.
+2. **Mailbox lane** for targets that are busy, unavailable, or unsafe for live
+   injection.
+
+The live lane remains based on Wardian's existing PTY/ConPTY input channel, but
+it becomes a state machine with provider profiles, per-session locking, and
+observable postconditions. The mailbox lane is Wardian-owned live state, not
+Beads.
+
+## Delivery Intent
+
+Extend the current `MessageInputMode` concept into an explicit delivery intent:
+
+- `message`: ordinary text meant for the provider composer.
+- `command`: provider command text that must remain the first input token, such
+  as a slash command.
+- `approval_action`: a provider approval/action response selected through a
+  structured Wardian UI or CLI flag.
+
+Approval intent must not be inferred from the message body. A plain
+`wardian send "yes" --to <agent>` remains a message. It is not an approval
+action.
+
+The approval action model should include only semantic actions Wardian can map
+through a provider recognizer:
+
+- `accept`
+- `reject`
+- `select { option }`
+- `free_text { text }`
+
+`free_text` is still provider-constrained. It is valid only when the recognizer
+confirms the visible action-required prompt accepts free-form text.
+
+## Caller Queue Policy
+
+Every send path should declare or default a queue policy:
+
+- `queue_if_busy`: submit live when safe; otherwise enqueue. This is the
+  default for normal messages.
+- `live_only`: submit only when live delivery is safe; otherwise return a
+  structured failure. This is appropriate for approval actions and selected
+  commands.
+- `mailbox_only`: always enqueue and return the queued message id.
+
+Existing `wardian send` behavior should remain compatible by defaulting to
+`message` plus `queue_if_busy` for normal sends. Existing `--as-command` remains
+`command`; command sends to broad targets stay unsupported unless a future
+design defines safe broadcast command behavior.
+
+## Provider Delivery Profile
+
+Each provider gets a delivery profile. A profile is not just timing constants;
+it must also expose recognizers:
+
+- provider id and display name
+- submit key bytes
+- minimum delay before submit
+- multiline strategy: literal, bracketed paste, or provider-specific fallback
+- large-prompt threshold for paste strategy
+- input-ready recognizer
+- submitted-turn recognizer
+- optional payload-visible recognizer
+- approval prompt recognizers and supported approval actions
+- command-specific restrictions
+- resumed-session caveats
+
+The first supported providers are:
+
+- `codex`
+- `claude`
+- `gemini`
+- `opencode`
+- `antigravity`
+
+Profiles may start conservatively. If a provider does not have a safe
+recognizer for a state or approval shape, Wardian must queue or reject instead
+of guessing.
+
+## Live Delivery State Machine
+
+Live delivery should advance through explicit states:
+
+1. `resolved_target`: Wardian resolved the target agent and provider profile.
+2. `input_channel_ready`: the target has a live input sender.
+3. `input_ready_observed`: fresh provider-specific terminal evidence says the
+   composer is ready for this intent.
+4. `locked`: Wardian acquired the per-session delivery lock.
+5. `payload_written`: Wardian wrote literal bytes or bracketed paste bytes.
+6. `payload_visible`: optional but preferred; Wardian observed the payload in
+   the terminal composer or provider transcript.
+7. `submit_sent`: Wardian sent the provider submit key after the configured
+   delay.
+8. `submitted_observed`: Wardian observed a new provider turn, composer clear,
+   processing status, or provider-specific submit evidence.
+
+The returned delivery state should be the most meaningful terminal state, not
+just the last write attempt. For example:
+
+- `submitted_observed`
+- `submit_sent_unverified`
+- `queued`
+- `queued_not_live`
+- `unsupported_approval_shape`
+- `not_input_ready`
+- `no_input_channel`
+- `send_failed`
+
+`submitted` may remain as a compatibility alias in older CLI fields, but new
+code should prefer the more specific states above.
+
+## Prompt Encoding
+
+Prompt normalization remains conservative:
+
+- Normalize CRLF and CR to LF.
+- Do not trim meaningful leading content for `command` or `approval_action`.
+- Preserve slash commands exactly for `command`.
+- Avoid adding the `From <sender>:` attribution prefix for `command` and
+  `approval_action`.
+
+For ordinary messages, Wardian may still add sender attribution when the sender
+is known. If the message is queued, the same rendered body must be stored so
+the live lane and mailbox lane do not disagree about what the target will see.
+
+For multiline or large prompts, profiles may use bracketed paste. Bracketed
+paste support must be proven by deterministic fake-TUI tests and opt-in
+real-provider tests before it is enabled for a provider by default.
+
+## Action-Required and Approval Handling
+
+`action_required` is not a blanket permission to inject text. Wardian may use
+live delivery for an approval action only when all of the following are true:
+
+- the caller used `approval_action` intent;
+- the provider profile has an approval recognizer for the current provider;
+- Wardian captured a fresh terminal snapshot;
+- the snapshot matches a known prompt fingerprint for that provider and
+  version/shape;
+- the requested semantic action maps to exactly one input sequence;
+- the snapshot has not changed before the input sequence is sent.
+
+Approval actions must not auto-retry after input is sent. A retry can answer a
+different prompt if the provider advances state. If the recognizer cannot prove
+the prompt shape, Wardian returns `unsupported_approval_shape` for `live_only`
+or queues/rejects according to the caller policy.
+
+Normal messages to `action_required` targets should queue by default rather
+than attempting to answer the visible prompt.
+
+## Mailbox Lane
+
+The mailbox lane is Wardian-owned live state. It is independent of provider
+transport and exists to avoid unsafe mid-turn injection. This slice keeps
+queued messages in the running backend process and drains them when the target
+returns to an idle input-ready boundary. Durable mailbox persistence remains a
+follow-up requirement before queued messages can survive app restart.
+
+Each queued item stores:
+
+- message id
+- source identity, when known
+- target session id
+- delivery intent
+- queue policy
+- rendered body
+- created timestamp
+- status: `pending`, `in_flight`, `delivered`, `failed`
+- FIFO order by enqueue id
+
+Queue behavior:
+
+- Messages for the same target are consumed in order.
+- Queue results are explicit in CLI/API JSON and include the message id.
+- Mailbox consumption occurs only at safe boundaries: provider startup or a
+  fresh input-ready transition after a turn. The first implementation drains
+  one pending message on each idle transition so a target is not flooded while
+  it is starting work on the first queued message.
+- Retry is allowed only when the terminal transaction failed before prompt
+  bytes entered the PTY, or when the target had no live input channel. If prompt
+  bytes were sent but the submit key failed, terminal state is partial or
+  unknown; the item is marked failed instead of retried to avoid duplicate
+  prompt submission.
+- Durable persistence should add provider id, large-body file references,
+  explicit ordering keys, cancellation, and expiration.
+
+The mailbox must not silently masquerade as live delivery. A caller that needs
+immediate action must use `live_only` and handle structured failure.
+
+## Structured Ask Reliability
+
+`wardian ask` should treat the structured reply store as completion source of
+truth. The successful reply body must be returned even if later watch evidence
+collection fails with `cursor_expired` or `gap_detected`.
+
+The ask response should keep returning watch evidence when available. If watch
+collection fails after a reply is recorded, the response should include the
+reply and a degraded evidence field instead of failing the whole ask. Delivery
+and watch cursor failures remain visible for debugging, but they do not discard
+the reply body.
+
+Pending ask requests should also be cleaned up after terminal completion,
+timeout, duplicate reply, or delivery failure so stale request ids do not
+accumulate.
+
+## API and CLI Compatibility
+
+Existing control schema version stays at `schema: 1` unless the implementation
+must make an incompatible response shape. New fields should be additive where
+possible.
+
+`DeliveryDetail` should continue to expose:
+
+- `uuid`
+- `name`
+- `provider`
+- `runtime_state`
+- `delivery_state`
+- `input_mode`
+- `error`
+
+Additive fields may include:
+
+- `intent`
+- `queue_policy`
+- `message_id`
+- `delivery_phase`
+- `observed_state`
+- `reason`
+- `profile`
+
+CLI exit behavior:
+
+- Live or queued delivery to at least one target is a successful send unless
+  the caller used `live_only`.
+- `live_only` returns non-zero when live delivery is unsafe or unsupported.
+- Partial failures remain non-zero and include per-target delivery details.
+- Unsupported approval shape returns a distinct error code so automation can
+  decide whether to queue, ask the user, or abandon the action.
+
+## Testing Strategy
+
+Use the lowest test layer that proves the behavior.
+
+### Unit Tests
+
+- Provider profile lookup and defaults for all five providers.
+- Prompt normalization for message, command, and approval intents.
+- Literal vs bracketed-paste chunk selection.
+- Per-session lock serialization.
+- Delivery routing by target status, intent, and queue policy.
+- Approval recognizer matching and non-matching snapshots.
+- Ask reply-store success when watch evidence fails.
+
+### Deterministic Native Fake-TUI Tests
+
+Add fake provider/TUI fixtures that simulate:
+
+- swallowed submit key;
+- submit key becoming newline;
+- delayed readiness;
+- existing composer text before send;
+- multiline paste handling;
+- long-prompt paste truncation or confirmation;
+- stale approval prompt that changes before submit;
+- concurrent sends to the same target.
+
+These tests run through the native Tauri/PTY layer, not browser-only E2E.
+
+### Real-Provider Native Tests
+
+Real-provider tests are opt-in because they depend on local provider
+installation, authentication, and account state. Run Windows ConPTY first,
+then macOS/Linux PTY.
+
+Provider matrix:
+
+- Codex
+- Claude
+- Gemini
+- OpenCode
+- Antigravity
+
+Input matrix:
+
+- short single-line message
+- multiline message
+- long message
+- leading slash command
+- trailing newline and no trailing newline
+- concurrent sends to the same target
+
+State matrix:
+
+- idle/input-ready
+- processing
+- action_required
+- fresh startup
+- resumed session
+
+Success criteria:
+
+- Prompt content appears exactly once.
+- Submit starts a new provider turn or returns a structured unverified state.
+- Multiline input does not become multiple accidental submissions.
+- Concurrent sends do not interleave.
+- Non-idle targets queue or fail according to policy.
+- Unknown approval shapes never receive guessed input.
+- `wardian ask` returns reply body even when watch cursor evidence expires.
+
+## Consequences
+
+Positive:
+
+- Wardian keeps the user-visible live session while reducing unsafe injection.
+- Automation gets truthful delivery states instead of a binary submitted/failed
+  result.
+- Mailbox fallback improves reliability for busy agents without changing the
+  primary interaction model for idle agents.
+- Approval behavior becomes auditable and provider-specific.
+
+Negative:
+
+- Provider profiles and recognizers add maintenance cost.
+- Some sends that previously attempted direct injection will now queue or fail
+  until recognizers prove safety.
+- Real-provider validation remains slower and environment-dependent.
+- Mailbox semantics introduce ordering, expiration, and cancellation behavior
+  that must be designed and tested carefully.
+
+## Rollout
+
+1. Add delivery intent, queue policy, result schema, and compatibility tests.
+2. Add provider profile skeletons and keep current behavior behind conservative
+   profiles.
+3. Implement the live delivery state machine with locks and observable states.
+4. Add deterministic fake-TUI native tests for failure modes.
+5. Add live mailbox state, idle-boundary drain, and explicit queued delivery
+   responses.
+6. Fix structured ask reply-store behavior independently of watch evidence.
+7. Enable bracketed paste and reduced provider delays one provider at a time
+   after fake-TUI and opt-in real-provider evidence.
+8. Add approval recognizers last, provider by provider. Until then,
+   `approval_action` should fail closed with `unsupported_approval_shape`.
+9. Add durable mailbox persistence, cancellation, expiration, and dedupe keys.

--- a/e2e-native/tests/cli-shared-state-native.test.mjs
+++ b/e2e-native/tests/cli-shared-state-native.test.mjs
@@ -1,8 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
 
 import {
   createNativeHarness,
@@ -24,6 +24,8 @@ const CONTROL_CLONE_NAME = `E2E-CLI-CONTROL-CLONE-${RUN_ID}`;
 const ASK_SESSION_NAME = `E2E-CLI-ASK-${RUN_ID}`;
 const ASK_ECHO_SESSION_NAME = `E2E-CLI-ASK-ECHO-${RUN_ID}`;
 const WATCH_READABLE_SESSION_NAME = `E2E-CLI-WATCH-READABLE-${RUN_ID}`;
+const ROUTE_QUEUE_SESSION_NAME = `E2E-CLI-ROUTE-QUEUE-${RUN_ID}`;
+const ROUTE_LIVE_ONLY_SESSION_NAME = `E2E-CLI-ROUTE-LIVE-${RUN_ID}`;
 
 function commandName(name) {
   return process.platform === "win32" ? `${name}.exe` : name;
@@ -46,7 +48,29 @@ function buildCli(harness) {
     `cargo build -p wardian-cli failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
   );
 
-  return path.join(harness.repoRoot, "target", "debug", commandName("wardian-cli"));
+  const localCandidate = path.join(harness.repoRoot, "target", "debug", commandName("wardian-cli"));
+  if (existsSync(localCandidate)) {
+    return localCandidate;
+  }
+
+  const metadata = spawnSync("cargo", ["metadata", "--no-deps", "--format-version", "1"], {
+    cwd: harness.repoRoot,
+    encoding: "utf8",
+    shell: process.platform === "win32",
+  });
+  assert.equal(
+    metadata.status,
+    0,
+    `cargo metadata failed\nstdout:\n${metadata.stdout}\nstderr:\n${metadata.stderr}`,
+  );
+  const targetDirectory = JSON.parse(metadata.stdout).target_directory;
+  const metadataCandidate = path.join(targetDirectory, "debug", commandName("wardian-cli"));
+  assert.equal(
+    existsSync(metadataCandidate),
+    true,
+    `wardian-cli binary was not found at ${metadataCandidate}`,
+  );
+  return metadataCandidate;
 }
 
 function runCli(cliPath, harness, args) {
@@ -66,11 +90,40 @@ function runCli(cliPath, harness, args) {
   };
 }
 
-async function withMockScenario(scenario, fn) {
+function runCliAsync(cliPath, harness, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cliPath, args, {
+      cwd: harness.repoRoot,
+      env: {
+        ...process.env,
+        WARDIAN_HOME: harness.isolatedHome,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withMockScenario(scenario, fn, delayMs = "50") {
   const previousScenario = process.env.WARDIAN_MOCK_SCENARIO;
   const previousDelay = process.env.WARDIAN_MOCK_DELAY_MS;
   process.env.WARDIAN_MOCK_SCENARIO = scenario;
-  process.env.WARDIAN_MOCK_DELAY_MS = "50";
+  process.env.WARDIAN_MOCK_DELAY_MS = delayMs;
   try {
     return await fn();
   } finally {
@@ -97,6 +150,57 @@ function runCliOk(cliPath, harness, args) {
   return result;
 }
 
+function deliveryDetailFromWatch(watchJson, state, messageId = null) {
+  const snapshotDetails = watchJson.delivery?.delivery ?? [];
+  const eventDetails = (watchJson.events ?? [])
+    .filter((event) => event.kind === "delivery")
+    .map((event) => event.payload);
+  return [...snapshotDetails, ...eventDetails].find((detail) => {
+    if (detail.delivery_state !== state) {
+      return false;
+    }
+    return messageId === null || detail.message_id === messageId;
+  });
+}
+
+async function waitForDeliveryState(cliPath, harness, target, state, messageId, timeoutMs = 30000) {
+  const startedAt = Date.now();
+  let since = null;
+  let lastResult = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const args = [
+      "agent",
+      "watch",
+      target,
+      "--until",
+      `delivery:${state}`,
+      "--include",
+      "delivery,events",
+      "--timeout",
+      "5s",
+    ];
+    if (since) {
+      args.push("--since", since);
+    }
+
+    lastResult = runCli(cliPath, harness, args);
+    if (lastResult.status === 0) {
+      const json = JSON.parse(lastResult.stdout);
+      const detail = deliveryDetailFromWatch(json, state, messageId);
+      if (detail) {
+        return { json, detail };
+      }
+      since = json.cursor;
+    }
+    await delay(250);
+  }
+
+  assert.fail(
+    `Timed out waiting for delivery ${state} message ${messageId}; last result: ${JSON.stringify(lastResult)}`,
+  );
+}
+
 function cliField(cliPath, harness, target, field) {
   return runCli(cliPath, harness, ["agent", target, "--field", field]);
 }
@@ -118,8 +222,20 @@ async function waitForCliField(cliPath, harness, target, field, expected, timeou
   );
 }
 
-async function createMockAgent(driver, workspacePath, { sessionId, sessionName, isOff }) {
-  const result = await driver.executeAsyncScript((sessionId, sessionName, folder, isOff, done) => {
+async function createMockAgent(
+  driver,
+  workspacePath,
+  { sessionId, sessionName, isOff, mockScenario = null, mockDelayMs = null },
+) {
+  const result = await driver.executeAsyncScript((sessionId, sessionName, folder, isOff, mockScenario, mockDelayMs, done) => {
+    const providerConfig =
+      mockScenario || mockDelayMs
+        ? {
+            type: "mock",
+            scenario: mockScenario,
+            delay_ms: mockDelayMs,
+          }
+        : undefined;
     window.__TAURI_INTERNALS__.invoke("spawn_agent", {
       req: {
         sessionName,
@@ -127,16 +243,48 @@ async function createMockAgent(driver, workspacePath, { sessionId, sessionName, 
         folder,
         resumeSession: sessionId,
         isOff,
-        configOverride: { provider: "mock" },
+        configOverride: providerConfig
+          ? { provider: "mock", provider_config: providerConfig }
+          : { provider: "mock" },
       },
     }).then(
       (agent) => done({ ok: true, agent }),
       (error) => done({ ok: false, error: String(error) }),
     );
-  }, sessionId, sessionName, workspacePath, isOff);
+  }, sessionId, sessionName, workspacePath, isOff, mockScenario, mockDelayMs);
 
   assert.equal(result.ok, true, `spawn_agent failed: ${result.error}`);
   return result.agent;
+}
+
+async function setAgentStatus(driver, sessionId, status) {
+  const result = await driver.executeAsyncScript((sessionId, status, done) => {
+    window.__TAURI_INTERNALS__.invoke("debug_set_agent_status", {
+      sessionId,
+      status,
+    }).then(
+      () => done({ ok: true }),
+      (error) => done({ ok: false, error: String(error) }),
+    );
+  }, sessionId, status);
+
+  assert.equal(result.ok, true, `debug_set_agent_status failed: ${result.error}`);
+}
+
+async function pushAgentOutput(driver, sessionId, output, transcriptText = null) {
+  const result = await driver.executeAsyncScript((sessionId, output, transcriptText, done) => {
+    window.__TAURI_INTERNALS__.invoke("debug_push_agent_watch_output", {
+      sessionId,
+      output,
+      transcriptText,
+      provider: "mock",
+    }).then(
+      () => done({ ok: true }),
+      (error) => done({ ok: false, error: String(error) }),
+    );
+  }, sessionId, output, transcriptText);
+
+  assert.equal(result.ok, true, `debug_push_agent_watch_output failed: ${result.error}`);
 }
 
 test("native app-created agent is readable through the CLI", { timeout: 180000 }, async (t) => {
@@ -322,6 +470,7 @@ test("native CLI control commands operate through the running app", { timeout: 1
     assert.equal(source.name, CONTROL_SESSION_NAME);
     assert.equal(source.class, "Reviewer");
     assert.equal(source.provider, "mock");
+    await setAgentStatus(session.driver, source.uuid, "action_required");
     await watchStep(harness, `Spawned ${CONTROL_SESSION_NAME} with mock action_required state through the CLI`);
     await waitForCliField(
       cliPath,
@@ -354,36 +503,17 @@ test("native CLI control commands operate through the running app", { timeout: 1
     ]);
     assert.equal(waitResult.stdout, "action_required\n");
 
-    await watchStep(harness, `Sending approval to ${CONTROL_SESSION_NAME} through the CLI`);
+    await watchStep(harness, `Queueing approval-like input to ${CONTROL_SESSION_NAME} through the CLI`);
     const sendResult = runCliOk(cliPath, harness, [
       "send",
       "y",
       "--to",
       CONTROL_SESSION_NAME,
-      "--wait-until",
-      "idle",
-      "--timeout",
-      "30s",
     ]);
-    assert.equal(JSON.parse(sendResult.stdout).status, "idle");
-
-    const watchResult = runCliOk(cliPath, harness, [
-      "agent",
-      "watch",
-      CONTROL_SESSION_NAME,
-      "--until",
-      "output:Action approved",
-      "--include",
-      "status,events,output,delivery",
-      "--timeout",
-      "30s",
-    ]);
-    const watched = JSON.parse(watchResult.stdout);
-    assert.match(watched.output.text, /Action approved/);
-    const idleStatusEvents = watched.events.filter(
-      (event) => event.kind === "status" && event.payload?.status === "idle",
-    );
-    assert.equal(idleStatusEvents.length, 1, JSON.stringify(watched.events));
+    const queued = JSON.parse(sendResult.stdout).delivery[0];
+    assert.equal(queued.delivery_state, "queued");
+    assert.equal(queued.runtime_state, "target_action_required");
+    assert.match(queued.message_id, /^msg_/);
 
     await watchStep(harness, `Cloning ${CONTROL_SESSION_NAME} through the CLI`);
     const cloneResult = runCliOk(cliPath, harness, [
@@ -396,6 +526,7 @@ test("native CLI control commands operate through the running app", { timeout: 1
     const cloneAgent = JSON.parse(cloneResult.stdout).agent;
     assert.equal(cloneAgent.name, CONTROL_CLONE_NAME);
     assert.notEqual(cloneAgent.uuid, source.uuid);
+    await setAgentStatus(session.driver, cloneAgent.uuid, "action_required");
     const teamResult = runCliOk(cliPath, harness, ["team", "show", "team-control"]);
     assert.deepEqual(JSON.parse(teamResult.stdout).team.agent_ids, [
       source.uuid,
@@ -410,6 +541,7 @@ test("native CLI control commands operate through the running app", { timeout: 1
 
     await watchStep(harness, `Resuming ${CONTROL_CLONE_NAME} through the CLI`);
     runCliOk(cliPath, harness, ["agent", "resume", CONTROL_CLONE_NAME]);
+    await setAgentStatus(session.driver, cloneAgent.uuid, "action_required");
     await waitForCliField(cliPath, harness, CONTROL_CLONE_NAME, "status", "action_required");
 
     await watchStep(harness, `Killing ${CONTROL_CLONE_NAME} through the CLI`);
@@ -425,6 +557,8 @@ test("native CLI control commands operate through the running app", { timeout: 1
       );
     }, source.uuid);
     assert.equal(removed.ok, true, `debug_remove_agent_input_sender failed: ${removed.error}`);
+    await setAgentStatus(session.driver, source.uuid, "idle");
+    await waitForCliField(cliPath, harness, CONTROL_SESSION_NAME, "status", "idle");
 
     const missingSender = runCli(cliPath, harness, [
       "send",
@@ -448,102 +582,225 @@ test("native CLI control commands operate through the running app", { timeout: 1
 });
 
 test("native CLI ask returns only output after its pre-send cursor", { timeout: 180000 }, async (t) => {
-  await withMockScenario("interactive_multi_turn", async () => {
-    const harness = await createNativeHarness();
-    assert.ok(harness.appPath);
+  await withMockScenario("interactive_echo_then_response", async () => {
+  const harness = await createNativeHarness();
+  assert.ok(harness.appPath);
 
-    try {
-      if (!skipNativeBuild) {
-        ensureNativeAppBuilt(harness);
-      }
-    } catch (error) {
-      t.skip(String(error));
-      return;
+  try {
+    if (!skipNativeBuild) {
+      ensureNativeAppBuilt(harness);
     }
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
 
-    prepareIsolatedHome(harness);
+  prepareIsolatedHome(harness);
 
-    const cliPath = buildCli(harness);
-    const workspacePath = path.join(harness.repoRoot, "e2e-native");
+  const cliPath = buildCli(harness);
+  const workspacePath = path.join(harness.repoRoot, "e2e-native");
 
-    let session;
-    try {
-      session = await startNativeSession(harness);
-    } catch (error) {
-      t.skip(String(error));
-      return;
-    }
+  let session;
+  try {
+    session = await startNativeSession(harness);
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
 
-    t.after(async () => {
-      await session.close();
-    });
+  t.after(async () => {
+    await session.close();
+  });
 
-    await waitForAppShell(session.driver, 20000);
-    await watchStep(harness, "Wardian app shell is ready for ask smoke");
+  await waitForAppShell(session.driver, 20000);
+  await watchStep(harness, "Wardian app shell is ready for ask smoke");
 
-    runCliOk(cliPath, harness, [
-      "agent",
-      "spawn",
-      "--provider",
-      "mock",
-      "--class",
-      "Reviewer",
-      "--name",
-      ASK_SESSION_NAME,
-      "--workspace",
-      workspacePath,
-    ]);
-    await waitForCliField(cliPath, harness, ASK_SESSION_NAME, "status", "action_required");
+  const agent = await createMockAgent(session.driver, workspacePath, {
+    sessionId: `e2e-cli-ask-${RUN_ID}`,
+    sessionName: ASK_SESSION_NAME,
+    isOff: false,
+    mockScenario: "interactive_echo_then_response",
+    mockDelayMs: 50,
+  });
+  await setAgentStatus(session.driver, agent.session_id, "action_required");
+  await pushAgentOutput(session.driver, agent.session_id, "STALE_BEFORE_ASK\r\n");
 
-    runCliOk(cliPath, harness, [
-      "send",
-      "STALE_BEFORE_ASK",
-      "--to",
-      ASK_SESSION_NAME,
-      "--wait-until",
-      "action_required",
-      "--timeout",
-      "30s",
-    ]);
+  const askPromise = runCliAsync(cliPath, harness, [
+    "ask",
+    ASK_SESSION_NAME,
+    "Say ASK_AFTER_CURSOR when ready",
+    "--until",
+    "output:ASK_AFTER_CURSOR",
+    "--timeout",
+    "30s",
+    "--tail",
+    "65536",
+  ]);
 
-    const staleWatch = runCliOk(cliPath, harness, [
-      "agent",
-      "watch",
-      ASK_SESSION_NAME,
-      "--until",
-      "output:STALE_BEFORE_ASK",
-      "--include",
-      "status,output,delivery",
-      "--timeout",
-      "30s",
-    ]);
-    assert.match(JSON.parse(staleWatch.stdout).output.text, /STALE_BEFORE_ASK/);
+  const queued = await waitForDeliveryState(
+    cliPath,
+    harness,
+    ASK_SESSION_NAME,
+    "queued",
+    null,
+  );
+  const queuedMessageId = queued.detail.message_id;
+  assert.ok(queuedMessageId);
+  assert.equal(queued.detail.runtime_state, "target_action_required");
 
-    const askOutput = runCliOk(cliPath, harness, [
-      "ask",
-      ASK_SESSION_NAME,
-      "ASK_AFTER_CURSOR",
-      "--until",
-      "output:ASK_AFTER_CURSOR",
-      "--timeout",
-      "30s",
-      "--tail",
-      "65536",
-    ]);
+  await pushAgentOutput(session.driver, agent.session_id, "PRE_DRAIN_ASK_AFTER_CURSOR\r\n");
+  const earlyResult = await Promise.race([
+    askPromise.then(() => "completed"),
+    delay(750).then(() => "pending"),
+  ]);
+  assert.equal(earlyResult, "pending", "pre-drain output must not satisfy queued ask");
 
-    const askJson = JSON.parse(askOutput.stdout);
-    assert.equal(askJson.ok, true);
-    assert.equal(askJson.target, ASK_SESSION_NAME);
-    assert.equal(askJson.condition, "output:ASK_AFTER_CURSOR");
-    assert.match(askJson.output.text, /ASK_AFTER_CURSOR/);
-    assert.doesNotMatch(askJson.output.text, /STALE_BEFORE_ASK/);
-    assert.ok(Array.isArray(askJson.delivery));
-    assert.equal(askJson.delivery[0].delivery_state, "submitted");
+  await setAgentStatus(session.driver, agent.session_id, "idle");
+  const drained = await waitForDeliveryState(
+    cliPath,
+    harness,
+    ASK_SESSION_NAME,
+    "submit_sent_unverified",
+    queuedMessageId,
+  );
+  assert.equal(drained.detail.runtime_state, "mailbox_drain");
+
+  const askOutput = await askPromise;
+  assert.equal(
+    askOutput.status,
+    0,
+    `wardian ask failed\nstdout:\n${askOutput.stdout}\nstderr:\n${askOutput.stderr}`,
+  );
+
+  const askJson = JSON.parse(askOutput.stdout);
+  assert.equal(askJson.ok, true);
+  assert.equal(askJson.target, ASK_SESSION_NAME);
+  assert.equal(askJson.condition, "output:ASK_AFTER_CURSOR");
+  assert.match(askJson.output.text, /ASK_AFTER_CURSOR/);
+  assert.doesNotMatch(askJson.output.text, /PRE_DRAIN_ASK_AFTER_CURSOR/);
+  assert.match(askJson.output.text, /Actual response after echo: ASK_AFTER_CURSOR/);
+  assert.doesNotMatch(askJson.output.text, /STALE_BEFORE_ASK/);
+  assert.ok(Array.isArray(askJson.delivery));
+  assert.equal(askJson.delivery[0].delivery_state, "queued");
+  assert.equal(askJson.delivery[0].runtime_state, "target_action_required");
   });
 });
 
 test("native CLI ask output waits ignore the submitted prompt echo", { timeout: 180000 }, async (t) => {
   await withMockScenario("interactive_echo_then_response", async () => {
+  const harness = await createNativeHarness();
+  assert.ok(harness.appPath);
+
+  try {
+    if (!skipNativeBuild) {
+      ensureNativeAppBuilt(harness);
+    }
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  prepareIsolatedHome(harness);
+
+  const cliPath = buildCli(harness);
+  const workspacePath = path.join(harness.repoRoot, "e2e-native");
+
+  let session;
+  try {
+    session = await startNativeSession(harness);
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  t.after(async () => {
+    await session.close();
+  });
+
+  await waitForAppShell(session.driver, 20000);
+  await watchStep(harness, "Wardian app shell is ready for ask echo guard");
+
+  const agent = await createMockAgent(session.driver, workspacePath, {
+    sessionId: `e2e-cli-ask-echo-${RUN_ID}`,
+    sessionName: ASK_ECHO_SESSION_NAME,
+    isOff: false,
+    mockScenario: "interactive_echo_then_response",
+    mockDelayMs: 700,
+  });
+  await setAgentStatus(session.driver, agent.session_id, "action_required");
+
+  const askPromise = runCliAsync(cliPath, harness, [
+    "ask",
+    ASK_ECHO_SESSION_NAME,
+    "Say AUTO_TEST_2_DONE when finished",
+    "--until",
+    "output:AUTO_TEST_2_DONE",
+    "--timeout",
+    "30s",
+    "--tail",
+    "65536",
+  ]);
+
+  const queued = await waitForDeliveryState(
+    cliPath,
+    harness,
+    ASK_ECHO_SESSION_NAME,
+    "queued",
+    null,
+  );
+  const queuedMessageId = queued.detail.message_id;
+  assert.ok(queuedMessageId);
+  assert.equal(queued.detail.runtime_state, "target_action_required");
+
+  await pushAgentOutput(session.driver, agent.session_id, "Say AUTO_TEST_2_DONE when finished\r\n");
+  const earlyResult = await Promise.race([
+    askPromise.then(() => "completed"),
+    delay(750).then(() => "pending"),
+  ]);
+  assert.equal(earlyResult, "pending", "pre-drain prompt echo should not satisfy the output wait");
+
+  await setAgentStatus(session.driver, agent.session_id, "idle");
+  const drained = await waitForDeliveryState(
+    cliPath,
+    harness,
+    ASK_ECHO_SESSION_NAME,
+    "submit_sent_unverified",
+    queuedMessageId,
+  );
+  assert.equal(drained.detail.runtime_state, "mailbox_drain");
+
+  const echoAfterDrainResult = await Promise.race([
+    askPromise.then(() => "completed"),
+    delay(1000).then(() => "pending"),
+  ]);
+  assert.equal(
+    echoAfterDrainResult,
+    "pending",
+    "submitted prompt echo should not satisfy the output wait",
+  );
+
+  const askOutput = await askPromise;
+  assert.equal(
+    askOutput.status,
+    0,
+    `wardian ask failed\nstdout:\n${askOutput.stdout}\nstderr:\n${askOutput.stderr}`,
+  );
+
+  const askJson = JSON.parse(askOutput.stdout);
+  assert.equal(askJson.ok, true);
+  assert.equal(askJson.target, ASK_ECHO_SESSION_NAME);
+  assert.equal(askJson.condition, "output:AUTO_TEST_2_DONE");
+  assert.match(
+    askJson.output.text,
+    /Actual response after echo: AUTO_TEST_2_DONE/,
+  );
+  assert.ok(Array.isArray(askJson.delivery));
+  assert.equal(askJson.delivery[0].delivery_state, "queued");
+  assert.equal(askJson.delivery[0].runtime_state, "target_action_required");
+  }, "700");
+});
+
+test("native CLI send routes processing mock by queue policy", { timeout: 180000 }, async (t) => {
     const harness = await createNativeHarness();
     assert.ok(harness.appPath);
 
@@ -574,42 +831,49 @@ test("native CLI ask output waits ignore the submitted prompt echo", { timeout: 
     });
 
     await waitForAppShell(session.driver, 20000);
-    await watchStep(harness, "Wardian app shell is ready for ask echo guard");
+    await watchStep(harness, "Wardian app shell is ready for delivery route smoke");
 
-    runCliOk(cliPath, harness, [
-      "agent",
-      "spawn",
-      "--provider",
-      "mock",
-      "--class",
-      "Reviewer",
-      "--name",
-      ASK_ECHO_SESSION_NAME,
-      "--workspace",
-      workspacePath,
+    const queueAgent = await createMockAgent(session.driver, workspacePath, {
+      sessionId: `e2e-cli-route-queue-${RUN_ID}`,
+      sessionName: ROUTE_QUEUE_SESSION_NAME,
+      isOff: false,
+    });
+    await setAgentStatus(session.driver, queueAgent.session_id, "processing");
+    await waitForCliField(cliPath, harness, ROUTE_QUEUE_SESSION_NAME, "status", "processing");
+
+    const queuedResult = runCliOk(cliPath, harness, [
+      "send",
+      "QUEUE_WHILE_PROCESSING",
+      "--to",
+      ROUTE_QUEUE_SESSION_NAME,
+      "--queue-policy",
+      "queue-if-busy",
     ]);
-    await waitForCliField(cliPath, harness, ASK_ECHO_SESSION_NAME, "status", "action_required");
+    const queuedDelivery = JSON.parse(queuedResult.stdout).delivery[0];
+    assert.equal(queuedDelivery.delivery_state, "queued");
+    assert.equal(queuedDelivery.runtime_state, "target_processing");
+    assert.match(queuedDelivery.message_id, /^msg_/);
 
-    const askOutput = runCliOk(cliPath, harness, [
-      "ask",
-      ASK_ECHO_SESSION_NAME,
-      "AUTO_TEST_2_DONE",
-      "--until",
-      "output:AUTO_TEST_2_DONE",
-      "--timeout",
-      "30s",
-      "--tail",
-      "65536",
+    const liveOnlyAgent = await createMockAgent(session.driver, workspacePath, {
+      sessionId: `e2e-cli-route-live-${RUN_ID}`,
+      sessionName: ROUTE_LIVE_ONLY_SESSION_NAME,
+      isOff: false,
+    });
+    await setAgentStatus(session.driver, liveOnlyAgent.session_id, "processing");
+    await waitForCliField(cliPath, harness, ROUTE_LIVE_ONLY_SESSION_NAME, "status", "processing");
+
+    const liveOnlyResult = runCli(cliPath, harness, [
+      "send",
+      "LIVE_ONLY_WHILE_PROCESSING",
+      "--to",
+      ROUTE_LIVE_ONLY_SESSION_NAME,
+      "--queue-policy",
+      "live-only",
     ]);
-
-    const askJson = JSON.parse(askOutput.stdout);
-    assert.equal(askJson.ok, true);
-    assert.equal(askJson.target, ASK_ECHO_SESSION_NAME);
-    assert.equal(askJson.condition, "output:AUTO_TEST_2_DONE");
-    assert.match(askJson.output.text, /Actual response after echo: .*AUTO_TEST_2_DONE/);
-    assert.ok(Array.isArray(askJson.delivery));
-    assert.equal(askJson.delivery[0].delivery_state, "submitted");
-  });
+    assert.notEqual(liveOnlyResult.status, 0);
+    const liveOnlyError = JSON.parse(liveOnlyResult.stderr);
+    const liveOnlyDelivery = liveOnlyError.error.details.delivery[0];
+    assert.equal(liveOnlyDelivery.delivery_state, "not_input_ready");
 });
 
 test("native CLI watch returns readable output by default and raw output on opt-in", { timeout: 180000 }, async (t) => {

--- a/e2e-native/tests/provider-delivery-real-native.test.mjs
+++ b/e2e-native/tests/provider-delivery-real-native.test.mjs
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+export const PROVIDERS = ["codex", "claude", "gemini", "opencode", "antigravity"];
+
+export const INPUT_CASES = [
+  {
+    name: "short",
+    input: "Reply with exactly WARDIAN_DELIVERY_SHORT.",
+  },
+  {
+    name: "multiline",
+    input: "Reply with these two lines:\nWARDIAN_DELIVERY_MULTI_1\nWARDIAN_DELIVERY_MULTI_2",
+  },
+  {
+    name: "long",
+    input: [
+      "Summarize this delivery validation paragraph in one sentence.",
+      "WARDIAN_DELIVERY_LONG ".repeat(80).trim(),
+    ].join("\n"),
+  },
+  {
+    name: "slash-command",
+    input: "/help",
+  },
+  {
+    name: "trailing-newline",
+    input: "Reply with exactly WARDIAN_DELIVERY_TRAILING.\n",
+  },
+];
+
+const runRealDelivery = process.env.WARDIAN_E2E_REAL_DELIVERY === "1";
+const allowPartialDelivery = process.env.WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL === "1";
+
+function parseDeliveryProviders(value) {
+  const requested = String(value ?? "")
+    .split(",")
+    .map((provider) => provider.trim().toLowerCase())
+    .filter(Boolean);
+
+  return requested.length > 0 ? requested : [...PROVIDERS];
+}
+
+function unknownProviders(providers) {
+  const known = new Set(PROVIDERS);
+  return providers.filter((provider) => !known.has(provider));
+}
+
+function missingProviders(providers) {
+  const selected = new Set(providers);
+  return PROVIDERS.filter((provider) => !selected.has(provider));
+}
+
+test("real provider delivery validation matrix is explicitly opted in", (t) => {
+  if (!runRealDelivery) {
+    assert.deepEqual(parseDeliveryProviders(process.env.WARDIAN_E2E_DELIVERY_PROVIDERS), PROVIDERS);
+    assert.ok(PROVIDERS.includes("antigravity"));
+    assert.equal(INPUT_CASES.length, 5);
+    t.skip("Set WARDIAN_E2E_REAL_DELIVERY=1 to run real-provider delivery validation.");
+    return;
+  }
+
+  const providers = parseDeliveryProviders(process.env.WARDIAN_E2E_DELIVERY_PROVIDERS);
+  const unknown = unknownProviders(providers);
+  assert.deepEqual(
+    unknown,
+    [],
+    `Unknown provider(s) in WARDIAN_E2E_DELIVERY_PROVIDERS: ${unknown.join(", ")}`,
+  );
+
+  if (!allowPartialDelivery) {
+    const missing = missingProviders(providers);
+    assert.deepEqual(
+      missing,
+      [],
+      `WARDIAN_E2E_DELIVERY_PROVIDERS must include the full delivery matrix unless WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL=1. Missing: ${missing.join(", ")}`,
+    );
+  }
+
+  assert.deepEqual(PROVIDERS, ["codex", "claude", "gemini", "opencode", "antigravity"]);
+  assert.deepEqual(
+    INPUT_CASES.map((inputCase) => inputCase.name),
+    ["short", "multiline", "long", "slash-command", "trailing-newline"],
+  );
+
+  for (const provider of providers) {
+    for (const inputCase of INPUT_CASES) {
+      assert.equal(typeof provider, "string");
+      assert.equal(typeof inputCase.input, "string");
+      assert.ok(inputCase.input.length > 0, `${provider}/${inputCase.name} input must not be empty`);
+    }
+  }
+});

--- a/scripts/mock-agent.cjs
+++ b/scripts/mock-agent.cjs
@@ -13,6 +13,8 @@
  *   basic         — init → user → generating → model_response → turn_completed
  *   resume        — init(session_id) → generating → model_response → turn_completed
  *   action_needed — init → user → action_required (waits for stdin) → turn_completed
+ *   delayed_ready — init → user → generating → MOCK_INPUT_READY → model_response → turn_completed
+ *   action_required_stale — init → action_required(APPROVAL_PROMPT_A) → action_required(APPROVAL_PROMPT_B)
  *   failure       — init → user → generating → exit(1)
  *   long_output   — init → user → 200 lines of text → model_response → turn_completed
  *   headless      — single JSON response object, then exit
@@ -47,8 +49,9 @@ function waitForStdin() {
     process.stdin.setEncoding("utf8");
     process.stdin.on("data", (chunk) => {
       data += chunk;
-      if (data.includes("\n")) {
-        resolve(data.trim());
+      if (/[\r\n]/.test(data)) {
+        const [line] = data.replace(/\r\n/g, "\n").split(/[\r\n]/);
+        resolve(line.trim());
       }
     });
     process.stdin.resume();
@@ -116,6 +119,31 @@ async function runActionNeeded() {
   }
   await sleep(delay);
   emit(events.turnCompleted());
+}
+
+async function runDelayedReady() {
+  emit(events.init());
+  await sleep(delay);
+  emit(events.user());
+  await sleep(delay);
+  emit(events.generating());
+  await sleep(delay * 20);
+  process.stdout.write("MOCK_INPUT_READY\n");
+  await sleep(delay);
+  emit(events.modelResponse("Mock delayed-ready response completed."));
+  await sleep(delay);
+  emit(events.turnCompleted());
+}
+
+async function runActionRequiredStale() {
+  emit(events.init());
+  await sleep(delay);
+  emit(events.actionRequired("APPROVAL_PROMPT_A"));
+  process.stdout.write("APPROVAL_PROMPT_A\n");
+  await sleep(delay * 20);
+  emit(events.actionRequired("APPROVAL_PROMPT_B"));
+  process.stdout.write("APPROVAL_PROMPT_B\n");
+  await new Promise(() => {});
 }
 
 async function runFailure() {
@@ -202,10 +230,11 @@ async function runInteractiveEchoThenResponse() {
 
   emit(events.actionRequired("Interactive echo test: waiting for input"));
   const input = await waitForStdin();
+  const marker = input.match(/[A-Z0-9_]{4,}/)?.[0] || input;
   await sleep(delay);
   emit(events.modelResponse(input));
   await sleep(delay);
-  emit(events.modelResponse(`Actual response after echo: ${input}`));
+  emit(events.modelResponse(`Actual response after echo: ${marker}`));
   await sleep(delay);
   emit(events.turnCompleted());
 }
@@ -233,6 +262,8 @@ async function main() {
     basic: runBasic,
     resume: runResume,
     action_needed: runActionNeeded,
+    delayed_ready: runDelayedReady,
+    action_required_stale: runActionRequiredStale,
     failure: runFailure,
     long_output: runLongOutput,
     headless: runHeadless,

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1979,6 +1979,9 @@ pub async fn kill_agent(
     if let Some(snapshot) = state_snapshot {
         manager::save_state_snapshot(&app, &snapshot);
     }
+    if agent.is_some() {
+        state.remove_agent_delivery_state(&session_id).await;
+    }
 
     #[allow(unused_mut)]
     if let Some(mut agent) = agent {

--- a/src-tauri/src/commands/debug.rs
+++ b/src-tauri/src/commands/debug.rs
@@ -1,5 +1,5 @@
 use crate::state::AppState;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 #[tauri::command]
 pub async fn debug_remove_agent_input_sender(
@@ -48,5 +48,28 @@ pub async fn debug_push_agent_watch_output(
             source: Some("debug".to_string()),
         });
     }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn debug_set_agent_status(
+    session_id: String,
+    status: String,
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    if !cfg!(debug_assertions) {
+        return Err("debug commands are disabled in production builds".to_string());
+    }
+
+    let current_status = {
+        let agents = state.agents.lock().await;
+        agents
+            .get(&session_id)
+            .ok_or_else(|| format!("agent not found: {session_id}"))?
+            .current_status
+            .clone()
+    };
+    crate::manager::set_agent_status(&app, &session_id, &current_status, &status);
     Ok(())
 }

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1,4 +1,4 @@
-use crate::state::AppState;
+use crate::state::{AppState, MailboxMessageDraft};
 use std::{
     fmt,
     path::{Path, PathBuf},
@@ -9,10 +9,11 @@ use tauri::{AppHandle, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
     AgentListResponse, AgentResponse, AgentWatchResponse, AgentWorktreeListResponse,
-    AgentWorktreeMutationResponse, AgentWorktreeSummary, AskResponse, ControlRequest,
-    DeliveryDetail, DeliveryErrorDetail, MessageInputMode, MessageOrigin, OkResponse,
-    ReplyResponse, ReplyStatus, SendMessageResponse, StructuredReply, WatchAgentSnapshot,
-    WatchDeliverySnapshot, WorkflowListResponse, WorkflowResponse, WorkflowSummary,
+    AgentWorktreeMutationResponse, AgentWorktreeSummary, ApprovalAction, AskResponse,
+    ControlRequest, DeliveryDetail, DeliveryErrorDetail, MessageInputMode, MessageOrigin,
+    OkResponse, QueuePolicy, ReplyResponse, ReplyStatus, SendMessageResponse, StructuredReply,
+    WatchAgentSnapshot, WatchDeliverySnapshot, WatchEvidenceError, WorkflowListResponse,
+    WorkflowResponse, WorkflowSummary,
 };
 use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
 
@@ -220,6 +221,8 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             message,
             thread,
             input_mode,
+            queue_policy,
+            approval_action,
             origin,
         } => {
             let state = app.state::<AppState>();
@@ -230,6 +233,8 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
                 &message,
                 thread.as_deref(),
                 input_mode,
+                queue_policy,
+                approval_action.as_ref(),
                 origin.as_ref(),
             )
             .await?;
@@ -642,6 +647,7 @@ async fn resolve_send_targets_in_state(state: &AppState, target: &str) -> Vec<St
         .unwrap_or_default()
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn deliver_message_to_target(
     app: Option<&AppHandle>,
     state: &AppState,
@@ -649,6 +655,8 @@ async fn deliver_message_to_target(
     message: &str,
     thread: Option<&str>,
     input_mode: MessageInputMode,
+    queue_policy: QueuePolicy,
+    approval_action: Option<&ApprovalAction>,
     origin: Option<&MessageOrigin>,
 ) -> Result<Vec<DeliveryDetail>, ControlError> {
     validate_send_message_options(target, thread, input_mode)?;
@@ -672,83 +680,128 @@ async fn deliver_message_to_target(
     };
 
     let mut delivered = 0usize;
-    let mut delivered_session_ids = Vec::new();
+    let mut queued = 0usize;
     let mut failures = Vec::new();
     let mut delivery = Vec::with_capacity(session_ids.len());
     for info in target_infos {
-        match senders.get(&info.uuid).and_then(Clone::clone) {
-            Some(tx) => {
-                let outbound_message = message_with_origin(
+        let outbound_message = message_with_origin(
+            state,
+            message,
+            input_mode,
+            origin,
+            info.status == "action_required",
+        )
+        .await;
+        match decide_delivery_route(&info.status, input_mode, queue_policy, approval_action) {
+            DeliveryRoute::Mailbox { runtime_state } => {
+                queued += 1;
+                let queued_uuid = info.uuid.clone();
+                let queued_status = info.status.clone();
+                let detail = enqueue_mailbox_delivery(
                     state,
-                    message,
+                    info,
+                    outbound_message,
                     input_mode,
+                    queue_policy,
+                    approval_action,
                     origin,
-                    info.status == "action_required",
+                    runtime_state,
                 )
                 .await;
-                let result = match wait_for_terminal_ready_for_control_send(state, &info).await {
-                    Ok(()) => {
-                        crate::utils::terminal_input::submit_prompt_chunks_via_sender(
-                            &tx,
-                            &info.provider,
-                            &outbound_message,
-                        )
-                        .await
-                    }
-                    Err(error) => Err(error),
-                };
-                match result {
-                    Ok(()) => {
-                        delivered += 1;
-                        let detail = DeliveryDetail {
-                            uuid: info.uuid,
-                            name: info.name,
-                            provider: info.provider,
-                            runtime_state: "live_pty_available".to_string(),
-                            delivery_state: "submitted".to_string(),
-                            input_mode,
-                            error: None,
-                        };
-                        delivered_session_ids.push(detail.uuid.clone());
-                        record_delivery_attempt(state, &detail).await;
-                        delivery.push(detail);
-                    }
-                    Err(error) => {
-                        failures.push(format!("{}: {error}", info.uuid));
-                        let detail = failed_delivery_detail(
-                            info,
-                            "live_pty_available",
-                            "send_failed",
-                            error,
-                            input_mode,
-                        );
-                        record_delivery_attempt(state, &detail).await;
-                        delivery.push(detail);
-                    }
+                record_delivery_attempt(state, &detail).await;
+                if let Some(app) = app {
+                    spawn_mailbox_drain_if_idle(app, &queued_uuid, &queued_status);
                 }
+                delivery.push(detail);
             }
-            None => {
-                failures.push(format!("{}: no input channel", info.uuid));
-                let runtime_state = if info.status == "off" {
-                    "target_off"
-                } else {
-                    "restored_without_sender"
-                };
-                let detail = failed_delivery_detail(
-                    info,
-                    runtime_state,
-                    "no_input_channel",
-                    "missing sender",
-                    input_mode,
-                );
+            DeliveryRoute::Reject { failure } => {
+                failures.push(format!("{}: {failure}", info.uuid));
+                let detail = rejected_delivery_detail(info, failure, input_mode, queue_policy);
                 record_delivery_attempt(state, &detail).await;
                 delivery.push(detail);
             }
+            DeliveryRoute::Live => match senders.get(&info.uuid).and_then(Clone::clone) {
+                Some(tx) => {
+                    let profile = crate::utils::delivery_profile::delivery_profile(&info.provider);
+                    let delivery_lock = state.delivery_lock_for(&info.uuid).await;
+                    let _delivery_guard = delivery_lock.lock().await;
+                    let result = match wait_for_terminal_ready_for_control_send(state, &info).await
+                    {
+                        Ok(()) => {
+                            crate::utils::terminal_input::submit_prompt_with_outcome_via_sender(
+                                &tx,
+                                &outbound_message,
+                                &info.provider,
+                            )
+                            .await
+                            .map_err(|error| error.to_string())
+                        }
+                        Err(error) => Err(error),
+                    };
+                    match result {
+                        Ok(outcome) => {
+                            delivered += 1;
+                            let detail = DeliveryDetail {
+                                uuid: info.uuid,
+                                name: info.name,
+                                provider: info.provider,
+                                runtime_state: "live_pty_available".to_string(),
+                                delivery_state: outcome.delivery_state,
+                                input_mode,
+                                queue_policy,
+                                message_id: None,
+                                delivery_phase: Some(outcome.delivery_phase),
+                                observed_state: outcome.observed_state,
+                                reason: outcome.reason,
+                                profile: Some(profile.provider),
+                                error: None,
+                            };
+                            record_delivery_attempt(state, &detail).await;
+                            mark_delivered_agents_prompt_started(
+                                app,
+                                state,
+                                std::slice::from_ref(&detail.uuid),
+                            )
+                            .await;
+                            delivery.push(detail);
+                        }
+                        Err(error) => {
+                            failures.push(format!("{}: {error}", info.uuid));
+                            let detail = failed_delivery_detail(
+                                info,
+                                "live_pty_available",
+                                "send_failed",
+                                error,
+                                input_mode,
+                                queue_policy,
+                            );
+                            record_delivery_attempt(state, &detail).await;
+                            delivery.push(detail);
+                        }
+                    }
+                }
+                None => {
+                    failures.push(format!("{}: no input channel", info.uuid));
+                    let runtime_state = if info.status == "off" {
+                        "target_off"
+                    } else {
+                        "restored_without_sender"
+                    };
+                    let detail = failed_delivery_detail(
+                        info,
+                        runtime_state,
+                        "no_input_channel",
+                        "missing sender",
+                        input_mode,
+                        queue_policy,
+                    );
+                    record_delivery_attempt(state, &detail).await;
+                    delivery.push(detail);
+                }
+            },
         }
     }
-    mark_delivered_agents_prompt_started(app, state, &delivered_session_ids).await;
-
-    if delivered == 0 {
+    if delivered + queued == 0 {
         return Err(ControlError::request_failed(format!(
             "message was not delivered to any matched agents: {}",
             failures.join("; ")
@@ -767,6 +820,110 @@ async fn deliver_message_to_target(
     Ok(delivery)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeliveryRoute {
+    Live,
+    Mailbox { runtime_state: &'static str },
+    Reject { failure: &'static str },
+}
+
+fn decide_delivery_route(
+    status: &str,
+    input_mode: MessageInputMode,
+    queue_policy: QueuePolicy,
+    _approval_action: Option<&ApprovalAction>,
+) -> DeliveryRoute {
+    if input_mode == MessageInputMode::ApprovalAction {
+        return DeliveryRoute::Reject {
+            failure: "unsupported_approval_shape",
+        };
+    }
+    if matches!(queue_policy, QueuePolicy::MailboxOnly) {
+        return DeliveryRoute::Mailbox {
+            runtime_state: "mailbox_only",
+        };
+    }
+
+    match status {
+        "idle" => DeliveryRoute::Live,
+        "processing" => match queue_policy {
+            QueuePolicy::QueueIfBusy => DeliveryRoute::Mailbox {
+                runtime_state: "target_processing",
+            },
+            QueuePolicy::LiveOnly => DeliveryRoute::Reject {
+                failure: "not_input_ready",
+            },
+            QueuePolicy::MailboxOnly => unreachable!("handled above"),
+        },
+        "action_required" => {
+            if input_mode == MessageInputMode::ApprovalAction {
+                DeliveryRoute::Reject {
+                    failure: "unsupported_approval_shape",
+                }
+            } else if matches!(queue_policy, QueuePolicy::QueueIfBusy)
+                && input_mode == MessageInputMode::Message
+            {
+                DeliveryRoute::Mailbox {
+                    runtime_state: "target_action_required",
+                }
+            } else {
+                DeliveryRoute::Reject {
+                    failure: "not_input_ready",
+                }
+            }
+        }
+        "off" | "error" => match queue_policy {
+            QueuePolicy::QueueIfBusy | QueuePolicy::MailboxOnly => DeliveryRoute::Mailbox {
+                runtime_state: "queued_not_live",
+            },
+            QueuePolicy::LiveOnly => DeliveryRoute::Reject {
+                failure: "target_not_live",
+            },
+        },
+        _ => DeliveryRoute::Reject {
+            failure: "not_input_ready",
+        },
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn enqueue_mailbox_delivery(
+    state: &AppState,
+    info: DeliveryTargetInfo,
+    body: String,
+    input_mode: MessageInputMode,
+    queue_policy: QueuePolicy,
+    approval_action: Option<&ApprovalAction>,
+    origin: Option<&MessageOrigin>,
+    runtime_state: &str,
+) -> DeliveryDetail {
+    let mut mailbox = state.mailbox.lock().await;
+    let record = mailbox.enqueue(MailboxMessageDraft {
+        target_session_id: info.uuid.clone(),
+        body,
+        input_mode,
+        queue_policy,
+        approval_action: approval_action.cloned(),
+        origin: origin.cloned(),
+    });
+
+    DeliveryDetail {
+        uuid: info.uuid,
+        name: info.name,
+        provider: info.provider,
+        runtime_state: runtime_state.to_string(),
+        delivery_state: "queued".to_string(),
+        input_mode,
+        queue_policy,
+        message_id: Some(record.id),
+        delivery_phase: Some("queued".to_string()),
+        observed_state: None,
+        reason: Some("target was not safe for live delivery".to_string()),
+        profile: None,
+        error: None,
+    }
+}
+
 async fn message_with_origin(
     state: &AppState,
     message: &str,
@@ -774,7 +931,10 @@ async fn message_with_origin(
     origin: Option<&MessageOrigin>,
     allow_bare_approval_response: bool,
 ) -> String {
-    if input_mode == MessageInputMode::Command {
+    if matches!(
+        input_mode,
+        MessageInputMode::Command | MessageInputMode::ApprovalAction
+    ) {
         return message.to_string();
     }
 
@@ -818,9 +978,25 @@ async fn wait_for_terminal_ready_for_control_send(
         wait_for_opencode_terminal_ready(state, &info.uuid, 15_000).await
     } else if info.provider == "codex" {
         wait_for_terminal_output(state, &info.uuid, 15_000, codex_output_has_ready_prompt).await
-    } else {
+    } else if current_agent_status_is_idle(state, &info.uuid).await? {
         Ok(())
+    } else {
+        Err(format!("Agent {} is not idle", info.uuid))
     }
+}
+
+async fn current_agent_status_is_idle(state: &AppState, session_id: &str) -> Result<bool, String> {
+    let status = {
+        let agents = state.agents.lock().await;
+        agents
+            .get(session_id)
+            .ok_or_else(|| format!("Agent {} not found or is off", session_id))?
+            .current_status
+            .lock()
+            .map(|value| value.clone())
+            .unwrap_or_default()
+    };
+    Ok(wardian_core::identity::normalize_status(&status) == "idle")
 }
 
 async fn wait_for_opencode_terminal_ready(
@@ -869,6 +1045,10 @@ async fn wait_for_terminal_output(
 ) -> Result<(), String> {
     let started = std::time::Instant::now();
     while started.elapsed() < std::time::Duration::from_millis(timeout_ms) {
+        if !current_agent_status_is_idle(state, session_id).await? {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            continue;
+        }
         let watch_state = {
             let agents = state.agents.lock().await;
             agents
@@ -979,25 +1159,68 @@ async fn handle_structured_ask(
         structured_delivery.body_file.as_deref(),
     )
     .await?;
-    let delivery = deliver_message_to_target(
+    let delivery = match deliver_message_to_target(
         Some(app),
         &state,
         target,
         &structured_delivery.prompt,
         thread,
         MessageInputMode::Message,
+        QueuePolicy::QueueIfBusy,
+        None,
         origin,
     )
-    .await?;
-    let reply = wait_for_structured_reply(&state, &request_id, timeout).await?;
+    .await
+    {
+        Ok(delivery) => delivery,
+        Err(error) => {
+            cleanup_ask_request(&state, &request_id).await;
+            return Err(error);
+        }
+    };
+    let reply = match wait_for_structured_reply(&state, &request_id, timeout).await {
+        Ok(reply) => reply,
+        Err(error) => {
+            cleanup_ask_request(&state, &request_id).await;
+            return Err(error);
+        }
+    };
+    let fallback_agent = ask_fallback_agent_snapshot(&state, &target_uuid, target).await;
+    let watch_result = structured_ask_watch_response(
+        &state,
+        &target_uuid,
+        watch_state,
+        &initial_cursor,
+        tail_bytes,
+    )
+    .await;
+    let response = build_ask_response_with_watch_result(
+        request_id.clone(),
+        target.to_string(),
+        delivery,
+        reply,
+        fallback_agent,
+        watch_result,
+    );
+    cleanup_ask_request(&state, &request_id).await;
+    ok_json(&response)
+}
+
+async fn structured_ask_watch_response(
+    state: &AppState,
+    target_uuid: &str,
+    watch_state: Arc<Mutex<crate::state::AgentWatchState>>,
+    initial_cursor: &str,
+    tail_bytes: Option<usize>,
+) -> Result<AgentWatchResponse, ControlError> {
     let snapshot = watch_state
         .lock()
         .map_err(|_| ControlError::request_failed("watch state lock poisoned"))?
-        .snapshot_since(Some(&initial_cursor), tail_bytes)
+        .snapshot_since(Some(initial_cursor), tail_bytes)
         .map_err(control_error_from_watch_state)?;
-    let agent = watch_agent_snapshot(&state, &target_uuid).await?;
+    let agent = watch_agent_snapshot(state, target_uuid).await?;
 
-    let watch = build_agent_watch_response(
+    Ok(build_agent_watch_response(
         agent,
         snapshot,
         &WatchIncludes::from_values(&[
@@ -1006,16 +1229,83 @@ async fn handle_structured_ask(
             "output".to_string(),
             "delivery".to_string(),
         ]),
-    );
-    ok_json(&AskResponse {
+    ))
+}
+
+fn build_ask_response_with_watch_result(
+    request_id: String,
+    target: String,
+    delivery: Vec<DeliveryDetail>,
+    reply: StructuredReply,
+    fallback_agent: WatchAgentSnapshot,
+    watch_result: Result<AgentWatchResponse, ControlError>,
+) -> AskResponse {
+    match watch_result {
+        Ok(watch) => AskResponse {
+            schema: wardian_core::control::CONTROL_SCHEMA,
+            ok: true,
+            request_id,
+            target,
+            delivery,
+            reply,
+            watch,
+            watch_error: None,
+        },
+        Err(error) => AskResponse {
+            schema: wardian_core::control::CONTROL_SCHEMA,
+            ok: true,
+            request_id,
+            target,
+            delivery,
+            reply,
+            watch: minimal_ask_watch_response(fallback_agent),
+            watch_error: Some(WatchEvidenceError {
+                code: error.code().to_string(),
+                message: error.to_string(),
+            }),
+        },
+    }
+}
+
+fn minimal_ask_watch_response(agent: WatchAgentSnapshot) -> AgentWatchResponse {
+    let cursor = format!("{}:degraded", agent.uuid);
+    AgentWatchResponse {
         schema: wardian_core::control::CONTROL_SCHEMA,
-        ok: true,
-        request_id,
-        target: target.to_string(),
-        delivery,
-        reply,
-        watch,
-    })
+        agent,
+        cursor: cursor.clone(),
+        events: Vec::new(),
+        output: wardian_core::control::WatchOutput {
+            cursor,
+            text: String::new(),
+            truncated: false,
+            omitted_bytes: 0,
+        },
+        transcript: None,
+        raw_output: None,
+        delivery: WatchDeliverySnapshot {
+            delivery: Vec::new(),
+        },
+    }
+}
+
+async fn ask_fallback_agent_snapshot(
+    state: &AppState,
+    target_uuid: &str,
+    target: &str,
+) -> WatchAgentSnapshot {
+    watch_agent_snapshot(state, target_uuid)
+        .await
+        .unwrap_or_else(|_| WatchAgentSnapshot {
+            uuid: target_uuid.to_string(),
+            name: target.to_string(),
+            provider: String::new(),
+            status: "unknown".to_string(),
+            last_status_at: None,
+        })
+}
+
+async fn cleanup_ask_request(state: &AppState, request_id: &str) {
+    state.ask_requests.lock().await.remove(request_id);
 }
 
 fn message_with_structured_reply_instruction(message: &str, request_id: &str) -> String {
@@ -1765,6 +2055,7 @@ fn failed_delivery_detail(
     error_code: &str,
     error_message: impl Into<String>,
     input_mode: MessageInputMode,
+    queue_policy: QueuePolicy,
 ) -> DeliveryDetail {
     DeliveryDetail {
         uuid: info.uuid,
@@ -1773,9 +2064,41 @@ fn failed_delivery_detail(
         runtime_state: runtime_state.to_string(),
         delivery_state: "failed".to_string(),
         input_mode,
+        queue_policy,
+        message_id: None,
+        delivery_phase: None,
+        observed_state: None,
+        reason: None,
+        profile: None,
         error: Some(DeliveryErrorDetail {
             code: error_code.to_string(),
             message: error_message.into(),
+        }),
+    }
+}
+
+fn rejected_delivery_detail(
+    info: DeliveryTargetInfo,
+    failure: &str,
+    input_mode: MessageInputMode,
+    queue_policy: QueuePolicy,
+) -> DeliveryDetail {
+    DeliveryDetail {
+        uuid: info.uuid,
+        name: info.name,
+        provider: info.provider,
+        runtime_state: "live_delivery_rejected".to_string(),
+        delivery_state: failure.to_string(),
+        input_mode,
+        queue_policy,
+        message_id: None,
+        delivery_phase: None,
+        observed_state: None,
+        reason: None,
+        profile: None,
+        error: Some(DeliveryErrorDetail {
+            code: failure.to_string(),
+            message: failure.to_string(),
         }),
     }
 }
@@ -1791,6 +2114,197 @@ async fn record_delivery_attempt(state: &AppState, detail: &DeliveryDetail) {
             watch_state.push_delivery(serde_json::json!(detail));
         }
     }
+}
+
+pub(crate) fn spawn_mailbox_drain_if_idle(
+    app: &AppHandle,
+    session_id: &str,
+    observed_status: &str,
+) {
+    if normalize_status(observed_status) != "idle" {
+        return;
+    }
+
+    let app = app.clone();
+    let session_id = session_id.to_string();
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<AppState>();
+        let _ = drain_next_mailbox_message_for_idle_agent(Some(&app), &state, &session_id).await;
+    });
+}
+
+enum MailboxSubmitError {
+    RetrySafe(String),
+    Terminal(crate::utils::delivery_transaction::TerminalDeliveryError),
+}
+
+impl MailboxSubmitError {
+    fn message(&self) -> String {
+        match self {
+            MailboxSubmitError::RetrySafe(message) => message.clone(),
+            MailboxSubmitError::Terminal(error) => error.to_string(),
+        }
+    }
+
+    fn phase(&self) -> Option<&'static str> {
+        match self {
+            MailboxSubmitError::RetrySafe(_) => None,
+            MailboxSubmitError::Terminal(error) => Some(error.phase),
+        }
+    }
+
+    fn retry_safe(&self) -> bool {
+        match self {
+            MailboxSubmitError::RetrySafe(_) => true,
+            MailboxSubmitError::Terminal(error) => error.retry_safe,
+        }
+    }
+}
+
+async fn drain_next_mailbox_message_for_idle_agent(
+    app: Option<&AppHandle>,
+    state: &AppState,
+    session_id: &str,
+) -> Result<Option<DeliveryDetail>, ControlError> {
+    let delivery_lock = state.delivery_lock_for(session_id).await;
+    let _delivery_guard = delivery_lock.lock().await;
+    let info = delivery_target_infos(state, &[session_id.to_string()])
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| ControlError::not_found(format!("agent not found: {session_id}")))?;
+    if info.status != "idle" {
+        return Ok(None);
+    }
+
+    let record = {
+        let mut mailbox = state.mailbox.lock().await;
+        mailbox.take_next_pending_for_target(session_id)
+    };
+    let Some(record) = record else {
+        return Ok(None);
+    };
+
+    let sender = state
+        .input_senders
+        .read()
+        .map_err(|_| ControlError::request_failed("input_senders lock poisoned"))?
+        .get(session_id)
+        .cloned();
+    let profile = crate::utils::delivery_profile::delivery_profile(&info.provider);
+    let detail = match sender {
+        Some(tx) => {
+            let result = match wait_for_terminal_ready_for_control_send(state, &info).await {
+                Ok(()) => {
+                    let submit_started = DeliveryDetail {
+                        uuid: info.uuid.clone(),
+                        name: info.name.clone(),
+                        provider: info.provider.clone(),
+                        runtime_state: "mailbox_drain".to_string(),
+                        delivery_state: "submit_started".to_string(),
+                        input_mode: record.input_mode,
+                        queue_policy: record.queue_policy,
+                        message_id: Some(record.id.clone()),
+                        delivery_phase: Some("payload_sent".to_string()),
+                        observed_state: Some("payload_sent".to_string()),
+                        reason: None,
+                        profile: Some(profile.provider.clone()),
+                        error: None,
+                    };
+                    crate::utils::terminal_input::submit_prompt_with_outcome_via_sender_after_payload(
+                        &tx,
+                        &record.body,
+                        &info.provider,
+                        || {
+                            let submit_started = submit_started.clone();
+                            async move {
+                                record_delivery_attempt(state, &submit_started).await;
+                            }
+                        },
+                    )
+                    .await
+                    .map_err(MailboxSubmitError::Terminal)
+                }
+                Err(error) => Err(MailboxSubmitError::RetrySafe(error)),
+            };
+            match result {
+                Ok(outcome) => {
+                    state.mailbox.lock().await.mark_delivered(&record.id);
+                    let detail = DeliveryDetail {
+                        uuid: info.uuid,
+                        name: info.name,
+                        provider: info.provider,
+                        runtime_state: "mailbox_drain".to_string(),
+                        delivery_state: outcome.delivery_state,
+                        input_mode: record.input_mode,
+                        queue_policy: record.queue_policy,
+                        message_id: Some(record.id),
+                        delivery_phase: Some(outcome.delivery_phase),
+                        observed_state: outcome.observed_state,
+                        reason: outcome.reason,
+                        profile: Some(profile.provider),
+                        error: None,
+                    };
+                    record_delivery_attempt(state, &detail).await;
+                    mark_delivered_agents_prompt_started(app, state, &[session_id.to_string()])
+                        .await;
+                    detail
+                }
+                Err(error) => {
+                    if error.retry_safe() {
+                        state.mailbox.lock().await.mark_pending(&record.id);
+                    } else {
+                        state.mailbox.lock().await.mark_failed(&record.id);
+                    }
+                    let mut detail = failed_delivery_detail(
+                        info,
+                        "mailbox_drain",
+                        "send_failed",
+                        error.message(),
+                        record.input_mode,
+                        record.queue_policy,
+                    );
+                    detail.message_id = Some(record.id);
+                    detail.delivery_phase = Some(
+                        error
+                            .phase()
+                            .unwrap_or(if error.retry_safe() {
+                                "queued"
+                            } else {
+                                "terminal_state_unknown"
+                            })
+                            .to_string(),
+                    );
+                    detail.reason = Some(if error.retry_safe() {
+                        "queued message remains pending for retry".to_string()
+                    } else {
+                        "queued message marked failed because terminal state is partial or unknown"
+                            .to_string()
+                    });
+                    record_delivery_attempt(state, &detail).await;
+                    detail
+                }
+            }
+        }
+        None => {
+            state.mailbox.lock().await.mark_pending(&record.id);
+            let mut detail = failed_delivery_detail(
+                info,
+                "mailbox_drain",
+                "no_input_channel",
+                "missing sender",
+                record.input_mode,
+                record.queue_policy,
+            );
+            detail.message_id = Some(record.id);
+            detail.delivery_phase = Some("queued".to_string());
+            detail.reason = Some("queued message remains pending for retry".to_string());
+            record_delivery_attempt(state, &detail).await;
+            detail
+        }
+    };
+
+    Ok(Some(detail))
 }
 
 async fn agent_config_to_identity(
@@ -2206,6 +2720,8 @@ mod tests {
             "hello",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             None,
         )
         .await
@@ -2213,6 +2729,128 @@ mod tests {
 
         assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
         assert_eq!(rx.recv().await.unwrap(), b"\x1b[13u".to_vec());
+    }
+
+    #[test]
+    fn delivery_route_queues_processing_message_when_queue_if_busy() {
+        let route = decide_delivery_route(
+            "processing",
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+        );
+
+        assert_eq!(
+            route,
+            DeliveryRoute::Mailbox {
+                runtime_state: "target_processing"
+            }
+        );
+    }
+
+    #[test]
+    fn delivery_route_rejects_processing_message_when_live_only() {
+        let route = decide_delivery_route(
+            "processing",
+            MessageInputMode::Message,
+            QueuePolicy::LiveOnly,
+            None,
+        );
+
+        assert_eq!(
+            route,
+            DeliveryRoute::Reject {
+                failure: "not_input_ready"
+            }
+        );
+    }
+
+    #[test]
+    fn delivery_route_queues_action_required_message_when_queue_if_busy() {
+        let route = decide_delivery_route(
+            "action_required",
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+        );
+
+        assert_eq!(
+            route,
+            DeliveryRoute::Mailbox {
+                runtime_state: "target_action_required"
+            }
+        );
+    }
+
+    #[test]
+    fn delivery_route_rejects_structured_approval_action_shape() {
+        let approval_action = ApprovalAction::Accept;
+        let route = decide_delivery_route(
+            "action_required",
+            MessageInputMode::ApprovalAction,
+            QueuePolicy::QueueIfBusy,
+            Some(&approval_action),
+        );
+
+        assert_eq!(
+            route,
+            DeliveryRoute::Reject {
+                failure: "unsupported_approval_shape"
+            }
+        );
+    }
+
+    #[test]
+    fn delivery_route_rejects_approval_action_without_payload() {
+        let route = decide_delivery_route(
+            "idle",
+            MessageInputMode::ApprovalAction,
+            QueuePolicy::LiveOnly,
+            None,
+        );
+
+        assert_eq!(
+            route,
+            DeliveryRoute::Reject {
+                failure: "unsupported_approval_shape"
+            }
+        );
+    }
+
+    #[test]
+    fn delivery_route_rejects_idle_structured_approval_action_shape() {
+        let approval_action = ApprovalAction::Accept;
+        let route = decide_delivery_route(
+            "idle",
+            MessageInputMode::ApprovalAction,
+            QueuePolicy::LiveOnly,
+            Some(&approval_action),
+        );
+
+        assert_eq!(
+            route,
+            DeliveryRoute::Reject {
+                failure: "unsupported_approval_shape"
+            }
+        );
+    }
+
+    #[test]
+    fn delivery_route_rejects_mailbox_only_structured_approval_action_shape() {
+        let approval_action = ApprovalAction::Accept;
+        let route = decide_delivery_route(
+            "processing",
+            MessageInputMode::ApprovalAction,
+            QueuePolicy::MailboxOnly,
+            Some(&approval_action),
+        );
+
+        assert_eq!(
+            route,
+            DeliveryRoute::Reject {
+                failure: "unsupported_approval_shape"
+            }
+        );
     }
 
     #[test]
@@ -2433,6 +3071,8 @@ mod tests {
             "hello",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             None,
         )
         .await
@@ -2449,10 +3089,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn codex_ready_prompt_is_not_ready_while_agent_is_processing() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "codex".to_string();
+            *agent.current_status.lock().unwrap() = "Processing".to_string();
+            agent
+                .watch_state
+                .lock()
+                .unwrap()
+                .push_output(b"\r\n\x1b[1m\xe2\x80\xba\x1b[22m Ready");
+        }
+
+        let result =
+            wait_for_terminal_output(&state, "agent-1", 1, codex_output_has_ready_prompt).await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn message_delivery_prefixes_agent_origin_with_sender_name() {
         let state = AppState::new();
         insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
         let (tx, mut rx) = tokio::sync::mpsc::channel(4);
         state
             .input_senders
@@ -2467,6 +3134,8 @@ mod tests {
             "check this",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             Some(&wardian_core::control::MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -2486,6 +3155,11 @@ mod tests {
         let state = AppState::new();
         insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
         let (tx, mut rx) = tokio::sync::mpsc::channel(4);
         state
             .input_senders
@@ -2500,6 +3174,8 @@ mod tests {
             "/goal test",
             None,
             MessageInputMode::Command,
+            QueuePolicy::QueueIfBusy,
+            None,
             Some(&wardian_core::control::MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -2527,7 +3203,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn message_delivery_keeps_bare_approval_responses_unprefixed() {
+    async fn message_delivery_queues_bare_approval_responses_when_action_required() {
         let state = AppState::new();
         insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -2543,13 +3219,15 @@ mod tests {
             .unwrap()
             .insert("agent-1".to_string(), tx);
 
-        deliver_message_to_target(
+        let delivery = deliver_message_to_target(
             None,
             &state,
             "CoderOne",
             "y",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             Some(&wardian_core::control::MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -2557,8 +3235,337 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(rx.recv().await.unwrap(), b"y".to_vec());
+        assert!(rx.try_recv().is_err());
+        assert_eq!(delivery[0].runtime_state, "target_action_required");
+        assert_eq!(delivery[0].delivery_state, "queued");
+        let queued = state.mailbox.lock().await.list_for_target("agent-1");
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].body, "y");
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_submits_next_pending_message_when_target_is_idle() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "codex".to_string();
+            *agent.current_status.lock().unwrap() = "Processing".to_string();
+            agent
+                .watch_state
+                .lock()
+                .unwrap()
+                .push_output(b"\r\n\x1b[1m\xe2\x80\xba\x1b[22m Ready");
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let queued = deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let message_id = queued[0].message_id.clone().unwrap();
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
+
+        let drained = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap()
+            .expect("drained message");
+
+        assert_eq!(rx.recv().await.unwrap(), b"queued work".to_vec());
         assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+        assert_eq!(drained.runtime_state, "mailbox_drain");
+        assert_eq!(drained.delivery_state, "submit_sent_unverified");
+        assert_eq!(drained.message_id.as_deref(), Some(message_id.as_str()));
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            let snapshot = agent
+                .watch_state
+                .lock()
+                .unwrap()
+                .snapshot_since(None, None)
+                .unwrap();
+            assert!(snapshot.events.iter().any(|event| {
+                event.kind == "delivery"
+                    && event.payload["delivery_state"] == "submit_started"
+                    && event.payload["message_id"] == message_id.as_str()
+            }));
+        }
+        let records = state.mailbox.lock().await.list_for_target("agent-1");
+        assert_eq!(
+            records[0].status,
+            crate::state::MailboxMessageStatus::Delivered
+        );
+        assert_eq!(
+            records[0].phase,
+            crate::state::MailboxDeliveryPhase::Terminal
+        );
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_waits_until_target_is_idle() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let drained = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap();
+
+        assert!(drained.is_none());
+        assert!(rx.try_recv().is_err());
+        let records = state.mailbox.lock().await.list_for_target("agent-1");
+        assert_eq!(
+            records[0].status,
+            crate::state::MailboxMessageStatus::Pending
+        );
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_missing_sender_leaves_message_pending_for_retry() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Action Required".to_string();
+        }
+
+        let queued = deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let message_id = queued[0].message_id.clone().unwrap();
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
+
+        let attempt = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap()
+            .expect("drain attempt");
+
+        assert_eq!(attempt.runtime_state, "mailbox_drain");
+        assert_eq!(attempt.delivery_state, "failed");
+        assert_eq!(attempt.message_id.as_deref(), Some(message_id.as_str()));
+        assert_eq!(
+            attempt.error.as_ref().map(|error| error.code.as_str()),
+            Some("no_input_channel")
+        );
+        let records = state.mailbox.lock().await.list_for_target("agent-1");
+        assert_eq!(
+            records[0].status,
+            crate::state::MailboxMessageStatus::Pending
+        );
+        assert_eq!(records[0].phase, crate::state::MailboxDeliveryPhase::Queued);
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_submit_key_failure_marks_failed_without_retry() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "codex".to_string();
+            *agent.current_status.lock().unwrap() = "Processing".to_string();
+            agent
+                .watch_state
+                .lock()
+                .unwrap()
+                .push_output(b"\r\n\x1b[1m\xe2\x80\xba\x1b[22m Ready");
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let queued = deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let message_id = queued[0].message_id.clone().unwrap();
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
+
+        let drain = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1");
+        tokio::pin!(drain);
+        let payload = tokio::select! {
+            payload = rx.recv() => payload.expect("payload"),
+            attempt = &mut drain => panic!("drain completed before payload was observed: {attempt:?}"),
+        };
+        assert_eq!(payload, b"queued work".to_vec());
+        drop(rx);
+
+        let attempt = drain.await.unwrap().expect("drain attempt");
+
+        assert_eq!(attempt.runtime_state, "mailbox_drain");
+        assert_eq!(attempt.delivery_state, "failed");
+        assert_eq!(attempt.message_id.as_deref(), Some(message_id.as_str()));
+        assert_eq!(
+            attempt.delivery_phase.as_deref(),
+            Some("payload_sent_submit_failed")
+        );
+        assert_eq!(
+            attempt.error.as_ref().map(|error| error.code.as_str()),
+            Some("send_failed")
+        );
+        assert!(attempt
+            .reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("partial or unknown"));
+        let records = state.mailbox.lock().await.list_for_target("agent-1");
+        assert_eq!(
+            records[0].status,
+            crate::state::MailboxMessageStatus::Failed
+        );
+        assert_eq!(
+            records[0].phase,
+            crate::state::MailboxDeliveryPhase::Terminal
+        );
+
+        let second_attempt = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap();
+        assert!(second_attempt.is_none());
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_payload_send_failure_does_not_emit_submit_started() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "codex".to_string();
+            *agent.current_status.lock().unwrap() = "Processing".to_string();
+            agent
+                .watch_state
+                .lock()
+                .unwrap()
+                .push_output(b"\r\n\x1b[1m\xe2\x80\xba\x1b[22m Ready");
+        }
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        drop(rx);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let queued = deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let message_id = queued[0].message_id.clone().unwrap();
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
+
+        let attempt = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap()
+            .expect("drain attempt");
+
+        assert_eq!(attempt.delivery_state, "failed");
+        assert_eq!(attempt.message_id.as_deref(), Some(message_id.as_str()));
+        assert_eq!(
+            attempt.delivery_phase.as_deref(),
+            Some("payload_send_failed")
+        );
+        let records = state.mailbox.lock().await.list_for_target("agent-1");
+        assert_eq!(
+            records[0].status,
+            crate::state::MailboxMessageStatus::Pending
+        );
+        let agents = state.agents.lock().await;
+        let agent = agents.get("agent-1").unwrap();
+        let snapshot = agent
+            .watch_state
+            .lock()
+            .unwrap()
+            .snapshot_since(None, None)
+            .unwrap();
+        assert!(!snapshot.events.iter().any(|event| {
+            event.kind == "delivery"
+                && event.payload["delivery_state"] == "submit_started"
+                && event.payload["message_id"] == message_id.as_str()
+        }));
     }
 
     #[tokio::test]
@@ -2585,6 +3592,8 @@ mod tests {
             "yes",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             Some(&wardian_core::control::MessageOrigin::WardianAgent {
                 session_id: "source-1".to_string(),
             }),
@@ -2607,6 +3616,8 @@ mod tests {
             "hello",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             None,
         )
         .await
@@ -2622,6 +3633,11 @@ mod tests {
     async fn message_delivery_reports_agent_without_input_channel() {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
 
         let error = deliver_message_to_target(
             None,
@@ -2630,6 +3646,8 @@ mod tests {
             "hello",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             None,
         )
         .await
@@ -2652,6 +3670,21 @@ mod tests {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         insert_test_agent(&state, "agent-2", "CoderTwo", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            *agents
+                .get("agent-1")
+                .unwrap()
+                .current_status
+                .lock()
+                .unwrap() = "Idle".to_string();
+            *agents
+                .get("agent-2")
+                .unwrap()
+                .current_status
+                .lock()
+                .unwrap() = "Idle".to_string();
+        }
         let (tx, mut rx) = tokio::sync::mpsc::channel(4);
         state
             .input_senders
@@ -2666,6 +3699,8 @@ mod tests {
             "hello",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             None,
         )
         .await
@@ -2706,12 +3741,14 @@ mod tests {
             "hello",
             None,
             MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
             None,
         )
         .await
         .unwrap();
 
-        assert!(rx.recv().await.is_some());
+        assert!(rx.try_recv().is_err());
         let agents = state.agents.lock().await;
         let agent = agents.get("agent-1").unwrap();
         let snapshot = agent
@@ -2841,6 +3878,47 @@ mod tests {
                 && event.payload["request_id"] == "ask_testrequest02"
                 && event.payload["body_file"] == body_file.display().to_string()
         }));
+    }
+
+    #[test]
+    fn ask_response_preserves_reply_when_watch_evidence_fails() {
+        let reply = wardian_core::control::StructuredReply {
+            request_id: "ask_testrequest03".to_string(),
+            status: wardian_core::control::ReplyStatus::Done,
+            body: "finished despite watch gap".to_string(),
+            target_session_id: "agent-1".to_string(),
+            source_session_id: Some("agent-1".to_string()),
+            replied_at: "2026-05-22T00:00:00.000Z".to_string(),
+        };
+        let response = build_ask_response_with_watch_result(
+            "ask_testrequest03".to_string(),
+            "CoderOne".to_string(),
+            Vec::new(),
+            reply,
+            WatchAgentSnapshot {
+                uuid: "agent-1".to_string(),
+                name: "CoderOne".to_string(),
+                provider: "codex".to_string(),
+                status: "idle".to_string(),
+                last_status_at: None,
+            },
+            Err(ControlError::coded(
+                "cursor_expired",
+                "watch evidence cursor expired",
+            )),
+        );
+
+        assert!(response.ok);
+        assert_eq!(response.reply.body, "finished despite watch gap");
+        assert_eq!(
+            response
+                .watch_error
+                .as_ref()
+                .map(|error| error.code.as_str()),
+            Some("cursor_expired")
+        );
+        assert_eq!(response.watch.agent.uuid, "agent-1");
+        assert_eq!(response.watch.output.text, "");
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -360,6 +360,7 @@ pub fn run() {
             commands::chat::load_agent_chat_transcript,
             commands::debug::debug_remove_agent_input_sender,
             commands::debug::debug_push_agent_watch_output,
+            commands::debug::debug_set_agent_status,
             commands::terminal::send_input_to_agent,
             commands::terminal::submit_prompt_to_agent,
             commands::terminal::send_binary_input_to_agent,

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -187,6 +187,8 @@ pub(crate) fn set_agent_status(
                     "current_status": next_status,
                 }),
             );
+
+            crate::control::spawn_mailbox_drain_if_idle(app, session_id, next_status);
         }
     }
 }

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -320,6 +320,33 @@ pub async fn spawn_agent(
         for (key, value) in opencode_interactive_env(&provider_cwd, &config)? {
             cmd.env(key, value);
         }
+    } else if config.provider == "mock" {
+        let mut has_config_scenario = false;
+        let mut has_config_delay = false;
+        if let ProviderConfig::Mock(mock) = &config.provider_config {
+            if let Some(scenario) = mock.scenario.as_deref().filter(|value| !value.is_empty()) {
+                cmd.env("WARDIAN_MOCK_SCENARIO", scenario);
+                has_config_scenario = true;
+            }
+            if let Some(delay_ms) = mock.delay_ms {
+                cmd.env("WARDIAN_MOCK_DELAY_MS", delay_ms.to_string());
+                has_config_delay = true;
+            }
+        }
+        for key in [
+            "WARDIAN_MOCK_SCENARIO",
+            "WARDIAN_MOCK_DELAY_MS",
+            "WARDIAN_MOCK_SCRIPT",
+        ] {
+            if (key == "WARDIAN_MOCK_SCENARIO" && has_config_scenario)
+                || (key == "WARDIAN_MOCK_DELAY_MS" && has_config_delay)
+            {
+                continue;
+            }
+            if let Ok(value) = std::env::var(key) {
+                cmd.env(key, value);
+            }
+        }
     }
     #[cfg(target_os = "macos")]
     cmd.env("PATH", macos_extended_path());

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -1,4 +1,5 @@
 use crate::state::active_agent::ActiveAgent;
+use crate::state::mailbox::MailboxState;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
@@ -19,6 +20,8 @@ pub struct AppState {
     pub agent_order: Mutex<Vec<String>>,
     pub agent_name_reservations: Mutex<HashSet<String>>,
     pub agent_lifecycle_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    pub delivery_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    pub mailbox: Mutex<MailboxState>,
     // Separate, lightweight map for stdin senders — completely independent from the
     // agents lock. Uses std::sync::RwLock for zero-contention reads from any thread.
     pub input_senders: RwLock<HashMap<String, tokio::sync::mpsc::Sender<Vec<u8>>>>,
@@ -52,6 +55,22 @@ impl AppState {
     pub fn new() -> Self {
         Self::default()
     }
+
+    pub async fn delivery_lock_for(&self, target_session_id: &str) -> Arc<Mutex<()>> {
+        let mut locks = self.delivery_locks.lock().await;
+        locks
+            .entry(target_session_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    pub async fn remove_agent_delivery_state(&self, target_session_id: &str) {
+        self.delivery_locks.lock().await.remove(target_session_id);
+        self.mailbox
+            .lock()
+            .await
+            .remove_for_target(target_session_id);
+    }
 }
 
 impl Default for AppState {
@@ -64,6 +83,8 @@ impl Default for AppState {
             agent_order: Mutex::new(Vec::new()),
             agent_name_reservations: Mutex::new(HashSet::new()),
             agent_lifecycle_locks: Mutex::new(HashMap::new()),
+            delivery_locks: Mutex::new(HashMap::new()),
+            mailbox: Mutex::new(MailboxState::default()),
             input_senders: RwLock::new(HashMap::new()),
             workflow_triggers: Mutex::new(HashMap::new()),
             workflow_runs: Mutex::new(HashMap::new()),
@@ -81,11 +102,37 @@ impl Default for AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::mailbox::MailboxMessageDraft;
+    use wardian_core::control::{MessageInputMode, QueuePolicy};
 
     #[test]
     fn app_state_constructs_without_panic() {
         let state = AppState::new();
         assert!(state.agent_order.blocking_lock().is_empty());
         drop(state);
+    }
+
+    #[tokio::test]
+    async fn removing_agent_delivery_state_prunes_lock_and_mailbox_records() {
+        let state = AppState::new();
+        let _lock = state.delivery_lock_for("agent-1").await;
+        state.mailbox.lock().await.enqueue(MailboxMessageDraft {
+            target_session_id: "agent-1".to_string(),
+            body: "queued".to_string(),
+            input_mode: MessageInputMode::Message,
+            queue_policy: QueuePolicy::QueueIfBusy,
+            approval_action: None,
+            origin: None,
+        });
+
+        state.remove_agent_delivery_state("agent-1").await;
+
+        assert!(!state.delivery_locks.lock().await.contains_key("agent-1"));
+        assert!(state
+            .mailbox
+            .lock()
+            .await
+            .list_for_target("agent-1")
+            .is_empty());
     }
 }

--- a/src-tauri/src/state/mailbox.rs
+++ b/src-tauri/src/state/mailbox.rs
@@ -1,0 +1,344 @@
+use serde::{Deserialize, Serialize};
+use wardian_core::control::{ApprovalAction, MessageInputMode, MessageOrigin, QueuePolicy};
+
+const MAX_TERMINAL_RECORDS_PER_TARGET: usize = 64;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MailboxMessageDraft {
+    pub target_session_id: String,
+    pub body: String,
+    pub input_mode: MessageInputMode,
+    pub queue_policy: QueuePolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_action: Option<ApprovalAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<MessageOrigin>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MailboxMessageRecord {
+    pub id: String,
+    pub target_session_id: String,
+    pub body: String,
+    pub input_mode: MessageInputMode,
+    pub queue_policy: QueuePolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_action: Option<ApprovalAction>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<MessageOrigin>,
+    pub created_at: String,
+    pub status: MailboxMessageStatus,
+    pub phase: MailboxDeliveryPhase,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MailboxMessageStatus {
+    Pending,
+    InFlight,
+    Delivered,
+    Failed,
+}
+
+impl MailboxMessageStatus {
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::Delivered | Self::Failed)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MailboxDeliveryPhase {
+    Queued,
+    Dispatching,
+    Submitted,
+    Terminal,
+}
+
+#[derive(Debug, Default)]
+pub struct MailboxState {
+    records: Vec<MailboxMessageRecord>,
+    last_millis: i64,
+    counter: u64,
+}
+
+impl MailboxState {
+    pub fn enqueue(&mut self, draft: MailboxMessageDraft) -> MailboxMessageRecord {
+        let created_at = now_rfc3339_millis();
+        let id = self.next_message_id();
+        let record = MailboxMessageRecord {
+            id,
+            target_session_id: draft.target_session_id,
+            body: draft.body,
+            input_mode: draft.input_mode,
+            queue_policy: draft.queue_policy,
+            approval_action: draft.approval_action,
+            origin: draft.origin,
+            created_at,
+            status: MailboxMessageStatus::Pending,
+            phase: MailboxDeliveryPhase::Queued,
+        };
+        self.records.push(record.clone());
+        record
+    }
+
+    pub fn all(&self) -> Vec<MailboxMessageRecord> {
+        self.records.clone()
+    }
+
+    pub fn list_for_target(&self, target_session_id: &str) -> Vec<MailboxMessageRecord> {
+        self.records
+            .iter()
+            .filter(|record| record.target_session_id == target_session_id)
+            .cloned()
+            .collect()
+    }
+
+    pub fn take_next_pending_for_target(
+        &mut self,
+        target_session_id: &str,
+    ) -> Option<MailboxMessageRecord> {
+        let record = self.records.iter_mut().find(|record| {
+            record.target_session_id == target_session_id
+                && record.status == MailboxMessageStatus::Pending
+        })?;
+        record.status = MailboxMessageStatus::InFlight;
+        record.phase = MailboxDeliveryPhase::Dispatching;
+        Some(record.clone())
+    }
+
+    pub fn mark_delivered(&mut self, id: &str) -> Option<MailboxMessageRecord> {
+        self.mark_terminal(id, MailboxMessageStatus::Delivered)
+    }
+
+    pub fn mark_failed(&mut self, id: &str) -> Option<MailboxMessageRecord> {
+        self.mark_terminal(id, MailboxMessageStatus::Failed)
+    }
+
+    pub fn mark_pending(&mut self, id: &str) -> Option<MailboxMessageRecord> {
+        let record = self.records.iter_mut().find(|record| record.id == id)?;
+        record.status = MailboxMessageStatus::Pending;
+        record.phase = MailboxDeliveryPhase::Queued;
+        Some(record.clone())
+    }
+
+    pub fn remove_for_target(&mut self, target_session_id: &str) -> usize {
+        let original_len = self.records.len();
+        self.records
+            .retain(|record| record.target_session_id != target_session_id);
+        original_len - self.records.len()
+    }
+
+    fn mark_terminal(
+        &mut self,
+        id: &str,
+        status: MailboxMessageStatus,
+    ) -> Option<MailboxMessageRecord> {
+        let updated = {
+            let record = self.records.iter_mut().find(|record| record.id == id)?;
+            record.status = status;
+            record.phase = MailboxDeliveryPhase::Terminal;
+            record.clone()
+        };
+        self.compact_terminal_records_for_target(&updated.target_session_id);
+        Some(updated)
+    }
+
+    fn compact_terminal_records_for_target(&mut self, target_session_id: &str) {
+        let terminal_count = self
+            .records
+            .iter()
+            .filter(|record| {
+                record.target_session_id == target_session_id && record.status.is_terminal()
+            })
+            .count();
+        let mut remove_count = terminal_count.saturating_sub(MAX_TERMINAL_RECORDS_PER_TARGET);
+        if remove_count == 0 {
+            return;
+        }
+
+        self.records.retain(|record| {
+            if remove_count > 0
+                && record.target_session_id == target_session_id
+                && record.status.is_terminal()
+            {
+                remove_count -= 1;
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    fn next_message_id(&mut self) -> String {
+        let now_millis = chrono::Utc::now().timestamp_millis();
+        let millis = now_millis.max(self.last_millis);
+        if millis == self.last_millis {
+            self.counter = self.counter.saturating_add(1);
+        } else {
+            self.last_millis = millis;
+            self.counter = 0;
+        }
+
+        format!("msg_{millis:013}_{:06}", self.counter)
+    }
+}
+
+fn now_rfc3339_millis() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wardian_core::control::{ApprovalAction, MessageInputMode, MessageOrigin, QueuePolicy};
+
+    fn message_for(target_session_id: &str, body: &str) -> MailboxMessageDraft {
+        MailboxMessageDraft {
+            target_session_id: target_session_id.to_string(),
+            body: body.to_string(),
+            input_mode: MessageInputMode::Message,
+            queue_policy: QueuePolicy::QueueIfBusy,
+            approval_action: None,
+            origin: None,
+        }
+    }
+
+    #[test]
+    fn enqueueing_message_records_pending_mailbox_entry() {
+        let mut mailbox = MailboxState::default();
+
+        let record = mailbox.enqueue(message_for("agent-1", "hello"));
+
+        assert_eq!(record.target_session_id, "agent-1");
+        assert_eq!(record.body, "hello");
+        assert_eq!(record.status, MailboxMessageStatus::Pending);
+        assert_eq!(record.phase, MailboxDeliveryPhase::Queued);
+        assert!(record.id.starts_with("msg_"));
+        assert_eq!(mailbox.all().len(), 1);
+    }
+
+    #[test]
+    fn message_ids_are_monotonic_with_stable_shape() {
+        let mut mailbox = MailboxState::default();
+
+        let first = mailbox.enqueue(message_for("agent-1", "one"));
+        let second = mailbox.enqueue(message_for("agent-1", "two"));
+
+        assert!(first.id.starts_with("msg_"));
+        assert!(second.id.starts_with("msg_"));
+        assert_ne!(first.id, second.id);
+        assert!(
+            first.id < second.id,
+            "ids should sort in enqueue order: {} then {}",
+            first.id,
+            second.id
+        );
+    }
+
+    #[test]
+    fn listing_can_filter_by_target_session_id() {
+        let mut mailbox = MailboxState::default();
+        mailbox.enqueue(message_for("agent-1", "one"));
+        mailbox.enqueue(message_for("agent-2", "two"));
+        mailbox.enqueue(message_for("agent-1", "three"));
+
+        let agent_one = mailbox.list_for_target("agent-1");
+
+        assert_eq!(agent_one.len(), 2);
+        assert!(agent_one
+            .iter()
+            .all(|record| record.target_session_id == "agent-1"));
+        assert_eq!(agent_one[0].body, "one");
+        assert_eq!(agent_one[1].body, "three");
+    }
+
+    #[test]
+    fn enqueue_preserves_approval_action_and_origin_metadata() {
+        let mut mailbox = MailboxState::default();
+        let origin = MessageOrigin::WardianAgent {
+            session_id: "source-agent".to_string(),
+        };
+        let approval_action = ApprovalAction::Select {
+            option: "allow_once".to_string(),
+        };
+
+        let record = mailbox.enqueue(MailboxMessageDraft {
+            target_session_id: "agent-1".to_string(),
+            body: "approve".to_string(),
+            input_mode: MessageInputMode::ApprovalAction,
+            queue_policy: QueuePolicy::MailboxOnly,
+            approval_action: Some(approval_action.clone()),
+            origin: Some(origin.clone()),
+        });
+
+        assert_eq!(record.input_mode, MessageInputMode::ApprovalAction);
+        assert_eq!(record.queue_policy, QueuePolicy::MailboxOnly);
+        assert_eq!(record.approval_action, Some(approval_action));
+        assert_eq!(record.origin, Some(origin));
+    }
+
+    #[test]
+    fn taking_next_pending_marks_only_first_target_message_in_flight() {
+        let mut mailbox = MailboxState::default();
+        let first = mailbox.enqueue(message_for("agent-1", "one"));
+        let second = mailbox.enqueue(message_for("agent-1", "two"));
+        mailbox.enqueue(message_for("agent-2", "other"));
+
+        let taken = mailbox.take_next_pending_for_target("agent-1").unwrap();
+
+        assert_eq!(taken.id, first.id);
+        assert_eq!(taken.status, MailboxMessageStatus::InFlight);
+        assert_eq!(taken.phase, MailboxDeliveryPhase::Dispatching);
+        let agent_one = mailbox.list_for_target("agent-1");
+        assert_eq!(agent_one[0].status, MailboxMessageStatus::InFlight);
+        assert_eq!(agent_one[1].id, second.id);
+        assert_eq!(agent_one[1].status, MailboxMessageStatus::Pending);
+    }
+
+    #[test]
+    fn terminal_markers_preserve_records_and_update_phase() {
+        let mut mailbox = MailboxState::default();
+        let delivered = mailbox.enqueue(message_for("agent-1", "one"));
+        let failed = mailbox.enqueue(message_for("agent-1", "two"));
+
+        let delivered = mailbox.mark_delivered(&delivered.id).unwrap();
+        let failed = mailbox.mark_failed(&failed.id).unwrap();
+
+        assert_eq!(delivered.status, MailboxMessageStatus::Delivered);
+        assert_eq!(delivered.phase, MailboxDeliveryPhase::Terminal);
+        assert_eq!(failed.status, MailboxMessageStatus::Failed);
+        assert_eq!(failed.phase, MailboxDeliveryPhase::Terminal);
+        assert_eq!(mailbox.all().len(), 2);
+    }
+
+    #[test]
+    fn terminal_compaction_keeps_only_recent_terminal_records_per_target() {
+        let mut mailbox = MailboxState::default();
+        let first = mailbox.enqueue(message_for("agent-1", "first"));
+        mailbox.mark_delivered(&first.id).unwrap();
+
+        for index in 0..70 {
+            let record = mailbox.enqueue(message_for("agent-1", &format!("message-{index}")));
+            mailbox.mark_delivered(&record.id).unwrap();
+        }
+
+        let records = mailbox.list_for_target("agent-1");
+        assert_eq!(records.len(), 64);
+        assert!(records.iter().all(|record| record.body != "first"));
+    }
+
+    #[test]
+    fn mark_pending_requeues_in_flight_message_for_retry() {
+        let mut mailbox = MailboxState::default();
+        let record = mailbox.enqueue(message_for("agent-1", "one"));
+        mailbox.take_next_pending_for_target("agent-1").unwrap();
+
+        let requeued = mailbox.mark_pending(&record.id).unwrap();
+
+        assert_eq!(requeued.status, MailboxMessageStatus::Pending);
+        assert_eq!(requeued.phase, MailboxDeliveryPhase::Queued);
+        let pending = mailbox.take_next_pending_for_target("agent-1").unwrap();
+        assert_eq!(pending.id, record.id);
+    }
+}

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -1,10 +1,15 @@
 pub mod active_agent;
 pub mod agent_watch;
 pub mod app_state;
+pub mod mailbox;
 pub mod terminal_text;
 pub mod user_terminal;
 
 pub use active_agent::ActiveAgent;
 pub use agent_watch::AgentWatchState;
 pub use app_state::{AppState, LibraryWatchRegistration};
+pub use mailbox::{
+    MailboxDeliveryPhase, MailboxMessageDraft, MailboxMessageRecord, MailboxMessageStatus,
+    MailboxState,
+};
 pub use user_terminal::UserTerminalSession;

--- a/src-tauri/src/utils/delivery_profile.rs
+++ b/src-tauri/src/utils/delivery_profile.rs
@@ -1,0 +1,143 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmitKey {
+    CarriageReturn,
+    OpenCodeKittyEnter,
+}
+
+impl SubmitKey {
+    pub fn bytes(self) -> &'static [u8] {
+        match self {
+            Self::CarriageReturn => b"\r",
+            Self::OpenCodeKittyEnter => b"\x1b[13u",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BracketedPasteProfile {
+    pub enabled: bool,
+    pub min_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeliveryProfile {
+    pub provider: String,
+    pub submit_key: SubmitKey,
+    pub submit_delay_ms: u64,
+    pub bracketed_paste: BracketedPasteProfile,
+    pub input_ready_markers: &'static [&'static str],
+    pub busy_markers: &'static [&'static str],
+}
+
+pub fn delivery_profile(provider: &str) -> DeliveryProfile {
+    let normalized = provider.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "codex" => DeliveryProfile {
+            provider: normalized,
+            submit_key: SubmitKey::CarriageReturn,
+            submit_delay_ms: 150,
+            bracketed_paste: BracketedPasteProfile {
+                enabled: true,
+                min_bytes: 2048,
+            },
+            input_ready_markers: &["›", "Use /skills"],
+            busy_markers: &["esc to interrupt", "Working"],
+        },
+        "claude" => DeliveryProfile {
+            provider: normalized,
+            submit_key: SubmitKey::CarriageReturn,
+            submit_delay_ms: 500,
+            bracketed_paste: BracketedPasteProfile {
+                enabled: true,
+                min_bytes: 2048,
+            },
+            input_ready_markers: &["❯"],
+            busy_markers: &["esc to interrupt"],
+        },
+        "gemini" => DeliveryProfile {
+            provider: normalized,
+            submit_key: SubmitKey::CarriageReturn,
+            submit_delay_ms: 500,
+            bracketed_paste: BracketedPasteProfile {
+                enabled: false,
+                min_bytes: usize::MAX,
+            },
+            input_ready_markers: &[">"],
+            busy_markers: &["Working"],
+        },
+        "opencode" => DeliveryProfile {
+            provider: normalized,
+            submit_key: SubmitKey::OpenCodeKittyEnter,
+            submit_delay_ms: 250,
+            bracketed_paste: BracketedPasteProfile {
+                enabled: true,
+                min_bytes: 2048,
+            },
+            input_ready_markers: &[">"],
+            busy_markers: &["Working"],
+        },
+        "antigravity" => DeliveryProfile {
+            provider: normalized,
+            submit_key: SubmitKey::CarriageReturn,
+            submit_delay_ms: 500,
+            bracketed_paste: BracketedPasteProfile {
+                enabled: false,
+                min_bytes: usize::MAX,
+            },
+            input_ready_markers: &[">"],
+            busy_markers: &["Working"],
+        },
+        _ => DeliveryProfile {
+            provider: normalized,
+            submit_key: SubmitKey::CarriageReturn,
+            submit_delay_ms: 1000,
+            bracketed_paste: BracketedPasteProfile {
+                enabled: false,
+                min_bytes: usize::MAX,
+            },
+            input_ready_markers: &[],
+            busy_markers: &[],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_profile_uses_short_submit_delay_and_return_key() {
+        let profile = delivery_profile("codex");
+
+        assert_eq!(profile.provider, "codex");
+        assert_eq!(profile.submit_key, SubmitKey::CarriageReturn);
+        assert!(profile.submit_delay_ms >= 150);
+        assert!(profile.submit_delay_ms < 1000);
+        assert!(profile.bracketed_paste.enabled);
+    }
+
+    #[test]
+    fn opencode_profile_uses_kitty_enter_key() {
+        let profile = delivery_profile("opencode");
+
+        assert_eq!(profile.submit_key.bytes(), b"\x1b[13u");
+    }
+
+    #[test]
+    fn every_user_provider_has_a_profile() {
+        for provider in ["codex", "claude", "gemini", "opencode", "antigravity"] {
+            let profile = delivery_profile(provider);
+            assert_eq!(profile.provider, provider);
+        }
+    }
+
+    #[test]
+    fn unknown_provider_falls_back_conservatively() {
+        let profile = delivery_profile("new-provider");
+
+        assert_eq!(profile.provider, "new-provider");
+        assert_eq!(profile.submit_key.bytes(), b"\r");
+        assert_eq!(profile.submit_delay_ms, 1000);
+        assert!(!profile.bracketed_paste.enabled);
+    }
+}

--- a/src-tauri/src/utils/delivery_transaction.rs
+++ b/src-tauri/src/utils/delivery_transaction.rs
@@ -1,0 +1,259 @@
+use crate::utils::delivery_profile::DeliveryProfile;
+use std::fmt;
+use std::future::Future;
+use tokio::sync::mpsc::Sender;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PayloadKind {
+    Literal,
+    BracketedPaste,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalPayloadPlan {
+    pub payload_kind: PayloadKind,
+    pub payload_bytes: Vec<u8>,
+    pub submit_key: Vec<u8>,
+    pub submit_delay_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalDeliveryOutcome {
+    pub delivery_state: String,
+    pub delivery_phase: String,
+    pub observed_state: Option<String>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TerminalDeliveryError {
+    pub phase: &'static str,
+    pub message: String,
+    pub retry_safe: bool,
+}
+
+impl TerminalDeliveryError {
+    fn retry_safe(phase: &'static str, message: String) -> Self {
+        Self {
+            phase,
+            message,
+            retry_safe: true,
+        }
+    }
+
+    fn terminal_state_unknown(phase: &'static str, message: String) -> Self {
+        Self {
+            phase,
+            message,
+            retry_safe: false,
+        }
+    }
+}
+
+impl fmt::Display for TerminalDeliveryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for TerminalDeliveryError {}
+
+pub fn bracketed_paste_bytes(prompt: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(prompt.len() + b"\x1b[200~\x1b[201~".len());
+    bytes.extend_from_slice(b"\x1b[200~");
+    bytes.extend_from_slice(prompt.as_bytes());
+    bytes.extend_from_slice(b"\x1b[201~");
+    bytes
+}
+
+pub fn plan_terminal_payload(profile: &DeliveryProfile, prompt: &str) -> TerminalPayloadPlan {
+    let use_bracketed_paste = profile.bracketed_paste.enabled
+        && (prompt.contains('\n') || prompt.len() >= profile.bracketed_paste.min_bytes);
+    let payload_kind = if use_bracketed_paste {
+        PayloadKind::BracketedPaste
+    } else {
+        PayloadKind::Literal
+    };
+    let payload_bytes = if use_bracketed_paste {
+        bracketed_paste_bytes(prompt)
+    } else {
+        prompt.as_bytes().to_vec()
+    };
+
+    TerminalPayloadPlan {
+        payload_kind,
+        payload_bytes,
+        submit_key: profile.submit_key.bytes().to_vec(),
+        submit_delay_ms: profile.submit_delay_ms,
+    }
+}
+
+pub async fn submit_terminal_transaction(
+    tx: &Sender<Vec<u8>>,
+    profile: &DeliveryProfile,
+    prompt: &str,
+) -> Result<TerminalDeliveryOutcome, TerminalDeliveryError> {
+    submit_terminal_transaction_with_payload_hook(tx, profile, prompt, || async {}).await
+}
+
+pub async fn submit_terminal_transaction_with_payload_hook<F, Fut>(
+    tx: &Sender<Vec<u8>>,
+    profile: &DeliveryProfile,
+    prompt: &str,
+    on_payload_sent: F,
+) -> Result<TerminalDeliveryOutcome, TerminalDeliveryError>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let plan = plan_terminal_payload(profile, prompt);
+    if plan.payload_bytes.is_empty() {
+        return Ok(TerminalDeliveryOutcome {
+            delivery_state: "empty".to_string(),
+            delivery_phase: "empty".to_string(),
+            observed_state: None,
+            reason: Some("prompt normalized to empty".to_string()),
+        });
+    }
+
+    tx.send(plan.payload_bytes).await.map_err(|e| {
+        TerminalDeliveryError::retry_safe(
+            "payload_send_failed",
+            format!("Failed to send prompt payload: {e}"),
+        )
+    })?;
+    on_payload_sent().await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(plan.submit_delay_ms)).await;
+
+    tx.send(plan.submit_key).await.map_err(|e| {
+        TerminalDeliveryError::terminal_state_unknown(
+            "payload_sent_submit_failed",
+            format!("Failed to send prompt submit key after payload send: {e}"),
+        )
+    })?;
+
+    Ok(TerminalDeliveryOutcome {
+        delivery_state: "submit_sent_unverified".to_string(),
+        delivery_phase: "submit_key_sent".to_string(),
+        observed_state: Some("bytes_sent".to_string()),
+        reason: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::delivery_profile::{delivery_profile, DeliveryProfile};
+
+    fn zero_delay_profile(provider: &str) -> DeliveryProfile {
+        let mut profile = delivery_profile(provider);
+        profile.submit_delay_ms = 0;
+        profile
+    }
+
+    #[test]
+    fn bracketed_paste_wraps_payload() {
+        let bytes = bracketed_paste_bytes("alpha\nbeta");
+
+        assert_eq!(bytes, b"\x1b[200~alpha\nbeta\x1b[201~".to_vec());
+    }
+
+    #[test]
+    fn plan_uses_literal_for_short_single_line() {
+        let profile = delivery_profile("codex");
+        let plan = plan_terminal_payload(&profile, "hello");
+
+        assert_eq!(plan.payload_kind, PayloadKind::Literal);
+        assert_eq!(plan.payload_bytes, b"hello".to_vec());
+        assert_eq!(plan.submit_key, b"\r".to_vec());
+        assert_eq!(plan.submit_delay_ms, profile.submit_delay_ms);
+    }
+
+    #[test]
+    fn plan_uses_bracketed_paste_for_multiline_when_enabled() {
+        let profile = delivery_profile("codex");
+        let plan = plan_terminal_payload(&profile, "hello\nworld");
+
+        assert_eq!(plan.payload_kind, PayloadKind::BracketedPaste);
+        assert_eq!(
+            plan.payload_bytes,
+            b"\x1b[200~hello\nworld\x1b[201~".to_vec()
+        );
+    }
+
+    #[test]
+    fn plan_uses_bracketed_paste_for_large_payload_when_enabled() {
+        let profile = delivery_profile("codex");
+        let prompt = "x".repeat(profile.bracketed_paste.min_bytes);
+        let plan = plan_terminal_payload(&profile, &prompt);
+
+        assert_eq!(plan.payload_kind, PayloadKind::BracketedPaste);
+    }
+
+    #[test]
+    fn plan_uses_literal_when_provider_disables_bracketed_paste() {
+        let profile = delivery_profile("antigravity");
+        let plan = plan_terminal_payload(&profile, "hello\nworld");
+
+        assert_eq!(plan.payload_kind, PayloadKind::Literal);
+        assert_eq!(plan.payload_bytes, b"hello\nworld".to_vec());
+    }
+
+    #[tokio::test]
+    async fn submit_transaction_sends_payload_waits_and_then_submit_key() {
+        let profile = zero_delay_profile("opencode");
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+
+        let outcome = submit_terminal_transaction(&tx, &profile, "hello")
+            .await
+            .expect("submit");
+
+        assert_eq!(rx.recv().await.expect("payload"), b"hello".to_vec());
+        assert_eq!(rx.recv().await.expect("submit key"), b"\x1b[13u".to_vec());
+        assert_eq!(outcome.delivery_state, "submit_sent_unverified");
+        assert_eq!(outcome.delivery_phase, "submit_key_sent");
+        assert_eq!(outcome.observed_state.as_deref(), Some("bytes_sent"));
+        assert_eq!(outcome.reason, None);
+    }
+
+    #[tokio::test]
+    async fn submit_transaction_treats_empty_prompt_as_non_error() {
+        let profile = zero_delay_profile("codex");
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+
+        let outcome = submit_terminal_transaction(&tx, &profile, "")
+            .await
+            .expect("submit");
+
+        assert!(rx.try_recv().is_err());
+        assert_eq!(outcome.delivery_state, "empty");
+        assert_eq!(outcome.delivery_phase, "empty");
+        assert_eq!(outcome.observed_state, None);
+        assert_eq!(
+            outcome.reason.as_deref(),
+            Some("prompt normalized to empty")
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_transaction_marks_submit_key_failure_as_unsafe_to_retry() {
+        let profile = zero_delay_profile("codex");
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1);
+
+        let submit =
+            tokio::spawn(async move { submit_terminal_transaction(&tx, &profile, "hello").await });
+        assert_eq!(rx.recv().await.expect("payload"), b"hello".to_vec());
+        drop(rx);
+
+        let error = submit
+            .await
+            .expect("task")
+            .expect_err("submit key send should fail");
+        assert_eq!(error.phase, "payload_sent_submit_failed");
+        assert!(!error.retry_safe);
+        assert!(error
+            .message
+            .contains("Failed to send prompt submit key after payload send"));
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,5 +1,7 @@
 pub mod app_settings;
 pub mod cli_install;
+pub mod delivery_profile;
+pub mod delivery_transaction;
 pub mod fs;
 pub mod logging;
 pub mod migration;
@@ -12,6 +14,8 @@ pub mod terminal_input;
 
 pub use app_settings::*;
 pub use cli_install::*;
+pub use delivery_profile::*;
+pub use delivery_transaction::*;
 pub use fs::*;
 pub use logging::*;
 pub use onboarding::*;

--- a/src-tauri/src/utils/terminal_input.rs
+++ b/src-tauri/src/utils/terminal_input.rs
@@ -1,11 +1,12 @@
-const TERMINAL_SUBMIT_DELAY_MS: u64 = 1000;
-const TERMINAL_SUBMIT_KEY: &[u8] = b"\r";
-const OPENCODE_SUBMIT_KEY: &[u8] = b"\x1b[13u";
-
+use std::future::Future;
 use tokio::sync::mpsc::Sender;
 
 pub fn normalize_prompt_for_terminal_submit(prompt: &str) -> String {
-    prompt.replace("\r\n", "\n").replace('\r', "\n").trim().to_string()
+    prompt
+        .replace("\r\n", "\n")
+        .replace('\r', "\n")
+        .trim()
+        .to_string()
 }
 
 pub fn provider_submit_chunks(provider_name: &str, prompt: &str) -> Result<Vec<Vec<u8>>, String> {
@@ -14,12 +15,11 @@ pub fn provider_submit_chunks(provider_name: &str, prompt: &str) -> Result<Vec<V
         return Ok(Vec::new());
     }
 
-    let submit_key = if provider_name.eq_ignore_ascii_case("opencode") {
-        OPENCODE_SUBMIT_KEY
-    } else {
-        TERMINAL_SUBMIT_KEY
-    };
-    Ok(vec![normalized.into_bytes(), submit_key.to_vec()])
+    let profile = crate::utils::delivery_profile::delivery_profile(provider_name);
+    Ok(vec![
+        normalized.into_bytes(),
+        profile.submit_key.bytes().to_vec(),
+    ])
 }
 
 pub async fn submit_prompt_chunks_via_sender(
@@ -27,27 +27,61 @@ pub async fn submit_prompt_chunks_via_sender(
     provider_name: &str,
     prompt: &str,
 ) -> Result<(), String> {
-    let chunks = provider_submit_chunks(provider_name, prompt)?;
-    if chunks.is_empty() {
-        return Ok(());
-    }
-
-    tx.send(chunks[0].clone())
+    submit_prompt_with_outcome_chunks_via_sender(tx, provider_name, prompt)
         .await
-        .map_err(|e| format!("Failed to send prompt text: {}", e))?;
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
 
-    // Windows ConPTY can acknowledge large prompt writes before provider TUIs
-    // have finished updating their editor state. Submitting too quickly leaves
-    // Claude/Gemini with text typed but not entered.
-    tokio::time::sleep(std::time::Duration::from_millis(TERMINAL_SUBMIT_DELAY_MS)).await;
+pub async fn submit_prompt_with_outcome_chunks_via_sender(
+    tx: &Sender<Vec<u8>>,
+    provider_name: &str,
+    prompt: &str,
+) -> Result<
+    crate::utils::delivery_transaction::TerminalDeliveryOutcome,
+    crate::utils::delivery_transaction::TerminalDeliveryError,
+> {
+    submit_prompt_with_outcome_chunks_via_sender_after_payload(
+        tx,
+        provider_name,
+        prompt,
+        || async {},
+    )
+    .await
+}
 
-    if let Some(submit_key) = chunks.get(1) {
-        tx.send(submit_key.clone())
-            .await
-            .map_err(|e| format!("Failed to send prompt submit key: {}", e))?;
+pub async fn submit_prompt_with_outcome_chunks_via_sender_after_payload<F, Fut>(
+    tx: &Sender<Vec<u8>>,
+    provider_name: &str,
+    prompt: &str,
+    on_payload_sent: F,
+) -> Result<
+    crate::utils::delivery_transaction::TerminalDeliveryOutcome,
+    crate::utils::delivery_transaction::TerminalDeliveryError,
+>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let normalized = normalize_prompt_for_terminal_submit(prompt);
+    if normalized.is_empty() {
+        let profile = crate::utils::delivery_profile::delivery_profile(provider_name);
+        return crate::utils::delivery_transaction::submit_terminal_transaction(
+            tx,
+            &profile,
+            &normalized,
+        )
+        .await;
     }
 
-    Ok(())
+    let profile = crate::utils::delivery_profile::delivery_profile(provider_name);
+    crate::utils::delivery_transaction::submit_terminal_transaction_with_payload_hook(
+        tx,
+        &profile,
+        &normalized,
+        on_payload_sent,
+    )
+    .await
 }
 
 pub async fn submit_prompt_via_sender(
@@ -58,10 +92,44 @@ pub async fn submit_prompt_via_sender(
     submit_prompt_chunks_via_sender(tx, provider_name, prompt).await
 }
 
+pub async fn submit_prompt_with_outcome_via_sender(
+    tx: &Sender<Vec<u8>>,
+    prompt: &str,
+    provider_name: &str,
+) -> Result<
+    crate::utils::delivery_transaction::TerminalDeliveryOutcome,
+    crate::utils::delivery_transaction::TerminalDeliveryError,
+> {
+    submit_prompt_with_outcome_chunks_via_sender(tx, provider_name, prompt).await
+}
+
+pub async fn submit_prompt_with_outcome_via_sender_after_payload<F, Fut>(
+    tx: &Sender<Vec<u8>>,
+    prompt: &str,
+    provider_name: &str,
+    on_payload_sent: F,
+) -> Result<
+    crate::utils::delivery_transaction::TerminalDeliveryOutcome,
+    crate::utils::delivery_transaction::TerminalDeliveryError,
+>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    submit_prompt_with_outcome_chunks_via_sender_after_payload(
+        tx,
+        provider_name,
+        prompt,
+        on_payload_sent,
+    )
+    .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         normalize_prompt_for_terminal_submit, provider_submit_chunks, submit_prompt_via_sender,
+        submit_prompt_with_outcome_via_sender,
     };
 
     #[test]
@@ -87,10 +155,32 @@ mod tests {
         assert_eq!(second, b"\r".to_vec());
     }
 
+    #[tokio::test]
+    async fn submit_prompt_with_outcome_returns_terminal_delivery_outcome() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+
+        let outcome = submit_prompt_with_outcome_via_sender(&tx, "hello", "gemini")
+            .await
+            .expect("submit prompt");
+
+        assert_eq!(rx.recv().await.expect("payload"), b"hello".to_vec());
+        assert_eq!(rx.recv().await.expect("submit key"), b"\r".to_vec());
+        assert_eq!(outcome.delivery_state, "submit_sent_unverified");
+        assert_eq!(outcome.delivery_phase, "submit_key_sent");
+        assert_eq!(outcome.observed_state.as_deref(), Some("bytes_sent"));
+    }
+
     #[test]
     fn opencode_submit_uses_kitty_protocol_return_key() {
         let chunks = provider_submit_chunks("opencode", "hello").expect("chunks");
 
         assert_eq!(chunks, vec![b"hello".to_vec(), b"\x1b[13u".to_vec()]);
+    }
+
+    #[test]
+    fn legacy_submit_chunks_keep_codex_multiline_literal() {
+        let chunks = provider_submit_chunks("codex", "hello\nworld").expect("chunks");
+
+        assert_eq!(chunks, vec![b"hello\nworld".to_vec(), b"\r".to_vec()]);
     }
 }


### PR DESCRIPTION
## Description
Adds provider-aware CLI delivery transport for Wardian agents:

- introduces explicit queue policy and approval-action command shapes
- routes idle targets through provider-aware terminal submit profiles/transactions
- adds a live mailbox lane for busy/action-required targets and drains queued messages at idle-safe boundaries
- gates queued `ask --until output/status` waits on same-message payload submission evidence, while preserving delivery-condition waits
- preserves structured ask replies when watch evidence collection degrades
- documents the current live mailbox scope and durable-mailbox follow-ups

## Related Issues
Fixes #355

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` (82 files / 793 tests passed; existing mocked-readiness and React act warnings still print to stderr)
- `npm run build`
- `npm run check:frontend-screenshot` (no frontend changes detected)
- `cargo fmt --check`
- `cargo test -p wardian-core` (66 passed)
- `cargo test -p wardian-cli` (unit and integration suites passed)
- `cd src-tauri && cargo test --lib` (684 passed)
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo clippy --all-targets --all-features`
- `node --check scripts/mock-agent.cjs`
- `node --check e2e-native/tests/cli-shared-state-native.test.mjs`
- `node --check e2e-native/tests/provider-delivery-real-native.test.mjs`
- `node --test --test-concurrency=1 e2e-native/tests/cli-shared-state-native.test.mjs` (7 passed, 1 real-provider opt-in test skipped)
- `git diff --check`
- secret-pattern scan with `rg` for common API key patterns: no matches
- Wardian subagent review on the final intended diff: Ready, no blocker/high findings

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable