### PR TITLE
Fix remote PWA E2E terminal stream mock

### DIFF
--- a/e2e/tests/remote-pwa.spec.ts
+++ b/e2e/tests/remote-pwa.spec.ts
@@ -41,17 +41,38 @@ test("remote mobile shell renders one-column agents and sends a CSRF-protected p
   await page.route("**/remote/api/agents/agent-1/chat", async (route) => {
     await route.fulfill({ contentType: "application/json", body: JSON.stringify({ events: [] }) });
   });
-  await page.route("**/remote/api/agents/agent-1/terminal", async (route) => {
+  await page.route("**/remote/api/ws-ticket", async (route) => {
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
-        snapshot: {
-          cursor: "agent-1:0000000000000001",
-          text: "terminal ready from e2e",
-          truncated: false,
-          omitted_bytes: 0,
-        },
+        ticket: "ws-ticket-e2e",
+        expires_at: "2099-05-21T08:05:00.000Z",
       }),
+    });
+  });
+  await page.routeWebSocket("**/remote/api/status-stream", async (ws) => {
+    ws.onMessage(() => {});
+  });
+  await page.routeWebSocket("**/remote/api/agents/agent-1/terminal-stream", async (ws) => {
+    let seeded = false;
+    ws.onMessage((message) => {
+      if (seeded) return;
+      expect(JSON.parse(String(message))).toMatchObject({
+        ticket: "ws-ticket-e2e",
+        cols: expect.any(Number),
+        rows: expect.any(Number),
+      });
+      seeded = true;
+      ws.send(
+        JSON.stringify({
+          type: "snapshot",
+          attachment_id: "attach-e2e",
+          owner_attachment_id: "attach-e2e",
+          cols: 80,
+          rows: 24,
+          state_base64: Buffer.from("terminal ready from e2e", "utf8").toString("base64"),
+        }),
+      );
     });
   });
   await page.route("**/remote/api/agents/action", async (route) => {
@@ -71,6 +92,7 @@ test("remote mobile shell renders one-column agents and sends a CSRF-protected p
   await expect(page.locator('[data-testid="remote-agent-detail"]')).toBeVisible();
   await expect(page.getByRole("button", { name: "Terminal", exact: true })).toHaveAttribute("aria-pressed", "true");
   await expect(page.getByText("terminal ready from e2e")).toBeVisible();
+  await page.getByRole("button", { name: "Chat", exact: true }).click();
   await page.getByLabel("Prompt Remote Coder").fill("status please");
   await page.getByRole("button", { name: "Send prompt" }).click();
 


### PR DESCRIPTION
## Description
Updates the remote PWA browser smoke test to match the current terminal attach contract.

The failing CI job was still mocking the old HTTP terminal snapshot endpoint. The remote agent detail view now opens a terminal WebSocket stream after requesting `/remote/api/ws-ticket`, so the test reached the detail view but rendered `Remote request failed: 404` instead of seeded terminal output.

This PR changes the smoke fixture to:
- mock `/remote/api/ws-ticket`
- mock the status stream WebSocket
- assert the terminal stream opens with the expected ticket and dimensions
- send the seeded terminal snapshot over `/remote/api/agents/agent-1/terminal-stream`
- switch from Terminal to Chat before filling the prompt textarea

## Related Issues
Fixes #407

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Reproduced CI failure locally before the fix: `npx playwright test --config e2e/playwright.config.ts e2e/tests/remote-pwa.spec.ts`
- `npx playwright test --config e2e/playwright.config.ts e2e/tests/remote-pwa.spec.ts --reporter=line` (rerun after review adjustment: 1 passed)
- `npm run test:e2e` (rerun after review adjustment: 42 passed, 17 skipped)
- `npm run lint` (rerun after review adjustment)
- `npm run test` (88 files, 871 tests; existing React `act(...)` and mocked-readiness stderr output still appears)
- `npm run build` (existing Vite chunk-size warning still appears)
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test` (735 unit tests + 7 mock provider E2E tests)
- `cd src-tauri && cargo clippy -- -D warnings`
- `git diff --check origin/main...HEAD`
- `npm run check:frontend-screenshot -- origin/main HEAD` (no frontend changes detected)
- Secrets scan: `rg -n "api[_-]?key|secret|token|password|\.env" e2e\tests\remote-pwa.spec.ts -S` returned no matches.
- Codex subagent review: no blocking findings; non-blocking note addressed by asserting the terminal stream open message includes the expected ticket and dimensions.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable; test fixture is straightforward)
- [x] I have made corresponding changes to the documentation (not applicable; test-only change)
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings (existing test/build warnings noted above)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
