### PR TITLE
docs(remote): expand Tailscale setup guide

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -32,6 +32,6 @@ Use this index to find the guide that matches the task you are trying to finish.
 ## Configure and Automate
 
 - [Settings](./settings.md): tune shell, provider, session, and theme behavior.
-- [Remote Control](./remote-control.md): pair a phone with the Wardian desktop over Tailscale HTTPS.
+- [Remote Control](./remote-control.md): set up Tailscale HTTPS, pair a phone, and install the Wardian remote PWA.
 - [Workflow View](./workflows.md): build and run visual automations from the app.
 - [Workflow Reference](../workflows/index.md): learn workflow triggers, nodes, scheduling, and troubleshooting.

--- a/docs/guide/remote-control.md
+++ b/docs/guide/remote-control.md
@@ -7,20 +7,141 @@ workflows, filesystem access, provider CLIs, PTYs, and telemetry.
 ## Requirements
 
 - Wardian desktop running on the host computer.
-- Tailscale enabled on the host and phone.
+- Tailscale installed and signed in on the Wardian host and the phone.
+- MagicDNS and HTTPS certificates enabled for the tailnet.
 - A trusted HTTPS origin such as `https://<machine>.<tailnet>.ts.net`.
 - Remote access configured to bind only to the Wardian loopback gateway.
 
-## Enable Remote Access
+Use Tailscale Serve, not Tailscale Funnel, for the v1 remote-control path.
+Serve keeps Wardian private to devices in the tailnet. Funnel publishes a
+service to the public internet and is outside the v1 security model.
+
+## Set Up Tailscale
+
+1. Install Tailscale on the computer running Wardian.
+2. Install Tailscale on the phone that will become the remote control.
+3. Sign both devices in to the same tailnet.
+4. Confirm both devices are online in the Tailscale admin console or from the
+   Wardian host:
+
+   ```bash
+   tailscale status
+   ```
+
+   PowerShell:
+
+   ```powershell
+   tailscale status
+   ```
+
+5. Open the Tailscale admin console and enable HTTPS certificates for the
+   tailnet. Follow Tailscale's current guide:
+   [Set up HTTPS certificates](https://tailscale.com/docs/how-to/set-up-https-certificates).
+
+Tailscale requires MagicDNS for tailnet HTTPS names. Tailscale's HTTPS
+certificate setup also notes that issued certificate names are recorded in
+Certificate Transparency logs, so rename the Wardian host first if the machine
+name reveals anything sensitive.
+
+## Get the HTTPS Origin
+
+Wardian needs the canonical HTTPS origin for the host computer, not the local
+loopback URL. The origin usually has this form:
+
+```text
+https://<machine>.<tailnet>.ts.net
+```
+
+You can get the DNS name from the Tailscale admin console by opening the
+Wardian host on the Machines page. You can also read it from the host CLI:
+
+```bash
+tailscale status --json | jq -r '.Self.DNSName' | sed 's/\.$//'
+```
+
+PowerShell:
+
+```powershell
+((tailscale status --json | ConvertFrom-Json).Self.DNSName).TrimEnd(".")
+```
+
+Prefix the resulting DNS name with `https://` before entering it in Wardian.
+For example, if the DNS name is `desktop.tailb6e29a.ts.net`, the Wardian origin
+is:
+
+```text
+https://desktop.tailb6e29a.ts.net
+```
+
+If you expose Wardian on a non-default Tailscale HTTPS port, include that port
+in the origin, such as `https://desktop.tailb6e29a.ts.net:8443`. Use port 443
+unless you have a specific reason to expose another HTTPS port.
+
+## Forward Wardian Through Tailscale Serve
+
+1. Open Wardian on the host computer.
+2. Open Settings, then Remote Access.
+3. Enter the Tailscale HTTPS origin.
+4. Leave the local gateway host as `127.0.0.1`.
+5. Use the displayed local gateway port as `<wardian-gateway-port>`.
+6. Enable remote access and save the gateway settings.
+7. On the Wardian host, forward the local gateway through Tailscale Serve:
+
+   ```bash
+   tailscale serve --bg --https=443 http://127.0.0.1:<wardian-gateway-port>
+   ```
+
+   PowerShell:
+
+   ```powershell
+   tailscale serve --bg --https=443 http://127.0.0.1:<wardian-gateway-port>
+   ```
+
+8. Verify the Serve configuration:
+
+   ```bash
+   tailscale serve status
+   ```
+
+   PowerShell:
+
+   ```powershell
+   tailscale serve status
+   ```
+
+9. From another device signed in to the same tailnet, open
+   `https://<machine>.<tailnet>.ts.net/remote`.
+
+If Tailscale Serve prompts you to enable HTTPS or approve Serve capabilities,
+complete that browser flow and rerun the command. Tailscale Serve forwards the
+HTTPS origin to Wardian's loopback gateway; Wardian itself must still bind only
+to `127.0.0.1`.
+
+To remove the forwarding rule later:
+
+```bash
+tailscale serve --https=443 off
+```
+
+PowerShell:
+
+```powershell
+tailscale serve --https=443 off
+```
+
+## Pair the Phone
 
 1. Open Settings.
 2. Open Remote Access.
-3. Enter the canonical Tailscale HTTPS origin and local gateway address.
-4. Save the remote access configuration.
-5. Start Tailscale Serve for the Wardian loopback gateway.
-6. Create a pairing code.
-7. Scan the code from the phone and approve the device on the desktop.
-8. Open the remote URL from the phone while connected to the same tailnet.
+3. Confirm the Tailscale HTTPS origin and local gateway port are saved.
+4. Create a pairing code.
+5. On the phone, open the camera or browser while Tailscale is connected.
+6. Scan the pairing code or open the pairing URL.
+7. Confirm that the phone opened the expected
+   `https://<machine>.<tailnet>.ts.net/remote` origin.
+8. Approve the pending device in Wardian on the desktop.
+9. Keep Tailscale connected on the phone and use the remote app from the
+   browser.
 
 The pairing code is short-lived and single use. The phone generates its own
 device key during pairing, then waits for explicit desktop approval before it
@@ -31,6 +152,52 @@ example, `<machine>.<tailnet>.ts.net` becomes
 `https://<machine>.<tailnet>.ts.net`. Enter the scheme explicitly only when you
 need to correct or replace it. The saved origin must still be HTTPS and must
 match the gateway origin used by the phone.
+
+Only create a pairing code while the phone is on a trusted private network path
+to the host. In v1, a paired phone receives full remote control for the exposed
+mobile surface.
+
+## Install the Phone PWA
+
+After pairing succeeds, install the remote app from the phone browser so it
+opens like a normal mobile app.
+
+On iPhone or iPad:
+
+1. Open the paired Wardian remote URL in Safari.
+2. Tap Share.
+3. Tap Add to Home Screen.
+4. Confirm the Wardian name and tap Add.
+
+On Android:
+
+1. Open the paired Wardian remote URL in Chrome.
+2. Open the browser menu.
+3. Tap Install app or Add to Home screen.
+4. Confirm the install prompt.
+
+The PWA still reaches the Wardian desktop through Tailscale. If the phone is
+offline, disconnected from Tailscale, revoked in Wardian, or outside the
+tailnet access rules, the installed app cannot send commands.
+
+## Troubleshooting Setup
+
+- **The phone cannot open `/remote`:** confirm Tailscale is connected on both
+  devices, the phone can see the host in the Tailscale app, and
+  `tailscale serve status` on the host shows the Wardian gateway forwarding
+  rule.
+- **The browser warns about the certificate:** confirm MagicDNS and HTTPS
+  certificates are enabled for the tailnet, then rerun the Tailscale Serve
+  command. The Wardian origin must be the full
+  `https://<machine>.<tailnet>.ts.net` name, not `http://127.0.0.1`.
+- **Wardian rejects the origin:** use only the scheme and host, plus an
+  optional port. Do not include `/remote`, query strings, fragments, IP
+  literals, or alternate hostnames in the origin field.
+- **The pairing code expires:** create a fresh code from the desktop. Pairing
+  offers are single use and intentionally short lived.
+- **The installed PWA opens but cannot control agents:** reopen Tailscale on
+  the phone, refresh the PWA, and confirm the device is still listed as paired
+  in Wardian Remote Access settings.
 
 ## Security Model
 


### PR DESCRIPTION
## Description
Expanded the Remote Control user guide with an end-to-end Tailscale setup path for Wardian remote access.

The guide now covers:
- Enabling Tailscale MagicDNS and HTTPS certificates, with a link to Tailscale's current HTTPS certificate setup guide.
- Finding the canonical `https://<machine>.<tailnet>.ts.net` origin from the admin console or CLI.
- Forwarding Wardian's loopback gateway through Tailscale Serve without using Funnel.
- Pairing a phone from Wardian Remote Access settings.
- Installing the paired remote PWA on iOS or Android.
- Setup troubleshooting for certificate, origin, Serve, and pairing failures.

## Related Issues
Fixes #387

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `git diff --check`
- [x] Narrow secret scan over touched docs: `rg -n "(?i)(api[_-]?key|secret|password|credential|token|\.env)" docs\guide\remote-control.md docs\guide\index.md` returned no matches
- [x] `npm run docs:build`
- [x] `npm run lint`
- [x] `npm run test` (`87` test files, `835` tests passed; existing React `act(...)` and mocked readiness stderr warnings still appear)
- [x] `npm run build` (passes; existing Vite large chunk warning still appears)
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test` (`698` lib tests and `7` mock provider tests passed)
- [x] `cd src-tauri && cargo clippy`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable; docs-only change)
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings (validation still shows existing test stderr warnings and the existing Vite chunk-size warning)
- [x] I have added tests that prove my fix is effective or that my feature works (not applicable; docs-only change)
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable