### PR TITLE
fix(providers): prevent antigravity watcher from auto-resuming on clear

### DIFF
--- a/docs/specs/2026-05-23-antigravity-clear-design.md
+++ b/docs/specs/2026-05-23-antigravity-clear-design.md
@@ -1,0 +1,24 @@
+# Antigravity Clear Session Fix
+
+- **Status:** Proposed
+- **Date:** 2026-05-23
+- **Decider:** Antigravity and Wardian maintainers
+
+## Context
+
+For `antigravity` agents, clearing the session using Wardian's clear command resets the internal config state (specifically setting `resume_session = None`), but doesn't prevent the background watcher thread from immediately falling back to and resuming the prior session. 
+
+When a session is cleared, `spawn_agent` is called with `is_restored = false` (which maps to `watcher_skip_existing_log = false` in the watcher thread). Since `config.resume_session` is `None`, the watcher thread immediately auto-detects the last active session ID from the workspace cache (`last_conversations.json`) or the newest conversation ID under `brain/`. It writes this prior conversation ID back to `config.resume_session`, resuming it and polling its log path, even though the spawned `agy` process is running a brand new conversation.
+
+## Decision
+
+To allow `antigravity` agents to be fully cleared and reset:
+
+1. In the watcher thread logic inside `src-tauri/src/manager/spawn.rs`, when the thread is started with `is_restored = false` (fresh launch or cleared launch), capture the conversation ID currently stored in the workspace cache or `brain/` directories as the `initial_conv_id`.
+2. Inside the watcher loop, when detecting the conversation ID to monitor, if the detected ID matches `initial_conv_id`, treat it as `None` (ignore it).
+3. Once the freshly spawned `agy` process writes a brand new conversation ID (which will not match `initial_conv_id`), the watcher thread will detect and lock onto it.
+
+## Consequences
+
+- Antigravity agents can be successfully cleared. The prior session will not be auto-resumed when starting a fresh session.
+- No schema changes are required in `AgentConfig` or `AntigravityProviderConfig`.

--- a/docs/specs/2026-05-23-antigravity-clear-design.md
+++ b/docs/specs/2026-05-23-antigravity-clear-design.md
@@ -1,6 +1,6 @@
 # Antigravity Clear Session Fix
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-23
 - **Decider:** Antigravity and Wardian maintainers
 

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -1188,6 +1188,24 @@ pub async fn spawn_agent(
         let watcher_skip_existing_log = is_restored;
         let watcher_workspace = cwd.clone();
 
+        let initial_ignored_conversation_id = if !watcher_skip_existing_log {
+            let home = AntigravityProvider::antigravity_home();
+            home.as_ref()
+                .and_then(|home| {
+                    AntigravityProvider::conversation_for_workspace(
+                        home,
+                        &watcher_workspace,
+                    )
+                })
+                .or_else(|| {
+                    home.as_ref().and_then(|home| {
+                        AntigravityProvider::latest_conversation_id(home)
+                    })
+                })
+        } else {
+            None
+        };
+
         std::thread::spawn(move || {
             let mut offset: u64 = 0;
             let mut positioned_initial_log = !watcher_skip_existing_log;
@@ -1210,7 +1228,7 @@ pub async fn spawn_agent(
                             .filter(|value| !value.is_empty())
                     });
                     configured.or_else(|| {
-                        home.as_ref()
+                        let detected = home.as_ref()
                             .and_then(|home| {
                                 AntigravityProvider::conversation_for_workspace(
                                     home,
@@ -1221,7 +1239,15 @@ pub async fn spawn_agent(
                                 home.as_ref().and_then(|home| {
                                     AntigravityProvider::latest_conversation_id(home)
                                 })
-                            })
+                            });
+                        if let Some(ref detected_id) = detected {
+                            if let Some(ref ignored_id) = initial_ignored_conversation_id {
+                                if detected_id == ignored_id {
+                                    return None;
+                                }
+                            }
+                        }
+                        detected
                     })
                 };
 

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -175,6 +175,20 @@ fn should_cleanup_stale_session_processes_before_spawn(is_restored: bool) -> boo
     !is_restored
 }
 
+fn filter_ignored_conversation_id(
+    detected: Option<String>,
+    ignored: Option<&str>,
+) -> Option<String> {
+    if let Some(ref detected_id) = detected {
+        if let Some(ignored_id) = ignored {
+            if detected_id == ignored_id {
+                return None;
+            }
+        }
+    }
+    detected
+}
+
 pub async fn spawn_agent(
     app: AppHandle,
     config: AgentConfig,
@@ -237,6 +251,24 @@ pub async fn spawn_agent(
     }
 
     let config_lock = std::sync::Arc::new(std::sync::Mutex::new(config.clone()));
+
+    let initial_ignored_conversation_id = if config.provider == "antigravity" && !is_restored {
+        let home = AntigravityProvider::antigravity_home();
+        home.as_ref()
+            .and_then(|home| {
+                AntigravityProvider::conversation_for_workspace(
+                    home,
+                    &cwd,
+                )
+            })
+            .or_else(|| {
+                home.as_ref().and_then(|home| {
+                    AntigravityProvider::latest_conversation_id(home)
+                })
+            })
+    } else {
+        None
+    };
 
     #[cfg(windows)]
     if should_cleanup_stale_session_processes_before_spawn(is_restored) {
@@ -1187,24 +1219,7 @@ pub async fn spawn_agent(
         let watcher_watch_state = watch_state.clone();
         let watcher_skip_existing_log = is_restored;
         let watcher_workspace = cwd.clone();
-
-        let initial_ignored_conversation_id = if !watcher_skip_existing_log {
-            let home = AntigravityProvider::antigravity_home();
-            home.as_ref()
-                .and_then(|home| {
-                    AntigravityProvider::conversation_for_workspace(
-                        home,
-                        &watcher_workspace,
-                    )
-                })
-                .or_else(|| {
-                    home.as_ref().and_then(|home| {
-                        AntigravityProvider::latest_conversation_id(home)
-                    })
-                })
-        } else {
-            None
-        };
+        let initial_ignored = initial_ignored_conversation_id.clone();
 
         std::thread::spawn(move || {
             let mut offset: u64 = 0;
@@ -1221,12 +1236,13 @@ pub async fn spawn_agent(
 
                 let home = AntigravityProvider::antigravity_home();
                 let conversation_id = {
-                    let configured = watcher_config.lock().ok().and_then(|cfg| {
+                    let configured = {
+                        let cfg = watcher_config.lock().unwrap_or_else(|e| e.into_inner());
                         cfg.resume_session
                             .as_ref()
                             .map(|value| value.trim().to_string())
                             .filter(|value| !value.is_empty())
-                    });
+                    };
                     configured.or_else(|| {
                         let detected = home.as_ref()
                             .and_then(|home| {
@@ -1240,14 +1256,7 @@ pub async fn spawn_agent(
                                     AntigravityProvider::latest_conversation_id(home)
                                 })
                             });
-                        if let Some(ref detected_id) = detected {
-                            if let Some(ref ignored_id) = initial_ignored_conversation_id {
-                                if detected_id == ignored_id {
-                                    return None;
-                                }
-                            }
-                        }
-                        detected
+                        filter_ignored_conversation_id(detected, initial_ignored.as_deref())
                     })
                 };
 
@@ -1479,5 +1488,25 @@ mod tests {
             OutputReadyEmitAction::Suppress
         );
         assert!(gate.finish_delayed_emit(true, start + OUTPUT_READY_EMIT_MIN_INTERVAL));
+    }
+
+    #[test]
+    fn test_filter_ignored_conversation_id() {
+        assert_eq!(
+            filter_ignored_conversation_id(Some("conv_abc".to_string()), Some("conv_abc")),
+            None
+        );
+        assert_eq!(
+            filter_ignored_conversation_id(Some("conv_xyz".to_string()), Some("conv_abc")),
+            Some("conv_xyz".to_string())
+        );
+        assert_eq!(
+            filter_ignored_conversation_id(Some("conv_abc".to_string()), None),
+            Some("conv_abc".to_string())
+        );
+        assert_eq!(
+            filter_ignored_conversation_id(None, Some("conv_abc")),
+            None
+        );
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the issue where Wardian's clear command for `antigravity` agents does not prevent the background watcher thread from immediately falling back to and resuming the prior session. 

The background watcher thread has been updated to pre-calculate the prior conversation ID (if starting a fresh/cleared session). Inside the loop, it ignores that conversation ID, waiting instead for the newly spawned `agy` process to write its new session ID to the workspace cache.

We also resolved an inconsistent lock recovery pattern in `spawn.rs`, extracted the filter logic to `filter_ignored_conversation_id`, and added unit tests for this function.

## Related Issues
Fixes #314

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## How Has This Been Tested?
Ran the Rust unit test suite:
- `cargo test` (which passed, including the new unit test `test_filter_ignored_conversation_id`).

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
