### PR TITLE
fix(ci): isolate provider hydration test state

### DIFF
--- a/src-tauri/src/state/interactions.rs
+++ b/src-tauri/src/state/interactions.rs
@@ -455,23 +455,24 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         wardian_core::db::init_db_at_path(&home.path().join("state.db")).unwrap();
 
+        let session_id = "hydrate-provider-agent-1";
         let state = InteractionState::default();
         let task = state
             .create_task(
                 Some("planner-1".to_string()),
-                "agent-1".to_string(),
+                session_id.to_string(),
                 InteractionBodyRef::Inline {
                     body: "review".to_string(),
                 },
             )
             .await;
         state
-            .complete_task_with_reply(&task.id, Some("agent-1"), ReplyStatus::Blocked, "blocked")
+            .complete_task_with_reply(&task.id, Some(session_id), ReplyStatus::Blocked, "blocked")
             .await
             .unwrap();
         state
             .start_provider_input_generation(
-                "agent-1",
+                session_id,
                 ProviderInputReadiness::Ready,
                 Some(ProviderReadyEvidence::ProviderEvent),
             )
@@ -490,7 +491,7 @@ mod tests {
         );
         assert_eq!(
             hydrated
-                .provider_input_state("agent-1")
+                .provider_input_state(session_id)
                 .await
                 .unwrap()
                 .state,


### PR DESCRIPTION
## Description
Isolates the persisted provider-input hydration test from unrelated parallel tests by using a dedicated session id instead of the shared `agent-1` key.

The main-branch backend CI failure in run 26443889021 showed `ActionRequired` being hydrated where the test expected `Ready`. The root cause is that provider input state persists through a process-global DB connection, while several tests write provider state for the same generic `agent-1` id.

## Related Issues
Fixes #411

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `cargo test state::interactions::tests::interactions_and_provider_state_hydrate_from_persistence -- --exact --nocapture`
- `cargo test state::interactions::tests -- --test-threads=8 --nocapture`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo check --workspace`
- `cargo llvm-cov --workspace --lcov --output-path coverage\rust-lcov.info`
- `npm run lint`
- `npm run test`
- `npm run build`
- `cargo audit` (passed with existing allowed warnings)
- `npm audit --audit-level=high`
- Codex subagent review: no findings

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable

Documentation and screenshots are not applicable: this is a backend test-isolation-only change with no user-facing behavior.