### PR TITLE
Fix Windows process cleanup and control timeout reporting

### DIFF
--- a/crates/wardian-cli/src/errors.rs
+++ b/crates/wardian-cli/src/errors.rs
@@ -10,6 +10,7 @@ pub enum ExitCode {
     DbUnavailable = 4,
     Ambiguous = 5,
     AppNotRunning = 6,
+    ControlEndpointTimeout = 7,
 }
 
 #[derive(Debug, Serialize)]
@@ -102,6 +103,19 @@ impl CliError {
             code: "app_not_running",
             message: "Wardian is not running. Start the app to use this command.".to_string(),
             hint: Some("Launch Wardian, then retry.".to_string()),
+            details: None,
+        }
+    }
+
+    pub fn control_endpoint_timeout(message: impl Into<String>) -> Self {
+        Self {
+            exit_code: ExitCode::ControlEndpointTimeout,
+            code: "control_endpoint_timeout",
+            message: message.into(),
+            hint: Some(
+                "Wardian is running but the control endpoint timed out; the app may be overloaded. Retry shortly or reduce active agent load."
+                    .to_string(),
+            ),
             details: None,
         }
     }

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -686,6 +686,8 @@ fn control_error(e: std::io::Error) -> CliError {
         .and_then(|inner| inner.downcast_ref::<live::WaitTargetNotFoundError>())
     {
         CliError::backend(ExitCode::NotFound, "not_found", wait_not_found.to_string())
+    } else if e.kind() == std::io::ErrorKind::TimedOut {
+        CliError::control_endpoint_timeout(e.to_string())
     } else if is_control_endpoint_unavailable(&e) {
         CliError::app_not_running()
     } else if let Some(endpoint_error) = e
@@ -761,9 +763,7 @@ fn parse_timeout(value: &str) -> Result<Duration, CliError> {
 fn is_control_endpoint_unavailable(error: &std::io::Error) -> bool {
     matches!(
         error.kind(),
-        std::io::ErrorKind::NotFound
-            | std::io::ErrorKind::ConnectionRefused
-            | std::io::ErrorKind::TimedOut
+        std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
     )
 }
 
@@ -990,6 +990,37 @@ mod tests {
         assert_eq!(cli_error.code, "not_found");
         assert_eq!(cli_error.code_i32(), 2);
         assert!(cli_error.message.contains("ghost"));
+    }
+
+    #[test]
+    fn control_error_reports_endpoint_timeout_separately_from_app_not_running() {
+        let error = std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "Wardian control endpoint timed out",
+        );
+
+        let cli_error = control_error(error);
+
+        assert_eq!(cli_error.code, "control_endpoint_timeout");
+        assert_ne!(cli_error.code_i32(), ExitCode::AppNotRunning as i32);
+        assert!(cli_error.message.contains("timed out"));
+        assert!(cli_error
+            .hint
+            .as_deref()
+            .is_some_and(|hint| hint.contains("overloaded")));
+    }
+
+    #[test]
+    fn control_error_still_maps_refused_endpoint_to_app_not_running() {
+        let error = std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "could not connect to Wardian control endpoint",
+        );
+
+        let cli_error = control_error(error);
+
+        assert_eq!(cli_error.code, "app_not_running");
+        assert_eq!(cli_error.code_i32(), ExitCode::AppNotRunning as i32);
     }
 
     #[test]

--- a/docs/specs/2026-05-28-windows-agent-process-control-reliability.md
+++ b/docs/specs/2026-05-28-windows-agent-process-control-reliability.md
@@ -1,0 +1,30 @@
+# Windows Agent Process and Control Reliability
+
+## Status
+
+Accepted
+
+## Context
+
+Wardian launches interactive providers through PTYs and supervises their process trees from the Rust backend. On Windows, some provider CLIs start through `.cmd` shims. During clear, resume, or worktree reassignment, the shim process can exit before Wardian runs `taskkill /PID <pid> /T /F`. A failed `taskkill` for an already-exited wrapper must not be logged as a cleanup failure, and Wardian must still look for session-marked descendants that may have outlived the wrapper.
+
+Separately, the CLI used the same `app_not_running` error for connection failures and control endpoint timeouts. Under heavy agent load, reads can still succeed while mutating control requests time out. Reporting that state as "app not running" hides the real overloaded-control condition.
+
+Slow telemetry passes contributed to the overload risk on Windows because each active agent triggered another full process scan to rediscover session-marked process roots. With many active agents, that made process sampling scale with agent count instead of with one process table pass.
+
+## Decision
+
+Windows cleanup treats an already-gone PID as a successful cleanup outcome. `taskkill` failures are classified with a post-failure process-existence check, so empty output from a vanished wrapper does not produce a noisy failure. Stale-session cleanup also performs a bounded follow-up scan for the same `WARDIAN_SESSION_ID`, giving newly visible descendants a chance to be reaped after the wrapper disappears.
+
+Telemetry now discovers Windows session process roots from the process marker data already collected during the current process-table pass. The metrics pass and app metrics calculation reuse those roots instead of calling a fresh process scan once per agent.
+
+CLI control endpoint timeouts now return `control_endpoint_timeout` with a retry/load hint and a distinct exit code. Missing or refused endpoints still return `app_not_running`.
+
+## Consequences
+
+- Normal Windows cleanup remains explicit and fast, while stale `.cmd` wrapper races no longer look like failed cleanup.
+- Orphaned provider descendants with `WARDIAN_SESSION_ID` markers are more likely to be reaped during clear, resume, and worktree reassignment.
+- Telemetry process sampling scales better with large rosters because Windows session-root discovery is single-pass per metrics tick.
+- Automation can distinguish an absent Wardian app from a live but overloaded control endpoint.
+
+Native runtime E2E remains the required layer for proving real ConPTY behavior. Unit tests cover error classification, stale-PID classification, and single-pass session-root discovery.

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -49,16 +49,28 @@ pub(crate) fn session_bootstrap_prompt() -> &'static str {
 
 #[cfg(windows)]
 pub(crate) fn cleanup_stale_session_processes(session_id: &str, provider: &str) {
-    for pid in find_wardian_session_process_roots(session_id, Some(std::process::id())) {
-        log_debug(&format!(
-            "[Wardian] Cleaning stale {} process tree for session {} via PID {}",
-            provider, session_id, pid
-        ));
-        if let Err(err) = force_kill_process_tree(pid) {
+    let mut attempted = std::collections::BTreeSet::new();
+    for _ in 0..2 {
+        let roots = find_wardian_session_process_roots(session_id, Some(std::process::id()));
+        let pending = roots
+            .into_iter()
+            .filter(|pid| attempted.insert(*pid))
+            .collect::<Vec<_>>();
+        if pending.is_empty() {
+            break;
+        }
+
+        for pid in pending {
             log_debug(&format!(
-                "[Wardian] Failed to clean stale process tree for session {} via PID {}: {}",
-                session_id, pid, err
+                "[Wardian] Cleaning stale {} process tree for session {} via PID {}",
+                provider, session_id, pid
             ));
+            if let Err(err) = force_kill_process_tree(pid) {
+                log_debug(&format!(
+                    "[Wardian] Failed to clean stale process tree for session {} via PID {}: {}",
+                    session_id, pid, err
+                ));
+            }
         }
     }
 }

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -191,12 +191,23 @@ struct ProcessSample {
     run_time: u64,
 }
 
+#[cfg(windows)]
+#[derive(Debug, Clone)]
+struct ProcessMarkerSnapshot {
+    pid: u32,
+    process_name: String,
+    command_line: String,
+    environ: Vec<String>,
+}
+
 #[derive(Debug, Clone)]
 struct SystemProcessSnapshot {
     logical_cpu_count: usize,
     children_map: HashMap<u32, Vec<u32>>,
     processes: HashMap<u32, ProcessSample>,
     sys_refresh: std::time::Duration,
+    #[cfg(windows)]
+    session_roots: HashMap<String, Vec<u32>>,
 }
 
 struct TelemetryAgentWorkGuard {
@@ -223,8 +234,45 @@ fn try_begin_agent_telemetry_work(session_id: &str) -> Option<TelemetryAgentWork
     })
 }
 
+#[cfg(windows)]
+fn discover_session_roots_from_process_markers(
+    session_ids: &[String],
+    markers: &[ProcessMarkerSnapshot],
+) -> HashMap<String, Vec<u32>> {
+    let mut roots = session_ids
+        .iter()
+        .map(|session_id| (session_id.clone(), Vec::new()))
+        .collect::<HashMap<_, _>>();
+
+    for marker in markers {
+        for session_id in session_ids {
+            if crate::utils::process::is_wardian_session_environment_candidate(
+                &marker.environ,
+                session_id,
+            ) || crate::utils::process::is_wardian_session_process_candidate(
+                &marker.process_name,
+                &marker.command_line,
+                session_id,
+            ) {
+                roots
+                    .entry(session_id.clone())
+                    .or_default()
+                    .push(marker.pid);
+            }
+        }
+    }
+
+    for pids in roots.values_mut() {
+        pids.sort_unstable();
+        pids.dedup();
+    }
+
+    roots
+}
+
 fn refresh_system_process_snapshot(
     sys_metrics: &tokio::sync::Mutex<sysinfo::System>,
+    #[cfg_attr(not(windows), allow(unused_variables))] session_ids: &[String],
 ) -> Option<SystemProcessSnapshot> {
     let mut sys = match sys_metrics.try_lock() {
         Ok(sys) => sys,
@@ -241,6 +289,8 @@ fn refresh_system_process_snapshot(
     let logical_cpu_count = sys.cpus().len();
     let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
     let mut processes = HashMap::new();
+    #[cfg(windows)]
+    let mut process_markers = Vec::new();
 
     for (pid, process) in sys.processes() {
         let pid = pid.as_u32();
@@ -255,6 +305,24 @@ fn refresh_system_process_snapshot(
                 run_time: process.run_time(),
             },
         );
+        #[cfg(windows)]
+        {
+            process_markers.push(ProcessMarkerSnapshot {
+                pid,
+                process_name: process.name().to_string_lossy().to_string(),
+                command_line: process
+                    .cmd()
+                    .iter()
+                    .map(|part| part.to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                environ: process
+                    .environ()
+                    .iter()
+                    .map(|entry| entry.to_string_lossy().to_string())
+                    .collect::<Vec<_>>(),
+            });
+        }
     }
 
     Some(SystemProcessSnapshot {
@@ -262,6 +330,8 @@ fn refresh_system_process_snapshot(
         children_map,
         processes,
         sys_refresh,
+        #[cfg(windows)]
+        session_roots: discover_session_roots_from_process_markers(session_ids, &process_markers),
     })
 }
 
@@ -593,9 +663,13 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
 
     let sys_metrics = state.system_metrics.clone();
     tokio::task::spawn_blocking(move || {
+        let session_ids = snapshots
+            .iter()
+            .map(|snap| snap.session_id.clone())
+            .collect::<Vec<_>>();
         let pass_started = std::time::Instant::now();
         let mut results = Vec::new();
-        let system_snapshot = refresh_system_process_snapshot(&sys_metrics);
+        let system_snapshot = refresh_system_process_snapshot(&sys_metrics, &session_ids);
         let mut slow_agents = Vec::new();
 
         for snap in &snapshots {
@@ -607,10 +681,11 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
 
             if let (Some(system_snapshot), Some(pid)) = (&system_snapshot, snap.process_id) {
                 #[cfg(windows)]
-                let discovered_roots = crate::utils::process::find_wardian_session_process_roots(
-                    &snap.session_id,
-                    Some(pid),
-                );
+                let discovered_roots = system_snapshot
+                    .session_roots
+                    .get(&snap.session_id)
+                    .cloned()
+                    .unwrap_or_default();
                 #[cfg(not(windows))]
                 let discovered_roots = Vec::new();
 
@@ -1108,6 +1183,8 @@ pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
         let logical_cpu_count = sys.cpus().len();
 
         let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
+        #[cfg(windows)]
+        let mut process_markers = Vec::new();
         for (pid, process) in sys.processes() {
             if let Some(parent) = process.parent() {
                 children_map
@@ -1115,19 +1192,48 @@ pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
                     .or_default()
                     .push(pid.as_u32());
             }
+            #[cfg(windows)]
+            {
+                process_markers.push(ProcessMarkerSnapshot {
+                    pid: pid.as_u32(),
+                    process_name: process.name().to_string_lossy().to_string(),
+                    command_line: process
+                        .cmd()
+                        .iter()
+                        .map(|part| part.to_string_lossy())
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                    environ: process
+                        .environ()
+                        .iter()
+                        .map(|entry| entry.to_string_lossy().to_string())
+                        .collect::<Vec<_>>(),
+                });
+            }
         }
 
         let mut excluded_roots: BTreeSet<u32> = BTreeSet::new();
+        #[cfg(windows)]
+        let session_roots = {
+            let session_ids = agent_roots
+                .iter()
+                .map(|(session_id, _)| session_id.clone())
+                .collect::<Vec<_>>();
+            discover_session_roots_from_process_markers(&session_ids, &process_markers)
+        };
         for (session_id, process_id) in &agent_roots {
             excluded_roots.insert(*process_id);
             #[cfg(not(windows))]
             let _ = session_id;
             #[cfg(windows)]
-            for discovered_pid in crate::utils::process::find_wardian_session_process_roots(
-                session_id,
-                Some(*process_id),
-            ) {
-                excluded_roots.insert(discovered_pid);
+            {
+                for discovered_pid in session_roots
+                    .get(session_id)
+                    .into_iter()
+                    .flat_map(|pids| pids.iter().copied())
+                {
+                    excluded_roots.insert(discovered_pid);
+                }
             }
         }
         let excluded_roots: Vec<u32> = excluded_roots.into_iter().collect();
@@ -1222,6 +1328,45 @@ mod tests {
         let app_pids = super::collect_app_process_pids(1, &[3, 7, 8], &children_map);
 
         assert_eq!(app_pids, BTreeSet::from([1_u32, 2, 6]));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn discovers_session_roots_for_multiple_agents_from_one_process_marker_snapshot() {
+        let markers = vec![
+            super::ProcessMarkerSnapshot {
+                pid: 10,
+                process_name: "cmd.exe".to_string(),
+                command_line: "cmd.exe /d /c codex.cmd resume session-a --cd D:/repo".to_string(),
+                environ: Vec::new(),
+            },
+            super::ProcessMarkerSnapshot {
+                pid: 11,
+                process_name: "node.exe".to_string(),
+                command_line: "node codex".to_string(),
+                environ: vec!["WARDIAN_SESSION_ID=session-a".to_string()],
+            },
+            super::ProcessMarkerSnapshot {
+                pid: 20,
+                process_name: "node.exe".to_string(),
+                command_line: "node other".to_string(),
+                environ: vec!["WARDIAN_SESSION_ID=session-b".to_string()],
+            },
+            super::ProcessMarkerSnapshot {
+                pid: 30,
+                process_name: "pwsh.exe".to_string(),
+                command_line: "pwsh -NoLogo".to_string(),
+                environ: Vec::new(),
+            },
+        ];
+
+        let roots = super::discover_session_roots_from_process_markers(
+            &["session-a".to_string(), "session-b".to_string()],
+            &markers,
+        );
+
+        assert_eq!(roots["session-a"], vec![10, 11]);
+        assert_eq!(roots["session-b"], vec![20]);
     }
 
     #[test]

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -164,6 +164,22 @@ pub fn assign_pid_to_job(job: &win32job::Job, pid: u32, context: &str) -> Result
 }
 
 #[cfg(windows)]
+pub fn process_exists(pid: u32) -> bool {
+    unsafe {
+        use winapi::um::handleapi::CloseHandle;
+        use winapi::um::processthreadsapi::OpenProcess;
+        use winapi::um::winnt::PROCESS_QUERY_LIMITED_INFORMATION;
+
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+        CloseHandle(handle);
+        true
+    }
+}
+
+#[cfg(windows)]
 fn is_supported_terminal_wrapper_process(process_name: &str) -> bool {
     matches!(
         process_name,
@@ -262,7 +278,27 @@ pub fn find_wardian_session_process_roots(session_id: &str, exclude_pid: Option<
 }
 
 #[cfg(windows)]
+fn taskkill_failure_indicates_process_gone(
+    stdout: &str,
+    stderr: &str,
+    process_exists_after_taskkill: bool,
+) -> bool {
+    if !process_exists_after_taskkill {
+        return true;
+    }
+
+    let combined = format!("{} {}", stdout, stderr).to_ascii_lowercase();
+    combined.contains("not found")
+        || combined.contains("no running instance")
+        || (combined.contains("process") && combined.contains("not running"))
+}
+
+#[cfg(windows)]
 pub fn force_kill_process_tree(pid: u32) -> Result<(), String> {
+    if !process_exists(pid) {
+        return Ok(());
+    }
+
     let output = new_headless_std_command("taskkill.exe")
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .output()
@@ -272,17 +308,13 @@ pub fn force_kill_process_tree(pid: u32) -> Result<(), String> {
         return Ok(());
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
-    let combined = format!("{} {}", stdout, stderr);
-
-    if combined.contains("not found")
-        || combined.contains("no running instance")
-        || combined.contains("process") && combined.contains("not running")
-    {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if taskkill_failure_indicates_process_gone(&stdout, &stderr, process_exists(pid)) {
         return Ok(());
     }
 
+    let combined = format!("{} {}", stdout, stderr).to_ascii_lowercase();
     Err(format!(
         "taskkill /PID {} /T /F failed: {}",
         pid,
@@ -369,6 +401,27 @@ mod tests {
         assert!(!super::is_wardian_session_environment_candidate(
             &["WARDIAN_SESSION_ID=other-session".to_string()],
             "019d331a-0500-7592-969f-8f437886f42b",
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn taskkill_empty_failure_is_success_only_when_process_is_already_gone() {
+        assert!(super::taskkill_failure_indicates_process_gone(
+            "", "", false
+        ));
+        assert!(!super::taskkill_failure_indicates_process_gone(
+            "", "", true
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn taskkill_process_not_found_text_is_success_even_if_exit_status_failed() {
+        assert!(super::taskkill_failure_indicates_process_gone(
+            "ERROR: The process \"123456\" not found.",
+            "",
+            true,
         ));
     }
 }


### PR DESCRIPTION
## Description
Fixes two Windows reliability issues in the agent/process and control layers:

- Treats already-exited Windows cleanup PIDs as successful and performs a bounded follow-up scan for session-marked descendants after stale cleanup.
- Reuses one Windows process marker snapshot per telemetry pass instead of doing a full session-root process scan per agent.
- Reports CLI live-control timeouts as `control_endpoint_timeout` instead of `app_not_running`, with a retry/load hint.

## Related Issues
Fixes #423

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `cargo test -p wardian-cli control_error`
- `cargo test -p Wardian utils::process`
- `cargo test -p Wardian manager::telemetry`
- `npm run lint`
- `npm run test`
- `npm run build`
- `cargo test -p wardian-cli`
- `cd src-tauri && cargo clippy`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo check`
- `npm run docs:build`

Note: `cargo fmt --check` was also inspected and reports pre-existing formatting drift in unrelated files (`crates/wardian-core/src/db.rs`, `src-tauri/src/commands/chat.rs`, `src-tauri/src/manager/spawn.rs`). Those unrelated formatting changes were not included in this PR.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable