### PR TITLE
feat(grid): add chat-first card composition mode

### DIFF
--- a/docs/guide/grid.md
+++ b/docs/guide/grid.md
@@ -30,7 +30,7 @@ Grid cards can render either:
 - **Terminal**: the provider terminal/TUI, including raw keyboard control, approvals, and raw output.
 - **Chat**: normalized user, assistant, status, tool, approval, and terminal-output events for faster scanning, plus a compact prompt composer for standard text input.
 
-Change this globally in **Settings > Grid > Grid card display**. The setting applies to the entire main Grid view. Card-level overrides are not available yet.
+Change the default globally in **Settings > Grid > Grid card display**. Each card also has a small **Terminal** / **Chat** mode switch in its header for temporary per-agent overrides. Switching from Terminal to Chat focuses that card's composer, and unsent Chat text stays with the agent while you switch modes.
 
 Chat mode sends ordinary text through the same provider submit path used by Wardian's command tools. Use **Enter** to send and **Shift+Enter** for a newline in the composer. When Wardian recognizes an action-required prompt with approval choices, Chat mode renders those choices as buttons that submit the matching response. Switch back to Terminal mode when you need raw TUI controls, provider-specific keybindings, or detailed terminal behavior.
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -107,7 +107,8 @@ main Grid view:
   Wardian recognizes an action-required prompt.
 
 Use Terminal mode when you need raw TUI controls, provider-specific keybindings,
-or detailed terminal behavior.
+or detailed terminal behavior. Individual Grid cards can still be switched
+between Terminal and Chat from the card header without changing this default.
 
 ## Watchlist
 

--- a/docs/specs/2026-05-26-chat-first-long-prompt-composition.md
+++ b/docs/specs/2026-05-26-chat-first-long-prompt-composition.md
@@ -1,0 +1,211 @@
+# Chat-First Long Prompt Composition
+
+- **Status:** Proposed
+- **Date:** 2026-05-26
+- **Decider:** Product/Engineering
+
+## Context
+
+Wardian users can type directly into provider terminals, but long prompt editing
+inside a provider TUI is not a normal text editor experience. Less
+terminal-savvy desktop users may expect mouse selection, click-to-position
+caret movement, native undo, and paragraph editing to work like a macOS text
+field. Provider TUIs do not expose that contract uniformly. Some support shell
+line-editor shortcuts, some implement their own composer, and some interpret
+mouse input as terminal selection rather than caret movement.
+
+The terminal grid is valuable because it preserves the real provider session:
+approvals, provider-specific controls, raw output, and keyboard behavior remain
+visible and debuggable. Adding a persistent external input panel to every
+terminal card would consume scarce grid space and create another place where
+Wardian might accidentally conflict with provider-specific entry fields.
+
+Wardian already has two safer composition surfaces:
+
+- **Chat mode** for a single agent, backed by Wardian's provider-aware prompt
+  submission path.
+- **Command panel** for selected-agent, broadcast, and quick-prompt workflows.
+
+Plan A is to make long-form prompt drafting a Chat-first workflow while keeping
+terminal mode a raw terminal.
+
+## Goals
+
+- Give desktop users a reliable place to draft and edit long prompts with
+  native textarea behavior.
+- Preserve raw terminal behavior and provider-specific TUI entry fields.
+- Avoid adding persistent input panels to terminal grid cards.
+- Route submitted prompts through Wardian's existing provider-aware delivery
+  path instead of typing blindly into provider composers.
+- Make the beginner-friendly path discoverable without turning terminal mode
+  into a chat UI.
+- Keep the Command panel focused on cross-agent and command-center workflows.
+
+## Non-Goals
+
+- Implementing mouse click-to-caret inside arbitrary provider TUIs.
+- Replacing terminal grid cards with a Warp-style split input/output model.
+- Synchronizing text already typed into a provider TUI back into Wardian's Chat
+  composer.
+- Reimplementing provider line editors, shell keybindings, or TUI-specific
+  editing semantics.
+- Adding provider-specific prompt panels inside terminal mode.
+
+## Decision
+
+Use Chat mode as the first-class long prompt composer for single-agent desktop
+workflows. Terminal mode remains raw and focused on TUI fidelity. The Command
+panel remains the multi-agent and command-center composition surface.
+
+The first implementation slice should be conservative:
+
+1. Add a low-friction affordance from terminal cards to Chat composition, such
+   as a compact `Compose` icon button in card chrome or a contextual terminal
+   action menu item.
+2. When activated, switch the selected agent card to Chat mode and focus the
+   Chat composer.
+3. Preserve terminal mode as the default raw-control surface unless the user or
+   future profile settings choose otherwise.
+4. Submit Chat prompts through the existing `submit_prompt_to_agent` path.
+5. If delivery is unsafe, keep the draft intact and show a clear failure state
+   rather than injecting text into the terminal.
+
+This keeps the product boundary clear: Chat is for composing, Terminal is for
+terminal control, and Command is for orchestration.
+
+## User Experience
+
+### Terminal Mode
+
+Terminal mode should not gain a permanent prompt editor. It may expose a small
+composition affordance that is easy to ignore:
+
+- Label or tooltip: `Compose in Chat`.
+- Action: switch to Chat mode for the same agent and focus the composer.
+- Placement: card header, compact toolbar, or existing card actions menu.
+- Visibility: available on desktop terminal cards; no large overlay or footer.
+
+Terminal focus, selection, provider TUI input, and raw keyboard handling remain
+unchanged.
+
+### Chat Mode
+
+Chat mode should behave like a normal desktop writing surface:
+
+- Mouse click positions the caret inside the textarea.
+- Drag and keyboard selection work with native platform behavior.
+- macOS shortcuts such as `Cmd+A`, `Cmd+Left`, `Cmd+Right`, `Option+Left`,
+  `Option+Right`, undo, and redo are handled by the browser textarea.
+- `Enter` sends and `Shift+Enter` inserts a newline.
+- The draft remains visible if submission fails.
+- Switching away from Chat mode should not discard an unsent draft unless the
+  user explicitly clears or sends it.
+
+The placeholder can stay concise, for example:
+
+```text
+Write a prompt...
+```
+
+Shortcut hints should be discoverable through existing tooltip or help surfaces
+rather than permanent instructional text in the grid.
+
+### Command Panel
+
+The Command panel stays optimized for:
+
+- Prompting multiple selected agents.
+- Broadcasting to a working set.
+- Reusing quick prompts.
+- Command-center operations where the user is not focused on one raw terminal.
+
+It should not become the default single-agent long prompt editor unless the user
+is already working from the command sidebar.
+
+## Delivery Behavior
+
+Chat submissions must use the same backend-owned provider delivery path as other
+Wardian prompt sends. This keeps provider-specific timing, submit keys,
+readiness checks, and failure states centralized.
+
+Required behavior:
+
+- Preserve user-entered text until the backend confirms the prompt was accepted
+  for delivery or queued.
+- Do not type partial text into the raw terminal from the frontend.
+- If the target is busy, action-required, or input-unsafe, follow the current
+  delivery policy and present the resulting state.
+- Do not infer approval actions from freeform Chat text.
+
+## Testing
+
+Use the lowest test layer that proves each behavior:
+
+- Frontend unit tests for the terminal-to-Chat affordance, mode switching, focus
+  behavior, and draft preservation.
+- Existing Chat composer tests for `Enter` send and `Shift+Enter` newline should
+  remain in place.
+- Browser E2E for the discoverable desktop flow: terminal card action switches
+  to Chat, focuses the composer, edits a long prompt, and submits it.
+- Backend delivery tests only if the submission contract changes.
+- Native runtime E2E only if the implementation changes PTY ownership,
+  terminal focus, or provider input injection.
+
+## Accessibility
+
+- The composition affordance must be keyboard reachable and have an accessible
+  name.
+- Focus movement from Terminal to Chat must be explicit and predictable.
+- Chat composer should keep native textarea semantics rather than custom cursor
+  or selection handling.
+- Error states must be exposed as visible text and not only color.
+
+## Risks
+
+- Users may still try to edit long prompts inside provider TUIs. The Chat
+  affordance needs to be discoverable enough to teach the safer path without
+  cluttering terminal mode.
+- Switching modes from a terminal card can surprise users if it steals focus
+  while they are typing. The affordance must require an explicit click or
+  keyboard command.
+- Provider delivery reliability remains bounded by the existing delivery
+  transport. This spec should not claim stronger delivery guarantees than the
+  backend can verify.
+
+## Open Questions
+
+- Should the terminal-to-Chat affordance live in the card header, card action
+  menu, or both?
+- Should draft preservation be per agent, per card, or global to the selected
+  agent session?
+- Should Wardian offer a beginner profile that defaults grid cards to Chat mode?
+- Are there provider-independent terminal improvements, informed by Warp's
+  behavior, that can become Plan B without modifying provider TUI input fields?
+
+## Plan B Input
+
+Warp's current model points to a provider-independent follow-up, but not to
+arbitrary terminal caret control:
+
+- Warp's Terminal and Agent modes keep terminal command entry and agent
+  conversations visually distinct.
+- Warp's rich input editor gives supported CLI coding agents an IDE-style
+  prompt editor with mouse caret placement, selection, undo, multiline input,
+  context attachment, and explicit focus transfer from the CLI agent to Warp's
+  editor.
+- Warp's full-screen app behavior still treats mouse input as terminal mouse
+  reporting. Clicks may be handled by Warp or forwarded to the running app as
+  ANSI mouse events, so caret movement inside an arbitrary TUI remains the
+  running app's responsibility.
+
+Sources:
+
+- [Warp Terminal and Agent modes](https://docs.warp.dev/agent-platform/local-agents/interacting-with-agents/terminal-and-agent-modes/)
+- [Warp rich input editor](https://docs.warp.dev/agent-platform/cli-agents/rich-input/)
+- [Warp full-screen apps](https://docs.warp.dev/terminal/more-features/full-screen-apps)
+
+If Wardian pursues Plan B, it should be a Wardian-owned rich prompt drawer for
+active agent sessions. It can offer textarea-grade editing, optional context
+attachment, clear focus state, and submission through Wardian's provider-aware
+delivery path. It should not try to reposition the caret inside provider TUI
+prompt fields.

--- a/docs/specs/2026-05-26-chat-first-long-prompt-composition.md
+++ b/docs/specs/2026-05-26-chat-first-long-prompt-composition.md
@@ -59,11 +59,11 @@ panel remains the multi-agent and command-center composition surface.
 
 The first implementation slice should be conservative:
 
-1. Add a low-friction affordance from terminal cards to Chat composition, such
-   as a compact `Compose` icon button in card chrome or a contextual terminal
-   action menu item.
-2. When activated, switch the selected agent card to Chat mode and focus the
-   Chat composer.
+1. Add a minimal per-card mode switch instead of a one-way compose button. The
+   control should be visible in both Terminal and Chat modes, show the current
+   mode, and let the user switch to the other mode.
+2. When switching from Terminal to Chat through this control, focus the Chat
+   composer for that agent.
 3. Preserve terminal mode as the default raw-control surface unless the user or
    future profile settings choose otherwise.
 4. Submit Chat prompts through the existing `submit_prompt_to_agent` path.
@@ -77,12 +77,13 @@ terminal control, and Command is for orchestration.
 
 ### Terminal Mode
 
-Terminal mode should not gain a permanent prompt editor. It may expose a small
-composition affordance that is easy to ignore:
+Terminal mode should not gain a permanent prompt editor. It should expose a
+small card-level mode switch that is easy to ignore:
 
-- Label or tooltip: `Compose in Chat`.
-- Action: switch to Chat mode for the same agent and focus the composer.
-- Placement: card header, compact toolbar, or existing card actions menu.
+- Label or tooltip: `Terminal` / `Chat`, with the current mode visible.
+- Action: switch modes for the same agent. Switching to Chat focuses the
+  composer.
+- Placement: card header or compact toolbar, not inside the terminal content.
 - Visibility: available on desktop terminal cards; no large overlay or footer.
 
 Terminal focus, selection, provider TUI input, and raw keyboard handling remain

--- a/package-lock.json
+++ b/package-lock.json
@@ -6481,9 +6481,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -203,6 +203,9 @@ fn prepare_agent_for_clear(agent: &mut ActiveAgent) -> PreparedAgentClear {
     if let Ok(mut log_last_modified) = agent.log_last_modified.lock() {
         *log_last_modified = None;
     }
+    if let Ok(mut watch_state) = agent.watch_state.lock() {
+        watch_state.clear();
+    }
 
     PreparedAgentClear {
         termination,
@@ -4522,6 +4525,17 @@ mod tests {
         *active.log_path.lock().unwrap() = Some(std::path::PathBuf::from("D:/tmp/agent.log"));
         *active.log_last_modified.lock().unwrap() = Some(std::time::SystemTime::now());
         *active.init_timestamp.lock().unwrap() = Some("2026-05-20T00:00:00Z".to_string());
+        {
+            let mut watch = active.watch_state.lock().unwrap();
+            watch.push_output(b"old terminal output");
+            watch.push_transcript(wardian_core::control::WatchTranscriptMessage {
+                role: "assistant".to_string(),
+                text: "old chat answer".to_string(),
+                provider: "codex".to_string(),
+                turn_id: Some("turn-before-clear".to_string()),
+                source: Some("transcript".to_string()),
+            });
+        }
 
         let prepared = prepare_agent_for_clear(&mut active);
 
@@ -4545,6 +4559,14 @@ mod tests {
         assert_eq!(*active.query_count.lock().unwrap(), 0);
         assert!(active.log_path.lock().unwrap().is_none());
         assert!(active.log_last_modified.lock().unwrap().is_none());
+        let watch_snapshot = active
+            .watch_state
+            .lock()
+            .unwrap()
+            .snapshot_since(None, None)
+            .expect("watch snapshot after clear");
+        assert!(watch_snapshot.output.text.is_empty());
+        assert!(watch_snapshot.transcript.messages.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -31,7 +31,15 @@ pub async fn load_agent_chat_transcript_for_state(
         return Err("session_id is required".to_string());
     }
 
-    let (watch_state, provider, resume_session, current_status, last_status_at, log_path) = {
+    let (
+        watch_state,
+        provider,
+        resume_session,
+        current_status,
+        last_status_at,
+        log_path,
+        cleared_provider_sessions,
+    ) = {
         let agents = state.agents.lock().await;
         let agent = agents
             .get(&session_id)
@@ -42,6 +50,11 @@ pub async fn load_agent_chat_transcript_for_state(
             .map_err(|_| "agent config lock poisoned".to_string())?;
         let provider = config.provider.clone();
         let resume_session = config.resume_session.clone();
+        let cleared_provider_sessions = if provider == "codex" {
+            config.codex_config().cleared_provider_sessions
+        } else {
+            Vec::new()
+        };
         let current_status = agent
             .current_status
             .lock()
@@ -64,6 +77,7 @@ pub async fn load_agent_chat_transcript_for_state(
             current_status,
             last_status_at,
             log_path,
+            cleared_provider_sessions,
         )
     };
 
@@ -73,8 +87,12 @@ pub async fn load_agent_chat_transcript_for_state(
         .snapshot_since(None, None)
         .map_err(|error| format!("watch state error: {} {}", error.code(), error.details()))?;
 
-    let mut provider_events =
-        load_provider_log_chat_events(&session_id, &provider, log_path.as_deref());
+    let mut provider_events = load_provider_log_chat_events(
+        &session_id,
+        &provider,
+        log_path.as_deref(),
+        &cleared_provider_sessions,
+    );
     if provider == "opencode" {
         provider_events.extend(load_opencode_db_chat_events(
             &session_id,
@@ -258,10 +276,14 @@ fn load_provider_log_chat_events(
     session_id: &str,
     provider: &str,
     log_path: Option<&Path>,
+    cleared_provider_sessions: &[String],
 ) -> Vec<AgentChatEvent> {
     let Some(path) = log_path else {
         return Vec::new();
     };
+    if provider_log_path_is_cleared(provider, path, cleared_provider_sessions) {
+        return Vec::new();
+    }
     let Ok(content) = read_provider_log_tail(path) else {
         return Vec::new();
     };
@@ -274,6 +296,24 @@ fn load_provider_log_chat_events(
             event
         })
         .collect()
+}
+
+fn provider_log_path_is_cleared(
+    provider: &str,
+    path: &Path,
+    cleared_provider_sessions: &[String],
+) -> bool {
+    if provider != "codex" || cleared_provider_sessions.is_empty() {
+        return false;
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or_default();
+    cleared_provider_sessions.iter().any(|session_id| {
+        let session_id = session_id.trim();
+        !session_id.is_empty() && file_name.contains(session_id)
+    })
 }
 
 fn read_provider_log_tail(path: &Path) -> std::io::Result<String> {
@@ -922,7 +962,7 @@ Do you want to proceed?
         )
         .expect("write log");
 
-        let chat_events = load_provider_log_chat_events("agent-1", "codex", Some(&log_path));
+        let chat_events = load_provider_log_chat_events("agent-1", "codex", Some(&log_path), &[]);
 
         assert_eq!(chat_events.len(), 2);
         assert_eq!(chat_events[0].kind, AgentChatEventKind::Message);
@@ -933,6 +973,29 @@ Do you want to proceed?
             Some("Rendered from the provider log")
         );
         assert_eq!(chat_events[0].metadata["provider_log"], true);
+    }
+
+    #[test]
+    fn skips_codex_provider_log_from_cleared_provider_session() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let cleared_session = "019db2f3-22de-7861-8bc6-1b86db1686db";
+        let log_path = temp
+            .path()
+            .join(format!("rollout-2026-04-20T00-00-00-{cleared_session}.jsonl"));
+        std::fs::write(
+            &log_path,
+            r#"{"type":"response_item","turn_id":"turn-1","payload":{"type":"message","role":"assistant","content":"Before clear"}}"#,
+        )
+        .expect("write log");
+
+        let chat_events = load_provider_log_chat_events(
+            "agent-1",
+            "codex",
+            Some(&log_path),
+            &[cleared_session.to_string()],
+        );
+
+        assert!(chat_events.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/state/agent_watch.rs
+++ b/src-tauri/src/state/agent_watch.rs
@@ -61,6 +61,12 @@ impl AgentWatchState {
         self.push_record(WatchRecordKind::Transcript { message })
     }
 
+    pub fn clear(&mut self) {
+        self.records.clear();
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        self.notify.notify_waiters();
+    }
+
     pub fn snapshot_since(
         &self,
         since: Option<&str>,

--- a/src/features/grid/AgentChatView.test.tsx
+++ b/src/features/grid/AgentChatView.test.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +11,7 @@ vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
 }));
 
 const invokeMock = vi.mocked(invoke);
+const listenMock = vi.mocked(listen);
 const writeTextMock = vi.mocked(writeText);
 
 function deferred<T>() {
@@ -46,6 +48,8 @@ const event = (overrides: Partial<AgentChatEvent>): AgentChatEvent => ({
 describe("AgentChatView", () => {
   beforeEach(() => {
     invokeMock.mockReset();
+    listenMock.mockReset();
+    listenMock.mockResolvedValue(vi.fn());
     writeTextMock.mockReset();
   });
 
@@ -89,6 +93,37 @@ describe("AgentChatView", () => {
     expect(screen.queryByText("codex")).not.toBeInTheDocument();
     expect(screen.queryByText("Processing")).not.toBeInTheDocument();
     expect(screen.queryByText("Read-only")).not.toBeInTheDocument();
+  });
+
+  it("clears rendered transcript rows when the backend clears the agent terminal", async () => {
+    let clearHandler: ((event: { payload?: { session_id?: string } }) => void) | null = null;
+    listenMock.mockImplementation(async (eventName, handler) => {
+      if (eventName === "agent-terminal-cleared") {
+        clearHandler = handler as typeof clearHandler;
+      }
+      return vi.fn();
+    });
+    invokeMock.mockResolvedValue([
+      event({
+        id: "message-before-clear",
+        kind: "message",
+        role: "assistant",
+        text: "This answer belongs to the old session",
+        sequence: 1,
+      }),
+    ]);
+
+    render(<AgentChatView sessionId="agent-1" status="Idle" />);
+
+    expect(await screen.findByText("This answer belongs to the old session")).toBeInTheDocument();
+    expect(clearHandler).toBeTruthy();
+
+    act(() => {
+      clearHandler?.({ payload: { session_id: "agent-1" } });
+    });
+
+    expect(screen.queryByText("This answer belongs to the old session")).not.toBeInTheDocument();
+    expect(screen.getByText("No chat transcript yet")).toBeInTheDocument();
   });
 
   it("hides routine status lifecycle rows covered by the card header", async () => {
@@ -629,6 +664,52 @@ describe("AgentChatView", () => {
     expect(input).toHaveValue("");
   });
 
+  it("focuses the composer when requested", async () => {
+    invokeMock.mockResolvedValue([]);
+
+    render(<AgentChatView sessionId="agent-1" status="Idle" autoFocusComposer />);
+
+    expect(await screen.findByLabelText("Message agent")).toHaveFocus();
+  });
+
+  it("notifies the parent when the requested composer focus is applied", async () => {
+    invokeMock.mockResolvedValue([]);
+    const onComposerAutoFocused = vi.fn();
+
+    render(
+      <AgentChatView
+        sessionId="agent-1"
+        status="Idle"
+        autoFocusComposer
+        onComposerAutoFocused={onComposerAutoFocused}
+      />,
+    );
+
+    expect(await screen.findByLabelText("Message agent")).toHaveFocus();
+    expect(onComposerAutoFocused).toHaveBeenCalledTimes(1);
+  });
+
+  it("can be controlled by a parent draft store", async () => {
+    invokeMock.mockResolvedValue([]);
+    const onDraftChange = vi.fn();
+
+    render(
+      <AgentChatView
+        sessionId="agent-1"
+        status="Idle"
+        draft="Saved draft"
+        onDraftChange={onDraftChange}
+      />,
+    );
+
+    const input = await screen.findByLabelText("Message agent");
+    expect(input).toHaveValue("Saved draft");
+
+    fireEvent.change(input, { target: { value: "Updated draft" } });
+
+    expect(onDraftChange).toHaveBeenCalledWith("Updated draft");
+  });
+
   it("submits on Enter and keeps Shift Enter as textarea input", async () => {
     invokeMock.mockImplementation((command) => {
       if (command === "load_agent_chat_transcript") return Promise.resolve([]);
@@ -725,6 +806,7 @@ describe("AgentChatView", () => {
   });
 
   it("refreshes the transcript while chat mode remains mounted", async () => {
+    vi.useFakeTimers();
     invokeMock
       .mockResolvedValueOnce([
         event({
@@ -754,10 +836,19 @@ describe("AgentChatView", () => {
         }),
       ]);
 
-    render(<AgentChatView sessionId="agent-1" refreshIntervalMs={10} />);
+    try {
+      render(<AgentChatView sessionId="agent-1" refreshIntervalMs={10} />);
 
-    expect(await screen.findByText("Initial transcript")).toBeInTheDocument();
-    expect(await screen.findByText("Updated transcript")).toBeInTheDocument();
+      await act(async () => {});
+      expect(screen.getByText("Initial transcript")).toBeInTheDocument();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10);
+      });
+      expect(screen.getByText("Updated transcript")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("ignores stale transcript responses that resolve after a newer refresh", async () => {

--- a/src/features/grid/AgentChatView.tsx
+++ b/src/features/grid/AgentChatView.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { Check, Copy, Loader2, SendHorizontal } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -7,7 +8,7 @@ import type { AgentChatEvent, AgentChatRole, AgentConfig, AgentTelemetry } from 
 import { submitInputToAgent } from "../../utils/terminalInput";
 import { toActivityBlock, type ActivityBlockModel, type ActivityTone } from "./activityBlocks";
 
-interface AgentChatViewProps {
+interface AgentChatViewBaseProps {
   sessionId: string;
   agent?: Pick<AgentConfig, "session_name" | "agent_class" | "provider">;
   provider?: AgentConfig["provider"];
@@ -17,7 +18,15 @@ interface AgentChatViewProps {
   telemetry?: Pick<AgentTelemetry, "current_status"> | null;
   className?: string;
   refreshIntervalMs?: number;
+  autoFocusComposer?: boolean;
+  onComposerAutoFocused?: () => void;
 }
+
+type AgentChatDraftControlProps =
+  | { draft?: undefined; onDraftChange?: undefined }
+  | { draft: string; onDraftChange: (value: string) => void };
+
+type AgentChatViewProps = AgentChatViewBaseProps & AgentChatDraftControlProps;
 
 type LoadState = "loading" | "ready" | "error";
 const CHAT_REFRESH_INTERVAL_MS = 3000;
@@ -60,16 +69,51 @@ export function AgentChatView({
   telemetry,
   className = "",
   refreshIntervalMs = CHAT_REFRESH_INTERVAL_MS,
+  autoFocusComposer = false,
+  draft,
+  onComposerAutoFocused,
+  onDraftChange,
 }: AgentChatViewProps) {
   const [events, setEvents] = useState<AgentChatEvent[]>([]);
   const [pendingMessages, setPendingMessages] = useState<AgentChatEvent[]>([]);
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
-  const [draft, setDraft] = useState("");
+  const [internalDraft, setInternalDraft] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const transcriptRequestRef = useRef(0);
+  const activeDraft = draft ?? internalDraft;
+  const setActiveDraft = onDraftChange ?? setInternalDraft;
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | null = null;
+
+    listen<{ session_id?: string }>("agent-terminal-cleared", (event) => {
+      if (event.payload?.session_id !== sessionId) return;
+      setEvents([]);
+      setPendingMessages([]);
+      setLoadState("ready");
+      setError(null);
+      setSubmitError(null);
+    })
+      .then((dispose) => {
+        if (disposed) {
+          dispose();
+          return;
+        }
+        unlisten = dispose;
+      })
+      .catch((reason) => {
+        console.warn("agent-terminal-cleared chat listener error:", reason);
+      });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [sessionId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -122,7 +166,7 @@ export function AgentChatView({
     setSubmitError(null);
     try {
       await submitInputToAgent(sessionId, prompt);
-      if (clearDraft) setDraft("");
+      if (clearDraft) setActiveDraft("");
       setPendingMessages((pending) => [
         ...pending,
         createPendingUserMessage(sessionId, agent?.provider ?? provider ?? providerFromEvents(events), prompt, maxSequence(events)),
@@ -136,7 +180,7 @@ export function AgentChatView({
   };
 
   const handleSubmit = () => {
-    void submitPrompt(draft, true);
+    void submitPrompt(activeDraft, true);
   };
 
   const handleApprovalSubmit = (response: string) => {
@@ -173,11 +217,13 @@ export function AgentChatView({
         ) : null}
       </div>
       <ChatComposer
+        autoFocus={autoFocusComposer}
         disabledReason={disabledReason}
-        draft={draft}
+        draft={activeDraft}
         hasActionRequired={hasActionRequired}
         isSubmitting={isSubmitting}
-        onChange={setDraft}
+        onAutoFocused={onComposerAutoFocused}
+        onChange={setActiveDraft}
         onSubmit={handleSubmit}
         submitError={submitError}
       />
@@ -563,24 +609,42 @@ function CopyIconButton({ label, value }: { label: string; value: string }) {
 }
 
 function ChatComposer({
+  autoFocus,
   disabledReason,
   draft,
   hasActionRequired,
   isSubmitting,
+  onAutoFocused,
   onChange,
   onSubmit,
   submitError,
 }: {
+  autoFocus: boolean;
   disabledReason: string | null;
   draft: string;
   hasActionRequired: boolean;
   isSubmitting: boolean;
+  onAutoFocused?: () => void;
   onChange: (value: string) => void;
   onSubmit: () => void;
   submitError: string | null;
 }) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const autoFocusConsumedRef = useRef(false);
   const placeholder = disabledReason ?? (hasActionRequired ? "Respond to action needed..." : "Message agent...");
   const canSubmit = draft.trim().length > 0 && !disabledReason;
+
+  useEffect(() => {
+    if (!autoFocus) {
+      autoFocusConsumedRef.current = false;
+      return;
+    }
+    if (!disabledReason && !autoFocusConsumedRef.current) {
+      textareaRef.current?.focus();
+      autoFocusConsumedRef.current = true;
+      onAutoFocused?.();
+    }
+  }, [autoFocus, disabledReason, onAutoFocused]);
 
   return (
     <form
@@ -603,6 +667,7 @@ function ChatComposer({
             }
           }}
           placeholder={placeholder}
+          ref={textareaRef}
           rows={1}
           value={draft}
         />

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -1487,7 +1487,7 @@ describe("Agent Watchlist Sidebar", () => {
     const alphaCard = alphaTerminal.closest('[data-testid="agent-card"]');
     expect(alphaCard).not.toBeNull();
 
-    fireEvent.click(within(alphaCard as HTMLElement).getAllByRole("button")[0]);
+    fireEvent.click(within(alphaCard as HTMLElement).getByRole("button", { name: "Maximize Alpha" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("terminal-agent-1")).toBeInTheDocument();

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
 import { GridView } from './GridView';
 import type { AgentConfig, AgentTelemetry } from '../types';
 import { useLayoutStore } from '../store/useLayoutStore';
@@ -26,10 +27,59 @@ vi.mock('../features/terminal/AgentTerminal', () => ({
 vi.mock('../features/grid/AgentChatView', () => ({
   AgentChatView: ({
     sessionId,
+    autoFocusComposer,
+    draft,
+    onComposerAutoFocused,
+    onDraftChange,
   }: {
     sessionId: string;
-  }) => <div data-testid={`chat-${sessionId}`}>Chat {sessionId}</div>,
+    autoFocusComposer?: boolean;
+    draft?: string;
+    onDraftChange?: (value: string) => void;
+    onComposerAutoFocused?: () => void;
+  }) => (
+    <MockAgentChatView
+      autoFocusComposer={autoFocusComposer}
+      draft={draft}
+      onComposerAutoFocused={onComposerAutoFocused}
+      onDraftChange={onDraftChange}
+      sessionId={sessionId}
+    />
+  ),
 }));
+
+function MockAgentChatView({
+  autoFocusComposer,
+  draft,
+  onComposerAutoFocused,
+  onDraftChange,
+  sessionId,
+}: {
+  autoFocusComposer?: boolean;
+  draft?: string;
+  onComposerAutoFocused?: () => void;
+  onDraftChange?: (value: string) => void;
+  sessionId: string;
+}) {
+  useEffect(() => {
+    if (!autoFocusComposer) return;
+    document.querySelector<HTMLTextAreaElement>(`[data-testid="chat-${sessionId}"]`)?.focus();
+    onComposerAutoFocused?.();
+  }, [autoFocusComposer, onComposerAutoFocused, sessionId]);
+
+  return (
+    <label>
+      Chat {sessionId}
+      <textarea
+        aria-label={`Mock chat composer ${sessionId}`}
+        data-autofocus={autoFocusComposer ? "true" : "false"}
+        data-testid={`chat-${sessionId}`}
+        onChange={(event) => onDraftChange?.(event.target.value)}
+        value={draft ?? ""}
+      />
+    </label>
+  );
+}
 
 const agents: AgentConfig[] = [
   { session_id: 'agent-1', session_name: 'Alpha', agent_class: 'Coder', folder: 'C:/project', is_off: false },
@@ -45,6 +95,7 @@ function renderGrid(
   options: {
     selectedAgentIds?: Set<string>;
     offAgentIds?: Set<string>;
+    onDelete?: (agentId: string) => void;
   } = {},
 ) {
   return render(
@@ -66,7 +117,7 @@ function renderGrid(
       onMouseDown={() => {}}
       onCardClick={() => {}}
       onMaximize={() => {}}
-      onDelete={() => {}}
+      onDelete={options.onDelete ?? (() => {})}
       onRename={() => {}}
       setEditingAgentId={() => {}}
       setTempName={() => {}}
@@ -189,6 +240,81 @@ describe('GridView maximize behavior', () => {
     expect(screen.getByTestId('chat-agent-1')).toBeInTheDocument();
     expect(screen.getByTestId('chat-agent-2')).toBeInTheDocument();
     expect(screen.queryByTestId('terminal-agent-1')).not.toBeInTheDocument();
+  });
+
+  it('shows a per-card mode switch and toggles one terminal card into focused chat', async () => {
+    useSettingsStore.getState().setGridCardDisplayMode('terminal');
+
+    renderGrid(null, agents);
+
+    const alphaMode = screen.getByRole('button', { name: 'Alpha mode: Terminal. Switch to Chat.' });
+    expect(screen.getByRole('button', { name: 'Beta mode: Terminal. Switch to Chat.' })).toBeInTheDocument();
+
+    fireEvent.click(alphaMode);
+
+    expect(screen.getByTestId('chat-agent-1')).toHaveFocus();
+    await waitFor(() => expect(screen.getByTestId('chat-agent-1')).toHaveAttribute('data-autofocus', 'false'));
+    expect(screen.queryByTestId('terminal-agent-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('terminal-agent-2')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Alpha mode: Chat. Switch to Terminal.' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha mode: Chat. Switch to Terminal.' }));
+
+    expect(screen.getByTestId('terminal-agent-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('chat-agent-1')).not.toBeInTheDocument();
+  });
+
+  it('keeps a per-agent chat draft when switching modes', () => {
+    useSettingsStore.getState().setGridCardDisplayMode('terminal');
+
+    renderGrid(null, agents);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha mode: Terminal. Switch to Chat.' }));
+    fireEvent.change(screen.getByTestId('chat-agent-1'), { target: { value: 'Long prompt draft' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha mode: Chat. Switch to Terminal.' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha mode: Terminal. Switch to Chat.' }));
+
+    expect(screen.getByTestId('chat-agent-1')).toHaveValue('Long prompt draft');
+  });
+
+  it('clears per-agent chat mode and draft state when deleting a card', () => {
+    const onDelete = vi.fn();
+    useSettingsStore.getState().setGridCardDisplayMode('terminal');
+
+    renderGrid(null, agents, vi.fn(), { onDelete });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha mode: Terminal. Switch to Chat.' }));
+    fireEvent.change(screen.getByTestId('chat-agent-1'), { target: { value: 'Draft to discard' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Alpha' }));
+
+    expect(onDelete).toHaveBeenCalledWith('agent-1');
+    expect(screen.getByTestId('terminal-agent-1')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha mode: Terminal. Switch to Chat.' }));
+
+    expect(screen.getByTestId('chat-agent-1')).toHaveValue('');
+  });
+
+  it('uses terminal card width when a chat-default card is switched to terminal', () => {
+    useSettingsStore.getState().setGridCardDisplayMode('chat');
+
+    const { container } = renderGrid(null, [agents[0]]);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.minWidth).toBe('360px');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha mode: Chat. Switch to Terminal.' }));
+
+    expect(screen.getByTestId('terminal-agent-1')).toBeInTheDocument();
+    expect(root.style.minWidth).toBe('520px');
+  });
+
+  it('shows hidden card action buttons when they receive keyboard focus', () => {
+    renderGrid(null, agents);
+
+    expect(screen.getByRole('button', { name: 'Maximize Alpha' })).toHaveClass('focus:opacity-100');
+    expect(screen.getByRole('button', { name: 'Delete Alpha' })).toHaveClass('focus:opacity-100');
   });
 
   it('gives a single visible agent the full grid width instead of a stale narrow track', () => {

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -11,6 +11,22 @@ import { ContextMenu, ContextMenuItem } from "../components/ContextMenu";
 
 const MIN_TERMINAL_CARD_WIDTH = 520;
 const MIN_CHAT_CARD_WIDTH = 360;
+type GridCardMode = "terminal" | "chat";
+
+function pruneRecordToIds<T>(record: Record<string, T>, allowedIds: Set<string>): Record<string, T> {
+  let changed = false;
+  const next: Record<string, T> = {};
+
+  Object.entries(record).forEach(([id, value]) => {
+    if (allowedIds.has(id)) {
+      next[id] = value;
+    } else {
+      changed = true;
+    }
+  });
+
+  return changed ? next : record;
+}
 
 interface GridViewProps {
   filteredAgents: AgentConfig[];
@@ -88,6 +104,9 @@ export const GridView: React.FC<GridViewProps> = ({
   const gridCardDisplayMode = useSettingsStore((state) => state.gridCardDisplayMode);
   const { isResizing, startResize, guidePos, resizeType } = useGridResize(containerRef);
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const [cardModeOverrides, setCardModeOverrides] = useState<Record<string, GridCardMode>>({});
+  const [chatDrafts, setChatDrafts] = useState<Record<string, string>>({});
+  const [composerFocusAgentId, setComposerFocusAgentId] = useState<string | null>(null);
 
   const [bgContextMenu, setBgContextMenu] = useState<{ x: number; y: number; visible: boolean }>({
     x: 0, y: 0, visible: false
@@ -139,7 +158,36 @@ export const GridView: React.FC<GridViewProps> = ({
   const visibleRowCount = renderedColumnCount > 0
     ? Math.ceil(visibleAgents.length / renderedColumnCount)
     : 0;
-  const minCardWidth = gridCardDisplayMode === 'chat' ? MIN_CHAT_CARD_WIDTH : MIN_TERMINAL_CARD_WIDTH;
+  const cardModeForAgent = (agentId: string): GridCardMode => cardModeOverrides[agentId] ?? gridCardDisplayMode;
+  const visibleCardModes = visibleAgents.map((agent) => cardModeForAgent(agent.session_id.toString()));
+  const visibleAgentIdKey = visibleAgents.map((agent) => agent.session_id.toString()).join('\0');
+
+  useEffect(() => {
+    const visibleIds = new Set(visibleAgentIdKey ? visibleAgentIdKey.split('\0') : []);
+    setCardModeOverrides((current) => pruneRecordToIds(current, visibleIds));
+    setChatDrafts((current) => pruneRecordToIds(current, visibleIds));
+    setComposerFocusAgentId((current) => current && visibleIds.has(current) ? current : null);
+  }, [visibleAgentIdKey]);
+
+  const clearLocalCardState = (agentId: string) => {
+    setCardModeOverrides((current) => {
+      if (!(agentId in current)) return current;
+      const next = { ...current };
+      delete next[agentId];
+      return next;
+    });
+    setChatDrafts((current) => {
+      if (!(agentId in current)) return current;
+      const next = { ...current };
+      delete next[agentId];
+      return next;
+    });
+    setComposerFocusAgentId((current) => current === agentId ? null : current);
+  };
+
+  const minCardWidth = visibleCardModes.some((mode) => mode === 'terminal')
+    ? MIN_TERMINAL_CARD_WIDTH
+    : MIN_CHAT_CARD_WIDTH;
   const idealGridMinWidth = (renderedColumnCount * minCardWidth) + (Math.max(0, renderedColumnCount - 1) * 8);
   const gridMinWidth = visibleAgents.length > 0
     ? renderedColumnCount > 1
@@ -196,6 +244,23 @@ export const GridView: React.FC<GridViewProps> = ({
         );
 
         const statusColorClass = getStatusColorClass(effectiveStatus);
+        const cardMode = cardModeForAgent(agentId);
+        const modeLabel = cardMode === 'chat' ? 'Chat' : 'Terminal';
+        const nextMode: GridCardMode = cardMode === 'chat' ? 'terminal' : 'chat';
+        const nextModeLabel = nextMode === 'chat' ? 'Chat' : 'Terminal';
+        const switchCardMode = (event: React.MouseEvent<HTMLButtonElement>) => {
+          event.stopPropagation();
+          setCardModeOverrides((current) => {
+            const nextOverrides = { ...current };
+            if (nextMode === gridCardDisplayMode) {
+              delete nextOverrides[agentId];
+            } else {
+              nextOverrides[agentId] = nextMode;
+            }
+            return nextOverrides;
+          });
+          setComposerFocusAgentId(nextMode === 'chat' ? agentId : null);
+        };
 
         return (
           <div
@@ -238,8 +303,19 @@ export const GridView: React.FC<GridViewProps> = ({
                 )}
               </div>
               <div className="flex items-center gap-1 flex-shrink-0">
+                   <button
+                     aria-label={`${agent.session_name} mode: ${modeLabel}. Switch to ${nextModeLabel}.`}
+                   className="inline-flex h-6 items-center rounded border border-wardian-light bg-[var(--color-wardian-card-bg-muted)] px-2 text-[10px] font-semibold leading-none text-muted-neutral transition-colors hover:text-primary focus:outline-none focus:ring-1 focus:ring-[var(--color-wardian-accent)]"
+                   onClick={switchCardMode}
+                   onMouseDown={(e) => e.stopPropagation()}
+                   title={`Switch to ${nextModeLabel}`}
+                   type="button"
+                 >
+                   {modeLabel}
+                 </button>
                  {isAgentMaximized ? (
                    <button 
+                     aria-label={`Minimize ${agent.session_name}`}
                      onClick={(e) => { e.stopPropagation(); onMaximize(null); }}
                      className="bg-wardian-card-bg-muted hover:bg-wardian-card-bg-muted/80 text-primary h-6 px-2 rounded text-[10px] font-bold transition-all flex items-center gap-1"
                    >
@@ -247,11 +323,11 @@ export const GridView: React.FC<GridViewProps> = ({
                      Minimize
                    </button>
                  ) : (
-                   <button onClick={(e) => { e.stopPropagation(); onMaximize(agentId); }} className="text-bright-neutral hover:text-primary transition-colors opacity-0 group-hover:opacity-100 h-6 w-6 p-1 flex items-center justify-center">
+                   <button aria-label={`Maximize ${agent.session_name}`} onClick={(e) => { e.stopPropagation(); onMaximize(agentId); }} className="text-bright-neutral hover:text-primary transition-colors opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-[var(--color-wardian-accent)] h-6 w-6 p-1 flex items-center justify-center">
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"></path></svg>
                    </button>
                  )}
-                  <button onClick={(e) => { e.stopPropagation(); onDelete(agentId); }} className="text-bright-neutral hover:text-wardian-error transition-colors opacity-0 group-hover:opacity-100 h-6 w-6 p-1 flex items-center justify-center"><svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path></svg></button>
+                  <button aria-label={`Delete ${agent.session_name}`} onClick={(e) => { e.stopPropagation(); clearLocalCardState(agentId); onDelete(agentId); }} className="text-bright-neutral hover:text-wardian-error transition-colors opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 focus:outline-none focus:ring-1 focus:ring-[var(--color-wardian-accent)] h-6 w-6 p-1 flex items-center justify-center"><svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12"></path></svg></button>
                </div>
             </div>
 
@@ -260,8 +336,10 @@ export const GridView: React.FC<GridViewProps> = ({
                 className="absolute inset-4 select-text"
                 onClick={(e) => e.stopPropagation()}
               >
-                {gridCardDisplayMode === 'chat' ? (
+                {cardMode === 'chat' ? (
                   <AgentChatView
+                    autoFocusComposer={composerFocusAgentId === agentId}
+                    draft={chatDrafts[agentId] ?? ""}
                     sessionId={agentId}
                     agent={agent}
                     provider={agent.provider}
@@ -269,6 +347,12 @@ export const GridView: React.FC<GridViewProps> = ({
                     status={effectiveStatus}
                     telemetry={metrics}
                     theme={theme}
+                    onComposerAutoFocused={() => {
+                      setComposerFocusAgentId((current) => current === agentId ? null : current);
+                    }}
+                    onDraftChange={(value) => {
+                      setChatDrafts((current) => ({ ...current, [agentId]: value }));
+                    }}
                   />
                 ) : (
                   <AgentTerminal
@@ -383,7 +467,10 @@ export const GridView: React.FC<GridViewProps> = ({
           onClone={onClone}
           onAddToList={onAddToList}
           onRemoveFromList={onRemoveFromList}
-          onDelete={onDelete}
+          onDelete={(agentId) => {
+            clearLocalCardState(agentId);
+            onDelete(agentId);
+          }}
           onClose={() => setContextMenu({ ...contextMenu, visible: false })}
         />
       )}


### PR DESCRIPTION
## Description
Adds the Plan A chat-first composition path for long prompts in the agent grid without adding persistent side panels. Each grid card can now switch between Terminal and Chat mode, preserving drafts per agent and keeping Terminal available for provider TUI work.

This also aligns Chat mode with Wardian Clear semantics: clearing an agent immediately clears rendered chat rows, drops retained watch transcript/output, and prevents cleared Codex provider-session logs from rehydrating old history.

Follow-up fixes address CI audit failure and review cleanup: the locked `tmp` transitive dependency is bumped to the patched version, `AgentChatView` now requires controlled draft props as a pair, and grid-local per-agent mode/draft/focus state is pruned when agents disappear or are deleted.

## Related Issues
Fixes #409

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm ci` - passed; found 0 vulnerabilities
- `npm audit --audit-level=high` - passed; found 0 vulnerabilities
- `npm run test` - 88 files passed, 880 tests passed
- `npm run test -- src/features/grid/AgentChatView.test.tsx` - 29 tests passed
- `npm run test -- src/views/GridView.test.tsx src/features/grid/AgentChatView.test.tsx` - 57 tests passed
- `npm run lint` - passed
- `npm run build` - passed; Vite emitted the existing large chunk warning
- `npm run docs:build` - passed
- `npm run check:frontend-screenshot -- origin/main HEAD` - passed with embedded screenshot evidence
- `cargo check` - passed
- `cargo clippy` - passed
- `cargo test` - 736 unit tests passed plus 7 mock provider E2E tests passed
- `git diff --check` - passed
- Reviewer subagent follow-up found no remaining issues after fixes for card width, one-shot composer focus, and keyboard-visible card controls

## Screenshots
![grid-card-mode-switch](https://raw.githubusercontent.com/wardian-app/Wardian/525127ebd8bc30c3289e6f3c01e7389e37195891/e2e/screenshots/chat-first-composer/20260526-050411/grid-card-mode-switch.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
