### PR TITLE
feat(explorer): open files in external editor

### DIFF
--- a/docs/developer/explorer-sidebar.md
+++ b/docs/developer/explorer-sidebar.md
@@ -2,15 +2,15 @@
 
 ## Overview
 The Explorer Sidebar is a dedicated panel found in the Wardian sidebar (`SidebarIconRail`), designed to give users direct access to their local workspace. Depending on whether an agent is actively selected, it contextualizes its root directory seamlessly:
-1. **Global View**: Shows the `~/.wardian/` home directory.
-2. **Agent View**: Shows the specific workspace configured for the active agent (`agent.config.folder`).
+1. **Global View**: Shows the configured `<WARDIAN_HOME>/` directory.
+2. **Agent View**: Shows the selected agent workspace or assigned Git worktree.
 
 ## Key Components
 
 ### 1. `ExplorerPanel.tsx`
 This is the main container component for the file explorer tab.
 - **Root Resolution**: It queries the backend command `get_explorer_root(sessionId)` to identify which path to render.
-- **Context Menu Context**: Provides right-click operations tailored to `FileTree` items (Reveal in OS, Delete, Copy Absolute Path, Preview).
+- **Context Menu Context**: Provides right-click operations tailored to `FileTree` items (Open Preview, Open in External App, Reveal in OS, Copy Absolute Path, Delete).
 - **Preview Modal**: Implements a themed modal overlay to securely display raw text file contents queried from the OS.
 
 ### 2. `FileTree.tsx`
@@ -24,6 +24,7 @@ The file system operations strictly enforce security and platform agnosticism:
 - `get_directory_tree`: Non-recursive listing of immediate children of a given path. Sorts directories first, then alphabetical.
 - `read_file_preview`: Simple text reader.
 - `reveal_in_explorer`: OS-specific `std::process::Command` routing to invoke `explorer`, `open`, or `xdg-open`.
+- `open_in_external_editor`: Opens a path with the Settings-selected external app mode (`system`, `vscode`, or `custom`) by spawning the platform command in Rust.
 - `delete_file`: Recursively deletes a directory or permanently removes a file string.
 
 ## Technical Decisions

--- a/docs/guide/explorer.md
+++ b/docs/guide/explorer.md
@@ -11,6 +11,7 @@ Use it when you need to inspect generated files, logs, prompt assets, or the sel
 - Browse the workspace for the agent selected in [Watchlists](./watchlists.md).
 - Inspect files after an agent reports completion in [Queue](./queue.md).
 - Open a quick preview before deciding whether to edit files in an external tool.
+- Open a file or folder in your configured local app or editor.
 - Reveal a file in the system file manager when you need native OS actions.
 
 ## Basic Workflow
@@ -18,7 +19,7 @@ Use it when you need to inspect generated files, logs, prompt assets, or the sel
 1. Select an agent in the right roster, or clear selection for global Wardian home browsing.
 2. Open the **Explorer** tab in the left sidebar.
 3. Expand folders to inspect files.
-4. Use preview, reveal, copy path, or delete from the file context menu.
+4. Use preview, open externally, reveal, copy path, or delete from the file context menu.
 5. Move to [Source Control](./source-control.md) when the selected root is a Git workspace and you need to review changes.
 
 ## Root Behavior
@@ -40,6 +41,7 @@ This allows you to manually browse common data, shared lineages, and global conf
 The Explorer supports standard right-click actions for rapid file management:
 
 - **Open Preview**: Opens a read-only plaintext viewer within Wardian for quick inspection of markdown, JSON, or log files.
+- **Open in External App**: Opens the selected file or folder using the configured Explorer editor preference. The default is the operating system's default app for that path. You can switch to VS Code or a custom executable in [Settings](./settings.md).
 - **Reveal in System Explorer**: Opens your OS file manager (Windows Explorer or macOS Finder) directly to the selected file or folder.
 - **Copy Path**: Copies the absolute path of the file to your clipboard.
 - **Delete**: Permanently removes the file or directory from your disk (requires confirmation).

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -1,8 +1,8 @@
 # Settings
 
 Settings controls Wardian's global app preferences, display behavior, terminal
-defaults, watchlist behavior, provider defaults, and provider maintenance
-utilities.
+defaults, Explorer behavior, watchlist behavior, provider defaults, and provider
+maintenance utilities.
 
 Open Settings from the gear icon on the left icon rail. It opens as a
 near-full-screen app modal and does not change the currently selected sidebar
@@ -19,7 +19,7 @@ computed defaults for the app and operating system.
 
 - `settings/app.json`: app preferences such as theme, top bar telemetry
   visibility, Grid card display, Watchlist new agent position, terminal font
-  size, terminal font family, and Gemini auto-patch.
+  size, terminal font family, Explorer external editor, and Gemini auto-patch.
 - `settings/shell.json`: runtime preferences such as shell selection, default
   provider, regular agent session policy, and Codex runtime defaults.
 
@@ -36,6 +36,8 @@ Categories:
 - **General**: app version and update status.
 - **Appearance**: app theme and top bar telemetry visibility.
 - **Grid**: display mode for agent cards in the main Grid view.
+- **Queue**: queue event desktop and sound notification rules.
+- **Explorer**: external app or editor used by the Explorer right-click menu.
 - **Watchlist**: roster behavior for newly spawned agents.
 - **Terminal**: terminal font and shell defaults.
 - **Agent Runtime**: default provider, regular agent session behavior, and
@@ -109,6 +111,23 @@ main Grid view:
 Use Terminal mode when you need raw TUI controls, provider-specific keybindings,
 or detailed terminal behavior. Individual Grid cards can still be switched
 between Terminal and Chat from the card header without changing this default.
+
+## Explorer
+
+The **External editor** control sets what happens when you choose **Open in
+External App** from the Explorer right-click menu:
+
+- **System default app** uses the operating system's registered app for the
+  selected file or folder. This is Wardian's default because it respects file
+  type associations and works without extra editor setup.
+- **VS Code (code command)** launches the `code` command-line entry point with
+  the selected path.
+- **Custom executable** launches the configured executable with the selected
+  path as its argument.
+
+If VS Code does not open, Wardian shows the launch error in Explorer. Verify the
+`code` command is available on Wardian's app process PATH or use Custom
+executable to point directly at your editor.
 
 ## Watchlist
 

--- a/docs/specs/2026-05-28-explorer-external-editor.md
+++ b/docs/specs/2026-05-28-explorer-external-editor.md
@@ -1,0 +1,22 @@
+# Explorer External Editor
+
+Wardian's Explorer context menu should let users open a file or folder in a local application directly from the tree. The default behavior is **System default app** because it respects each file type, works across operating systems, and does not require VS Code's `code` command to be installed on `PATH`.
+
+Settings adds an **Explorer** category with an **External editor** row. Users can choose:
+
+- **System default app**: open the selected path with the operating system's registered application.
+- **VS Code (code command)**: launch VS Code's command-line entry point with the selected path.
+- **Custom executable**: launch a user-provided executable with the selected path as its argument.
+
+The setting is global and stored in `settings/app.json` as sparse app overrides:
+
+```json
+{
+  "external_editor": "system",
+  "external_editor_custom_executable": null
+}
+```
+
+The Explorer right-click menu exposes **Open in External App** for files and folders. Backend launching stays in Rust so platform-specific process behavior is tested once and the frontend only passes the selected path plus the current editor setting. Launch failures are shown in Explorer so users can fix missing `code` commands, unavailable platform openers, or invalid custom executable paths.
+
+Verification should cover frontend menu behavior, Settings rendering and persistence, backend command argument construction, and documentation updates for Explorer and Settings.

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1,7 +1,20 @@
+use serde::Deserialize;
 use std::fs;
 use std::path::Path;
 use wardian_core::models::AgentConfig;
 use wardian_core::models::FileNode;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExternalEditorLaunchSettings {
+    pub external_editor: String,
+    pub external_editor_custom_executable: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExternalEditorLaunchSpec {
+    program: String,
+    args: Vec<String>,
+}
 
 fn resolve_agent_visible_workspace(config: &AgentConfig) -> String {
     if config.git_worktree == Some(true) {
@@ -125,6 +138,79 @@ pub async fn reveal_in_explorer(path: String) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+pub async fn open_in_external_editor(
+    path: String,
+    editor: ExternalEditorLaunchSettings,
+) -> Result<(), String> {
+    let launch = external_editor_launch(Path::new(&path), &editor)?;
+    std::process::Command::new(&launch.program)
+        .args(&launch.args)
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn external_editor_launch(
+    path: &Path,
+    editor: &ExternalEditorLaunchSettings,
+) -> Result<ExternalEditorLaunchSpec, String> {
+    let path_arg = path.to_string_lossy().into_owned();
+    match editor.external_editor.trim() {
+        "vscode" => Ok(ExternalEditorLaunchSpec {
+            program: vscode_command().to_string(),
+            args: vec![path_arg],
+        }),
+        "custom" => {
+            let program = editor
+                .external_editor_custom_executable
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| "Custom editor executable is not configured.".to_string())?;
+            Ok(ExternalEditorLaunchSpec {
+                program: program.to_string(),
+                args: vec![path_arg],
+            })
+        }
+        _ => Ok(system_default_open_launch(path_arg)),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn vscode_command() -> &'static str {
+    "code.cmd"
+}
+
+#[cfg(not(target_os = "windows"))]
+fn vscode_command() -> &'static str {
+    "code"
+}
+
+#[cfg(target_os = "windows")]
+fn system_default_open_launch(path: String) -> ExternalEditorLaunchSpec {
+    ExternalEditorLaunchSpec {
+        program: "cmd".to_string(),
+        args: vec!["/C".to_string(), "start".to_string(), "".to_string(), path],
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn system_default_open_launch(path: String) -> ExternalEditorLaunchSpec {
+    ExternalEditorLaunchSpec {
+        program: "open".to_string(),
+        args: vec![path],
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn system_default_open_launch(path: String) -> ExternalEditorLaunchSpec {
+    ExternalEditorLaunchSpec {
+        program: "xdg-open".to_string(),
+        args: vec![path],
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn windows_explorer_args(path: &Path) -> Vec<String> {
     let normalized_path = path.to_string_lossy().replace('/', "\\");
@@ -201,5 +287,119 @@ mod tests {
         let args = windows_explorer_args(&dir_path);
         assert_eq!(args.len(), 1);
         assert_eq!(args[0], dir_path.to_string_lossy().replace('/', "\\"));
+    }
+
+    #[test]
+    fn external_editor_launch_uses_system_default_by_default() {
+        let launch = external_editor_launch(
+            Path::new("/tmp/project/notes.md"),
+            &ExternalEditorLaunchSettings {
+                external_editor: "system".to_string(),
+                external_editor_custom_executable: None,
+            },
+        )
+        .expect("launch spec");
+
+        assert!(launch.args.contains(&"/tmp/project/notes.md".to_string()));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn external_editor_launch_uses_windows_start_for_system_default() {
+        let launch = external_editor_launch(
+            Path::new("C:/Users/Test Project/notes.md"),
+            &ExternalEditorLaunchSettings {
+                external_editor: "system".to_string(),
+                external_editor_custom_executable: None,
+            },
+        )
+        .expect("launch spec");
+
+        assert_eq!(launch.program, "cmd");
+        assert_eq!(
+            launch.args,
+            vec![
+                "/C".to_string(),
+                "start".to_string(),
+                "".to_string(),
+                "C:/Users/Test Project/notes.md".to_string()
+            ]
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn external_editor_launch_uses_macos_open_for_system_default() {
+        let launch = external_editor_launch(
+            Path::new("/tmp/project/notes.md"),
+            &ExternalEditorLaunchSettings {
+                external_editor: "system".to_string(),
+                external_editor_custom_executable: None,
+            },
+        )
+        .expect("launch spec");
+
+        assert_eq!(launch.program, "open");
+        assert_eq!(launch.args, vec!["/tmp/project/notes.md".to_string()]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn external_editor_launch_uses_xdg_open_for_system_default() {
+        let launch = external_editor_launch(
+            Path::new("/tmp/project/notes.md"),
+            &ExternalEditorLaunchSettings {
+                external_editor: "system".to_string(),
+                external_editor_custom_executable: None,
+            },
+        )
+        .expect("launch spec");
+
+        assert_eq!(launch.program, "xdg-open");
+        assert_eq!(launch.args, vec!["/tmp/project/notes.md".to_string()]);
+    }
+
+    #[test]
+    fn external_editor_launch_uses_vscode_command_when_selected() {
+        let launch = external_editor_launch(
+            Path::new("/tmp/project/notes.md"),
+            &ExternalEditorLaunchSettings {
+                external_editor: "vscode".to_string(),
+                external_editor_custom_executable: None,
+            },
+        )
+        .expect("launch spec");
+
+        assert!(launch.program == "code" || launch.program == "code.cmd");
+        assert_eq!(launch.args, vec!["/tmp/project/notes.md".to_string()]);
+    }
+
+    #[test]
+    fn external_editor_launch_uses_custom_executable_when_selected() {
+        let launch = external_editor_launch(
+            Path::new("/tmp/project/notes.md"),
+            &ExternalEditorLaunchSettings {
+                external_editor: "custom".to_string(),
+                external_editor_custom_executable: Some("/opt/editor/bin/editor".to_string()),
+            },
+        )
+        .expect("launch spec");
+
+        assert_eq!(launch.program, "/opt/editor/bin/editor");
+        assert_eq!(launch.args, vec!["/tmp/project/notes.md".to_string()]);
+    }
+
+    #[test]
+    fn external_editor_launch_rejects_custom_without_executable() {
+        let error = external_editor_launch(
+            Path::new("/tmp/project/notes.md"),
+            &ExternalEditorLaunchSettings {
+                external_editor: "custom".to_string(),
+                external_editor_custom_executable: Some("   ".to_string()),
+            },
+        )
+        .expect_err("custom editor should require executable");
+
+        assert_eq!(error, "Custom editor executable is not configured.");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -401,6 +401,7 @@ pub fn run() {
             commands::fs::get_directory_tree,
             commands::fs::delete_file,
             commands::fs::reveal_in_explorer,
+            commands::fs::open_in_external_editor,
             commands::fs::read_file_preview,
             commands::git::git_status,
             commands::git::git_current_branch,

--- a/src-tauri/src/utils/app_settings.rs
+++ b/src-tauri/src/utils/app_settings.rs
@@ -21,6 +21,10 @@ pub struct AppSettings {
     pub watchlist_new_agent_position: String,
     #[serde(default = "default_titlebar_telemetry_visible")]
     pub titlebar_telemetry_visible: bool,
+    #[serde(default = "default_external_editor")]
+    pub external_editor: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_editor_custom_executable: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -39,6 +43,10 @@ pub struct AppSettingsOverrides {
     pub watchlist_new_agent_position: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub titlebar_telemetry_visible: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_editor: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_editor_custom_executable: Option<Option<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -67,6 +75,8 @@ impl Default for AppSettings {
             grid_card_display_mode: default_grid_card_display_mode(),
             watchlist_new_agent_position: default_watchlist_new_agent_position(),
             titlebar_telemetry_visible: default_titlebar_telemetry_visible(),
+            external_editor: default_external_editor(),
+            external_editor_custom_executable: None,
         }
     }
 }
@@ -92,6 +102,10 @@ fn default_titlebar_telemetry_visible() -> bool {
         cfg!(debug_assertions),
         option_env!("WARDIAN_UPDATE_CHANNEL"),
     )
+}
+
+fn default_external_editor() -> String {
+    "system".to_string()
 }
 
 fn titlebar_telemetry_visible_default_for_build(
@@ -221,6 +235,10 @@ fn normalize_app_settings(mut settings: AppSettings) -> AppSettings {
         normalize_grid_card_display_mode(&settings.grid_card_display_mode);
     settings.watchlist_new_agent_position =
         normalize_watchlist_new_agent_position(&settings.watchlist_new_agent_position);
+    settings.external_editor = normalize_external_editor(&settings.external_editor);
+    settings.external_editor_custom_executable = settings
+        .external_editor_custom_executable
+        .and_then(|value| trim_to_option(&value));
     settings
 }
 
@@ -274,6 +292,14 @@ fn app_settings_from_overrides_for_build(
         titlebar_telemetry_visible: overrides.titlebar_telemetry_visible.unwrap_or_else(|| {
             titlebar_telemetry_visible_default_for_build(debug_build, update_channel)
         }),
+        external_editor: overrides
+            .external_editor
+            .clone()
+            .unwrap_or(defaults.external_editor),
+        external_editor_custom_executable: overrides
+            .external_editor_custom_executable
+            .clone()
+            .unwrap_or(defaults.external_editor_custom_executable),
     })
 }
 
@@ -291,6 +317,12 @@ fn normalize_app_overrides(mut overrides: AppSettingsOverrides) -> AppSettingsOv
     overrides.watchlist_new_agent_position = overrides
         .watchlist_new_agent_position
         .map(|position| normalize_watchlist_new_agent_position(&position));
+    overrides.external_editor = overrides
+        .external_editor
+        .map(|editor| normalize_external_editor(&editor));
+    overrides.external_editor_custom_executable = overrides
+        .external_editor_custom_executable
+        .map(|executable| executable.and_then(|value| trim_to_option(&value)));
     overrides
 }
 
@@ -315,6 +347,11 @@ fn app_overrides_from_settings(
         titlebar_telemetry_visible: (settings.titlebar_telemetry_visible
             != defaults.titlebar_telemetry_visible)
             .then_some(settings.titlebar_telemetry_visible),
+        external_editor: (settings.external_editor != defaults.external_editor)
+            .then(|| settings.external_editor.clone()),
+        external_editor_custom_executable: (settings.external_editor_custom_executable
+            != defaults.external_editor_custom_executable)
+            .then(|| settings.external_editor_custom_executable.clone()),
     }
 }
 
@@ -337,6 +374,14 @@ fn normalize_watchlist_new_agent_position(value: &str) -> String {
     match value.trim() {
         "bottom" => "bottom".to_string(),
         _ => "top".to_string(),
+    }
+}
+
+fn normalize_external_editor(value: &str) -> String {
+    match value.trim() {
+        "vscode" => "vscode".to_string(),
+        "custom" => "custom".to_string(),
+        _ => "system".to_string(),
     }
 }
 
@@ -371,6 +416,8 @@ mod tests {
         assert_eq!(settings.grid_card_display_mode, "terminal");
         assert_eq!(settings.watchlist_new_agent_position, "top");
         assert!(settings.titlebar_telemetry_visible);
+        assert_eq!(settings.external_editor, "system");
+        assert_eq!(settings.external_editor_custom_executable, None);
     }
 
     #[test]
@@ -432,6 +479,8 @@ mod tests {
             grid_card_display_mode: "chat".to_string(),
             watchlist_new_agent_position: "top".to_string(),
             titlebar_telemetry_visible: true,
+            external_editor: "custom".to_string(),
+            external_editor_custom_executable: Some("/opt/editor/bin/editor".to_string()),
         };
 
         let saved = save_app_settings_to_path(&path, &settings).expect("save settings");
@@ -455,6 +504,8 @@ mod tests {
             grid_card_display_mode: "terminal".to_string(),
             watchlist_new_agent_position: "top".to_string(),
             titlebar_telemetry_visible: true,
+            external_editor: "system".to_string(),
+            external_editor_custom_executable: None,
         };
 
         save_app_settings_to_path(&path, &settings).expect("save settings");
@@ -479,7 +530,8 @@ mod tests {
               "schema_version": 2,
               "overrides": {
                 "terminal_font_family": "JetBrains Mono, monospace",
-                "watchlist_new_agent_position": "bottom"
+                "watchlist_new_agent_position": "bottom",
+                "external_editor": "vscode"
               }
             }"#,
         )
@@ -496,6 +548,7 @@ mod tests {
         );
         assert_eq!(loaded.grid_card_display_mode, "terminal");
         assert_eq!(loaded.watchlist_new_agent_position, "bottom");
+        assert_eq!(loaded.external_editor, "vscode");
     }
 
     #[test]
@@ -511,7 +564,9 @@ mod tests {
               "terminal_font_size": 4,
               "terminal_font_family": "   ",
               "grid_card_display_mode": "cards",
-              "watchlist_new_agent_position": "middle"
+              "watchlist_new_agent_position": "middle",
+              "external_editor": "emacs",
+              "external_editor_custom_executable": "   "
             }"#,
         )
         .expect("write settings");
@@ -524,5 +579,7 @@ mod tests {
         assert_eq!(loaded.terminal_font_family, None);
         assert_eq!(loaded.grid_card_display_mode, "terminal");
         assert_eq!(loaded.watchlist_new_agent_position, "top");
+        assert_eq!(loaded.external_editor, "system");
+        assert_eq!(loaded.external_editor_custom_executable, None);
     }
 }

--- a/src/features/explorer/ExplorerPanel.test.tsx
+++ b/src/features/explorer/ExplorerPanel.test.tsx
@@ -2,16 +2,34 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { invoke } from '@tauri-apps/api/core';
+import type React from 'react';
 import { ExplorerPanel } from './ExplorerPanel';
 import type { AgentConfig } from '../../types';
+import { useSettingsStore } from '../../store/useSettingsStore';
 
 vi.mock('./FileTree', () => ({
-  FileTree: ({ path }: { path: string }) => <div data-testid="file-tree">{path}</div>,
+  FileTree: ({ path, onContextMenu }: { path: string; onContextMenu?: (event: React.MouseEvent, node: unknown) => void }) => (
+    <div
+      data-testid="file-tree"
+      onContextMenu={(event) => onContextMenu?.(event, {
+        name: 'notes.md',
+        path: 'C:\\Users\\test\\repo\\notes.md',
+        is_dir: false,
+        extension: 'md',
+      })}
+    >
+      {path}
+    </div>
+  ),
 }));
 
 describe('ExplorerPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useSettingsStore.setState({
+      externalEditor: 'system',
+      externalEditorCustomExecutable: '',
+    });
   });
 
   it('uses compact sidebar title typography', () => {
@@ -41,6 +59,58 @@ describe('ExplorerPanel', () => {
         path: 'C:\\Users\\test\\.wardian',
       });
     });
+  });
+
+  it('opens a right-clicked file in the configured external editor', async () => {
+    useSettingsStore.setState({
+      externalEditor: 'vscode',
+      externalEditorCustomExecutable: '',
+    });
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
+      if (command === 'git_status') return { files: [] };
+      return null;
+    });
+
+    render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
+
+    const tree = await screen.findByTestId('file-tree');
+    await userEvent.pointer({ keys: '[MouseRight]', target: tree });
+    await userEvent.click(await screen.findByRole('button', { name: 'Open in External App' }));
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('open_in_external_editor', {
+        path: 'C:\\Users\\test\\repo\\notes.md',
+        editor: {
+          external_editor: 'vscode',
+          external_editor_custom_executable: null,
+        },
+      });
+    });
+  });
+
+  it('shows a visible error when the configured external editor cannot open', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    useSettingsStore.setState({
+      externalEditor: 'vscode',
+      externalEditorCustomExecutable: '',
+    });
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
+      if (command === 'git_status') return { files: [] };
+      if (command === 'open_in_external_editor') throw new Error('program not found');
+      return null;
+    });
+
+    render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
+
+    const tree = await screen.findByTestId('file-tree');
+    await userEvent.pointer({ keys: '[MouseRight]', target: tree });
+    await userEvent.click(await screen.findByRole('button', { name: 'Open in External App' }));
+
+    expect(await screen.findByText(/External app open failed for VS Code/i)).toBeInTheDocument();
+    expect(screen.getByText(/program not found/i)).toBeInTheDocument();
+    consoleError.mockRestore();
   });
 
   it('re-resolves the explorer root when the selected agent worktree assignment changes', async () => {

--- a/src/features/explorer/ExplorerPanel.tsx
+++ b/src/features/explorer/ExplorerPanel.tsx
@@ -5,14 +5,28 @@ import { FolderOpen } from 'lucide-react';
 import { FileTree, FileNode } from './FileTree';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { AgentConfig, GitStatusResult } from '../../types';
+import { useSettingsStore } from '../../store/useSettingsStore';
 
 interface ExplorerPanelProps {
   selectedAgentIds: Set<string>;
   agents: AgentConfig[];
 }
 
+const externalEditorLabel = (editor: string) => {
+  switch (editor) {
+    case 'vscode':
+      return 'VS Code';
+    case 'custom':
+      return 'Custom executable';
+    default:
+      return 'System default app';
+  }
+};
+
 export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, agents }) => {
   const confirm = useConfirm();
+  const externalEditor = useSettingsStore((state) => state.externalEditor);
+  const externalEditorCustomExecutable = useSettingsStore((state) => state.externalEditorCustomExecutable);
   const [rootPath, setRootPath] = useState<string | null>(null);
   const [gitStatusMap, setGitStatusMap] = useState<Record<string, string>>({});
   const changedDirectories = useMemo(() => {
@@ -39,6 +53,7 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
   const [previewContent, setPreviewContent] = useState<string | null>(null);
   const [previewTitle, setPreviewTitle] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [externalOpenError, setExternalOpenError] = useState<string | null>(null);
 
   const selectedAgentId = selectedAgentIds.size === 1 ? Array.from(selectedAgentIds)[0] : null;
   const selectedAgent = agents.find((agent) => agent.session_id === selectedAgentId) ?? null;
@@ -113,6 +128,27 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
     setMenuPos(null);
   };
 
+  const handleOpenExternalEditor = async () => {
+    if (activeNode) {
+      try {
+        await invoke('open_in_external_editor', {
+          path: activeNode.path,
+          editor: {
+            external_editor: externalEditor,
+            external_editor_custom_executable: externalEditorCustomExecutable.trim() || null,
+          },
+        });
+        setExternalOpenError(null);
+      } catch (err) {
+        console.error("External editor open failed:", err);
+        setExternalOpenError(
+          `External app open failed for ${externalEditorLabel(externalEditor)}: ${String(err)}`,
+        );
+      }
+    }
+    setMenuPos(null);
+  };
+
   const handleOpenRoot = async () => {
     if (!rootPath) return;
     try {
@@ -174,6 +210,15 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
           </button>
         </div>
       )}
+
+      {externalOpenError && (
+        <div
+          role="alert"
+          className="mb-2 rounded-md border border-wardian-error/40 bg-wardian-error/10 px-3 py-2 text-xs leading-relaxed text-wardian-error"
+        >
+          {externalOpenError}
+        </div>
+      )}
       
       <div className="flex-1 overflow-auto w-full relative min-h-0 -mx-3 px-3">
         {rootPath ? (
@@ -207,6 +252,9 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
               Open Preview
             </button>
           )}
+          <button className="w-full text-left px-4 py-2 hover:bg-wardian-card-bg-muted transition-colors text-primary" onClick={handleOpenExternalEditor}>
+            Open in External App
+          </button>
           <button className="w-full text-left px-4 py-2 hover:bg-wardian-card-bg-muted transition-colors text-primary" onClick={handleReveal}>
             Reveal in OS
           </button>

--- a/src/features/settings/SettingsModal.test.tsx
+++ b/src/features/settings/SettingsModal.test.tsx
@@ -51,6 +51,8 @@ describe("SettingsModal", () => {
       gridCardDisplayMode: "terminal",
       watchlistNewAgentPosition: "top",
       titlebarTelemetryVisible: true,
+      externalEditor: "system",
+      externalEditorCustomExecutable: "",
       shell_id: "auto",
       custom_executable: "",
       custom_args: "",
@@ -293,6 +295,38 @@ describe("SettingsModal", () => {
       });
     });
     expect(useSettingsStore.getState().watchlistNewAgentPosition).toBe("bottom");
+  });
+
+  it("loads and saves the Explorer external editor preference", async () => {
+    useSettingsStore.setState({
+      externalEditor: "system",
+      externalEditorCustomExecutable: "",
+    });
+    render(<SettingsModal isOpen onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Explorer" }));
+
+    const select = screen.getByLabelText("External editor");
+    expect(select).toHaveValue("system");
+    expect(screen.getByRole("option", { name: "VS Code (code command)" })).toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: "custom" } });
+    fireEvent.change(screen.getByLabelText("Custom editor executable"), {
+      target: { value: "C:/Tools/editor.exe" },
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("save_app_settings", {
+        settings: expect.objectContaining({
+          schema_version: 2,
+          overrides: expect.objectContaining({
+            external_editor: "custom",
+            external_editor_custom_executable: "C:/Tools/editor.exe",
+          }),
+        }),
+      });
+    });
+    expect(useSettingsStore.getState().externalEditor).toBe("custom");
   });
 
   it("loads and saves the top bar telemetry preference", async () => {

--- a/src/features/settings/SettingsModal.tsx
+++ b/src/features/settings/SettingsModal.tsx
@@ -13,7 +13,7 @@ import { useAppUpdate } from "./useAppUpdate";
 import { RemoteAccessSettings } from "./RemoteAccessSettings";
 import { QUEUE_EVENT_LABELS, QUEUE_EVENT_TYPES } from "../queue/queueFilters";
 import { useQueueStore } from "../../store/useQueueStore";
-import type { AppThemeSetting, WatchlistNewAgentPosition } from "../../types/settings";
+import type { AppThemeSetting, ExternalEditorSetting, WatchlistNewAgentPosition } from "../../types/settings";
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -25,6 +25,7 @@ type SettingsCategory =
   | "Appearance"
   | "Grid"
   | "Queue"
+  | "Explorer"
   | "Watchlist"
   | "Terminal"
   | "Agent Runtime"
@@ -46,6 +47,7 @@ const categories: SettingsCategory[] = [
   "Appearance",
   "Grid",
   "Queue",
+  "Explorer",
   "Watchlist",
   "Terminal",
   "Agent Runtime",
@@ -110,6 +112,20 @@ const rowDefinitions: SettingsRowDefinition[] = [
     label: "Sound alerts",
     detail: "Choose which queue events play Wardian's local notification tone.",
     keywords: ["queue", "notifications", "sound", "tone", "action needed"],
+  },
+  {
+    id: "external-editor",
+    category: "Explorer",
+    label: "External editor",
+    detail: "Choose how Explorer opens files and folders from the right-click menu.",
+    keywords: ["explorer", "files", "editor", "open", "vscode", "default app"],
+  },
+  {
+    id: "custom-editor-executable",
+    category: "Explorer",
+    label: "Custom editor executable",
+    detail: "Used only when External editor is set to Custom executable.",
+    keywords: ["explorer", "files", "editor", "custom", "executable", "path"],
   },
   {
     id: "watchlist-new-agent-position",
@@ -332,6 +348,10 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
     setTerminalFontFamily,
     titlebarTelemetryVisible,
     setTitlebarTelemetryVisible,
+    externalEditor,
+    setExternalEditor,
+    externalEditorCustomExecutable,
+    setExternalEditorCustomExecutable,
     gridCardDisplayMode,
     setGridCardDisplayMode,
     watchlistNewAgentPosition,
@@ -419,7 +439,9 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
   const visibleRows = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     const rowsForCurrentShell = rowDefinitions.filter(
-      (row) => shell_id === "custom" || (row.id !== "custom-shell-executable" && row.id !== "custom-shell-args"),
+      (row) =>
+        (shell_id === "custom" || (row.id !== "custom-shell-executable" && row.id !== "custom-shell-args")) &&
+        (externalEditor === "custom" || row.id !== "custom-editor-executable"),
     );
     if (normalizedQuery) {
       return rowsForCurrentShell.filter((row) =>
@@ -430,7 +452,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
       );
     }
     return rowsForCurrentShell.filter((row) => row.category === activeCategory);
-  }, [activeCategory, query, shell_id]);
+  }, [activeCategory, externalEditor, query, shell_id]);
 
   const groupedRows = categories
     .map((category) => ({
@@ -480,6 +502,16 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
 
   const handleWatchlistNewAgentPositionChange = async (value: WatchlistNewAgentPosition) => {
     setWatchlistNewAgentPosition(value);
+    await useSettingsStore.getState().saveAppSettings();
+  };
+
+  const handleExternalEditorChange = async (value: ExternalEditorSetting) => {
+    setExternalEditor(value);
+    await useSettingsStore.getState().saveAppSettings();
+  };
+
+  const handleExternalEditorCustomExecutableChange = async (value: string) => {
+    setExternalEditorCustomExecutable(value);
     await useSettingsStore.getState().saveAppSettings();
   };
 
@@ -723,6 +755,33 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose })
                 onChange={setSoundNotification}
               />
             </div>
+          </SettingRow>
+        );
+      case "external-editor":
+        return (
+          <SettingRow key={row.id} label={row.label} detail={row.detail}>
+            <select
+              aria-label="External editor"
+              value={externalEditor}
+              onChange={(event) => void handleExternalEditorChange(event.target.value as ExternalEditorSetting)}
+              className={optionClass}
+            >
+              <option value="system">System default app</option>
+              <option value="vscode">VS Code (code command)</option>
+              <option value="custom">Custom executable</option>
+            </select>
+          </SettingRow>
+        );
+      case "custom-editor-executable":
+        return (
+          <SettingRow key={row.id} label={row.label} detail={row.detail}>
+            <input
+              aria-label="Custom editor executable"
+              value={externalEditorCustomExecutable}
+              onChange={(event) => void handleExternalEditorCustomExecutableChange(event.target.value)}
+              placeholder="Path to editor executable"
+              className={optionClass}
+            />
           </SettingRow>
         );
       case "shell":

--- a/src/store/useSettingsStore.test.ts
+++ b/src/store/useSettingsStore.test.ts
@@ -21,6 +21,8 @@ function resetAppPreferences() {
     gridCardDisplayMode: 'terminal',
     watchlistNewAgentPosition: 'top',
     titlebarTelemetryVisible: true,
+    externalEditor: 'system',
+    externalEditorCustomExecutable: '',
     app_settings_overrides: {},
     app_settings_loaded: false,
   });
@@ -140,6 +142,8 @@ describe('app settings persistence', () => {
       grid_card_display_mode: 'chat',
       watchlist_new_agent_position: 'bottom',
       titlebar_telemetry_visible: false,
+      external_editor: 'vscode',
+      external_editor_custom_executable: null,
     });
 
     await useSettingsStore.getState().loadAppSettings();
@@ -152,6 +156,7 @@ describe('app settings persistence', () => {
     expect(useSettingsStore.getState().gridCardDisplayMode).toBe('chat');
     expect(useSettingsStore.getState().watchlistNewAgentPosition).toBe('bottom');
     expect(useSettingsStore.getState().titlebarTelemetryVisible).toBe(false);
+    expect(useSettingsStore.getState().externalEditor).toBe('vscode');
     expect(useSettingsStore.getState().app_settings_loaded).toBe(true);
   });
 
@@ -164,6 +169,8 @@ describe('app settings persistence', () => {
       grid_card_display_mode: 'chat',
       watchlist_new_agent_position: 'bottom',
       titlebar_telemetry_visible: false,
+      external_editor: 'custom',
+      external_editor_custom_executable: 'C:/Tools/editor.exe',
     });
 
     useSettingsStore.getState().setTheme('light');
@@ -173,6 +180,8 @@ describe('app settings persistence', () => {
     useSettingsStore.getState().setGridCardDisplayMode('chat');
     useSettingsStore.getState().setWatchlistNewAgentPosition('bottom');
     useSettingsStore.getState().setTitlebarTelemetryVisible(false);
+    useSettingsStore.getState().setExternalEditor('custom');
+    useSettingsStore.getState().setExternalEditorCustomExecutable('C:/Tools/editor.exe');
 
     await useSettingsStore.getState().saveAppSettings();
 
@@ -186,6 +195,8 @@ describe('app settings persistence', () => {
           grid_card_display_mode: 'chat',
           watchlist_new_agent_position: 'bottom',
           titlebar_telemetry_visible: false,
+          external_editor: 'custom',
+          external_editor_custom_executable: 'C:/Tools/editor.exe',
         }),
       }),
     });
@@ -194,6 +205,7 @@ describe('app settings persistence', () => {
     expect(useSettingsStore.getState().gridCardDisplayMode).toBe('chat');
     expect(useSettingsStore.getState().watchlistNewAgentPosition).toBe('bottom');
     expect(useSettingsStore.getState().titlebarTelemetryVisible).toBe(false);
+    expect(useSettingsStore.getState().externalEditor).toBe('custom');
   });
 
   it('keeps migrated local preferences when no backend app settings file exists yet', async () => {

--- a/src/store/useSettingsStore.ts
+++ b/src/store/useSettingsStore.ts
@@ -10,6 +10,7 @@ import type {
   CodexRuntimePolicy,
   CodexSandboxMode,
   DefaultProviderSetting,
+  ExternalEditorSetting,
   SettingsDocument,
   ShellOption,
   ShellSettings,
@@ -74,6 +75,7 @@ const CODEX_APPROVAL_POLICIES: CodexApprovalPolicy[] = ['untrusted', 'on-failure
 const DEFAULT_PROVIDER_SETTINGS: DefaultProviderSetting[] = ['auto', 'claude', 'codex', 'gemini', 'antigravity', 'opencode'];
 const GRID_CARD_DISPLAY_MODES: GridCardDisplayMode[] = ['terminal', 'chat'];
 const WATCHLIST_NEW_AGENT_POSITIONS: WatchlistNewAgentPosition[] = ['top', 'bottom'];
+const EXTERNAL_EDITOR_SETTINGS: ExternalEditorSetting[] = ['system', 'vscode', 'custom'];
 
 export const DEFAULT_CODEX_RUNTIME_POLICY: CodexRuntimePolicy = {
   sandbox_mode: 'workspace-write',
@@ -123,6 +125,14 @@ export function normalizeWatchlistNewAgentPosition(
     : 'top';
 }
 
+export function normalizeExternalEditorSetting(
+  value: string | null | undefined,
+): ExternalEditorSetting {
+  return EXTERNAL_EDITOR_SETTINGS.includes(value as ExternalEditorSetting)
+    ? value as ExternalEditorSetting
+    : 'system';
+}
+
 interface SettingsState {
   theme: AppThemeSetting;
   autoPatchGemini: boolean;
@@ -131,6 +141,8 @@ interface SettingsState {
   gridCardDisplayMode: GridCardDisplayMode;
   watchlistNewAgentPosition: WatchlistNewAgentPosition;
   titlebarTelemetryVisible: boolean;
+  externalEditor: ExternalEditorSetting;
+  externalEditorCustomExecutable: string;
   shell_id: string;
   custom_executable: string;
   custom_args: string;
@@ -150,6 +162,8 @@ interface SettingsState {
   setGridCardDisplayMode: (value: GridCardDisplayMode) => void;
   setWatchlistNewAgentPosition: (value: WatchlistNewAgentPosition) => void;
   setTitlebarTelemetryVisible: (value: boolean) => void;
+  setExternalEditor: (value: ExternalEditorSetting) => void;
+  setExternalEditorCustomExecutable: (value: string) => void;
   setShellId: (shellId: string) => void;
   setCustomExecutable: (value: string) => void;
   setCustomArgs: (value: string) => void;
@@ -175,6 +189,8 @@ type PersistedSettingsState = Pick<
   | 'gridCardDisplayMode'
   | 'watchlistNewAgentPosition'
   | 'titlebarTelemetryVisible'
+  | 'externalEditor'
+  | 'externalEditorCustomExecutable'
 >;
 
 const DEFAULT_SHELL_SETTINGS: ShellSettings = {
@@ -194,6 +210,8 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
   grid_card_display_mode: 'terminal',
   watchlist_new_agent_position: 'top',
   titlebar_telemetry_visible: true,
+  external_editor: 'system',
+  external_editor_custom_executable: null,
 };
 
 const EMPTY_APP_SETTINGS_OVERRIDES: AppSettingsOverrides = {};
@@ -265,6 +283,12 @@ function appOverridesFromSettings(settings: AppSettings): AppSettingsOverrides {
     ...((settings.titlebar_telemetry_visible !== false) !== DEFAULT_APP_SETTINGS.titlebar_telemetry_visible
       ? { titlebar_telemetry_visible: settings.titlebar_telemetry_visible !== false }
       : {}),
+    ...(normalizeExternalEditorSetting(settings.external_editor) !== DEFAULT_APP_SETTINGS.external_editor
+      ? { external_editor: normalizeExternalEditorSetting(settings.external_editor) }
+      : {}),
+    ...((settings.external_editor_custom_executable?.trim() ?? '') !== ''
+      ? { external_editor_custom_executable: settings.external_editor_custom_executable?.trim() ?? null }
+      : {}),
   };
 }
 
@@ -277,6 +301,8 @@ function appOverridesFromState(state: SettingsState): AppSettingsOverrides {
     grid_card_display_mode: state.gridCardDisplayMode,
     watchlist_new_agent_position: state.watchlistNewAgentPosition,
     titlebar_telemetry_visible: state.titlebarTelemetryVisible,
+    external_editor: state.externalEditor,
+    external_editor_custom_executable: state.externalEditorCustomExecutable.trim() || null,
   });
 }
 
@@ -331,6 +357,12 @@ function normalizeAppOverrides(overrides: AppSettingsOverrides | undefined): App
     ...(typeof overrides?.titlebar_telemetry_visible === 'boolean'
       ? { titlebar_telemetry_visible: overrides.titlebar_telemetry_visible }
       : {}),
+    ...(overrides?.external_editor
+      ? { external_editor: normalizeExternalEditorSetting(overrides.external_editor) }
+      : {}),
+    ...('external_editor_custom_executable' in (overrides ?? {})
+      ? { external_editor_custom_executable: overrides?.external_editor_custom_executable?.trim() || null }
+      : {}),
   };
 }
 
@@ -365,7 +397,9 @@ function stateHasMigratedAppPreferences(state: SettingsState) {
     state.terminalFontFamily.trim() !== '' ||
     state.gridCardDisplayMode !== DEFAULT_APP_SETTINGS.grid_card_display_mode ||
     state.watchlistNewAgentPosition !== DEFAULT_APP_SETTINGS.watchlist_new_agent_position ||
-    state.titlebarTelemetryVisible !== DEFAULT_APP_SETTINGS.titlebar_telemetry_visible
+    state.titlebarTelemetryVisible !== DEFAULT_APP_SETTINGS.titlebar_telemetry_visible ||
+    state.externalEditor !== DEFAULT_APP_SETTINGS.external_editor ||
+    state.externalEditorCustomExecutable.trim() !== ''
   );
 }
 
@@ -379,6 +413,8 @@ export const useSettingsStore = create<SettingsState>()(
       gridCardDisplayMode: 'terminal',
       watchlistNewAgentPosition: 'top',
       titlebarTelemetryVisible: true,
+      externalEditor: 'system',
+      externalEditorCustomExecutable: '',
       shell_id: DEFAULT_SHELL_SETTINGS.shell_id,
       custom_executable: DEFAULT_SHELL_SETTINGS.custom_executable ?? '',
       custom_args: DEFAULT_SHELL_SETTINGS.custom_args ?? '',
@@ -432,6 +468,23 @@ export const useSettingsStore = create<SettingsState>()(
         titlebarTelemetryVisible,
         app_settings_overrides: { ...state.app_settings_overrides, titlebar_telemetry_visible: titlebarTelemetryVisible },
       })),
+      setExternalEditor: (externalEditor) => set((state) => {
+        const normalized = normalizeExternalEditorSetting(externalEditor);
+        return {
+          externalEditor: normalized,
+          app_settings_overrides: { ...state.app_settings_overrides, external_editor: normalized },
+        };
+      }),
+      setExternalEditorCustomExecutable: (externalEditorCustomExecutable) => set((state) => {
+        const trimmed = externalEditorCustomExecutable.trim();
+        const { external_editor_custom_executable: _removed, ...rest } = state.app_settings_overrides;
+        return {
+          externalEditorCustomExecutable,
+          app_settings_overrides: trimmed
+            ? { ...state.app_settings_overrides, external_editor_custom_executable: trimmed }
+            : rest,
+        };
+      }),
       setShellId: (shell_id) => set((state) => ({
         shell_id,
         shell_settings_overrides: { ...state.shell_settings_overrides, shell_id },
@@ -516,6 +569,8 @@ export const useSettingsStore = create<SettingsState>()(
             gridCardDisplayMode: normalizeGridCardDisplayMode(settings.grid_card_display_mode),
             watchlistNewAgentPosition: normalizeWatchlistNewAgentPosition(settings.watchlist_new_agent_position),
             titlebarTelemetryVisible: settings.titlebar_telemetry_visible !== false,
+            externalEditor: normalizeExternalEditorSetting(settings.external_editor),
+            externalEditorCustomExecutable: settings.external_editor_custom_executable?.trim() ?? '',
             app_settings_overrides: normalizeAppOverrides(overrides),
             app_settings_loaded: true,
           });
@@ -533,6 +588,8 @@ export const useSettingsStore = create<SettingsState>()(
           grid_card_display_mode: normalizeGridCardDisplayMode(get().gridCardDisplayMode),
           watchlist_new_agent_position: normalizeWatchlistNewAgentPosition(get().watchlistNewAgentPosition),
           titlebar_telemetry_visible: get().titlebarTelemetryVisible,
+          external_editor: normalizeExternalEditorSetting(get().externalEditor),
+          external_editor_custom_executable: get().externalEditorCustomExecutable.trim() || null,
         };
         const settings: SettingsDocument<AppSettings, AppSettingsOverrides> = {
           schema_version: 2,
@@ -550,6 +607,8 @@ export const useSettingsStore = create<SettingsState>()(
           gridCardDisplayMode: normalizeGridCardDisplayMode(saved.grid_card_display_mode),
           watchlistNewAgentPosition: normalizeWatchlistNewAgentPosition(saved.watchlist_new_agent_position),
           titlebarTelemetryVisible: saved.titlebar_telemetry_visible !== false,
+          externalEditor: normalizeExternalEditorSetting(saved.external_editor),
+          externalEditorCustomExecutable: saved.external_editor_custom_executable?.trim() ?? '',
           app_settings_overrides: normalizeAppOverrides(overrides),
           app_settings_loaded: true,
         });
@@ -646,6 +705,8 @@ export const useSettingsStore = create<SettingsState>()(
           gridCardDisplayMode: normalizeGridCardDisplayMode(state.gridCardDisplayMode ?? state.grid_card_display_mode),
           watchlistNewAgentPosition: normalizeWatchlistNewAgentPosition(state.watchlistNewAgentPosition),
           titlebarTelemetryVisible: typeof state.titlebarTelemetryVisible === 'boolean' ? state.titlebarTelemetryVisible : true,
+          externalEditor: normalizeExternalEditorSetting(state.externalEditor),
+          externalEditorCustomExecutable: state.externalEditorCustomExecutable?.trim() ?? '',
         };
       },
       partialize: (state) => ({
@@ -656,6 +717,8 @@ export const useSettingsStore = create<SettingsState>()(
         gridCardDisplayMode: normalizeGridCardDisplayMode(state.gridCardDisplayMode),
         watchlistNewAgentPosition: normalizeWatchlistNewAgentPosition(state.watchlistNewAgentPosition),
         titlebarTelemetryVisible: state.titlebarTelemetryVisible,
+        externalEditor: normalizeExternalEditorSetting(state.externalEditor),
+        externalEditorCustomExecutable: state.externalEditorCustomExecutable.trim(),
       }),
     }
   )

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -10,6 +10,7 @@ export type CodexApprovalPolicy = 'untrusted' | 'on-failure' | 'on-request' | 'n
 export type DefaultProviderSetting = 'auto' | 'claude' | 'codex' | 'gemini' | 'antigravity' | 'opencode';
 export type AppThemeSetting = 'dark' | 'light' | 'system';
 export type WatchlistNewAgentPosition = 'top' | 'bottom';
+export type ExternalEditorSetting = 'system' | 'vscode' | 'custom';
 
 export interface CodexRuntimePolicy {
   sandbox_mode: CodexSandboxMode;
@@ -49,6 +50,8 @@ export interface AppSettings {
   grid_card_display_mode: 'terminal' | 'chat';
   watchlist_new_agent_position: WatchlistNewAgentPosition;
   titlebar_telemetry_visible: boolean;
+  external_editor: ExternalEditorSetting;
+  external_editor_custom_executable: string | null;
 }
 
 export interface AppSettingsOverrides {
@@ -59,6 +62,8 @@ export interface AppSettingsOverrides {
   grid_card_display_mode?: 'terminal' | 'chat';
   watchlist_new_agent_position?: WatchlistNewAgentPosition;
   titlebar_telemetry_visible?: boolean;
+  external_editor?: ExternalEditorSetting;
+  external_editor_custom_executable?: string | null;
 }
 
 export interface SettingsDocument<TSettings, TOverrides> {


### PR DESCRIPTION
## Description
Adds an Explorer right-click action to open the selected file or folder in a local external application.

The default is the operating system file-type handler. Users can also choose the VS Code `code` command or a custom executable in Settings > Explorer. Failed launches now surface a visible Explorer alert instead of only logging to the console.

Cross-platform behavior:
- Windows system default: `cmd /C start "" <path>`
- macOS system default: `open <path>`
- Linux system default: `xdg-open <path>`
- VS Code mode: uses the `code` command and reports a visible error if it is not on the app process PATH
- Custom mode: validates the executable path and passes the selected file/folder as a single argument

## Related Issues
Fixes #418

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- Wardian-Reviewer review requested after it became idle; important findings were addressed before PR creation.
- `npm run lint`
- `npm run test`
- `npm run build`
- `npm run docs:build`
- `cargo check --manifest-path src-tauri\Cargo.toml`
- `cargo test --manifest-path src-tauri\Cargo.toml`
- `cargo clippy --manifest-path src-tauri\Cargo.toml`
- `cargo test --manifest-path src-tauri\Cargo.toml external_editor_launch`
- `npm run test -- src/features/explorer/ExplorerPanel.test.tsx src/features/settings/SettingsModal.test.tsx`
- `git diff --check`
- diff secret-pattern scan over `docs`, `src`, and `src-tauri`
- `npm run check:frontend-screenshot -- origin/main HEAD` with this PR body image

## Screenshots
![Explorer external editor setting](https://raw.githubusercontent.com/wardian-app/Wardian/pr-evidence-explorer-external-editor/pr-evidence/explorer-external-editor/settings-external-editor.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable