### PR TITLE
ci: run full test suite on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Lint (TypeScript)
         run: npm run lint
       - name: Unit Tests
-        if: github.event_name == 'pull_request'
         run: npm run test
       - name: Coverage Report
         if: github.event_name == 'pull_request'
@@ -62,7 +61,6 @@ jobs:
   backend-windows:
     name: Backend (Windows - Lint, Test & Check)
     runs-on: windows-latest
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -115,7 +113,6 @@ jobs:
   backend-linux-coverage:
     name: Backend (Linux - Test & Coverage)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Install system dependencies

--- a/src/config/ciWorkflow.test.ts
+++ b/src/config/ciWorkflow.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import ciWorkflow from "../../.github/workflows/ci.yml?raw";
+
+describe("CI workflow contract", () => {
+  it("runs test jobs on main branch pushes as well as pull requests", () => {
+    expect(ciWorkflow).not.toContain("Unit Tests\n        if: github.event_name == 'pull_request'");
+    expect(ciWorkflow).not.toContain("backend-windows:\n    name: Backend (Windows - Lint, Test & Check)\n    runs-on: windows-latest\n    if: github.event_name == 'pull_request'");
+    expect(ciWorkflow).not.toContain("backend-linux-coverage:\n    name: Backend (Linux - Test & Coverage)\n    runs-on: ubuntu-latest\n    if: github.event_name == 'pull_request'");
+    expect(ciWorkflow).toContain("run: npm run test");
+    expect(ciWorkflow).toContain("cargo clippy --workspace -- -D warnings");
+    expect(ciWorkflow).toContain("cargo test --workspace");
+    expect(ciWorkflow).toContain("cargo check --workspace");
+    expect(ciWorkflow).toContain("cargo llvm-cov --workspace --lcov --output-path coverage/rust-lcov.info");
+  });
+});


### PR DESCRIPTION
## Description
Restores full main-branch CI coverage now that Actions minute limits are no longer the constraint:

- runs frontend unit tests on `push` to `main`, not only pull requests
- runs Windows backend clippy/test/check on `push` to `main`, not only pull requests
- runs Linux backend coverage tests on `push` to `main`, not only pull requests
- adds a workflow contract test to keep these jobs from regressing back to PR-only gates

## Related Issues
N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation/tooling update

## How Has This Been Tested?
- `npm run test -- src/config/ciWorkflow.test.ts`
- `npm run lint`
- `npm run test`
- `npm run build`

`actionlint` was not run locally because it is not installed on this machine.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable