### PR TITLE
Fix Antigravity provider label and Windows shim launch

### DIFF
--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -547,7 +547,7 @@ pub(crate) fn interactive_provider_launch(
     provider_args: &[String],
 ) -> Result<crate::utils::shell::ShellLaunchSpec, String> {
     #[cfg(windows)]
-    if provider_name == "opencode" {
+    if matches!(provider_name, "opencode" | "antigravity") {
         let bin_path = std::path::Path::new(bin);
         let is_native_exe = bin_path
             .extension()
@@ -675,6 +675,23 @@ mod tests {
             Some(value) => std::env::set_var("PATH", value),
             None => std::env::remove_var("PATH"),
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn antigravity_interactive_launch_wraps_windows_cmd_shims() {
+        let launch = interactive_provider_launch(
+            "antigravity",
+            r"C:\Users\test\AppData\Roaming\npm\agy.cmd",
+            &["--prompt-interactive".to_string(), String::new()],
+        )
+        .expect("launch");
+
+        assert!(launch.executable.ends_with("cmd.exe") || launch.executable == "cmd.exe");
+        assert_eq!(launch.args[0], "/d");
+        assert_eq!(launch.args[1], "/c");
+        assert!(launch.args[2].contains("agy.cmd"));
+        assert!(launch.args[2].contains("--prompt-interactive"));
     }
 
     #[test]

--- a/src-tauri/src/providers/readiness.rs
+++ b/src-tauri/src/providers/readiness.rs
@@ -66,7 +66,7 @@ pub fn provider_readiness(provider_id: &str) -> ProviderReadiness {
     };
 
     let (executable, base_args) = provider.get_executable();
-    readiness_from_launch_parts(&provider_id, provider.name(), &executable, &base_args, None)
+    readiness_from_launch_parts(&provider_id, &display_name, &executable, &base_args, None)
 }
 
 pub fn ensure_provider_available_for_launch(provider_id: &str) -> Result<(), String> {
@@ -276,6 +276,37 @@ mod tests {
             .expect("antigravity descriptor");
 
         assert_eq!(descriptor.display_name, "Antigravity");
+    }
+
+    #[test]
+    fn antigravity_readiness_uses_capitalized_descriptor_label() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let previous_path = std::env::var_os("PATH");
+        let previous_pathext = std::env::var_os("PATHEXT");
+        let temp = tempfile::tempdir().expect("temp dir");
+        let executable = if cfg!(windows) {
+            temp.path().join("agy.exe")
+        } else {
+            temp.path().join("agy")
+        };
+        std::fs::write(&executable, "").expect("fake agy");
+        std::env::set_var("PATH", temp.path());
+        #[cfg(windows)]
+        std::env::set_var("PATHEXT", ".EXE");
+
+        let readiness = provider_readiness("antigravity");
+
+        assert!(readiness.available);
+        assert_eq!(readiness.display_name, "Antigravity");
+
+        match previous_path {
+            Some(value) => std::env::set_var("PATH", value),
+            None => std::env::remove_var("PATH"),
+        }
+        match previous_pathext {
+            Some(value) => std::env::set_var("PATHEXT", value),
+            None => std::env::remove_var("PATHEXT"),
+        }
     }
 
     #[test]

--- a/src/features/agents/providerOptions.test.ts
+++ b/src/features/agents/providerOptions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ProviderReadiness } from '../../types';
-import { buildUngatedProviderOptions, resolveEffectiveProvider } from './providerOptions';
+import { buildProviderOptions, buildUngatedProviderOptions, resolveEffectiveProvider } from './providerOptions';
 
 const readiness = (provider: ProviderReadiness['provider'], available: boolean): ProviderReadiness => ({
   provider,
@@ -19,6 +19,23 @@ describe('provider option helpers', () => {
       { value: 'antigravity', label: 'Antigravity', available: true, reason: null },
       { value: 'opencode', label: 'OpenCode', available: true, reason: null },
     ]);
+  });
+
+  it('uses canonical labels for known providers when readiness labels are stale', () => {
+    expect(buildProviderOptions([
+      {
+        provider: 'antigravity',
+        display_name: 'antigravity',
+        available: true,
+        executable: 'agy',
+        reason: null,
+      },
+    ])).toContainEqual({
+      value: 'antigravity',
+      label: 'Antigravity',
+      available: true,
+      reason: null,
+    });
   });
 
   it('auto prefers Claude when available', () => {

--- a/src/features/agents/providerOptions.ts
+++ b/src/features/agents/providerOptions.ts
@@ -34,7 +34,7 @@ export function buildProviderOptions(readiness: ProviderReadiness[]): ProviderOp
   return PROVIDER_ORDER.map((provider) => {
     const entry = byProvider.get(provider);
     const available = entry?.available ?? false;
-    const label = entry?.display_name ?? providerDisplayName(provider);
+    const label = providerDisplayName(provider);
     return {
       value: provider,
       label: available ? label : `${label} - not installed`,


### PR DESCRIPTION
## Description
Fixes the Antigravity provider presentation and Windows launch behavior:

- Use canonical frontend provider labels for known providers so stale readiness metadata cannot render `antigravity` in the provider dropdown.
- Return the descriptor-backed Antigravity readiness display name from Rust.
- Route Antigravity through the same Windows `.cmd` shim wrapping path used by OpenCode for interactive launches, avoiding a visible terminal window during CLI instantiation.

## Related Issues
Fixes #405

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Codex subagent review: no blocking findings. Residual risk noted by reviewer: Windows launch behavior is covered at launch-spec/unit level, not by a real-provider native E2E/manual Antigravity spawn.
- `npm run lint`
- `npm run test` (88 files, 871 tests; existing React `act(...)` and mocked readiness stderr output still appears)
- `npm run build` (existing Vite chunk-size warning still appears)
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test` (735 unit tests + 7 mock provider E2E tests)
- `cd src-tauri && cargo clippy -- -D warnings`
- `git diff --check origin/main...HEAD`
- Secrets scan: `rg -n "api[_-]?key|secret|token|password|\.env" src src-tauri crates -S` returned only expected test/env/token-symbol references.
- Screenshot gate dry run: `npm run check:frontend-screenshot -- origin/main HEAD`

## Screenshots
![antigravity-provider-label](https://raw.githubusercontent.com/wardian-app/Wardian/pr-405-antigravity-screenshot/e2e/screenshots/antigravity-provider/20260526-044120/antigravity-provider.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable; no hard-to-understand areas added)
- [x] I have made corresponding changes to the documentation (not applicable; existing docs already use `Antigravity` and no user workflow changed)
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings (existing test/build warnings noted above)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
