### PR TITLE
fix(runtime): isolate debug app home

### DIFF
--- a/crates/wardian-core/src/paths.rs
+++ b/crates/wardian-core/src/paths.rs
@@ -1,36 +1,82 @@
 use std::path::{Path, PathBuf};
 
 pub fn wardian_home() -> Option<PathBuf> {
-    if let Ok(value) = std::env::var("WARDIAN_HOME") {
-        if !value.trim().is_empty() {
-            return Some(PathBuf::from(value));
-        }
+    if let Some(home) = wardian_home_env() {
+        return Some(home);
     }
 
-    dirs::home_dir().map(|home| home.join(".wardian"))
+    default_production_home()
 }
 
 pub fn wardian_home_for_manifest(manifest_dir: &Path) -> Option<PathBuf> {
-    if let Ok(value) = std::env::var("WARDIAN_HOME") {
-        if !value.trim().is_empty() {
-            return Some(PathBuf::from(value));
-        }
-    }
-
     #[cfg(debug_assertions)]
     {
-        Some(
-            debug_target_dir_for_manifest(manifest_dir)
-                .join("debug")
-                .join(".wardian"),
-        )
+        let debug_home = debug_home_for_manifest(manifest_dir);
+        if let Some(env_home) = wardian_home_env() {
+            let production_home = default_production_home();
+            if debug_production_home_allowed()
+                || production_home
+                    .as_ref()
+                    .is_none_or(|home| !same_path_lexically(&env_home, home))
+            {
+                return Some(env_home);
+            }
+        }
+
+        Some(debug_home)
     }
 
     #[cfg(not(debug_assertions))]
     {
         let _ = manifest_dir;
-        dirs::home_dir().map(|home| home.join(".wardian"))
+        wardian_home()
     }
+}
+
+fn wardian_home_env() -> Option<PathBuf> {
+    std::env::var("WARDIAN_HOME").ok().and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+    })
+}
+
+fn default_production_home() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".wardian"))
+}
+
+#[cfg(debug_assertions)]
+fn debug_home_for_manifest(manifest_dir: &Path) -> PathBuf {
+    debug_target_dir_for_manifest(manifest_dir)
+        .join("debug")
+        .join(".wardian")
+}
+
+#[cfg(debug_assertions)]
+fn debug_production_home_allowed() -> bool {
+    std::env::var("WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME")
+        .map(|value| value.trim() == "1")
+        .unwrap_or(false)
+}
+
+#[cfg(debug_assertions)]
+fn same_path_lexically(left: &Path, right: &Path) -> bool {
+    let normalize = |path: &Path| {
+        let mut text = path
+            .components()
+            .collect::<PathBuf>()
+            .to_string_lossy()
+            .replace('\\', "/");
+        while text.ends_with('/') && text.len() > 1 {
+            text.pop();
+        }
+        #[cfg(windows)]
+        {
+            text = text.to_ascii_lowercase();
+        }
+        text
+    };
+
+    normalize(left) == normalize(right)
 }
 
 #[cfg(debug_assertions)]
@@ -100,6 +146,7 @@ mod tests {
     fn debug_home_for_tauri_manifest_uses_workspace_target_dir() {
         let _guard = crate::tests::env_lock();
         std::env::remove_var("WARDIAN_HOME");
+        std::env::remove_var("WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME");
 
         let workspace_root = PathBuf::from("/repo/Wardian");
         let manifest_dir = workspace_root.join("src-tauri");
@@ -108,5 +155,63 @@ mod tests {
             wardian_home_for_manifest(&manifest_dir).unwrap(),
             workspace_root.join("target").join("debug").join(".wardian")
         );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn debug_app_home_ignores_inherited_default_production_home() {
+        let _guard = crate::tests::env_lock();
+        let production_home = dirs::home_dir().unwrap().join(".wardian");
+        let workspace_root = PathBuf::from("/repo/Wardian");
+        let manifest_dir = workspace_root.join("src-tauri");
+
+        std::env::set_var("WARDIAN_HOME", &production_home);
+        std::env::remove_var("WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME");
+
+        assert_eq!(
+            wardian_home_for_manifest(&manifest_dir).unwrap(),
+            workspace_root.join("target").join("debug").join(".wardian")
+        );
+
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn debug_app_home_honors_explicit_non_production_home() {
+        let _guard = crate::tests::env_lock();
+        let explicit_home = PathBuf::from("/tmp/wardian-dev-home");
+        let workspace_root = PathBuf::from("/repo/Wardian");
+        let manifest_dir = workspace_root.join("src-tauri");
+
+        std::env::set_var("WARDIAN_HOME", &explicit_home);
+        std::env::remove_var("WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME");
+
+        assert_eq!(
+            wardian_home_for_manifest(&manifest_dir).unwrap(),
+            explicit_home
+        );
+
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn debug_app_home_can_intentionally_use_production_home() {
+        let _guard = crate::tests::env_lock();
+        let production_home = dirs::home_dir().unwrap().join(".wardian");
+        let workspace_root = PathBuf::from("/repo/Wardian");
+        let manifest_dir = workspace_root.join("src-tauri");
+
+        std::env::set_var("WARDIAN_HOME", &production_home);
+        std::env::set_var("WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME", "1");
+
+        assert_eq!(
+            wardian_home_for_manifest(&manifest_dir).unwrap(),
+            production_home
+        );
+
+        std::env::remove_var("WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME");
+        std::env::remove_var("WARDIAN_HOME");
     }
 }

--- a/docs/developer/setup.md
+++ b/docs/developer/setup.md
@@ -60,6 +60,8 @@ Run the desktop app in development mode:
 npm run dev
 ```
 
+Debug desktop builds do not use the production Wardian home by default. If `WARDIAN_HOME` is unset, or if a managed agent shell inherited the default production home, the dev app rewrites its process environment to `target/debug/.wardian` before opening the database, control endpoint, remote gateway, or restored agents.
+
 When testing the CLI against a dev app, set the same explicit `WARDIAN_HOME` in both terminals:
 
 macOS/Linux shell:
@@ -131,6 +133,7 @@ Official release builds opt into signed updater artifacts with the release-only 
 | Variable | Purpose | Default |
 |---|---|---|
 | `WARDIAN_HOME` | Redirect all state to an isolated directory | `~/.wardian` |
+| `WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME` | Allow a debug desktop build to use the default production home when set to `1` | unset |
 | `WARDIAN_MOCK_SCENARIO` | Mock provider scenario for native E2E tests | `basic` |
 | `WARDIAN_MOCK_DELAY_MS` | Delay between mock provider events (ms) | `100` |
 | `WARDIAN_E2E_REAL_ANTIGRAVITY` | Enable real Antigravity provider in native E2E | unset |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -34,7 +34,7 @@ Wardian also attempts to add that `bin` directory to the user PATH. On Windows, 
 
 Set `WARDIAN_HOME` to redirect state, the CLI install location, and the live app control endpoint for tests or isolated runs.
 
-For development, set the same `WARDIAN_HOME` before starting the desktop app and before running CLI commands. Otherwise the app debug home and the CLI default production home may differ.
+For development, `npm run dev` uses the app debug home by default and ignores an inherited default production home from a managed agent shell. Set the same non-production `WARDIAN_HOME` before starting the dev desktop app and before running CLI commands when you want the CLI to inspect that dev app's live state.
 
 When the desktop app is running for the same `WARDIAN_HOME`, the CLI asks the app for live agent snapshots before falling back to `state.db`. Request `status_source` when you need to know which path answered:
 

--- a/docs/specs/2026-05-23-dev-home-isolation.md
+++ b/docs/specs/2026-05-23-dev-home-isolation.md
@@ -1,0 +1,22 @@
+# Dev Home Isolation
+
+## Context
+
+Wardian-managed agent terminals normally inherit `WARDIAN_HOME` from the running production desktop app. Starting a debug desktop build from that shell with `npm run dev` could therefore point the dev app at the same production home. The dev app would then attempt to bind the same control endpoint, use the same remote gateway port, clean up persisted sessions, and restore agents from the production state files.
+
+## Decision
+
+Debug desktop builds treat the default production home as an inherited unsafe value unless explicitly allowed:
+
+- If `WARDIAN_HOME` is unset, the app uses `target/debug/.wardian`.
+- If `WARDIAN_HOME` points at a non-production path, the app honors it. Native E2E and manual CLI/app tests can continue to share an explicit isolated home.
+- If `WARDIAN_HOME` points at the default production home, the app uses `target/debug/.wardian` instead.
+- If `WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME=1`, the debug app may intentionally use the default production home.
+
+The app rewrites its own process `WARDIAN_HOME` to the resolved home before initializing migrations, the database, control endpoint names, remote services, restored agents, or spawned provider processes.
+
+Startup also claims the Wardian control endpoint synchronously during Tauri setup. If another app instance already owns that endpoint for the same home, setup fails before remote gateway startup, stale process cleanup, restore, or state writes.
+
+## Consequences
+
+`npm run dev` is safe by default from a Wardian-managed terminal. Developers who need the CLI and dev app to share state should set an explicit non-production `WARDIAN_HOME` in both terminals. Release builds and the standalone CLI continue to treat `WARDIAN_HOME` as the highest-priority home override.

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -20,9 +20,67 @@ use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
 const STRUCTURED_ASK_INLINE_MESSAGE_MAX_BYTES: usize = 4096;
 const STRUCTURED_ASK_REQUESTS_DIR: &str = "requests";
 
-pub fn spawn_control_server(app: AppHandle) {
+#[cfg(windows)]
+pub(crate) type ControlEndpointClaim = tokio::net::windows::named_pipe::NamedPipeServer;
+
+#[cfg(unix)]
+pub(crate) struct ControlEndpointClaim {
+    listener: Option<tokio::net::UnixListener>,
+    socket_path: PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for ControlEndpointClaim {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn claim_control_endpoint() -> std::io::Result<ControlEndpointClaim> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    let pipe_name = wardian_core::control::pipe_name()
+        .ok_or_else(|| std::io::Error::other("could not resolve Wardian control pipe"))?;
+    ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(&pipe_name)
+}
+
+#[cfg(unix)]
+pub(crate) fn claim_control_endpoint() -> std::io::Result<ControlEndpointClaim> {
+    use std::os::unix::net::UnixStream;
+    use tokio::net::UnixListener;
+
+    let socket_path = wardian_core::control::socket_path()
+        .ok_or_else(|| std::io::Error::other("could not resolve Wardian control socket"))?;
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    match UnixListener::bind(&socket_path) {
+        Ok(listener) => Ok(ControlEndpointClaim {
+            listener: Some(listener),
+            socket_path,
+        }),
+        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+            if UnixStream::connect(&socket_path).is_ok() {
+                Err(error)
+            } else {
+                let _ = std::fs::remove_file(&socket_path);
+                UnixListener::bind(&socket_path).map(|listener| ControlEndpointClaim {
+                    listener: Some(listener),
+                    socket_path,
+                })
+            }
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub fn spawn_control_server(app: AppHandle, claim: ControlEndpointClaim) {
     tauri::async_runtime::spawn(async move {
-        if let Err(error) = run_control_server(app).await {
+        if let Err(error) = run_control_server(app, claim).await {
             crate::utils::logging::log_debug(&format!(
                 "[Wardian] control server unavailable: {error}"
             ));
@@ -31,18 +89,21 @@ pub fn spawn_control_server(app: AppHandle) {
 }
 
 #[cfg(windows)]
-async fn run_control_server(app: AppHandle) -> std::io::Result<()> {
+async fn run_control_server(
+    app: AppHandle,
+    first_server: ControlEndpointClaim,
+) -> std::io::Result<()> {
     use tokio::net::windows::named_pipe::ServerOptions;
 
     let pipe_name = wardian_core::control::pipe_name()
         .ok_or_else(|| std::io::Error::other("could not resolve Wardian control pipe"))?;
 
-    let mut first_instance = true;
+    let mut next_server = Some(first_server);
     loop {
-        let server = ServerOptions::new()
-            .first_pipe_instance(first_instance)
-            .create(&pipe_name)?;
-        first_instance = false;
+        let server = match next_server.take() {
+            Some(server) => server,
+            None => ServerOptions::new().create(&pipe_name)?,
+        };
         server.connect().await?;
         let app_handle = app.clone();
         tauri::async_runtime::spawn(async move {
@@ -56,17 +117,14 @@ async fn run_control_server(app: AppHandle) -> std::io::Result<()> {
 }
 
 #[cfg(unix)]
-async fn run_control_server(app: AppHandle) -> std::io::Result<()> {
-    use tokio::net::UnixListener;
-
-    let socket_path = wardian_core::control::socket_path()
-        .ok_or_else(|| std::io::Error::other("could not resolve Wardian control socket"))?;
-    if let Some(parent) = socket_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let _ = std::fs::remove_file(&socket_path);
-    let listener = UnixListener::bind(socket_path)?;
-
+async fn run_control_server(
+    app: AppHandle,
+    mut claim: ControlEndpointClaim,
+) -> std::io::Result<()> {
+    let listener = claim
+        .listener
+        .take()
+        .ok_or_else(|| std::io::Error::other("Wardian control endpoint was already claimed"))?;
     loop {
         let (stream, _) = listener.accept().await?;
         let app_handle = app.clone();
@@ -2508,6 +2566,29 @@ mod tests {
     use crate::state::ActiveAgent;
     use std::sync::{Arc, Mutex};
     use wardian_core::models::{AgentConfig, WorkflowDefinition, WorkflowNode, WorkflowSettings};
+
+    #[tokio::test]
+    async fn control_endpoint_claim_is_exclusive_for_current_home() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("WARDIAN_HOME", temp.path());
+
+        let first = claim_control_endpoint().expect("first endpoint claim");
+        let second = claim_control_endpoint().expect_err("second claim should fail");
+
+        assert!(
+            matches!(
+                second.kind(),
+                std::io::ErrorKind::AlreadyExists
+                    | std::io::ErrorKind::AddrInUse
+                    | std::io::ErrorKind::PermissionDenied
+            ),
+            "unexpected endpoint claim error: {second}"
+        );
+
+        drop(first);
+        std::env::remove_var("WARDIAN_HOME");
+    }
 
     fn test_agent(session_id: &str, session_name: &str, agent_class: &str) -> ActiveAgent {
         ActiveAgent {

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -78,7 +78,7 @@ pub(crate) fn claim_control_endpoint() -> std::io::Result<ControlEndpointClaim> 
     }
 }
 
-pub fn spawn_control_server(app: AppHandle, claim: ControlEndpointClaim) {
+pub(crate) fn spawn_control_server(app: AppHandle, claim: ControlEndpointClaim) {
     tauri::async_runtime::spawn(async move {
         if let Err(error) = run_control_server(app, claim).await {
             crate::utils::logging::log_debug(&format!(
@@ -2574,7 +2574,10 @@ mod tests {
         std::env::set_var("WARDIAN_HOME", temp.path());
 
         let first = claim_control_endpoint().expect("first endpoint claim");
-        let second = claim_control_endpoint().expect_err("second claim should fail");
+        let second = match claim_control_endpoint() {
+            Ok(_) => panic!("second claim should fail"),
+            Err(error) => error,
+        };
 
         assert!(
             matches!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,6 +179,13 @@ pub fn run() {
     builder
         .manage(AppState::new())
         .setup(|app| {
+            let control_endpoint_claim = control::claim_control_endpoint().map_err(|error| {
+                std::io::Error::new(
+                    error.kind(),
+                    format!("Wardian control endpoint is already owned for this WARDIAN_HOME: {error}"),
+                )
+            })?;
+
             if let Ok(resource_dir) = app.path().resource_dir() {
                 if let Some(app_home) = crate::utils::fs::get_wardian_home() {
                     if let Err(err) = crate::utils::cli_install::install_cli_from_resources_to_home(
@@ -193,7 +200,7 @@ pub fn run() {
             }
 
             let app_handle = app.handle().clone();
-            control::spawn_control_server(app_handle.clone());
+            control::spawn_control_server(app_handle.clone(), control_endpoint_claim);
             remote::gateway::spawn_remote_gateway(app_handle.clone());
             manager::init_agent_classes(&app_handle);
 

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -17,12 +17,7 @@ pub fn get_wardian_home() -> Option<std::path::PathBuf> {
 
 pub fn ensure_process_wardian_home_env() -> Option<std::path::PathBuf> {
     let home = get_wardian_home()?;
-    if std::env::var("WARDIAN_HOME")
-        .map(|value| value.trim().is_empty())
-        .unwrap_or(true)
-    {
-        unsafe { std::env::set_var("WARDIAN_HOME", &home) };
-    }
+    unsafe { std::env::set_var("WARDIAN_HOME", &home) };
     Some(home)
 }
 
@@ -32,10 +27,30 @@ mod process_home_env_contract_tests {
     fn ensure_process_wardian_home_env_sets_missing_env_to_resolved_app_home() {
         let _guard = crate::utils::wardian_test_env_lock();
         unsafe { std::env::remove_var("WARDIAN_HOME") };
+        unsafe { std::env::remove_var("WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME") };
 
         let resolved = super::ensure_process_wardian_home_env().expect("resolved home");
         let env_home = std::env::var("WARDIAN_HOME").expect("WARDIAN_HOME env");
 
+        assert_eq!(std::path::PathBuf::from(env_home), resolved);
+
+        unsafe { std::env::remove_var("WARDIAN_HOME") };
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn ensure_process_wardian_home_env_replaces_inherited_production_home_with_debug_home() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let production_home = dirs::home_dir().unwrap().join(".wardian");
+        unsafe {
+            std::env::set_var("WARDIAN_HOME", &production_home);
+            std::env::remove_var("WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME");
+        }
+
+        let resolved = super::ensure_process_wardian_home_env().expect("resolved home");
+        let env_home = std::env::var("WARDIAN_HOME").expect("WARDIAN_HOME env");
+
+        assert_ne!(resolved, production_home);
         assert_eq!(std::path::PathBuf::from(env_home), resolved);
 
         unsafe { std::env::remove_var("WARDIAN_HOME") };


### PR DESCRIPTION
## Description
Debug desktop launches now isolate themselves from an inherited production `WARDIAN_HOME`. The resolver keeps explicit non-production homes for E2E/manual CLI testing, allows an intentional production opt-in with `WARDIAN_DEBUG_ALLOW_PRODUCTION_HOME=1`, and rewrites the app process environment before runtime initialization.

Startup also claims the home-scoped Wardian control endpoint during Tauri setup. If another desktop app already owns the endpoint for that home, setup fails before remote gateway startup, stale process cleanup, restored agent spawning, or state writes.

## Related Issues
Fixes #371

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] Documentation update

## How Has This Been Tested?
Local verification:
- `cargo test -p wardian-core`
- `cargo test -p Wardian`
- `cargo check -p Wardian`
- `cargo clippy -p wardian-core -- -D warnings`
- `cargo clippy -p Wardian -- -D warnings`
- `npm run lint`
- `npm run build`
- `npm run docs:build`
- `cargo test -p Wardian control_endpoint_claim_is_exclusive_for_current_home -- --nocapture` after the portability follow-up commit

CI verification on PR #372:
- Backend (Linux - Test & Coverage): pass
- Backend (Windows - Lint, Test & Check): pass
- Frontend (Lint & Test): pass
- Security & Dependency Audit: pass
- Build docs: pass

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable