### PR TITLE
fix(terminal): WebGL leak, clear-time PTY race, codex dedup, cursor style

### DIFF
--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -9,7 +9,7 @@ use crate::utils::logging::{log_debug, log_terminal_trace_bytes, log_terminal_tr
 use crate::utils::PtyUtf8Decoder;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use std::io::{BufRead, Read, Seek, Write};
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
 use wardian_core::models::{AgentConfig, AgentEvent, ProviderConfig};
 
 use super::claude::{claude_permission_hook_matches_session, claude_project_dir_name};
@@ -245,10 +245,19 @@ pub async fn spawn_agent(
 
     let pty_system = NativePtySystem::default();
 
+    let (initial_cols, initial_rows) = {
+        let app_state = app.state::<AppState>();
+        let sizes = app_state.pty_sizes.read().ok();
+        sizes
+            .as_ref()
+            .and_then(|sizes| sizes.get(&config.session_id).copied())
+            .unwrap_or((80, 24))
+    };
+
     let pair = pty_system
         .openpty(PtySize {
-            rows: 24,
-            cols: 80,
+            rows: initial_rows,
+            cols: initial_cols,
             pixel_width: 0,
             pixel_height: 0,
         })
@@ -1358,6 +1367,10 @@ pub async fn resize_pty(
     .await
     .map_err(|e| format!("Failed to join PTY resize task: {}", e))?
     .map_err(|e| format!("Failed to resize PTY: {}", e))?;
+
+    if let Ok(mut sizes) = state.pty_sizes.write() {
+        sizes.insert(session_id, (cols, rows));
+    }
     Ok(())
 }
 

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -38,6 +38,10 @@ pub struct AppState {
     pub ask_requests: Mutex<HashMap<String, AskRequestRecord>>,
     // Live-only remote-control authentication and ticket records.
     pub remote_runtime: Mutex<crate::remote::models::RemoteRuntimeState>,
+    // Last frontend-reported PTY size per session. Used to open a freshly-spawned
+    // PTY at the user's actual terminal dimensions instead of the 80x24 default,
+    // which otherwise causes deformed/duplicated TUI output across clear/resume.
+    pub pty_sizes: RwLock<HashMap<String, (u16, u16)>>,
 }
 
 #[derive(Debug, Clone)]
@@ -74,6 +78,7 @@ impl Default for AppState {
             user_terminal: Mutex::new(None),
             ask_requests: Mutex::new(HashMap::new()),
             remote_runtime: Mutex::new(crate::remote::models::RemoteRuntimeState::default()),
+            pty_sizes: RwLock::new(HashMap::new()),
         }
     }
 }

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -150,7 +150,7 @@ describe("AgentTerminal scrollback", () => {
     expect(shouldExposeTerminalDebug({ DEV: false, VITE_WARDIAN_TERMINAL_DEBUG: "1" })).toBe(true);
   });
 
-  it("reuses the live xterm instance on remount while preserving prior session state", async () => {
+  it("recreates the xterm on remount and seeds it from the persisted parser state", async () => {
     const firstRender = render(
       <AgentTerminal sessionId="codex-1" theme="dark" />,
     );
@@ -160,19 +160,19 @@ describe("AgentTerminal scrollback", () => {
       expect(firstInstance.write).toHaveBeenCalledWith("hello from codex\n", expect.any(Function));
     });
 
+    const firstInstance = getLatestTerminalInstance();
     firstRender.unmount();
+    expect(firstInstance.dispose).toHaveBeenCalled();
 
     render(<AgentTerminal sessionId="codex-1" theme="dark" />);
 
     await waitFor(() => {
-      expect(mockTerminal).toHaveBeenCalledTimes(1);
+      expect(mockTerminal).toHaveBeenCalledTimes(2);
     });
 
-    await waitFor(() => {
-      const secondInstance = getLatestTerminalInstance();
-      expect(secondInstance.write).toHaveBeenCalledWith("hello from codex\n", expect.any(Function));
-    });
-
+    const secondInstance = getLatestTerminalInstance();
+    expect(secondInstance).not.toBe(firstInstance);
+    expect(secondInstance.open).toHaveBeenCalled();
   });
 
   it("captures readable terminal output for queue summaries", async () => {
@@ -656,7 +656,7 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
-  it("re-reports the current PTY size after a backend terminal clear even when the card size did not change", async () => {
+  it("force-resizes the new PTY on its first output after a backend terminal clear", async () => {
     const listeners = new Map<string, (event: { payload: { session_id: string } }) => void>();
 
     mockListen.mockImplementation(async (eventName, handler) => {
@@ -672,10 +672,21 @@ describe("AgentTerminal scrollback", () => {
     await waitFor(() => {
       expect(listeners.has("agent-terminal-cleared")).toBe(true);
     });
-    mockInvoke.mockClear();
 
+    mockInvoke.mockClear();
     act(() => {
       listeners.get("agent-terminal-cleared")?.({ payload: { session_id: "gemini-clear-size" } });
+    });
+
+    // Clear must not resize against the dead PTY — backend hasn't spawned the
+    // replacement yet, so any invoke here would silently fail and poison state.
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "resize_agent_terminal",
+      expect.objectContaining({ sessionId: "gemini-clear-size" }),
+    );
+
+    act(() => {
+      listeners.get("agent-pty-output-ready")?.({ payload: { session_id: "gemini-clear-size" } });
     });
 
     await waitFor(() => {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -73,6 +73,7 @@ type TerminalSessionEntry = {
   drainQueued: boolean;
   generation: number;
   disposed: boolean;
+  pendingForceResize: boolean;
 } & TerminalOutputState;
 
 const terminalSessionMap = new Map<string, TerminalSessionEntry>();
@@ -131,7 +132,6 @@ declare global {
         allLines: string[];
         recentWritePreviews: string[];
         recentNormalizedWritePreviews: string[];
-        lastStableHomeRedrawPreview: string | null;
       } | null;
     };
   }
@@ -236,13 +236,6 @@ if (typeof window !== "undefined" && shouldExposeTerminalDebug()) {
           allLines,
         recentWritePreviews: [...entry.recentWritePreviews],
         recentNormalizedWritePreviews: [...entry.recentNormalizedWritePreviews],
-        lastStableHomeRedrawPreview: entry.lastStableHomeRedrawOutput
-          ? entry.lastStableHomeRedrawOutput
-              .replace(/\u001b/g, "\\x1b")
-              .replace(/\r/g, "\\r")
-              .replace(/\n/g, "\\n")
-              .slice(0, 300)
-          : null,
       };
       },
     }),
@@ -270,11 +263,16 @@ function terminalCursorPositionReply(entry: TerminalSessionEntry) {
   return { row, col };
 }
 
-function readParserScrollbackLineSet(entry: TerminalSessionEntry) {
+function readParserKnownLineSet(entry: TerminalSessionEntry) {
+  // Include both scrollback (0..baseY-1) and the viewport (baseY..length-1).
+  // Codex home-redraw reconstruction uses this set to decide whether a "dropped"
+  // line is already represented somewhere in the parser buffer. Without viewport
+  // coverage, a content shuffle that the drop heuristic misidentifies can push a
+  // still-visible line into scrollback, duplicating it.
   const buffer = entry.parser.buffer.active;
-  const scrollbackLineCount = Math.max(0, buffer.baseY ?? 0);
+  const lineCount = Math.max(0, buffer.length ?? 0);
   return new Set(
-    Array.from({ length: scrollbackLineCount }, (_, index) =>
+    Array.from({ length: lineCount }, (_, index) =>
       buffer.getLine(index)?.translateToString(true).replace(/\s+/g, " ").trim() || "",
     ).filter(Boolean),
   );
@@ -325,19 +323,21 @@ function disposeTerminalSession(sessionId: string) {
   entry.disposed = true;
   entry.outputReadyUnlisten?.();
   entry.terminalClearedUnlisten?.();
-  const renderer = entry.renderer;
-  if (renderer?.resizeTimeout) {
-    clearTimeout(renderer.resizeTimeout);
+  if (entry.renderer) {
+    disposeRenderer(entry.renderer);
+    entry.renderer = null;
   }
-  if (renderer?.fitTimeout) {
-    clearTimeout(renderer.fitTimeout);
-  }
-  renderer?.serializeAddon.dispose();
-  renderer?.webglAddon?.dispose();
-  renderer?.term.dispose();
   entry.parserSerializeAddon.dispose();
   entry.parser.dispose();
   terminalSessionMap.delete(sessionId);
+}
+
+function disposeRenderer(renderer: TerminalRendererEntry) {
+  clearRendererTimers(renderer);
+  renderer.serializeAddon.dispose();
+  renderer.webglAddon?.dispose();
+  renderer.webglAddon = null;
+  renderer.term.dispose();
 }
 function clearTerminalSession(sessionId: string) {
   const entry = terminalSessionMap.get(sessionId);
@@ -356,8 +356,7 @@ function clearTerminalSession(sessionId: string) {
   entry.lastHomeRedrawLines = null;
   entry.homeRedrawScrollbackSeen?.clear();
   entry.transientHomeRedrawActive = false;
-  entry.existingScrollbackLines = undefined;
-  entry.lastStableHomeRedrawOutput = undefined;
+  entry.existingKnownLines = undefined;
 
   const parserWithReset = entry.parser as HeadlessTerminal & { reset?: () => void };
   if (typeof parserWithReset.reset === "function") {
@@ -371,9 +370,13 @@ function clearTerminalSession(sessionId: string) {
     entry.renderer.term.reset();
     entry.renderer.term.scrollToBottom();
     entry.renderer.term.refresh(0, Math.max(0, entry.renderer.term.rows - 1));
-    void reportTerminalSize(sessionId, entry, entry.renderer.term.cols, entry.renderer.term.rows);
   }
-  
+
+  // The backend emits agent-terminal-cleared before the new PTY is spawned,
+  // so we can't usefully resize here. Flag a force-resize that drainPty will
+  // run on the next agent-pty-output-ready, by which point the new PTY exists.
+  entry.pendingForceResize = true;
+
   entry.titleHandlerRef.current?.("");
 }
 
@@ -393,8 +396,13 @@ async function reportTerminalSize(
     return;
   }
 
-  entry.lastReportedSize = { cols, rows };
-  await invoke("resize_agent_terminal", { sessionId, cols, rows }).catch(() => {});
+  try {
+    await invoke("resize_agent_terminal", { sessionId, cols, rows });
+    entry.lastReportedSize = { cols, rows };
+  } catch {
+    // Leave lastReportedSize untouched so the next fit can retry. Poisoning the
+    // cache here would block resizes for PTYs that come back up (e.g. after clear).
+  }
 }
 
 async function fitTerminalToContainer(
@@ -461,6 +469,16 @@ async function drainPty(sessionId: string) {
 
   entry.drainInFlight = true;
   try {
+    if (entry.pendingForceResize && entry.renderer) {
+      entry.pendingForceResize = false;
+      await reportTerminalSize(
+        sessionId,
+        entry,
+        entry.renderer.term.cols,
+        entry.renderer.term.rows,
+        { force: true },
+      );
+    }
     do {
       entry.drainQueued = false;
       const drainGeneration = entry.generation;
@@ -490,7 +508,7 @@ async function drainPty(sessionId: string) {
       }
 
       if (rawChunks.length > 0) {
-        entry.existingScrollbackLines = readParserScrollbackLineSet(entry);
+        entry.existingKnownLines = readParserKnownLineSet(entry);
         const batchedWrite = normalizeTerminalOutputBatch(rawChunks, entry.provider, entry);
         const rendererWasAtBottom = entry.renderer
           ? entry.renderer.term.buffer.active.viewportY >= entry.renderer.term.buffer.active.baseY
@@ -506,7 +524,7 @@ async function drainPty(sessionId: string) {
           entry.recentNormalizedWritePreviews.splice(0, entry.recentNormalizedWritePreviews.length - 12);
         }
         useQueueStore.getState().appendAgentTerminalOutput(sessionId, batchedWrite, entry.provider);
-        entry.existingScrollbackLines = undefined;
+        entry.existingKnownLines = undefined;
         entry.parser.write(batchedWrite);
         if (entry.renderer) {
           entry.renderer.term.write(batchedWrite, () => {
@@ -575,6 +593,7 @@ async function getOrCreateTerminalSession(sessionId: string, provider?: string) 
     drainQueued: false,
     generation: 0,
     disposed: false,
+    pendingForceResize: false,
     lastHomeRedrawLines: null,
     homeRedrawScrollbackSeen: new Set(),
     transientHomeRedrawActive: false,
@@ -651,6 +670,8 @@ function createRenderer(sessionId: string, entry: TerminalSessionEntry) {
     fontSize: terminalFontSize,
     customGlyphs: true,
     cursorBlink: true,
+    cursorStyle: "bar",
+    cursorInactiveStyle: "bar",
     scrollback: TERMINAL_SCROLLBACK_LINES,
     allowProposedApi: true,
     convertEol: false,
@@ -797,7 +818,6 @@ function mountRenderer(
     }
 
     renderer.term.open(renderer.host);
-    activateWebglRenderer(renderer);
   }
   attachRendererHost(session, container);
   activateWebglRenderer(renderer);
@@ -945,8 +965,9 @@ export const AgentTerminal = memo(function AgentTerminal({
     return () => {
       isMounted = false;
       resizeObserver?.disconnect();
-      if (entry?.renderer) {
-        clearRendererTimers(entry.renderer);
+      if (entry && !entry.disposed && entry.renderer) {
+        disposeRenderer(entry.renderer);
+        entry.renderer = null;
       }
       if (entry && entry.titleHandlerRef.current === onTitleChangeRef.current) {
         entry.titleHandlerRef.current = undefined;

--- a/src/features/terminal/UserTerminalPanel.tsx
+++ b/src/features/terminal/UserTerminalPanel.tsx
@@ -146,6 +146,8 @@ export function UserTerminalPanel({
       allowProposedApi: true,
       convertEol: false,
       cursorBlink: true,
+      cursorStyle: "bar",
+      cursorInactiveStyle: "bar",
       fontFamily: effectiveTerminalFontFamily(terminalFontFamily),
       fontSize: terminalFontSize,
       scrollback: 2_000,

--- a/src/features/terminal/terminalCapabilities.test.ts
+++ b/src/features/terminal/terminalCapabilities.test.ts
@@ -169,7 +169,6 @@ describe("terminal capability broker", () => {
   it("preserves partial Codex numbered redraw chunks after a complete audit response is stable", () => {
     const state: TerminalOutputState = {
       lastHomeRedrawLines: null,
-      lastStableHomeRedrawOutput: "ROW_001\r\nROW_050",
     };
     const partialResizeChunk = Array.from({ length: 48 }, (_, index) =>
       `ROW_${String(index + 1).padStart(3, "0")}`,
@@ -271,7 +270,7 @@ describe("terminal capability broker", () => {
   it("preserves Claude resize repaint frames without synthetic scrollback repair", () => {
     const state: TerminalOutputState = {
       lastHomeRedrawLines: null,
-      existingScrollbackLines: new Set([
+      existingKnownLines: new Set([
         " ▐▛███▜▌   Claude Code v2.1.140",
         "❯ CCopy the exact 50-line block below and output nothing else:",
         "important earlier conversation line",
@@ -289,7 +288,6 @@ describe("terminal capability broker", () => {
   it("preserves legitimate lower-numbered Codex output after a previous numbered response", () => {
     const state: TerminalOutputState = {
       lastHomeRedrawLines: null,
-      lastStableHomeRedrawOutput: "Step 1\r\nStep 10",
     };
     const nextResponse =
       "\u001b[?25l\u001b[HStep 1\u001b[K\r\nStep 2\u001b[K\r\nStep 3\u001b[K";
@@ -438,11 +436,27 @@ describe("terminal capability broker", () => {
   it("preserves Codex redraw lines that already exist in scrollback", () => {
     const state: TerminalOutputState = {
       lastHomeRedrawLines: ["already in scrollback", "visible next", "visible tail"],
-      existingScrollbackLines: new Set(["already in scrollback"]),
+      existingKnownLines: new Set(["already in scrollback"]),
     };
     const nextFrame = "\u001b[?25l\u001b[Hvisible next\u001b[K\r\nvisible tail\u001b[K\r\nfresh\u001b[K";
 
     expect(normalizeOpenCodeOutput(nextFrame, "codex", state)).toBe(nextFrame);
+  });
+
+  it("does not push a Codex line into scrollback if it is still in the viewport after a shuffle", () => {
+    // Codex sometimes repaints with a reordered frame where no line actually
+    // scrolled off the top. The findDroppedHomeRedrawLines suffix-match misses
+    // and the fallback flags lines as "dropped" purely because they moved.
+    // existingKnownLines covers the parser's viewport, so dedupe should skip
+    // the false positive and leave the frame untouched.
+    const shuffleState: TerminalOutputState = {
+      lastHomeRedrawLines: ["foo", "bar", "baz", "qux"],
+      existingKnownLines: new Set(["foo", "bar", "baz", "qux"]),
+    };
+    const shuffleFrame =
+      "[?25l[Hqux[K\r\nfoo[K\r\nbar[K\r\nbaz[K";
+
+    expect(normalizeOpenCodeOutput(shuffleFrame, "codex", shuffleState)).toBe(shuffleFrame);
   });
 
   it("journals non-overlapping Codex home-redraw frames without repeating seen lines", () => {

--- a/src/features/terminal/terminalCapabilities.ts
+++ b/src/features/terminal/terminalCapabilities.ts
@@ -38,9 +38,11 @@ export type TerminalCapabilityPlan = {
 export type TerminalOutputState = {
   lastHomeRedrawLines: string[] | null;
   homeRedrawScrollbackSeen?: Set<string>;
-  existingScrollbackLines?: Set<string>;
+  // Lines already represented in the parser buffer (scrollback + viewport).
+  // Used by home-redraw reconstruction to avoid pushing duplicates when the
+  // drop heuristic misfires on content shuffles.
+  existingKnownLines?: Set<string>;
   transientHomeRedrawActive?: boolean;
-  lastStableHomeRedrawOutput?: string;
 };
 
 const ANSI_SEQUENCE = /\u001b\][^\u0007]*(?:\u0007|\u001b\\)|\u001b\[[0-?]*[ -/]*[@-~]/g;
@@ -260,9 +262,8 @@ function reconstructHomeRedrawScrollback(
     const normalizedLine = normalizePlainLine(line);
     if (
       seen.has(normalizedLine) ||
-      state.existingScrollbackLines?.has(normalizedLine) ||
-      state.existingScrollbackLines?.has(line) ||
-      (normalizedLine && state.existingScrollbackLines?.has(normalizedLine))
+      state.existingKnownLines?.has(normalizedLine) ||
+      state.existingKnownLines?.has(line)
     ) {
       return false;
     }


### PR DESCRIPTION
## Summary

Four related fixes in the terminal subsystem, found while chasing a `Too many active WebGL contexts` warning and pulling on the threads it exposed.

### 1. WebGL context leak on `AgentTerminal` unmount
- `terminalSessionMap` retained the xterm `Terminal` + `WebglAddon` for every session ever opened. Chrome caps WebGL contexts (~16) — past that point Chrome force-evicts the oldest context and logs the warning.
- The React unmount cleanup now disposes the renderer (new `disposeRenderer` helper extracted from `disposeTerminalSession`). The headless `parser` + `parserSerializeAddon` persist on the session entry, so remount creates a fresh xterm and reseeds from the serialized state.
- Also: removed a duplicate `activateWebglRenderer` call inside `mountRenderer` and consolidated timer cleanup through `clearRendererTimers`.

### 2. `clear` command produced deformed/duplicated terminal output
Two collaborating bugs:
- **Backend**: `spawn_agent` opened every new PTY at hardcoded `80×24` (`src-tauri/src/manager/spawn.rs`). After a clear, the new TUI started drawing at 80×24 inside the user's much larger viewport — lines wrapped, the bottom rows showed stale content, and cursor-relative redraws produced visible artifacts.
- **Frontend**: `clearTerminalSession` called `reportTerminalSize` *against the dead/not-yet-spawned PTY*. The invoke failed silently, but `lastReportedSize` was set *before* awaiting the invoke, poisoning the cache. The next fit then proposed the same dimensions, matched the poisoned cache, and skipped resizing — so the new PTY stayed at 80×24 indefinitely.

Fix:
- Backend now caches last reported PTY size per session on `AppState.pty_sizes`; `resize_pty` writes successful resizes; `spawn_agent` consults it and opens new PTYs at the user's actual dimensions (falling back to 80×24 only on first ever spawn).
- Frontend: `clearTerminalSession` no longer calls `reportTerminalSize` — it sets a `pendingForceResize` flag instead. `drainPty` consumes that flag on the next `agent-pty-output-ready`, at which point the new PTY is alive and a force-resize syncs dimensions before reading.
- `reportTerminalSize` now caches `lastReportedSize` only after the invoke succeeds, so transient failures can no longer block future resizes.

### 3. Codex duplicated lines
`reconstructHomeRedrawScrollback` preserves content that scrolls off the top of a codex home-redraw by synthesizing a `^[[999;1H<line>\r\n` prelude. `findDroppedHomeRedrawLines` uses suffix matching, falling back to set-difference when no suffix matches. The fallback flags any line that just *moved* as "dropped" — and the dedupe guard (`existingScrollbackLines`) only sampled the parser's scrollback (`0..baseY`), missing the viewport. Result: a content shuffle would push a still-visible line into scrollback, where the natural overwrite would then leave the same text on screen — duplicate.

Fix: `readParserScrollbackLineSet` now walks the full parser buffer (renamed `readParserKnownLineSet`). Field on `TerminalOutputState` renamed `existingScrollbackLines` → `existingKnownLines` with a doc comment, to keep the misnomer from hiding the same class of bug again. Added a regression test for the shuffle pattern.

### 4. Terminal cursor style
Default `cursorStyle: "bar"` and `cursorInactiveStyle: "bar"` on `AgentTerminal` and `UserTerminalPanel`. TUI providers still win via DECSCUSR; this affects pre-init and non-TUI sessions.

![Terminal cursor — block (before) vs bar (after)](https://github.com/wardian-app/Wardian/releases/download/_gh-attach-assets/before-after.png)


### Cleanup
- Removed dead `lastStableHomeRedrawOutput` field — declared and reset but never written to, only surfaced as a perpetually-null debug field.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run test` — 794 passed (one new regression test for codex shuffle dedupe; updated tests for renderer disposal on remount and force-resize after clear)
- [x] `npm run build` — clean
- [x] `cd src-tauri && cargo check` — clean
- [x] `cd src-tauri && cargo clippy --no-deps` — clean
- [ ] Manual: confirm no `Too many active WebGL contexts` warning after opening many agents and tabbing between them
- [ ] Manual: confirm `wardian clear` produces a clean fresh terminal at the right dimensions across providers
- [ ] Manual: confirm codex no longer duplicates lines on content shuffle

> Note: `cargo test --lib` has pre-existing compile errors in `src-tauri/src/control.rs` (`AskResponse`/`DeliveryDetail` struct field drift) — confirmed by running against a stashed clean tree. Unrelated to this PR.
