### PR TITLE
fix(mailbox): validate real-provider delivery

### DIFF
--- a/docs/developer/native-e2e.md
+++ b/docs/developer/native-e2e.md
@@ -86,7 +86,9 @@ It starts the native app with an isolated `WARDIAN_HOME`, creates agents through
 
 ## Real Providers
 
-Real-provider checks are opt-in. Keep them isolated and only use them when the mock provider cannot prove the behavior.
+Real-provider checks are opt-in. Keep them isolated and use them for every provider-runtime claim. The mock provider can prove Wardian-owned behavior such as routing, queueing, rendering, state sharing, and deterministic PTY plumbing. It cannot prove that a real provider CLI accepts input, exposes a ready prompt, clears a compose field, resumes a session, or responds through its real transcript path.
+
+Never make a mock-backed test spoof a real provider identity to validate Codex, Claude, Gemini, OpenCode, or Antigravity behavior. If a test would need that, write an opt-in real-provider native E2E test or leave a skipped test with `// @real-provider-only`.
 
 ```bash
 WARDIAN_E2E_REAL_OPENCODE=1 WARDIAN_E2E_REAL_WORKSPACE=<absolute-workspace-path> npm run test:e2e:native

--- a/docs/guide/provider-readiness.md
+++ b/docs/guide/provider-readiness.md
@@ -26,7 +26,7 @@ You can choose a preferred launch provider in [Settings](./settings.md). `Auto` 
 
 ## Opt-In Delivery Validation
 
-Maintainers can run the real-provider delivery matrix after all provider CLIs are installed, authenticated, and trusted for the target workspace. This validation is opt-in because it can send prompts to live provider accounts.
+Maintainers can run the real-provider delivery matrix after all provider CLIs are installed, authenticated, and trusted for the target workspace. This validation is opt-in because it sends prompts to live provider accounts. Provider-runtime claims must use this real-provider layer or another real-provider native E2E test; mock-provider tests are only valid for Wardian-owned routing, state, queueing, UI, and deterministic terminal plumbing.
 
 The full delivery matrix includes Codex, Claude, Gemini, OpenCode, and Antigravity:
 
@@ -63,6 +63,28 @@ Remove-Item Env:\WARDIAN_E2E_DELIVERY_PROVIDERS
 ```
 
 When `WARDIAN_E2E_REAL_DELIVERY=1` is set, unknown provider names fail the test. Antigravity is required in the matrix unless `WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL=1` is also set.
+
+By default the real delivery test runs one short mailbox-only prompt per selected provider. Use `WARDIAN_E2E_DELIVERY_CASES=all` for the full input case set, or a comma list such as `mailbox-short,mailbox-multiline`.
+
+Use cheap or fast model overrides where the provider exposes a model flag. The test defaults Claude to `haiku`, Gemini to `gemini-2.5-flash`, and OpenCode to `opencode/deepseek-v4-flash-free`. Override these with provider-specific environment variables:
+
+```bash
+WARDIAN_E2E_DELIVERY_CLAUDE_MODEL=haiku WARDIAN_E2E_REAL_DELIVERY=1 WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL=1 WARDIAN_E2E_DELIVERY_PROVIDERS=claude npm run test:e2e:native:fast -- e2e-native/tests/provider-delivery-real-native.test.mjs
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_E2E_DELIVERY_CLAUDE_MODEL = "haiku"
+$env:WARDIAN_E2E_REAL_DELIVERY = "1"
+$env:WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL = "1"
+$env:WARDIAN_E2E_DELIVERY_PROVIDERS = "claude"
+npm run test:e2e:native:fast -- e2e-native/tests/provider-delivery-real-native.test.mjs
+Remove-Item Env:\WARDIAN_E2E_DELIVERY_CLAUDE_MODEL
+Remove-Item Env:\WARDIAN_E2E_REAL_DELIVERY
+Remove-Item Env:\WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL
+Remove-Item Env:\WARDIAN_E2E_DELIVERY_PROVIDERS
+```
 
 ## Shared Checks
 

--- a/docs/specs/2026-05-28-real-provider-test-boundary.md
+++ b/docs/specs/2026-05-28-real-provider-test-boundary.md
@@ -1,0 +1,100 @@
+# Real Provider Test Boundary
+
+## Context
+
+Wardian supports deterministic mock-provider tests for app-owned behavior and
+opt-in real-provider tests for provider-owned runtime behavior. These layers
+must stay separate. A mock provider can prove that Wardian routes a message,
+records a delivery event, renders terminal output, or updates state, but it
+cannot prove that a real provider CLI accepts PTY input, exposes a ready prompt,
+clears its compose field, resumes a session, or responds through its real
+transcript/runtime path.
+
+## Rule
+
+Provider-related claims require actual providers. If a test says Codex, Claude,
+Gemini, OpenCode, or Antigravity behavior works, it must launch that provider's
+real CLI in native E2E or be marked as skipped with `// @real-provider-only`.
+
+Mock-backed tests may cover only Wardian-owned contracts:
+
+- control endpoint routing
+- mailbox persistence and delivery event recording
+- queue-policy decisions
+- frontend rendering and navigation
+- deterministic PTY plumbing
+- workflow execution against a simulated provider
+
+Mock-backed tests must not spoof a real provider identity to validate
+provider-specific readiness, terminal input, output parsing, prompt clearing,
+or live communication.
+
+## Real Provider Delivery
+
+Use `e2e-native/tests/provider-delivery-real-native.test.mjs` for real delivery
+validation. It is opt-in because it sends prompts to live provider accounts:
+
+```bash
+WARDIAN_E2E_REAL_DELIVERY=1 WARDIAN_E2E_DELIVERY_PROVIDERS=codex,claude,gemini,opencode,antigravity npm run test:e2e:native:fast -- e2e-native/tests/provider-delivery-real-native.test.mjs
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_E2E_REAL_DELIVERY = "1"
+$env:WARDIAN_E2E_DELIVERY_PROVIDERS = "codex,claude,gemini,opencode,antigravity"
+npm run test:e2e:native:fast -- e2e-native/tests/provider-delivery-real-native.test.mjs
+Remove-Item Env:\WARDIAN_E2E_REAL_DELIVERY
+Remove-Item Env:\WARDIAN_E2E_DELIVERY_PROVIDERS
+```
+
+The default case is one short mailbox-only prompt per provider. Use
+`WARDIAN_E2E_DELIVERY_CASES=all` for the full input case set, or a comma list
+such as `mailbox-short,mailbox-multiline`.
+
+## Cheap Models
+
+Use cheap or fast model settings where the provider exposes a stable model flag.
+The real delivery test applies these defaults:
+
+- Claude: `haiku`
+- Gemini: `gemini-2.5-flash`
+- OpenCode: `opencode/deepseek-v4-flash-free`
+
+Override any provider with:
+
+```bash
+WARDIAN_E2E_DELIVERY_CLAUDE_MODEL=<model>
+WARDIAN_E2E_DELIVERY_GEMINI_MODEL=<model>
+WARDIAN_E2E_DELIVERY_OPENCODE_MODEL=<model>
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_E2E_DELIVERY_CLAUDE_MODEL = "<model>"
+$env:WARDIAN_E2E_DELIVERY_GEMINI_MODEL = "<model>"
+$env:WARDIAN_E2E_DELIVERY_OPENCODE_MODEL = "<model>"
+```
+
+Set a provider-specific model variable to an empty value to use that provider's
+default model. For providers without a model flag, use provider-specific custom
+args only when the provider supports them:
+
+```bash
+WARDIAN_E2E_DELIVERY_ANTIGRAVITY_ARGS="--some-provider-arg value"
+```
+
+## Review Checklist
+
+When adding or reviewing a provider-related test, ask:
+
+- Does this test launch the real provider binary?
+- Does it use the provider's actual terminal/runtime path?
+- Does it depend on provider auth, account state, or model behavior?
+- If it uses the mock provider, is the assertion limited to Wardian-owned logic?
+- Is any provider-specific gap marked `// @real-provider-only` instead of
+  silently represented by a mock?
+
+If the answer is unclear, the test name or comments must be tightened before
+the test is accepted.

--- a/e2e-native/tests/cli-shared-state-native.test.mjs
+++ b/e2e-native/tests/cli-shared-state-native.test.mjs
@@ -270,6 +270,11 @@ async function createMockAgent(
   workspacePath,
   { sessionId, sessionName, isOff, mockScenario = null, mockDelayMs = null },
 ) {
+  // Mock agents are only valid for Wardian-owned contracts: shared state,
+  // routing, queueing, watch surfaces, and deterministic terminal plumbing.
+  // Do not use this helper to claim provider-specific behavior for Codex,
+  // Claude, Gemini, OpenCode, or Antigravity. Provider-runtime claims belong in
+  // opt-in real-provider native E2E tests.
   const result = await driver.executeAsyncScript((sessionId, sessionName, folder, isOff, mockScenario, mockDelayMs, done) => {
     const providerConfig =
       mockScenario || mockDelayMs
@@ -993,7 +998,7 @@ test("native CLI send routes processing mock by queue policy", { timeout: 180000
     ]);
     const queuedDelivery = JSON.parse(queuedResult.stdout).delivery[0];
     assert.equal(queuedDelivery.delivery_state, "queued");
-    assert.equal(queuedDelivery.runtime_state, "target_processing");
+    assert.equal(queuedDelivery.runtime_state, "provider_input_not_ready");
     assert.match(queuedDelivery.message_id, /^msg_/);
 
     const liveOnlyAgent = await createMockAgent(session.driver, workspacePath, {

--- a/e2e-native/tests/provider-delivery-real-native.test.mjs
+++ b/e2e-native/tests/provider-delivery-real-native.test.mjs
@@ -1,49 +1,118 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+  createNativeHarness,
+  ensureNativeAppBuilt,
+  prepareIsolatedHome,
+  startNativeSession,
+  waitForAppShell,
+} from "../lib/harness.mjs";
 
 export const PROVIDERS = ["codex", "claude", "gemini", "opencode", "antigravity"];
 
 export const INPUT_CASES = [
   {
-    name: "short",
-    input: "Reply with exactly WARDIAN_DELIVERY_SHORT.",
+    name: "mailbox-short",
+    prompt: (marker) => `Reply with exactly ${marker}.`,
+    expectOutput: true,
   },
   {
-    name: "multiline",
-    input: "Reply with these two lines:\nWARDIAN_DELIVERY_MULTI_1\nWARDIAN_DELIVERY_MULTI_2",
+    name: "mailbox-multiline",
+    prompt: (marker) => `Reply with these two lines:\n${marker}_LINE_1\n${marker}_LINE_2`,
+    expectOutput: true,
   },
   {
-    name: "long",
-    input: [
-      "Summarize this delivery validation paragraph in one sentence.",
-      "WARDIAN_DELIVERY_LONG ".repeat(80).trim(),
-    ].join("\n"),
-  },
-  {
-    name: "slash-command",
-    input: "/help",
-  },
-  {
-    name: "trailing-newline",
-    input: "Reply with exactly WARDIAN_DELIVERY_TRAILING.\n",
+    name: "mailbox-trailing-newline",
+    prompt: (marker) => `Reply with exactly ${marker}.\n`,
+    expectOutput: true,
   },
 ];
 
+const DEFAULT_CASES = ["mailbox-short"];
+const DEFAULT_PROVIDER_MODELS = {
+  claude: "haiku",
+  gemini: "gemini-2.5-flash",
+  opencode: "opencode/deepseek-v4-flash-free",
+};
+
 const runRealDelivery = process.env.WARDIAN_E2E_REAL_DELIVERY === "1";
 const allowPartialDelivery = process.env.WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL === "1";
+const workspacePath = process.env.WARDIAN_E2E_REAL_WORKSPACE || process.cwd();
+const skipNativeBuild = process.env.WARDIAN_NATIVE_SKIP_BUILD === "1";
 
-function parseDeliveryProviders(value) {
-  const requested = String(value ?? "")
-    .split(",")
-    .map((provider) => provider.trim().toLowerCase())
-    .filter(Boolean);
-
-  return requested.length > 0 ? requested : [...PROVIDERS];
+function commandName(name) {
+  return process.platform === "win32" ? `${name}.exe` : name;
 }
 
-function unknownProviders(providers) {
-  const known = new Set(PROVIDERS);
-  return providers.filter((provider) => !known.has(provider));
+function buildCli(harness) {
+  const result = spawnSync(
+    "cargo",
+    ["build", "-p", "wardian-cli", "--bin", "wardian-cli"],
+    {
+      cwd: harness.repoRoot,
+      encoding: "utf8",
+      shell: process.platform === "win32",
+    },
+  );
+
+  assert.equal(
+    result.status,
+    0,
+    `cargo build -p wardian-cli failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+
+  return path.join(harness.repoRoot, "target", "debug", commandName("wardian-cli"));
+}
+
+function runCli(cliPath, harness, args) {
+  return spawnSync(cliPath, args, {
+    cwd: harness.repoRoot,
+    env: {
+      ...process.env,
+      WARDIAN_HOME: harness.isolatedHome,
+    },
+    encoding: "utf8",
+  });
+}
+
+function runCliOk(cliPath, harness, args) {
+  const result = runCli(cliPath, harness, args);
+  assert.equal(
+    result.status,
+    0,
+    `wardian ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return result;
+}
+
+function parseCommaList(value, fallback) {
+  const requested = String(value ?? "")
+    .split(",")
+    .map((item) => item.trim().toLowerCase())
+    .filter(Boolean);
+
+  return requested.length > 0 ? requested : [...fallback];
+}
+
+function parseDeliveryProviders(value) {
+  return parseCommaList(value, PROVIDERS);
+}
+
+function parseDeliveryCases(value) {
+  const requested = parseCommaList(value, DEFAULT_CASES);
+  if (requested.includes("all")) {
+    return INPUT_CASES.map((inputCase) => inputCase.name);
+  }
+  return requested;
+}
+
+function unknownValues(values, knownValues) {
+  const known = new Set(knownValues);
+  return values.filter((value) => !known.has(value));
 }
 
 function missingProviders(providers) {
@@ -51,21 +120,170 @@ function missingProviders(providers) {
   return PROVIDERS.filter((provider) => !selected.has(provider));
 }
 
-test("real provider delivery validation matrix is explicitly opted in", (t) => {
-  if (!runRealDelivery) {
-    assert.deepEqual(parseDeliveryProviders(process.env.WARDIAN_E2E_DELIVERY_PROVIDERS), PROVIDERS);
-    assert.ok(PROVIDERS.includes("antigravity"));
-    assert.equal(INPUT_CASES.length, 5);
-    t.skip("Set WARDIAN_E2E_REAL_DELIVERY=1 to run real-provider delivery validation.");
-    return;
+function providerModel(provider) {
+  const envName = `WARDIAN_E2E_DELIVERY_${provider.toUpperCase()}_MODEL`;
+  if (Object.prototype.hasOwnProperty.call(process.env, envName)) {
+    return process.env[envName]?.trim() || null;
+  }
+  return DEFAULT_PROVIDER_MODELS[provider] ?? null;
+}
+
+function providerCustomArgs(provider) {
+  const envName = `WARDIAN_E2E_DELIVERY_${provider.toUpperCase()}_ARGS`;
+  return process.env[envName]?.trim() || null;
+}
+
+function configOverrideForProvider(provider) {
+  const config = { provider };
+  const model = providerModel(provider);
+  const customArgs = providerCustomArgs(provider);
+  if (model) {
+    config.model = model;
+  }
+  if (customArgs) {
+    config.custom_args = customArgs;
+  }
+  return config;
+}
+
+async function readDebugTail(harness) {
+  try {
+    const logPath = path.join(harness.isolatedHome, "wardian_debug.log");
+    const content = await fs.readFile(logPath, "utf8");
+    return content.split(/\r?\n/).filter(Boolean).slice(-100).join("\n");
+  } catch {
+    return "No wardian_debug.log found.";
+  }
+}
+
+async function spawnRealProviderAgent(driver, provider, sessionName, folder) {
+  const configOverride = configOverrideForProvider(provider);
+  const result = await driver.executeAsyncScript((sessionName, provider, folder, configOverride, done) => {
+    window.__TAURI_INTERNALS__.invoke("spawn_agent", {
+      req: {
+        sessionName,
+        agentClass: "RealProviderE2E",
+        folder,
+        isOff: false,
+        configOverride,
+      },
+    }).then(
+      (agent) => done({ ok: true, agent }),
+      (error) => done({ ok: false, error: String(error), provider }),
+    );
+  }, sessionName, provider, folder, configOverride);
+
+  assert.equal(
+    result.ok,
+    true,
+    `real ${provider} spawn_agent failed: ${result.error}`,
+  );
+  assert.equal(result.agent.provider, provider);
+  return result.agent;
+}
+
+async function waitForDeliveryState(cliPath, harness, target, state, messageId, timeoutMs = 60000) {
+  const startedAt = Date.now();
+  let lastResult = null;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    lastResult = runCli(cliPath, harness, [
+      "agent",
+      "watch",
+      target,
+      "--until",
+      `delivery:${state}`,
+      "--include",
+      "delivery,events",
+      "--timeout",
+      "2s",
+    ]);
+
+    if (lastResult.status === 0) {
+      const json = JSON.parse(lastResult.stdout);
+      const details = [
+        ...(json.delivery?.delivery ?? []),
+        ...(json.events ?? [])
+          .filter((event) => event.kind === "delivery")
+          .map((event) => event.payload),
+      ];
+      const detail = details.find((candidate) => {
+        if (candidate.delivery_state !== state) {
+          return false;
+        }
+        return !messageId || candidate.message_id === messageId;
+      });
+      if (detail) {
+        return detail;
+      }
+    }
   }
 
+  assert.fail(
+    `Timed out waiting for delivery ${state} message ${messageId}; last result: ${JSON.stringify(lastResult)}`,
+  );
+}
+
+async function runRealDeliveryCase({ cliPath, harness, provider, agentName, inputCase, runId }) {
+  const marker = `WARDIAN_REAL_DELIVERY_${provider.toUpperCase()}_${inputCase.name.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}_${runId}`;
+  const queued = runCliOk(cliPath, harness, [
+    "send",
+    inputCase.prompt(marker),
+    "--to",
+    agentName,
+    "--queue-policy",
+    "mailbox-only",
+  ]);
+  const queuedDelivery = JSON.parse(queued.stdout).delivery[0];
+  assert.equal(queuedDelivery.delivery_state, "queued");
+  assert.equal(queuedDelivery.runtime_state, "mailbox_only");
+  assert.match(queuedDelivery.message_id, /^msg_/);
+
+  const drained = await waitForDeliveryState(
+    cliPath,
+    harness,
+    agentName,
+    "submit_sent_unverified",
+    queuedDelivery.message_id,
+  );
+  assert.equal(drained.runtime_state, "mailbox_drain");
+  assert.equal(drained.provider, provider);
+
+  if (inputCase.expectOutput) {
+    const expected = inputCase.name === "mailbox-multiline" ? `${marker}_LINE_2` : marker;
+    const watched = runCliOk(cliPath, harness, [
+      "agent",
+      "watch",
+      agentName,
+      "--until",
+      `output:${expected}`,
+      "--include",
+      "status,transcript,output,delivery",
+      "--timeout",
+      "180s",
+    ]);
+    const watchJson = JSON.parse(watched.stdout);
+    const transcript = watchJson.transcript?.latest_text ?? "";
+    const output = watchJson.output?.text ?? "";
+    assert.match(`${transcript}\n${output}`, new RegExp(expected));
+  }
+}
+
+test("real provider delivery validation uses actual provider CLIs", { timeout: 900000 }, async (t) => {
   const providers = parseDeliveryProviders(process.env.WARDIAN_E2E_DELIVERY_PROVIDERS);
-  const unknown = unknownProviders(providers);
+  const caseNames = parseDeliveryCases(process.env.WARDIAN_E2E_DELIVERY_CASES);
+  const unknownProviders = unknownValues(providers, PROVIDERS);
+  const unknownCases = unknownValues(caseNames, INPUT_CASES.map((inputCase) => inputCase.name));
+
   assert.deepEqual(
-    unknown,
+    unknownProviders,
     [],
-    `Unknown provider(s) in WARDIAN_E2E_DELIVERY_PROVIDERS: ${unknown.join(", ")}`,
+    `Unknown provider(s) in WARDIAN_E2E_DELIVERY_PROVIDERS: ${unknownProviders.join(", ")}`,
+  );
+  assert.deepEqual(
+    unknownCases,
+    [],
+    `Unknown case(s) in WARDIAN_E2E_DELIVERY_CASES: ${unknownCases.join(", ")}`,
   );
 
   if (!allowPartialDelivery) {
@@ -73,21 +291,66 @@ test("real provider delivery validation matrix is explicitly opted in", (t) => {
     assert.deepEqual(
       missing,
       [],
-      `WARDIAN_E2E_DELIVERY_PROVIDERS must include the full delivery matrix unless WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL=1. Missing: ${missing.join(", ")}`,
+      `WARDIAN_E2E_DELIVERY_PROVIDERS must include the full provider matrix unless WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL=1. Missing: ${missing.join(", ")}`,
     );
   }
 
-  assert.deepEqual(PROVIDERS, ["codex", "claude", "gemini", "opencode", "antigravity"]);
-  assert.deepEqual(
-    INPUT_CASES.map((inputCase) => inputCase.name),
-    ["short", "multiline", "long", "slash-command", "trailing-newline"],
-  );
+  if (!runRealDelivery) {
+    t.skip("Set WARDIAN_E2E_REAL_DELIVERY=1 to run real-provider delivery validation.");
+    return;
+  }
 
+  const harness = await createNativeHarness();
+  try {
+    if (!skipNativeBuild) {
+      ensureNativeAppBuilt(harness);
+    }
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  prepareIsolatedHome(harness);
+  const cliPath = buildCli(harness);
+  const runId = `${process.pid}_${Date.now()}`;
+
+  let session;
+  try {
+    session = await startNativeSession(harness);
+  } catch (error) {
+    t.skip(String(error));
+    return;
+  }
+
+  t.after(async () => {
+    await session.close();
+  });
+
+  await waitForAppShell(session.driver, 20000);
+
+  const selectedCases = INPUT_CASES.filter((inputCase) => caseNames.includes(inputCase.name));
   for (const provider of providers) {
-    for (const inputCase of INPUT_CASES) {
-      assert.equal(typeof provider, "string");
-      assert.equal(typeof inputCase.input, "string");
-      assert.ok(inputCase.input.length > 0, `${provider}/${inputCase.name} input must not be empty`);
+    const agentName = `E2E-RealDelivery-${provider}-${runId}`;
+    try {
+      await spawnRealProviderAgent(session.driver, provider, agentName, workspacePath);
+      for (const inputCase of selectedCases) {
+        await runRealDeliveryCase({
+          cliPath,
+          harness,
+          provider,
+          agentName,
+          inputCase,
+          runId,
+        });
+      }
+    } catch (error) {
+      const debugTail = await readDebugTail(harness);
+      assert.fail(
+        `Real provider delivery failed for ${provider}: ${error.message}\n\n` +
+          `Model: ${providerModel(provider) ?? "<provider default>"}\n` +
+          `Custom args: ${providerCustomArgs(provider) ?? "<none>"}\n` +
+          `--- Wardian debug tail ---\n${debugTail}`,
+      );
     }
   }
 });

--- a/e2e-native/tests/provider-delivery-real-native.test.mjs
+++ b/e2e-native/tests/provider-delivery-real-native.test.mjs
@@ -104,7 +104,7 @@ function parseDeliveryProviders(value) {
 
 function parseDeliveryCases(value) {
   const requested = parseCommaList(value, DEFAULT_CASES);
-  if (requested.includes("all")) {
+  if (requested.length === 1 && requested[0] === "all") {
     return INPUT_CASES.map((inputCase) => inputCase.name);
   }
   return requested;
@@ -268,6 +268,14 @@ async function runRealDeliveryCase({ cliPath, harness, provider, agentName, inpu
     assert.match(`${transcript}\n${output}`, new RegExp(expected));
   }
 }
+
+test("real provider delivery case parser expands all only as the sole entry", () => {
+  assert.deepEqual(
+    parseDeliveryCases("all"),
+    INPUT_CASES.map((inputCase) => inputCase.name),
+  );
+  assert.deepEqual(parseDeliveryCases("all,mailbox-short"), ["all", "mailbox-short"]);
+});
 
 test("real provider delivery validation uses actual provider CLIs", { timeout: 900000 }, async (t) => {
   const providers = parseDeliveryProviders(process.env.WARDIAN_E2E_DELIVERY_PROVIDERS);

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1081,7 +1081,22 @@ async fn wait_for_terminal_ready_for_control_send(
     } else if info.provider == "codex" {
         wait_for_terminal_output(state, &info.uuid, 15_000, codex_output_has_ready_prompt).await
     } else if info.provider == "claude" {
-        wait_for_terminal_output(state, &info.uuid, 15_000, claude_output_has_ready_prompt).await
+        if current_agent_status_is_idle(state, &info.uuid).await? {
+            Ok(())
+        } else {
+            wait_for_terminal_output(state, &info.uuid, 15_000, claude_output_has_ready_prompt)
+                .await
+        }
+    } else if info.provider == "gemini" {
+        wait_for_terminal_output(state, &info.uuid, 15_000, gemini_output_has_ready_prompt).await
+    } else if info.provider == "antigravity" {
+        wait_for_terminal_output(
+            state,
+            &info.uuid,
+            15_000,
+            antigravity_output_has_ready_prompt,
+        )
+        .await
     } else if provider_input_has_known_not_ready_state(state, &info.uuid).await {
         Err(format!("Agent {} provider input is not ready", info.uuid))
     } else if current_agent_status_is_idle(state, &info.uuid).await? {
@@ -1294,6 +1309,49 @@ fn claude_ready_prompt_trailing_metadata_line(line: &str) -> bool {
         .all(|ch| ch == '─' || ch == '-' || ch.is_whitespace())
 }
 
+fn gemini_output_has_ready_prompt(output: &str) -> bool {
+    let cleaned = strip_ansi_controls(output).replace('\r', "\n");
+    let tail = cleaned
+        .lines()
+        .rev()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(12);
+    for line in tail {
+        if line.contains("Type your message or @path/to/file") {
+            return true;
+        }
+    }
+    false
+}
+
+fn antigravity_output_has_ready_prompt(output: &str) -> bool {
+    let cleaned = strip_ansi_controls(output).replace('\r', "\n");
+    let lines = cleaned
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    for (index, line) in lines.iter().enumerate().rev().take(16) {
+        if *line != ">" {
+            continue;
+        }
+        let has_ready_footer = lines
+            .iter()
+            .skip(index + 1)
+            .take(4)
+            .any(|line| antigravity_ready_prompt_footer_line(line));
+        if has_ready_footer {
+            return true;
+        }
+    }
+    false
+}
+
+fn antigravity_ready_prompt_footer_line(line: &str) -> bool {
+    line.contains("Press up to edit queued messages") || line.contains("? for shortcuts")
+}
+
 async fn mark_delivered_agents_prompt_started(
     app: Option<&AppHandle>,
     state: &AppState,
@@ -1303,8 +1361,12 @@ async fn mark_delivered_agents_prompt_started(
         return;
     }
 
-    let agents = state.agents.lock().await;
     for session_id in session_ids {
+        state
+            .interactions
+            .start_provider_input_generation(session_id, ProviderInputReadiness::Busy, None)
+            .await;
+        let agents = state.agents.lock().await;
         if let Some(agent) = agents.get(session_id) {
             if crate::manager::mark_agent_prompt_started(agent) {
                 if let Some(app) = app {
@@ -2404,6 +2466,18 @@ pub(crate) fn spawn_mailbox_drain_if_idle(
     });
 }
 
+fn spawn_delayed_mailbox_drain_retry(app: Option<&AppHandle>, session_id: &str) {
+    let Some(app) = app.cloned() else {
+        return;
+    };
+    let session_id = session_id.to_string();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(2_000)).await;
+        let state = app.state::<AppState>();
+        let _ = drain_next_mailbox_message_for_idle_agent(Some(&app), &state, &session_id).await;
+    });
+}
+
 enum MailboxSubmitError {
     RetrySafe(String),
     Terminal(crate::utils::delivery_transaction::TerminalDeliveryError),
@@ -2556,6 +2630,9 @@ async fn drain_next_mailbox_message_for_idle_agent(
                             .to_string()
                     });
                     record_delivery_attempt(state, &detail).await;
+                    if error.retry_safe() {
+                        spawn_delayed_mailbox_drain_retry(app, session_id);
+                    }
                     detail
                 }
             }
@@ -3753,12 +3830,12 @@ mod tests {
             .unwrap();
         assert_eq!(
             input_state.state,
-            wardian_core::control::ProviderInputReadiness::Ready
+            wardian_core::control::ProviderInputReadiness::Busy
         );
     }
 
     #[tokio::test]
-    async fn mailbox_drain_can_complete_booting_claude_from_prompt_evidence() {
+    async fn mailbox_drain_can_complete_booting_claude_from_idle_status() {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "ClaudeOne", "Coder").await;
         {
@@ -3766,10 +3843,6 @@ mod tests {
             let agent = agents.get("agent-1").unwrap();
             agent.config.lock().unwrap().provider = "claude".to_string();
             *agent.current_status.lock().unwrap() = "Idle".to_string();
-            agent.watch_state.lock().unwrap().push_output(
-                "ClaudeCode v2.1.150\r\n❯ Try \"write a test\"\r\n────────────────⏵⏵ dontask on · Haiku 4.5"
-                    .as_bytes(),
-            );
         }
         state
             .interactions
@@ -3823,7 +3896,233 @@ mod tests {
             .unwrap();
         assert_eq!(
             input_state.state,
-            wardian_core::control::ProviderInputReadiness::Ready
+            wardian_core::control::ProviderInputReadiness::Busy
+        );
+    }
+
+    #[test]
+    fn claude_ready_prompt_detector_accepts_visible_prompt_tail() {
+        assert!(claude_output_has_ready_prompt(
+            "ClaudeCode v2.1.150\r\n❯ Try \"write a test\"\r\n────────────────⏵⏵ dontask on · Haiku 4.5"
+        ));
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_can_complete_booting_gemini_from_prompt_evidence() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "GeminiOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "gemini".to_string();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+            agent.watch_state.lock().unwrap().push_output(
+                "\r\n? for shortcuts\r\n────────────────────────────────────────────────────────\r\n YOLO Ctrl+Y                                      5 context files · 2 MCP servers · 25 skills\r\n▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\r\n *  Type your message or @path/to/file\r\n▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀\r\n workspace (/directory)              /model                      context                quota\r\n".as_bytes(),
+            );
+        }
+        state
+            .interactions
+            .record_provider_input_state(
+                "agent-1",
+                4,
+                wardian_core::control::ProviderInputReadiness::Booting,
+                None,
+            )
+            .await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let queued = deliver_message_to_target(
+            None,
+            &state,
+            "GeminiOne",
+            "queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let message_id = queued[0].message_id.clone().unwrap();
+
+        let drained = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap()
+            .expect("drained message");
+
+        assert_eq!(drained.runtime_state, "mailbox_drain");
+        assert_eq!(drained.delivery_state, "submit_sent_unverified");
+        assert_eq!(drained.message_id.as_deref(), Some(message_id.as_str()));
+        assert_eq!(rx.try_recv().unwrap(), b"queued work".to_vec());
+        assert_eq!(rx.try_recv().unwrap(), b"\r".to_vec());
+        let input_state = state
+            .interactions
+            .provider_input_state("agent-1")
+            .await
+            .unwrap();
+        assert_eq!(
+            input_state.state,
+            wardian_core::control::ProviderInputReadiness::Busy
+        );
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_can_complete_booting_antigravity_from_prompt_evidence() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "AntigravityOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "antigravity".to_string();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+            agent.watch_state.lock().unwrap().push_output(
+                "\r\n────────────────────────────────────────────────────────\r\n>\r\n────────────────────────────────────────────────────────\r\n  Press up to edit queued messages                                               Gemini 3.5 Flash (High)\r\n".as_bytes(),
+            );
+        }
+        state
+            .interactions
+            .record_provider_input_state(
+                "agent-1",
+                4,
+                wardian_core::control::ProviderInputReadiness::Booting,
+                None,
+            )
+            .await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let queued = deliver_message_to_target(
+            None,
+            &state,
+            "AntigravityOne",
+            "queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let message_id = queued[0].message_id.clone().unwrap();
+
+        let drained = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap()
+            .expect("drained message");
+
+        assert_eq!(drained.runtime_state, "mailbox_drain");
+        assert_eq!(drained.delivery_state, "submit_sent_unverified");
+        assert_eq!(drained.message_id.as_deref(), Some(message_id.as_str()));
+        assert_eq!(rx.try_recv().unwrap(), b"queued work".to_vec());
+        assert_eq!(rx.try_recv().unwrap(), b"\r".to_vec());
+        let input_state = state
+            .interactions
+            .provider_input_state("agent-1")
+            .await
+            .unwrap();
+        assert_eq!(
+            input_state.state,
+            wardian_core::control::ProviderInputReadiness::Busy
+        );
+    }
+
+    #[tokio::test]
+    async fn mailbox_drain_marks_provider_busy_after_one_submitted_message() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "codex".to_string();
+            *agent.current_status.lock().unwrap() = "Processing".to_string();
+            agent
+                .watch_state
+                .lock()
+                .unwrap()
+                .push_output(b"\r\n\x1b[1m\xe2\x80\xba\x1b[22m Ready");
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let first = deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "first queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let second = deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "second queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::QueueIfBusy,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(first[0].delivery_state, "queued");
+        assert_eq!(second[0].delivery_state, "queued");
+        state
+            .interactions
+            .record_provider_input_state(
+                "agent-1",
+                4,
+                wardian_core::control::ProviderInputReadiness::Ready,
+                Some(wardian_core::control::ProviderReadyEvidence::PromptDetected),
+            )
+            .await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
+
+        let drained = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap()
+            .expect("first message drains");
+        let blocked = drain_next_mailbox_message_for_idle_agent(None, &state, "agent-1")
+            .await
+            .unwrap();
+
+        assert_eq!(drained.delivery_state, "submit_sent_unverified");
+        assert!(blocked.is_none());
+        assert_eq!(rx.try_recv().unwrap(), b"first queued work".to_vec());
+        assert_eq!(rx.try_recv().unwrap(), b"\r".to_vec());
+        assert!(rx.try_recv().is_err());
+        let input_state = state
+            .interactions
+            .provider_input_state("agent-1")
+            .await
+            .unwrap();
+        assert_eq!(
+            input_state.state,
+            wardian_core::control::ProviderInputReadiness::Busy
         );
     }
 


### PR DESCRIPTION
## Description
- Fix mailbox drain readiness for real Claude, Gemini, and Antigravity sessions so queued mailbox messages can drain when provider input becomes usable.
- Mark provider input busy immediately after mailbox delivery submits one message, preventing one ready prompt from draining multiple queued messages at once.
- Replace the misleading mock-backed provider delivery check with an opt-in native E2E that launches actual provider CLIs, and document the mock-vs-real-provider boundary for future agents.

## Related Issues
Fixes #413

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test` (88 files, 880 tests passed)
- [x] `npm run build`
- [x] `npm run docs:build`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test` (740 lib/bin tests plus mock provider E2E tests passed)
- [x] `cd src-tauri && cargo clippy`
- [x] `node --test e2e-native/tests/provider-delivery-real-native.test.mjs` (skips by default unless real-provider opt-in is set)
- [x] `npm run test:e2e:native:fast -- --test-name-pattern "native CLI send routes processing mock by queue policy" e2e-native/tests/cli-shared-state-native.test.mjs`
- [x] Real-provider native smoke: `WARDIAN_E2E_REAL_DELIVERY=1 WARDIAN_E2E_DELIVERY_ALLOW_PARTIAL=1 WARDIAN_E2E_DELIVERY_PROVIDERS=claude,gemini,antigravity WARDIAN_E2E_DELIVERY_CASES=mailbox-short node --test --test-concurrency=1 e2e-native/tests/provider-delivery-real-native.test.mjs`
- [x] `git diff --check`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable