### PR TITLE
feat(terminal): add conservative mac select-all shortcut

### DIFF
--- a/docs/guide/grid.md
+++ b/docs/guide/grid.md
@@ -34,6 +34,8 @@ Change this globally in **Settings > Grid > Grid card display**. The setting app
 
 Chat mode sends ordinary text through the same provider submit path used by Wardian's command tools. Use **Enter** to send and **Shift+Enter** for a newline in the composer. When Wardian recognizes an action-required prompt with approval choices, Chat mode renders those choices as buttons that submit the matching response. Switch back to Terminal mode when you need raw TUI controls, provider-specific keybindings, or detailed terminal behavior.
 
+In Terminal mode, Wardian follows conservative terminal shortcut handling. On macOS, **Cmd+A** selects the visible terminal buffer. Windows and Linux control-key combinations, including **Ctrl+A** and **Ctrl+Shift+A**, continue through to the shell or provider TUI by default.
+
 ![Grid chat mode showing normalized agent messages, action-needed output, and prompt composers](../assets/screenshots/grid-chat/chat-composer.png)
 
 ## Important Limits

--- a/src/features/remote/RemoteAgentDetailView.tsx
+++ b/src/features/remote/RemoteAgentDetailView.tsx
@@ -15,6 +15,7 @@ import {
   normalizeRemoteTerminalOutput,
   type TerminalOutputState,
 } from "../terminal/terminalCapabilities";
+import { installConservativeTerminalShortcuts } from "../terminal/terminalShortcuts";
 
 function formatProviderName(provider: string | null | undefined): string {
   if (!provider) return "-";
@@ -338,6 +339,7 @@ function TerminalPane({
       scrollback: 1_000,
       theme: remoteTerminalTheme(),
     });
+    installConservativeTerminalShortcuts(terminal);
     const fitAddon = new FitAddon();
     terminal.loadAddon?.(fitAddon);
     terminal.open?.(host);

--- a/src/features/remote/RemoteMobileApp.test.tsx
+++ b/src/features/remote/RemoteMobileApp.test.tsx
@@ -80,6 +80,8 @@ describe("RemoteMobileApp", () => {
       reset: vi.fn(),
       dispose: vi.fn(),
       focus: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
+      selectAll: vi.fn(),
       loadAddon: vi.fn(),
       scrollLines: vi.fn(),
       scrollToBottom: vi.fn(),
@@ -532,6 +534,11 @@ describe("RemoteMobileApp", () => {
     expect(screen.getByTestId("remote-terminal-attach")).not.toHaveClass("min-h-[280px]");
     const terminalCallsForOptions = vi.mocked(Terminal).mock.calls;
     const terminalOptions = terminalCallsForOptions[terminalCallsForOptions.length - 1]?.[0] as Record<string, unknown> | undefined;
+    const terminalResults = vi.mocked(Terminal).mock.results;
+    const terminalInstance = terminalResults[terminalResults.length - 1]?.value as {
+      attachCustomKeyEventHandler?: ReturnType<typeof vi.fn>;
+    };
+    expect(terminalInstance.attachCustomKeyEventHandler).toHaveBeenCalledTimes(1);
     expect(terminalOptions?.theme).toEqual(
       expect.objectContaining({
         background: "rgb(250, 251, 252)",

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -92,6 +92,8 @@ describe("AgentTerminal scrollback", () => {
         reset: vi.fn(),
         dispose: vi.fn(),
         focus: vi.fn(),
+        attachCustomKeyEventHandler: vi.fn(),
+        selectAll: vi.fn(),
         scrollToBottom: vi.fn(),
         scrollToLine: vi.fn((line: number) => {
           terminal.buffer.active.viewportY = line;
@@ -151,6 +153,14 @@ describe("AgentTerminal scrollback", () => {
     expect(shouldExposeTerminalDebug({ DEV: false, VITE_WARDIAN_TERMINAL_DEBUG: undefined })).toBe(false);
     expect(shouldExposeTerminalDebug({ DEV: true, VITE_WARDIAN_TERMINAL_DEBUG: undefined })).toBe(true);
     expect(shouldExposeTerminalDebug({ DEV: false, VITE_WARDIAN_TERMINAL_DEBUG: "1" })).toBe(true);
+  });
+
+  it("installs conservative terminal shortcuts on the renderer", async () => {
+    render(<AgentTerminal sessionId="codex-shortcuts" theme="dark" />);
+
+    await waitFor(() => {
+      expect(getLatestTerminalInstance().attachCustomKeyEventHandler).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("reuses the live renderer on a quick remount without recreating the WebGL context", async () => {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -14,6 +14,7 @@ import {
   shouldHomeCursorBeforeTransientResize,
   type TerminalOutputState,
 } from "./terminalCapabilities";
+import { installConservativeTerminalShortcuts } from "./terminalShortcuts";
 import { effectiveTerminalFontFamily, useSettingsStore } from "../../store/useSettingsStore";
 import { useQueueStore } from "../../store/useQueueStore";
 
@@ -804,6 +805,7 @@ function createRenderer(sessionId: string, entry: TerminalSessionEntry) {
     term.options.scrollOnUserInput = false;
     applyProviderTerminalOptions(term, entry.provider);
   }
+  installConservativeTerminalShortcuts(term);
 
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);

--- a/src/features/terminal/UserTerminalPanel.test.tsx
+++ b/src/features/terminal/UserTerminalPanel.test.tsx
@@ -19,6 +19,8 @@ const onDataMock = vi.fn((_handler: (data: string) => void) => ({ dispose: vi.fn
 const onBinaryMock = vi.fn((_handler: (data: string) => void) => ({ dispose: vi.fn() }));
 const disposeMock = vi.fn();
 const focusMock = vi.fn();
+const attachCustomKeyEventHandlerMock = vi.fn();
+const selectAllMock = vi.fn();
 const writeMock = vi.fn();
 const clearMock = vi.fn();
 const refreshMock = vi.fn();
@@ -34,6 +36,8 @@ vi.mock("@xterm/xterm", () => ({
     onBinary: onBinaryMock,
     dispose: disposeMock,
     focus: focusMock,
+    attachCustomKeyEventHandler: attachCustomKeyEventHandlerMock,
+    selectAll: selectAllMock,
     write: writeMock,
     clear: clearMock,
     refresh: refreshMock,
@@ -91,6 +95,22 @@ describe("UserTerminalPanel", () => {
       "href",
       "https://docs.wardian.org/guide/cli",
     );
+  });
+
+  it("installs conservative terminal shortcuts", async () => {
+    render(
+      <UserTerminalPanel
+        theme="dark"
+        height={320}
+        selectedWorkspace={null}
+        onHeightChange={vi.fn()}
+        onHide={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(attachCustomKeyEventHandlerMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("drains all queued PTY output when mounted", async () => {

--- a/src/features/terminal/UserTerminalPanel.tsx
+++ b/src/features/terminal/UserTerminalPanel.tsx
@@ -8,6 +8,7 @@ import "@xterm/xterm/css/xterm.css";
 import { FolderOpen, RefreshCcw, X } from "lucide-react";
 import { effectiveTerminalFontFamily, useSettingsStore } from "../../store/useSettingsStore";
 import { DocsLink } from "../../components/DocsLink";
+import { installConservativeTerminalShortcuts } from "./terminalShortcuts";
 
 const DARK_TERM_THEME = {
   background: "#020402",
@@ -153,6 +154,7 @@ export function UserTerminalPanel({
       scrollback: 2_000,
       theme: termTheme,
     });
+    installConservativeTerminalShortcuts(term);
     const fitAddon = new FitAddon();
     const unicodeAddon = new Unicode11Addon();
     term.loadAddon(fitAddon);

--- a/src/features/terminal/terminalShortcuts.test.ts
+++ b/src/features/terminal/terminalShortcuts.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { installConservativeTerminalShortcuts, isMacPlatform } from "./terminalShortcuts";
+
+function keyboardEvent(init: Partial<KeyboardEvent> = {}) {
+  return {
+    type: "keydown",
+    key: "a",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    ...init,
+  } as unknown as KeyboardEvent;
+}
+
+function shortcutHarness(platform: string) {
+  const installed: { handler?: (event: KeyboardEvent) => boolean } = {};
+  const terminal = {
+    attachCustomKeyEventHandler: vi.fn((nextHandler: (event: KeyboardEvent) => boolean) => {
+      installed.handler = nextHandler;
+    }),
+    selectAll: vi.fn(),
+  };
+
+  installConservativeTerminalShortcuts(terminal, { platform });
+
+  const handler = installed.handler;
+  if (!handler) {
+    throw new Error("shortcut handler was not installed");
+  }
+
+  return { terminal, handler };
+}
+
+describe("terminalShortcuts", () => {
+  it.each([
+    ["MacIntel", true],
+    ["MacPPC", true],
+    ["Win32", false],
+    ["Linux x86_64", false],
+  ])("detects mac platform for %s", (platform, expected) => {
+    expect(isMacPlatform(platform)).toBe(expected);
+  });
+
+  it("selects the terminal buffer for Cmd+A on macOS", () => {
+    const { terminal, handler } = shortcutHarness("MacIntel");
+    const event = keyboardEvent({ metaKey: true });
+
+    const shouldProcess = handler(event);
+
+    expect(shouldProcess).toBe(false);
+    expect(terminal.selectAll).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not intercept Cmd+A keyup on macOS", () => {
+    const { terminal, handler } = shortcutHarness("MacIntel");
+    const event = keyboardEvent({ type: "keyup", metaKey: true });
+
+    expect(handler(event)).toBe(true);
+    expect(terminal.selectAll).not.toHaveBeenCalled();
+  });
+
+  it.each(["Win32", "Linux x86_64"])("passes Ctrl+A through on %s", (platform) => {
+    const { terminal, handler } = shortcutHarness(platform);
+    const event = keyboardEvent({ ctrlKey: true });
+
+    expect(handler(event)).toBe(true);
+    expect(terminal.selectAll).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it.each(["Win32", "Linux x86_64"])("passes Ctrl+Shift+A through on %s", (platform) => {
+    const { terminal, handler } = shortcutHarness(platform);
+    const event = keyboardEvent({ ctrlKey: true, shiftKey: true });
+
+    expect(handler(event)).toBe(true);
+    expect(terminal.selectAll).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("passes Cmd+A through on non-mac platforms", () => {
+    const { terminal, handler } = shortcutHarness("Win32");
+    const event = keyboardEvent({ metaKey: true });
+
+    expect(handler(event)).toBe(true);
+    expect(terminal.selectAll).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/terminal/terminalShortcuts.ts
+++ b/src/features/terminal/terminalShortcuts.ts
@@ -1,0 +1,34 @@
+type TerminalShortcutTarget = {
+  attachCustomKeyEventHandler: (handler: (event: KeyboardEvent) => boolean) => void;
+  selectAll: () => void;
+};
+
+type TerminalShortcutOptions = {
+  platform?: string;
+};
+
+export function isMacPlatform(platform = navigator.platform) {
+  return platform.toLowerCase().startsWith("mac");
+}
+
+export function installConservativeTerminalShortcuts(
+  terminal: TerminalShortcutTarget,
+  options: TerminalShortcutOptions = {},
+) {
+  const isMac = isMacPlatform(options.platform);
+
+  terminal.attachCustomKeyEventHandler((event) => {
+    if (event.type !== "keydown") {
+      return true;
+    }
+
+    if (isMac && event.metaKey && !event.ctrlKey && !event.altKey && event.key.toLowerCase() === "a") {
+      event.preventDefault();
+      event.stopPropagation();
+      terminal.selectAll();
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -57,6 +57,8 @@ vi.mock("@xterm/xterm", () => ({
     reset: vi.fn(),
     dispose: vi.fn(),
     focus: vi.fn(),
+    attachCustomKeyEventHandler: vi.fn(),
+    selectAll: vi.fn(),
     loadAddon: vi.fn(),
     scrollLines: vi.fn(),
     scrollToBottom: vi.fn(),


### PR DESCRIPTION
## Description
Adds a conservative VS Code-style terminal shortcut layer for Wardian xterm surfaces. On macOS, Cmd+A selects the terminal buffer. Windows/Linux Ctrl+A and Ctrl+Shift+A continue through to the shell/provider TUI by default so provider-owned input fields are not disturbed.

The shared shortcut helper is installed in:
- Agent grid terminals
- The standalone user terminal panel
- Remote terminal attach

## Related Issues
Fixes #403

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- RED: `npm run test -- src/features/terminal/terminalShortcuts.test.ts` initially failed because the helper did not exist.
- `npm run test -- src/features/terminal/terminalShortcuts.test.ts src/features/terminal/AgentTerminal.test.tsx src/features/terminal/UserTerminalPanel.test.tsx src/features/remote/RemoteMobileApp.test.tsx`
- `npm run lint`
- `npm run build`
- `npm run test`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo clippy`
- `npm run docs:build`

## Screenshots
![macOS Cmd+A terminal select-all evidence](https://raw.githubusercontent.com/wardian-app/Wardian/0754eeed907b8d754af88e54fe76982c6ee19c82/pr-evidence/403/mac-cmd-a-select-all.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
