### PR TITLE
fix(runtime): claim control endpoint outside Tokio context

### DIFF
--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -42,9 +42,23 @@ pub(crate) fn claim_control_endpoint() -> std::io::Result<ControlEndpointClaim> 
 
     let pipe_name = wardian_core::control::pipe_name()
         .ok_or_else(|| std::io::Error::other("could not resolve Wardian control pipe"))?;
-    ServerOptions::new()
-        .first_pipe_instance(true)
-        .create(&pipe_name)
+
+    // `ServerOptions::create` registers the pipe handle with Tokio's IOCP reactor and
+    // panics if invoked outside a Tokio runtime context. The Tauri `setup` hook runs
+    // on the main thread before the async runtime is entered, so when no runtime is
+    // ambient we enter the Tauri-managed one. When a runtime is already current
+    // (e.g. inside a `#[tokio::test]` or any `tauri::async_runtime::spawn` task) we
+    // call `create` directly to avoid nesting `block_on`, which Tokio rejects.
+    let create_pipe = || {
+        ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&pipe_name)
+    };
+    if tokio::runtime::Handle::try_current().is_ok() {
+        create_pipe()
+    } else {
+        tauri::async_runtime::block_on(async { create_pipe() })
+    }
 }
 
 #[cfg(unix)]
@@ -2566,6 +2580,30 @@ mod tests {
     use crate::state::ActiveAgent;
     use std::sync::{Arc, Mutex};
     use wardian_core::models::{AgentConfig, WorkflowDefinition, WorkflowNode, WorkflowSettings};
+
+    /// Regression test for the silent release-build crash where `claim_control_endpoint`
+    /// was called from Tauri's `setup` hook (no Tokio runtime context), causing
+    /// `tokio::net::windows::named_pipe::ServerOptions::create` to panic with
+    /// "there is no reactor running". This test runs as a plain `#[test]` — *not*
+    /// `#[tokio::test]` — so the absence of an ambient runtime mirrors the real
+    /// setup-hook environment. The claim must succeed without panicking.
+    #[test]
+    fn control_endpoint_claim_succeeds_without_ambient_tokio_runtime() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("WARDIAN_HOME", temp.path());
+
+        assert!(
+            tokio::runtime::Handle::try_current().is_err(),
+            "test precondition: no Tokio runtime must be ambient on this thread, \
+             otherwise we are not exercising the setup-hook code path"
+        );
+
+        let claim = claim_control_endpoint().expect("claim must not panic or fail outside a runtime");
+        drop(claim);
+
+        std::env::remove_var("WARDIAN_HOME");
+    }
 
     #[tokio::test]
     async fn control_endpoint_claim_is_exclusive_for_current_home() {

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -36,6 +36,24 @@ impl Drop for ControlEndpointClaim {
     }
 }
 
+/// Run a synchronous closure inside a Tokio runtime context.
+///
+/// The Tauri `setup` hook runs on the main thread before any async runtime is
+/// entered, but several Tokio I/O constructors (e.g. `NamedPipeServer::create`
+/// on Windows, `UnixListener::bind` on Unix) register their handles with the
+/// reactor and panic when called outside a runtime. When a runtime is already
+/// current (e.g. inside a `#[tokio::test]` or a `tauri::async_runtime::spawn`
+/// task), invoke `f` directly to avoid nesting `block_on`, which Tokio rejects.
+/// Otherwise enter the Tauri-managed runtime via `block_on`. `f` is non-async,
+/// so `block_on` returns synchronously.
+fn run_in_tokio_runtime<R>(f: impl FnOnce() -> R) -> R {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        f()
+    } else {
+        tauri::async_runtime::block_on(async { f() })
+    }
+}
+
 #[cfg(windows)]
 pub(crate) fn claim_control_endpoint() -> std::io::Result<ControlEndpointClaim> {
     use tokio::net::windows::named_pipe::ServerOptions;
@@ -43,22 +61,11 @@ pub(crate) fn claim_control_endpoint() -> std::io::Result<ControlEndpointClaim> 
     let pipe_name = wardian_core::control::pipe_name()
         .ok_or_else(|| std::io::Error::other("could not resolve Wardian control pipe"))?;
 
-    // `ServerOptions::create` registers the pipe handle with Tokio's IOCP reactor and
-    // panics if invoked outside a Tokio runtime context. The Tauri `setup` hook runs
-    // on the main thread before the async runtime is entered, so when no runtime is
-    // ambient we enter the Tauri-managed one. When a runtime is already current
-    // (e.g. inside a `#[tokio::test]` or any `tauri::async_runtime::spawn` task) we
-    // call `create` directly to avoid nesting `block_on`, which Tokio rejects.
-    let create_pipe = || {
+    run_in_tokio_runtime(|| {
         ServerOptions::new()
             .first_pipe_instance(true)
             .create(&pipe_name)
-    };
-    if tokio::runtime::Handle::try_current().is_ok() {
-        create_pipe()
-    } else {
-        tauri::async_runtime::block_on(async { create_pipe() })
-    }
+    })
 }
 
 #[cfg(unix)]
@@ -72,10 +79,10 @@ pub(crate) fn claim_control_endpoint() -> std::io::Result<ControlEndpointClaim> 
         std::fs::create_dir_all(parent)?;
     }
 
-    match UnixListener::bind(&socket_path) {
+    run_in_tokio_runtime(|| match UnixListener::bind(&socket_path) {
         Ok(listener) => Ok(ControlEndpointClaim {
             listener: Some(listener),
-            socket_path,
+            socket_path: socket_path.clone(),
         }),
         Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
             if UnixStream::connect(&socket_path).is_ok() {
@@ -84,12 +91,12 @@ pub(crate) fn claim_control_endpoint() -> std::io::Result<ControlEndpointClaim> 
                 let _ = std::fs::remove_file(&socket_path);
                 UnixListener::bind(&socket_path).map(|listener| ControlEndpointClaim {
                     listener: Some(listener),
-                    socket_path,
+                    socket_path: socket_path.clone(),
                 })
             }
         }
         Err(error) => Err(error),
-    }
+    })
 }
 
 pub(crate) fn spawn_control_server(app: AppHandle, claim: ControlEndpointClaim) {


### PR DESCRIPTION
## Description

Release builds crashed on startup after #372 with a Tokio panic:

```
thread 'main' panicked at tokio-1.52.1/src/net/windows/named_pipe.rs:132:17:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

`claim_control_endpoint` is invoked from Tauri's `setup` hook, which runs on the main thread before any Tokio runtime is entered. Tokio's `NamedPipeServer::create` registers the pipe handle with the IOCP reactor and panics when called outside a runtime context, taking the whole process down before the window finishes loading.

## Fix

`claim_control_endpoint` is now runtime-aware:

- If a Tokio runtime is already current (e.g. inside `#[tokio::test]` or a `tauri::async_runtime::spawn` task), call `ServerOptions::create` directly.
- Otherwise (the setup hook path), enter the Tauri-managed runtime via `tauri::async_runtime::block_on`. The future is non-awaiting so `block_on` returns synchronously.

This avoids nesting `block_on` (which Tokio rejects) while ensuring the setup hook works.

## Why the existing test missed this

The unit test that shipped with #372, `control_endpoint_claim_is_exclusive_for_current_home`, is `#[tokio::test]` — so an ambient runtime was always present when it ran, masking the bug in production.

## Regression test

`control_endpoint_claim_succeeds_without_ambient_tokio_runtime` is a plain `#[test]` (deliberately **not** `#[tokio::test]`). It has an explicit precondition:

```rust
assert!(
    tokio::runtime::Handle::try_current().is_err(),
    "test precondition: no Tokio runtime must be ambient on this thread, \
     otherwise we are not exercising the setup-hook code path"
);
```

so the test self-verifies that it's reproducing the real setup-hook environment. Against the original code it panics; against the fix it passes.

## Verification

- `cargo test -p Wardian --lib control::tests::control_endpoint_claim -- --test-threads=1` — 2/2 pass (both the original exclusivity test and the new regression test)
- `cargo build --release -p Wardian` — clean
- `npm run tauri build` — clean (frontend rebuild + Rust release + NSIS bundle)
- Launched `target/release/Wardian.exe` directly: stays alive past the prior crash window (was exiting with code 101 in ~4s, now runs indefinitely until killed)

## Related Issues

Hotfix for regression introduced by #372.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)