### PR TITLE
feat(workflow): wardian-workflow library + node type registry (v2 sub-project 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5687,6 +5687,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "wardian-core",
+ "wardian-workflow",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,6 +4130,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5519,6 +5532,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5683,6 +5702,18 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "uuid",
+]
+
+[[package]]
+name = "wardian-workflow"
+version = "0.3.6"
+dependencies = [
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_norway",
+ "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "src-tauri",
   "crates/wardian-core",
   "crates/wardian-cli",
+  "crates/wardian-workflow",
 ]
 
 [workspace.package]

--- a/crates/wardian-cli/Cargo.toml
+++ b/crates/wardian-cli/Cargo.toml
@@ -18,6 +18,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 tokio = { version = "1.49.0", features = ["io-util", "net", "rt", "time"] }
 wardian-core = { path = "../wardian-core" }
+wardian-workflow = { path = "../wardian-workflow" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -73,6 +73,21 @@ pub enum WorkflowCommand {
     },
     /// Validate a blueprint `.md` file and report diagnostics.
     Validate { path: String },
+    /// Write the node-type JSON schema artifact for the builder.
+    GenSchema {
+        #[arg(long, default_value = "src/features/workflows/nodeRegistry.schema.json")]
+        out: String,
+        /// Exit non-zero if the file on disk differs (CI drift guard).
+        #[arg(long)]
+        check: bool,
+    },
+    /// Write the generated node-type reference doc.
+    GenDocs {
+        #[arg(long, default_value = "docs/workflows/node-reference-v2.md")]
+        out: String,
+        #[arg(long)]
+        check: bool,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -65,6 +65,14 @@ pub enum WorkflowCommand {
     Show { target: String },
     Run { target: String },
     Stop { run_instance_id: String },
+    /// Print the node type registry (the contract agents author against).
+    NodeTypes {
+        /// Emit the machine-readable JSON schema instead of a summary table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Validate a blueprint `.md` file and report diagnostics.
+    Validate { path: String },
 }
 
 // ---------------------------------------------------------------------------
@@ -313,6 +321,24 @@ mod tests {
     fn parses_agent_target_shorthand() {
         let cli = Cli::try_parse_from(["wardian", "agent", "coder-a1"]).unwrap();
         assert!(matches!(cli.command, Command::Agent(_)));
+    }
+
+    #[test]
+    fn parses_workflow_node_types_json() {
+        let cli = Cli::try_parse_from(["wardian", "workflow", "node-types", "--json"]).unwrap();
+        let Command::Workflow(args) = cli.command else { panic!("expected Workflow") };
+        assert!(matches!(args.command, WorkflowCommand::NodeTypes { json: true }));
+    }
+
+    #[test]
+    fn parses_workflow_validate_path() {
+        let cli =
+            Cli::try_parse_from(["wardian", "workflow", "validate", "wf.md"]).unwrap();
+        let Command::Workflow(args) = cli.command else { panic!("expected Workflow") };
+        assert!(matches!(
+            args.command,
+            WorkflowCommand::Validate { ref path } if path == "wf.md"
+        ));
     }
 
     #[test]

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -62,9 +62,15 @@ pub struct WorkflowArgs {
 #[derive(Debug, Subcommand)]
 pub enum WorkflowCommand {
     List,
-    Show { target: String },
-    Run { target: String },
-    Stop { run_instance_id: String },
+    Show {
+        target: String,
+    },
+    Run {
+        target: String,
+    },
+    Stop {
+        run_instance_id: String,
+    },
     /// Print the node type registry (the contract agents author against).
     NodeTypes {
         /// Emit the machine-readable JSON schema instead of a summary table.
@@ -72,10 +78,15 @@ pub enum WorkflowCommand {
         json: bool,
     },
     /// Validate a blueprint `.md` file and report diagnostics.
-    Validate { path: String },
+    Validate {
+        path: String,
+    },
     /// Write the node-type JSON schema artifact for the builder.
     GenSchema {
-        #[arg(long, default_value = "src/features/workflows/nodeRegistry.schema.json")]
+        #[arg(
+            long,
+            default_value = "src/features/workflows/nodeRegistry.schema.json"
+        )]
         out: String,
         /// Exit non-zero if the file on disk differs (CI drift guard).
         #[arg(long)]
@@ -341,15 +352,21 @@ mod tests {
     #[test]
     fn parses_workflow_node_types_json() {
         let cli = Cli::try_parse_from(["wardian", "workflow", "node-types", "--json"]).unwrap();
-        let Command::Workflow(args) = cli.command else { panic!("expected Workflow") };
-        assert!(matches!(args.command, WorkflowCommand::NodeTypes { json: true }));
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
+        assert!(matches!(
+            args.command,
+            WorkflowCommand::NodeTypes { json: true }
+        ));
     }
 
     #[test]
     fn parses_workflow_validate_path() {
-        let cli =
-            Cli::try_parse_from(["wardian", "workflow", "validate", "wf.md"]).unwrap();
-        let Command::Workflow(args) = cli.command else { panic!("expected Workflow") };
+        let cli = Cli::try_parse_from(["wardian", "workflow", "validate", "wf.md"]).unwrap();
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
         assert!(matches!(
             args.command,
             WorkflowCommand::Validate { ref path } if path == "wf.md"

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -381,7 +381,35 @@ fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
                 serde_json::to_string_pretty(&serde_json::json!({"schema":1,"ok":true})).unwrap()
             ))
         }
+        WorkflowCommand::NodeTypes { json } => render_workflow_node_types(json),
+        WorkflowCommand::Validate { path } => render_workflow_validate(&path),
     }
+}
+
+fn render_workflow_node_types(json: bool) -> Result<String, CliError> {
+    if json {
+        return Ok(format!("{}\n", wardian_workflow::ts_schema_json()));
+    }
+    // Human summary: one line per node type.
+    let mut lines = String::from("NODE TYPES\n");
+    for def in wardian_workflow::node_types() {
+        lines.push_str(&format!("  {:<18} {:<8} {}\n", def.id, format!("{:?}", def.kind).to_lowercase(), def.description));
+    }
+    Ok(lines)
+}
+
+fn render_workflow_validate(path: &str) -> Result<String, CliError> {
+    let blueprint = wardian_workflow::parse_file(std::path::Path::new(path))
+        .map_err(|e| CliError::generic(e.to_string()))?;
+    let report = wardian_workflow::validate(&blueprint);
+    let body = serde_json::json!({
+        "schema": 1,
+        "ok": report.is_valid(),
+        "diagnostics": report.diagnostics,
+    });
+    serde_json::to_string_pretty(&body)
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string()))
 }
 
 // ---------------------------------------------------------------------------
@@ -921,6 +949,33 @@ fn identity_error(error: identity::IdentityError) -> CliError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn workflow_node_types_json_lists_task_type() {
+        let out = render_workflow_node_types(true).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(json["schema"], 2);
+        assert!(json["node_types"].as_array().unwrap().iter().any(|t| t["id"] == "task"));
+    }
+
+    #[test]
+    fn workflow_validate_reports_unknown_node_type() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.md");
+        std::fs::write(
+            &path,
+            "---\nschema: 2\nid: bad\nname: Bad\nnodes:\n  - id: x\n    type: frobnicate\nedges: []\n---\n",
+        )
+        .unwrap();
+        let out = render_workflow_validate(path.to_str().unwrap()).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(json["ok"], false);
+        assert!(json["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["code"] == "unknown_node_type"));
+    }
 
     #[test]
     fn control_error_preserves_backend_not_supported_code() {

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -383,6 +383,12 @@ fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
         }
         WorkflowCommand::NodeTypes { json } => render_workflow_node_types(json),
         WorkflowCommand::Validate { path } => render_workflow_validate(&path),
+        WorkflowCommand::GenSchema { out, check } => {
+            render_workflow_gen(&out, GenKind::Schema, check)
+        }
+        WorkflowCommand::GenDocs { out, check } => {
+            render_workflow_gen(&out, GenKind::Docs, check)
+        }
     }
 }
 
@@ -410,6 +416,36 @@ fn render_workflow_validate(path: &str) -> Result<String, CliError> {
     serde_json::to_string_pretty(&body)
         .map(|json| format!("{json}\n"))
         .map_err(|e| CliError::generic(e.to_string()))
+}
+
+#[derive(Clone, Copy)]
+enum GenKind {
+    Schema,
+    Docs,
+}
+
+fn render_workflow_gen(out: &str, kind: GenKind, check: bool) -> Result<String, CliError> {
+    let generated = match kind {
+        GenKind::Schema => format!("{}\n", wardian_workflow::ts_schema_json()),
+        GenKind::Docs => wardian_workflow::reference_doc(),
+    };
+    let path = std::path::Path::new(out);
+    if check {
+        let current = std::fs::read_to_string(path).unwrap_or_default();
+        if current != generated {
+            return Err(CliError::backend(
+                ExitCode::Generic,
+                "drift",
+                format!("{out} is out of date; run the matching gen command and commit"),
+            ));
+        }
+        return Ok(format!("{out} is up to date\n"));
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| CliError::generic(e.to_string()))?;
+    }
+    std::fs::write(path, &generated).map_err(|e| CliError::generic(e.to_string()))?;
+    Ok(format!("wrote {out}\n"))
 }
 
 // ---------------------------------------------------------------------------
@@ -975,6 +1011,24 @@ mod tests {
             .unwrap()
             .iter()
             .any(|d| d["code"] == "unknown_node_type"));
+    }
+
+    #[test]
+    fn gen_schema_check_detects_drift() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("schema.json");
+        std::fs::write(&path, "{}").unwrap();
+        let err = render_workflow_gen(&path.to_string_lossy(), GenKind::Schema, true).unwrap_err();
+        assert_eq!(err.code, "drift");
+    }
+
+    #[test]
+    fn gen_schema_writes_file_when_not_checking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("schema.json");
+        let out = render_workflow_gen(&path.to_string_lossy(), GenKind::Schema, false).unwrap();
+        assert!(out.contains("wrote"));
+        assert!(path.exists());
     }
 
     #[test]

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -386,9 +386,7 @@ fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
         WorkflowCommand::GenSchema { out, check } => {
             render_workflow_gen(&out, GenKind::Schema, check)
         }
-        WorkflowCommand::GenDocs { out, check } => {
-            render_workflow_gen(&out, GenKind::Docs, check)
-        }
+        WorkflowCommand::GenDocs { out, check } => render_workflow_gen(&out, GenKind::Docs, check),
     }
 }
 
@@ -399,7 +397,12 @@ fn render_workflow_node_types(json: bool) -> Result<String, CliError> {
     // Human summary: one line per node type.
     let mut lines = String::from("NODE TYPES\n");
     for def in wardian_workflow::node_types() {
-        lines.push_str(&format!("  {:<18} {:<8} {}\n", def.id, format!("{:?}", def.kind).to_lowercase(), def.description));
+        lines.push_str(&format!(
+            "  {:<18} {:<8} {}\n",
+            def.id,
+            format!("{:?}", def.kind).to_lowercase(),
+            def.description
+        ));
     }
     Ok(lines)
 }
@@ -991,7 +994,11 @@ mod tests {
         let out = render_workflow_node_types(true).unwrap();
         let json: serde_json::Value = serde_json::from_str(&out).unwrap();
         assert_eq!(json["schema"], 2);
-        assert!(json["node_types"].as_array().unwrap().iter().any(|t| t["id"] == "task"));
+        assert!(json["node_types"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t["id"] == "task"));
     }
 
     #[test]

--- a/crates/wardian-workflow/Cargo.toml
+++ b/crates/wardian-workflow/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "wardian-workflow"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
+serde_norway = "0.9"
+thiserror = { workspace = true }
+once_cell = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/wardian-workflow/src/blueprint.rs
+++ b/crates/wardian-workflow/src/blueprint.rs
@@ -1,5 +1,118 @@
-// implemented in a later task
+use serde::{Deserialize, Serialize};
 
-pub struct Blueprint;
-pub struct Edge;
-pub struct Node;
+/// Optional canvas position (round-tripped but not interpreted by the engine).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Position {
+    pub x: f64,
+    pub y: f64,
+}
+
+/// A node in the workflow graph. `fields` holds the authored values, validated
+/// against the node type's `FieldDef`s in the registry. `parent` names the
+/// containing `loop` node when this node lives inside a loop body.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Node {
+    pub id: String,
+    pub r#type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub fields: serde_json::Map<String, serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<Position>,
+}
+
+fn default_out() -> String {
+    "out".to_string()
+}
+fn default_in() -> String {
+    "in".to_string()
+}
+
+/// A directed edge between two node ports. Ports default to `out` -> `in`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Edge {
+    pub from: String,
+    pub to: String,
+    #[serde(default = "default_out")]
+    pub from_port: String,
+    #[serde(default = "default_in")]
+    pub to_port: String,
+}
+
+/// The full in-memory blueprint: the structured graph plus the human-readable
+/// markdown body that follows the front-matter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Blueprint {
+    #[serde(default = "default_schema")]
+    pub schema: u32,
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub nodes: Vec<Node>,
+    #[serde(default)]
+    pub edges: Vec<Edge>,
+    /// Markdown body after the front-matter. Not part of the YAML; populated by
+    /// the parser and skipped during YAML (de)serialization.
+    #[serde(skip)]
+    pub body: String,
+}
+
+fn default_schema() -> u32 {
+    2
+}
+
+impl Blueprint {
+    pub fn find_node(&self, id: &str) -> Option<&Node> {
+        self.nodes.iter().find(|n| n.id == id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_omits_optional_fields_when_empty() {
+        let node = Node {
+            id: "plan".into(),
+            r#type: "task".into(),
+            name: None,
+            parent: None,
+            fields: serde_json::Map::new(),
+            position: None,
+        };
+        let json = serde_json::to_value(&node).unwrap();
+        assert_eq!(json["id"], "plan");
+        assert_eq!(json["type"], "task");
+        assert!(json.get("parent").is_none());
+        assert!(json.get("position").is_none());
+    }
+
+    #[test]
+    fn edge_defaults_ports_when_deserialized_without_them() {
+        let edge: Edge = serde_json::from_value(serde_json::json!({
+            "from": "plan",
+            "to": "implement"
+        }))
+        .unwrap();
+        assert_eq!(edge.from_port, "out");
+        assert_eq!(edge.to_port, "in");
+    }
+
+    #[test]
+    fn blueprint_collects_nodes_and_edges() {
+        let bp = Blueprint {
+            schema: 2,
+            id: "demo".into(),
+            name: "Demo".into(),
+            nodes: vec![],
+            edges: vec![],
+            body: String::new(),
+        };
+        assert_eq!(bp.schema, 2);
+        assert!(bp.find_node("missing").is_none());
+    }
+}

--- a/crates/wardian-workflow/src/blueprint.rs
+++ b/crates/wardian-workflow/src/blueprint.rs
@@ -1,0 +1,5 @@
+// implemented in a later task
+
+pub struct Blueprint;
+pub struct Edge;
+pub struct Node;

--- a/crates/wardian-workflow/src/diff.rs
+++ b/crates/wardian-workflow/src/diff.rs
@@ -1,0 +1,1 @@
+// implemented in a later task

--- a/crates/wardian-workflow/src/diff.rs
+++ b/crates/wardian-workflow/src/diff.rs
@@ -1,1 +1,84 @@
-// implemented in a later task
+use crate::blueprint::Blueprint;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// A structural diff between two blueprints, keyed by node id. Node ids are the
+/// stable identity; everything else is compared by value.
+#[derive(Debug, Clone, Serialize, Default, PartialEq)]
+pub struct BlueprintDiff {
+    pub added_nodes: Vec<String>,
+    pub removed_nodes: Vec<String>,
+    pub changed_nodes: Vec<String>,
+}
+
+impl BlueprintDiff {
+    pub fn is_empty(&self) -> bool {
+        self.added_nodes.is_empty() && self.removed_nodes.is_empty() && self.changed_nodes.is_empty()
+    }
+}
+
+/// Compute the node-level diff from `before` to `after`. Output vectors are
+/// sorted for deterministic results.
+pub fn diff(before: &Blueprint, after: &Blueprint) -> BlueprintDiff {
+    let before_map: BTreeMap<&str, &crate::blueprint::Node> =
+        before.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+    let after_map: BTreeMap<&str, &crate::blueprint::Node> =
+        after.nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+
+    let mut d = BlueprintDiff::default();
+    for (id, node) in &after_map {
+        match before_map.get(id) {
+            None => d.added_nodes.push((*id).to_string()),
+            Some(prev) if prev != node => d.changed_nodes.push((*id).to_string()),
+            Some(_) => {}
+        }
+    }
+    for id in before_map.keys() {
+        if !after_map.contains_key(id) {
+            d.removed_nodes.push((*id).to_string());
+        }
+    }
+    d.added_nodes.sort();
+    d.removed_nodes.sort();
+    d.changed_nodes.sort();
+    d
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blueprint::{Blueprint, Node};
+
+    fn node(id: &str) -> Node {
+        Node { id: id.into(), r#type: "task".into(), name: None, parent: None, fields: serde_json::Map::new(), position: None }
+    }
+    fn bp(nodes: Vec<Node>) -> Blueprint {
+        Blueprint { schema: 2, id: "d".into(), name: "D".into(), nodes, edges: vec![], body: String::new() }
+    }
+
+    #[test]
+    fn detects_added_and_removed_nodes() {
+        let before = bp(vec![node("a"), node("b")]);
+        let after = bp(vec![node("b"), node("c")]);
+        let d = diff(&before, &after);
+        assert_eq!(d.added_nodes, vec!["c".to_string()]);
+        assert_eq!(d.removed_nodes, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn detects_changed_node() {
+        let before = bp(vec![node("a")]);
+        let mut changed = node("a");
+        changed.name = Some("renamed".into());
+        let after = bp(vec![changed]);
+        let d = diff(&before, &after);
+        assert_eq!(d.changed_nodes, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn identical_blueprints_have_empty_diff() {
+        let before = bp(vec![node("a")]);
+        let after = bp(vec![node("a")]);
+        assert!(diff(&before, &after).is_empty());
+    }
+}

--- a/crates/wardian-workflow/src/diff.rs
+++ b/crates/wardian-workflow/src/diff.rs
@@ -13,7 +13,9 @@ pub struct BlueprintDiff {
 
 impl BlueprintDiff {
     pub fn is_empty(&self) -> bool {
-        self.added_nodes.is_empty() && self.removed_nodes.is_empty() && self.changed_nodes.is_empty()
+        self.added_nodes.is_empty()
+            && self.removed_nodes.is_empty()
+            && self.changed_nodes.is_empty()
     }
 }
 
@@ -50,10 +52,24 @@ mod tests {
     use crate::blueprint::{Blueprint, Node};
 
     fn node(id: &str) -> Node {
-        Node { id: id.into(), r#type: "task".into(), name: None, parent: None, fields: serde_json::Map::new(), position: None }
+        Node {
+            id: id.into(),
+            r#type: "task".into(),
+            name: None,
+            parent: None,
+            fields: serde_json::Map::new(),
+            position: None,
+        }
     }
     fn bp(nodes: Vec<Node>) -> Blueprint {
-        Blueprint { schema: 2, id: "d".into(), name: "D".into(), nodes, edges: vec![], body: String::new() }
+        Blueprint {
+            schema: 2,
+            id: "d".into(),
+            name: "D".into(),
+            nodes,
+            edges: vec![],
+            body: String::new(),
+        }
     }
 
     #[test]

--- a/crates/wardian-workflow/src/error.rs
+++ b/crates/wardian-workflow/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+/// Errors returned by the workflow library's IO and (de)serialization paths.
+/// Semantic problems with an otherwise-parseable blueprint are reported as
+/// [`crate::validate::Diagnostic`]s, not as `WorkflowError`.
+#[derive(Debug, Error)]
+pub enum WorkflowError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("blueprint is missing the `---` front-matter block")]
+    MissingFrontMatter,
+
+    #[error("front-matter is not valid YAML: {0}")]
+    Yaml(String),
+
+    #[error("could not serialize blueprint: {0}")]
+    Serialize(String),
+}
+
+pub type Result<T> = std::result::Result<T, WorkflowError>;

--- a/crates/wardian-workflow/src/field_type.rs
+++ b/crates/wardian-workflow/src/field_type.rs
@@ -1,0 +1,1 @@
+// implemented in a later task

--- a/crates/wardian-workflow/src/field_type.rs
+++ b/crates/wardian-workflow/src/field_type.rs
@@ -1,1 +1,108 @@
-// implemented in a later task
+use serde::{Deserialize, Serialize};
+
+/// The closed set of field-type primitives every node field is composed from.
+/// `kind` is the serde tag so the generated TS schema and `--json` output are
+/// self-describing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FieldType {
+    Text,
+    LongText,
+    Prompt,
+    Code { language: String },
+    Enum { options: Vec<String> },
+    Bool,
+    Number,
+    Duration,
+    Path,
+    AgentRef,
+    RoleRef,
+    ClassRef,
+    McpRef,
+    WorkflowRef,
+    JsonSchema,
+    KvMap,
+    /// Declares a named outgoing branch on the node (e.g. Decision choices).
+    BranchPort,
+    Cron,
+    SecretRef,
+}
+
+/// A single field on a node type: its primitive type plus authoring metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FieldDef {
+    pub id: String,
+    #[serde(flatten)]
+    pub field_type: FieldType,
+    pub label: String,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub multiple: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub help: String,
+}
+
+impl FieldDef {
+    pub fn new(id: impl Into<String>, field_type: FieldType, label: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            field_type,
+            label: label.into(),
+            required: false,
+            multiple: false,
+            default: None,
+            help: String::new(),
+        }
+    }
+
+    pub fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+
+    pub fn multiple(mut self) -> Self {
+        self.multiple = true;
+        self
+    }
+
+    pub fn help(mut self, text: impl Into<String>) -> Self {
+        self.help = text.into();
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_type_serializes_with_snake_case_kind_tag() {
+        let enum_ty = FieldType::Enum {
+            options: vec!["a".into(), "b".into()],
+        };
+        let json = serde_json::to_value(&enum_ty).unwrap();
+        assert_eq!(json["kind"], "enum");
+        assert_eq!(json["options"][0], "a");
+    }
+
+    #[test]
+    fn code_field_carries_language() {
+        let ty = FieldType::Code {
+            language: "python".into(),
+        };
+        let json = serde_json::to_value(&ty).unwrap();
+        assert_eq!(json["kind"], "code");
+        assert_eq!(json["language"], "python");
+    }
+
+    #[test]
+    fn field_def_defaults_are_not_required_and_single() {
+        let def = FieldDef::new("prompt", FieldType::Prompt, "Prompt");
+        assert!(!def.required);
+        assert!(!def.multiple);
+        assert!(def.default.is_none());
+    }
+}

--- a/crates/wardian-workflow/src/field_type.rs
+++ b/crates/wardian-workflow/src/field_type.rs
@@ -9,8 +9,12 @@ pub enum FieldType {
     Text,
     LongText,
     Prompt,
-    Code { language: String },
-    Enum { options: Vec<String> },
+    Code {
+        language: String,
+    },
+    Enum {
+        options: Vec<String>,
+    },
     Bool,
     Number,
     Duration,

--- a/crates/wardian-workflow/src/lib.rs
+++ b/crates/wardian-workflow/src/lib.rs
@@ -14,8 +14,16 @@ pub mod projections;
 pub mod registry;
 pub mod validate;
 
-pub use blueprint::{Blueprint, Edge, Node};
+pub use blueprint::{Blueprint, Edge, Node, Position};
+pub use diff::{diff, BlueprintDiff};
 pub use error::{Result, WorkflowError};
+pub use field_type::{FieldDef, FieldType};
+pub use normalize::normalize;
+pub use parse::{parse_file, parse_str, to_string};
+pub use projections::reference_doc::reference_doc;
+pub use projections::ts_schema::{ts_schema_json, ts_schema_value};
+pub use registry::{find_node_type, node_types, NodeKind, NodeTypeDef, PortDef};
+pub use validate::{validate, Diagnostic, Severity, ValidationReport};
 
 #[cfg(test)]
 fn _crate_compiles() {}

--- a/crates/wardian-workflow/src/lib.rs
+++ b/crates/wardian-workflow/src/lib.rs
@@ -1,0 +1,21 @@
+//! `wardian-workflow` is the single gate for Workflow Engine v2 blueprints.
+//!
+//! It parses, validates, normalizes, diffs, and round-trips the declarative
+//! `.md` blueprint, and owns the Node Type Registry that every other surface
+//! (builder, CLI, docs) is generated from.
+
+pub mod blueprint;
+pub mod diff;
+pub mod error;
+pub mod field_type;
+pub mod normalize;
+pub mod parse;
+pub mod projections;
+pub mod registry;
+pub mod validate;
+
+pub use blueprint::{Blueprint, Edge, Node};
+pub use error::{Result, WorkflowError};
+
+#[cfg(test)]
+fn _crate_compiles() {}

--- a/crates/wardian-workflow/src/normalize.rs
+++ b/crates/wardian-workflow/src/normalize.rs
@@ -1,0 +1,1 @@
+// implemented in a later task

--- a/crates/wardian-workflow/src/normalize.rs
+++ b/crates/wardian-workflow/src/normalize.rs
@@ -1,1 +1,73 @@
-// implemented in a later task
+use crate::blueprint::Blueprint;
+
+/// Put a blueprint into canonical form so equivalent graphs serialize
+/// identically: nodes sorted by id, edges sorted by (from, from_port, to,
+/// to_port). This makes diffs stable and round-trips deterministic.
+pub fn normalize(blueprint: &mut Blueprint) {
+    blueprint.nodes.sort_by(|a, b| a.id.cmp(&b.id));
+    blueprint.edges.sort_by(|a, b| {
+        (&a.from, &a.from_port, &a.to, &a.to_port)
+            .cmp(&(&b.from, &b.from_port, &b.to, &b.to_port))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blueprint::{Blueprint, Edge, Node};
+
+    fn node(id: &str, ty: &str) -> Node {
+        Node {
+            id: id.into(),
+            r#type: ty.into(),
+            name: None,
+            parent: None,
+            fields: serde_json::Map::new(),
+            position: None,
+        }
+    }
+
+    #[test]
+    fn sorts_nodes_and_edges_deterministically() {
+        let mut bp = Blueprint {
+            schema: 2,
+            id: "demo".into(),
+            name: "Demo".into(),
+            nodes: vec![node("b", "task"), node("a", "task")],
+            edges: vec![
+                Edge {
+                    from: "b".into(),
+                    to: "a".into(),
+                    from_port: "out".into(),
+                    to_port: "in".into(),
+                },
+                Edge {
+                    from: "a".into(),
+                    to: "b".into(),
+                    from_port: "out".into(),
+                    to_port: "in".into(),
+                },
+            ],
+            body: String::new(),
+        };
+        normalize(&mut bp);
+        assert_eq!(bp.nodes[0].id, "a");
+        assert_eq!(bp.edges[0].from, "a");
+    }
+
+    #[test]
+    fn normalize_is_idempotent() {
+        let mut bp = Blueprint {
+            schema: 2,
+            id: "demo".into(),
+            name: "Demo".into(),
+            nodes: vec![node("a", "task")],
+            edges: vec![],
+            body: String::new(),
+        };
+        normalize(&mut bp);
+        let once = bp.clone();
+        normalize(&mut bp);
+        assert_eq!(once, bp);
+    }
+}

--- a/crates/wardian-workflow/src/normalize.rs
+++ b/crates/wardian-workflow/src/normalize.rs
@@ -6,8 +6,7 @@ use crate::blueprint::Blueprint;
 pub fn normalize(blueprint: &mut Blueprint) {
     blueprint.nodes.sort_by(|a, b| a.id.cmp(&b.id));
     blueprint.edges.sort_by(|a, b| {
-        (&a.from, &a.from_port, &a.to, &a.to_port)
-            .cmp(&(&b.from, &b.from_port, &b.to, &b.to_port))
+        (&a.from, &a.from_port, &a.to, &a.to_port).cmp(&(&b.from, &b.from_port, &b.to, &b.to_port))
     });
 }
 

--- a/crates/wardian-workflow/src/parse.rs
+++ b/crates/wardian-workflow/src/parse.rs
@@ -1,0 +1,1 @@
+// implemented in a later task

--- a/crates/wardian-workflow/src/parse.rs
+++ b/crates/wardian-workflow/src/parse.rs
@@ -18,7 +18,10 @@ pub fn parse_str(text: &str) -> Result<Blueprint> {
     let trimmed = text.strip_prefix('\u{feff}').unwrap_or(text);
     let after_open = trimmed
         .strip_prefix(FENCE)
-        .and_then(|rest| rest.strip_prefix('\n').or_else(|| rest.strip_prefix("\r\n")))
+        .and_then(|rest| {
+            rest.strip_prefix('\n')
+                .or_else(|| rest.strip_prefix("\r\n"))
+        })
         .ok_or(WorkflowError::MissingFrontMatter)?;
 
     let (yaml, body) = split_front_matter(after_open).ok_or(WorkflowError::MissingFrontMatter)?;

--- a/crates/wardian-workflow/src/parse.rs
+++ b/crates/wardian-workflow/src/parse.rs
@@ -1,1 +1,101 @@
-// implemented in a later task
+use crate::blueprint::Blueprint;
+use crate::error::{Result, WorkflowError};
+use std::path::Path;
+
+const FENCE: &str = "---";
+
+/// Parse a blueprint from a `.md` file on disk.
+pub fn parse_file(path: &Path) -> Result<Blueprint> {
+    let text = std::fs::read_to_string(path)?;
+    parse_str(&text)
+}
+
+/// Parse a blueprint from in-memory `.md` text.
+///
+/// The file must start with a `---` fence, contain a YAML front-matter block,
+/// a closing `---` fence, and then an optional markdown body.
+pub fn parse_str(text: &str) -> Result<Blueprint> {
+    let trimmed = text.strip_prefix('\u{feff}').unwrap_or(text);
+    let after_open = trimmed
+        .strip_prefix(FENCE)
+        .and_then(|rest| rest.strip_prefix('\n').or_else(|| rest.strip_prefix("\r\n")))
+        .ok_or(WorkflowError::MissingFrontMatter)?;
+
+    let (yaml, body) = split_front_matter(after_open).ok_or(WorkflowError::MissingFrontMatter)?;
+
+    let mut blueprint: Blueprint =
+        serde_norway::from_str(yaml).map_err(|e| WorkflowError::Yaml(e.to_string()))?;
+    blueprint.body = body.trim_start_matches(['\n', '\r']).to_string();
+    Ok(blueprint)
+}
+
+/// Split the text following the opening fence into (yaml, body) using the first
+/// line that is exactly `---`.
+fn split_front_matter(after_open: &str) -> Option<(&str, &str)> {
+    let mut offset = 0usize;
+    for line in after_open.split_inclusive('\n') {
+        let bare = line.trim_end_matches(['\n', '\r']);
+        if bare == FENCE {
+            let yaml = &after_open[..offset];
+            let body = &after_open[offset + line.len()..];
+            return Some((yaml, body));
+        }
+        offset += line.len();
+    }
+    None
+}
+
+/// Serialize a blueprint back to `.md` text: front-matter fences around the YAML
+/// graph, then the markdown body.
+pub fn to_string(blueprint: &Blueprint) -> Result<String> {
+    let yaml =
+        serde_norway::to_string(blueprint).map_err(|e| WorkflowError::Serialize(e.to_string()))?;
+    let mut out = String::new();
+    out.push_str(FENCE);
+    out.push('\n');
+    out.push_str(&yaml);
+    if !yaml.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(FENCE);
+    out.push('\n');
+    if !blueprint.body.is_empty() {
+        out.push('\n');
+        out.push_str(&blueprint.body);
+        if !blueprint.body.ends_with('\n') {
+            out.push('\n');
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL: &str = include_str!("../tests/fixtures/minimal.md");
+
+    #[test]
+    fn parses_front_matter_and_body() {
+        let bp = parse_str(MINIMAL).unwrap();
+        assert_eq!(bp.id, "minimal");
+        assert_eq!(bp.nodes.len(), 2);
+        assert_eq!(bp.edges.len(), 1);
+        assert!(bp.body.contains("# Minimal"));
+        assert!(bp.body.contains("used in tests"));
+    }
+
+    #[test]
+    fn missing_front_matter_is_an_error() {
+        let err = parse_str("no front matter here").unwrap_err();
+        assert!(matches!(err, crate::WorkflowError::MissingFrontMatter));
+    }
+
+    #[test]
+    fn round_trip_preserves_graph_and_body() {
+        let bp = parse_str(MINIMAL).unwrap();
+        let text = to_string(&bp).unwrap();
+        let again = parse_str(&text).unwrap();
+        assert_eq!(bp, again);
+    }
+}

--- a/crates/wardian-workflow/src/projections/mod.rs
+++ b/crates/wardian-workflow/src/projections/mod.rs
@@ -1,0 +1,2 @@
+pub mod reference_doc;
+pub mod ts_schema;

--- a/crates/wardian-workflow/src/projections/reference_doc.rs
+++ b/crates/wardian-workflow/src/projections/reference_doc.rs
@@ -1,0 +1,1 @@
+// implemented in a later task

--- a/crates/wardian-workflow/src/projections/reference_doc.rs
+++ b/crates/wardian-workflow/src/projections/reference_doc.rs
@@ -78,7 +78,11 @@ mod tests {
         let md = reference_doc();
         assert!(md.starts_with("# Workflow Node Reference"));
         for def in crate::registry::node_types() {
-            assert!(md.contains(&format!("## {}", def.label)), "missing {}", def.label);
+            assert!(
+                md.contains(&format!("## {}", def.label)),
+                "missing {}",
+                def.label
+            );
         }
     }
 

--- a/crates/wardian-workflow/src/projections/reference_doc.rs
+++ b/crates/wardian-workflow/src/projections/reference_doc.rs
@@ -1,1 +1,92 @@
-// implemented in a later task
+use crate::field_type::FieldType;
+use crate::registry::{node_types, NodeKind};
+use std::fmt::Write as _;
+
+/// Render the node-type reference as markdown, generated from the registry so
+/// it can never drift from the contract agents author against.
+pub fn reference_doc() -> String {
+    let mut out = String::new();
+    out.push_str("# Workflow Node Reference\n\n");
+    out.push_str("> Generated from the node type registry. Do not edit by hand.\n\n");
+
+    for def in node_types() {
+        let _ = writeln!(out, "## {}", def.label);
+        let _ = writeln!(out);
+        let _ = writeln!(out, "- **id:** `{}`", def.id);
+        let _ = writeln!(out, "- **kind:** {}", kind_label(def.kind));
+        let _ = writeln!(out, "- **category:** {}", def.category);
+        let _ = writeln!(out, "- **version:** {}", def.version);
+        let _ = writeln!(out);
+        let _ = writeln!(out, "{}", def.description);
+        let _ = writeln!(out);
+
+        if def.fields.is_empty() {
+            let _ = writeln!(out, "_No fields._\n");
+        } else {
+            let _ = writeln!(out, "### Fields\n");
+            for field in &def.fields {
+                let req = if field.required { " (required)" } else { "" };
+                let mult = if field.multiple { ", multiple" } else { "" };
+                let _ = writeln!(
+                    out,
+                    "- `{}` — {} [{}{}{}]",
+                    field.id,
+                    field.label,
+                    type_label(&field.field_type),
+                    req,
+                    mult
+                );
+            }
+            let _ = writeln!(out);
+        }
+
+        let ports: Vec<&str> = if let Some(f) = &def.outputs_from_field {
+            let _ = writeln!(out, "Outgoing ports are derived from the `{f}` field.\n");
+            vec![]
+        } else {
+            def.outputs.iter().map(|p| p.id.as_str()).collect()
+        };
+        if !ports.is_empty() {
+            let _ = writeln!(out, "Outgoing ports: {}\n", ports.join(", "));
+        }
+    }
+    out
+}
+
+fn kind_label(kind: NodeKind) -> &'static str {
+    match kind {
+        NodeKind::Agent => "agent",
+        NodeKind::Engine => "engine",
+        NodeKind::Trigger => "trigger",
+    }
+}
+
+fn type_label(ty: &FieldType) -> String {
+    match ty {
+        FieldType::Code { language } => format!("code:{language}"),
+        FieldType::Enum { options } => format!("enum:{}", options.join("|")),
+        other => format!("{other:?}").to_lowercase(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doc_has_a_section_per_node_type() {
+        let md = reference_doc();
+        assert!(md.starts_with("# Workflow Node Reference"));
+        for def in crate::registry::node_types() {
+            assert!(md.contains(&format!("## {}", def.label)), "missing {}", def.label);
+        }
+    }
+
+    #[test]
+    fn doc_lists_fields_with_required_marker() {
+        let md = reference_doc();
+        // `task.prompt` is required.
+        assert!(md.contains("`prompt`"));
+        assert!(md.contains("required"));
+    }
+}

--- a/crates/wardian-workflow/src/projections/ts_schema.rs
+++ b/crates/wardian-workflow/src/projections/ts_schema.rs
@@ -1,0 +1,1 @@
+// implemented in a later task

--- a/crates/wardian-workflow/src/projections/ts_schema.rs
+++ b/crates/wardian-workflow/src/projections/ts_schema.rs
@@ -27,7 +27,11 @@ mod tests {
         assert_eq!(types.len(), crate::registry::node_types().len());
         let task = types.iter().find(|t| t["id"] == "task").unwrap();
         assert_eq!(task["kind"], "agent");
-        assert!(task["fields"].as_array().unwrap().iter().any(|f| f["id"] == "prompt"));
+        assert!(task["fields"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|f| f["id"] == "prompt"));
     }
 
     #[test]

--- a/crates/wardian-workflow/src/projections/ts_schema.rs
+++ b/crates/wardian-workflow/src/projections/ts_schema.rs
@@ -1,1 +1,39 @@
-// implemented in a later task
+use crate::registry::node_types;
+
+/// The registry as a self-describing JSON value the TS builder consumes. The
+/// `NodeTypeDef`/`FieldDef` serde derives carry the shape; this just wraps them
+/// with a schema version.
+pub fn ts_schema_value() -> serde_json::Value {
+    serde_json::json!({
+        "schema": 2,
+        "node_types": node_types(),
+    })
+}
+
+/// Pretty-printed JSON for writing to a committed artifact the builder imports.
+pub fn ts_schema_json() -> String {
+    serde_json::to_string_pretty(&ts_schema_value()).expect("registry serializes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_lists_every_node_type_with_fields_and_ports() {
+        let value = ts_schema_value();
+        assert_eq!(value["schema"], 2);
+        let types = value["node_types"].as_array().unwrap();
+        assert_eq!(types.len(), crate::registry::node_types().len());
+        let task = types.iter().find(|t| t["id"] == "task").unwrap();
+        assert_eq!(task["kind"], "agent");
+        assert!(task["fields"].as_array().unwrap().iter().any(|f| f["id"] == "prompt"));
+    }
+
+    #[test]
+    fn schema_is_pretty_json_string() {
+        let s = ts_schema_json();
+        assert!(s.starts_with('{'));
+        assert!(s.contains("\"node_types\""));
+    }
+}

--- a/crates/wardian-workflow/src/registry.rs
+++ b/crates/wardian-workflow/src/registry.rs
@@ -1,0 +1,1 @@
+// implemented in a later task

--- a/crates/wardian-workflow/src/registry.rs
+++ b/crates/wardian-workflow/src/registry.rs
@@ -1,1 +1,342 @@
-// implemented in a later task
+use crate::field_type::{FieldDef, FieldType};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeKind {
+    /// Delegates to a Wardian agent.
+    Agent,
+    /// Deterministic step executed by the engine itself.
+    Engine,
+    /// Entry point that starts a run.
+    Trigger,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PortDef {
+    pub id: String,
+    pub label: String,
+}
+
+impl PortDef {
+    fn new(id: &str, label: &str) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+        }
+    }
+}
+
+/// The contract for one node type. Behavior lives in the engine (sub-project
+/// #2), keyed by `id`; this struct is the authoring + validation contract.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeTypeDef {
+    pub id: String,
+    pub kind: NodeKind,
+    pub category: String,
+    pub label: String,
+    pub icon: String,
+    pub description: String,
+    pub fields: Vec<FieldDef>,
+    pub inputs: Vec<PortDef>,
+    pub outputs: Vec<PortDef>,
+    /// When set, the node's outgoing ports are derived at runtime from the
+    /// named `branch_port` field instead of from `outputs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outputs_from_field: Option<String>,
+    pub version: u32,
+}
+
+static NODE_TYPES: Lazy<Vec<NodeTypeDef>> = Lazy::new(build_registry);
+
+/// All node types in the v2 taxonomy.
+pub fn node_types() -> &'static [NodeTypeDef] {
+    &NODE_TYPES
+}
+
+/// Look up a node type by its `id` (e.g. `"task"`).
+pub fn find_node_type(id: &str) -> Option<&'static NodeTypeDef> {
+    NODE_TYPES.iter().find(|n| n.id == id)
+}
+
+fn default_in() -> Vec<PortDef> {
+    vec![PortDef::new("in", "In")]
+}
+fn default_out() -> Vec<PortDef> {
+    vec![PortDef::new("out", "Out")]
+}
+
+fn build_registry() -> Vec<NodeTypeDef> {
+    vec![
+        // ----- Agent steps -----
+        NodeTypeDef {
+            id: "task".into(),
+            kind: NodeKind::Agent,
+            category: "Agent".into(),
+            label: "Task".into(),
+            icon: "robot".into(),
+            description: "Delegate work to an agent; returns structured output.".into(),
+            fields: vec![
+                FieldDef::new("agent", FieldType::AgentRef, "Agent")
+                    .required()
+                    .help("Agent or role to run this task."),
+                FieldDef::new("prompt", FieldType::Prompt, "Prompt").required(),
+                FieldDef::new("output_schema", FieldType::JsonSchema, "Output schema"),
+            ],
+            inputs: default_in(),
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "decision".into(),
+            kind: NodeKind::Agent,
+            category: "Agent".into(),
+            label: "Decision".into(),
+            icon: "git-branch".into(),
+            description: "Agent chooses one of the declared outgoing branches.".into(),
+            fields: vec![
+                FieldDef::new("agent", FieldType::AgentRef, "Agent").required(),
+                FieldDef::new("prompt", FieldType::Prompt, "Prompt").required(),
+                FieldDef::new("choices", FieldType::BranchPort, "Choices")
+                    .multiple()
+                    .required()
+                    .help("Named branches the agent may choose between."),
+            ],
+            inputs: default_in(),
+            outputs: vec![],
+            outputs_from_field: Some("choices".into()),
+            version: 1,
+        },
+        // ----- Engine steps -----
+        NodeTypeDef {
+            id: "branch".into(),
+            kind: NodeKind::Engine,
+            category: "Control".into(),
+            label: "Branch".into(),
+            icon: "git-fork".into(),
+            description: "Deterministic condition on run state.".into(),
+            fields: vec![FieldDef::new("condition", FieldType::Text, "Condition").required()],
+            inputs: default_in(),
+            outputs: vec![
+                PortDef::new("on_true", "True"),
+                PortDef::new("on_false", "False"),
+            ],
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "loop".into(),
+            kind: NodeKind::Engine,
+            category: "Control".into(),
+            label: "Loop".into(),
+            icon: "repeat".into(),
+            description: "Container: repeats its body subgraph until a bound is hit.".into(),
+            fields: vec![
+                FieldDef::new("max_iterations", FieldType::Number, "Max iterations"),
+                FieldDef::new("until", FieldType::Text, "Until condition"),
+            ],
+            inputs: default_in(),
+            outputs: vec![PortDef::new("body", "Body"), PortDef::new("done", "Done")],
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "join".into(),
+            kind: NodeKind::Engine,
+            category: "Control".into(),
+            label: "Join".into(),
+            icon: "merge".into(),
+            description: "Synchronization barrier; waits for all inbound edges.".into(),
+            fields: vec![],
+            inputs: default_in(),
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "shell".into(),
+            kind: NodeKind::Engine,
+            category: "Action".into(),
+            label: "Shell".into(),
+            icon: "terminal".into(),
+            description: "Run a shell command.".into(),
+            fields: vec![
+                FieldDef::new("command", FieldType::LongText, "Command").required(),
+                FieldDef::new("cwd", FieldType::Path, "Working directory"),
+            ],
+            inputs: default_in(),
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "script".into(),
+            kind: NodeKind::Engine,
+            category: "Action".into(),
+            label: "Script".into(),
+            icon: "file-code".into(),
+            description: "Run a local script through a selected runtime.".into(),
+            fields: vec![
+                FieldDef::new(
+                    "runtime",
+                    FieldType::Enum {
+                        options: vec!["python".into(), "node".into(), "sh".into()],
+                    },
+                    "Runtime",
+                )
+                .required(),
+                FieldDef::new("path", FieldType::Path, "Script path").required(),
+            ],
+            inputs: default_in(),
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "state".into(),
+            kind: NodeKind::Engine,
+            category: "State".into(),
+            label: "State".into(),
+            icon: "database".into(),
+            description: "Read or write run or shared storage.".into(),
+            fields: vec![
+                FieldDef::new(
+                    "op",
+                    FieldType::Enum {
+                        options: vec!["get".into(), "set".into(), "delete".into()],
+                    },
+                    "Operation",
+                )
+                .required(),
+                FieldDef::new("entries", FieldType::KvMap, "Entries"),
+            ],
+            inputs: default_in(),
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "notify".into(),
+            kind: NodeKind::Engine,
+            category: "State".into(),
+            label: "Notify".into(),
+            icon: "bell".into(),
+            description: "Send an operator-facing notification.".into(),
+            fields: vec![FieldDef::new("message", FieldType::Prompt, "Message").required()],
+            inputs: default_in(),
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "sub_workflow".into(),
+            kind: NodeKind::Engine,
+            category: "Action".into(),
+            label: "Sub-workflow".into(),
+            icon: "workflow".into(),
+            description: "Call another workflow blueprint.".into(),
+            fields: vec![FieldDef::new("workflow", FieldType::WorkflowRef, "Workflow").required()],
+            inputs: default_in(),
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        // ----- Triggers -----
+        NodeTypeDef {
+            id: "manual_trigger".into(),
+            kind: NodeKind::Trigger,
+            category: "Trigger".into(),
+            label: "Manual Trigger".into(),
+            icon: "play".into(),
+            description: "Start the workflow on demand.".into(),
+            fields: vec![FieldDef::new("input_schema", FieldType::JsonSchema, "Input schema")],
+            inputs: vec![],
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "scheduled_trigger".into(),
+            kind: NodeKind::Trigger,
+            category: "Trigger".into(),
+            label: "Scheduled Trigger".into(),
+            icon: "clock".into(),
+            description: "Start the workflow on a schedule.".into(),
+            fields: vec![FieldDef::new("cron", FieldType::Cron, "Schedule").required()],
+            inputs: vec![],
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+        NodeTypeDef {
+            id: "file_watcher".into(),
+            kind: NodeKind::Trigger,
+            category: "Trigger".into(),
+            label: "File Watcher".into(),
+            icon: "eye".into(),
+            description: "Start the workflow on matching file events.".into(),
+            fields: vec![FieldDef::new("path", FieldType::Path, "Watch path").required()],
+            inputs: vec![],
+            outputs: default_out(),
+            outputs_from_field: None,
+            version: 1,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_contains_the_v2_taxonomy() {
+        let ids: Vec<&str> = node_types().iter().map(|n| n.id.as_str()).collect();
+        for expected in [
+            "task",
+            "decision",
+            "branch",
+            "loop",
+            "join",
+            "shell",
+            "script",
+            "state",
+            "notify",
+            "sub_workflow",
+            "manual_trigger",
+            "scheduled_trigger",
+            "file_watcher",
+        ] {
+            assert!(ids.contains(&expected), "missing node type: {expected}");
+        }
+    }
+
+    #[test]
+    fn lookup_returns_known_node_type() {
+        let task = find_node_type("task").expect("task exists");
+        assert_eq!(task.kind, NodeKind::Agent);
+        assert!(task.fields.iter().any(|f| f.id == "prompt"));
+        assert!(task.fields.iter().any(|f| f.id == "agent"));
+    }
+
+    #[test]
+    fn lookup_unknown_returns_none() {
+        assert!(find_node_type("nope").is_none());
+    }
+
+    #[test]
+    fn decision_derives_ports_from_a_field() {
+        let decision = find_node_type("decision").expect("decision exists");
+        assert_eq!(decision.kind, NodeKind::Agent);
+        assert_eq!(decision.outputs_from_field.as_deref(), Some("choices"));
+    }
+
+    #[test]
+    fn loop_declares_body_and_done_ports() {
+        let lp = find_node_type("loop").expect("loop exists");
+        let outs: Vec<&str> = lp.outputs.iter().map(|p| p.id.as_str()).collect();
+        assert!(outs.contains(&"body"));
+        assert!(outs.contains(&"done"));
+    }
+}

--- a/crates/wardian-workflow/src/registry.rs
+++ b/crates/wardian-workflow/src/registry.rs
@@ -251,7 +251,11 @@ fn build_registry() -> Vec<NodeTypeDef> {
             label: "Manual Trigger".into(),
             icon: "play".into(),
             description: "Start the workflow on demand.".into(),
-            fields: vec![FieldDef::new("input_schema", FieldType::JsonSchema, "Input schema")],
+            fields: vec![FieldDef::new(
+                "input_schema",
+                FieldType::JsonSchema,
+                "Input schema",
+            )],
             inputs: vec![],
             outputs: default_out(),
             outputs_from_field: None,

--- a/crates/wardian-workflow/src/validate.rs
+++ b/crates/wardian-workflow/src/validate.rs
@@ -1,0 +1,1 @@
+// implemented in a later task

--- a/crates/wardian-workflow/src/validate.rs
+++ b/crates/wardian-workflow/src/validate.rs
@@ -24,7 +24,12 @@ pub struct Diagnostic {
 
 impl Diagnostic {
     fn error(code: &'static str, message: impl Into<String>, node: Option<&str>) -> Self {
-        Self { severity: Severity::Error, code, message: message.into(), node: node.map(str::to_string) }
+        Self {
+            severity: Severity::Error,
+            code,
+            message: message.into(),
+            node: node.map(str::to_string),
+        }
     }
 }
 
@@ -36,10 +41,16 @@ pub struct ValidationReport {
 
 impl ValidationReport {
     pub fn is_valid(&self) -> bool {
-        !self.diagnostics.iter().any(|d| d.severity == Severity::Error)
+        !self
+            .diagnostics
+            .iter()
+            .any(|d| d.severity == Severity::Error)
     }
     pub fn errors(&self) -> Vec<&Diagnostic> {
-        self.diagnostics.iter().filter(|d| d.severity == Severity::Error).collect()
+        self.diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .collect()
     }
 }
 
@@ -68,7 +79,10 @@ pub fn validate(blueprint: &Blueprint) -> ValidationReport {
         let Some(def) = find_node_type(&node.r#type) else {
             report.diagnostics.push(Diagnostic::error(
                 "unknown_node_type",
-                format!("unknown node type `{}` (see `wardian workflow node-types`)", node.r#type),
+                format!(
+                    "unknown node type `{}` (see `wardian workflow node-types`)",
+                    node.r#type
+                ),
                 Some(&node.id),
             ));
             continue;
@@ -79,7 +93,10 @@ pub fn validate(blueprint: &Blueprint) -> ValidationReport {
             if field.required && present.is_none() {
                 report.diagnostics.push(Diagnostic::error(
                     "missing_required_field",
-                    format!("node `{}` is missing required field `{}`", node.id, field.id),
+                    format!(
+                        "node `{}` is missing required field `{}`",
+                        node.id, field.id
+                    ),
                     Some(&node.id),
                 ));
             }
@@ -103,7 +120,10 @@ pub fn validate(blueprint: &Blueprint) -> ValidationReport {
             if !parent_is_loop {
                 report.diagnostics.push(Diagnostic::error(
                     "invalid_parent",
-                    format!("node `{}` parent `{}` is not a loop node", node.id, parent_id),
+                    format!(
+                        "node `{}` parent `{}` is not a loop node",
+                        node.id, parent_id
+                    ),
                     Some(&node.id),
                 ));
             }
@@ -115,7 +135,10 @@ pub fn validate(blueprint: &Blueprint) -> ValidationReport {
         if !node_ids.contains(edge.from.as_str()) || !node_ids.contains(edge.to.as_str()) {
             report.diagnostics.push(Diagnostic::error(
                 "dangling_edge",
-                format!("edge `{}` -> `{}` references a missing node", edge.from, edge.to),
+                format!(
+                    "edge `{}` -> `{}` references a missing node",
+                    edge.from, edge.to
+                ),
                 None,
             ));
         }
@@ -138,9 +161,18 @@ pub fn validate(blueprint: &Blueprint) -> ValidationReport {
 /// belong to later sub-projects.
 fn check_value_kind(field_type: &FieldType, value: &serde_json::Value) -> Option<String> {
     match field_type {
-        FieldType::Bool => value.is_boolean().then_some(()).map_or(Some("expected a boolean".into()), |_| None),
-        FieldType::Number => value.is_number().then_some(()).map_or(Some("expected a number".into()), |_| None),
-        FieldType::KvMap => value.is_object().then_some(()).map_or(Some("expected an object".into()), |_| None),
+        FieldType::Bool => value
+            .is_boolean()
+            .then_some(())
+            .map_or(Some("expected a boolean".into()), |_| None),
+        FieldType::Number => value
+            .is_number()
+            .then_some(())
+            .map_or(Some("expected a number".into()), |_| None),
+        FieldType::KvMap => value
+            .is_object()
+            .then_some(())
+            .map_or(Some("expected an object".into()), |_| None),
         FieldType::Enum { options } => match value.as_str() {
             Some(s) if options.iter().any(|o| o == s) => None,
             Some(s) => Some(format!("`{s}` is not one of {options:?}")),
@@ -156,15 +188,22 @@ fn check_value_kind(field_type: &FieldType, value: &serde_json::Value) -> Option
 
 /// Kahn's algorithm over only the edges between *real* nodes.
 fn has_cycle(blueprint: &Blueprint) -> bool {
-    let mut indegree: HashMap<&str, usize> = blueprint.nodes.iter().map(|n| (n.id.as_str(), 0)).collect();
+    let mut indegree: HashMap<&str, usize> =
+        blueprint.nodes.iter().map(|n| (n.id.as_str(), 0)).collect();
     let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
     for edge in &blueprint.edges {
         if indegree.contains_key(edge.from.as_str()) && indegree.contains_key(edge.to.as_str()) {
-            adj.entry(edge.from.as_str()).or_default().push(edge.to.as_str());
+            adj.entry(edge.from.as_str())
+                .or_default()
+                .push(edge.to.as_str());
             *indegree.get_mut(edge.to.as_str()).unwrap() += 1;
         }
     }
-    let mut queue: Vec<&str> = indegree.iter().filter(|(_, d)| **d == 0).map(|(k, _)| *k).collect();
+    let mut queue: Vec<&str> = indegree
+        .iter()
+        .filter(|(_, d)| **d == 0)
+        .map(|(k, _)| *k)
+        .collect();
     let mut visited = 0usize;
     while let Some(n) = queue.pop() {
         visited += 1;
@@ -190,21 +229,47 @@ mod tests {
         let mut fields = serde_json::Map::new();
         fields.insert("agent".into(), serde_json::json!("role:coder"));
         fields.insert("prompt".into(), serde_json::json!("do it"));
-        Node { id: id.into(), r#type: "task".into(), name: None, parent: None, fields, position: None }
+        Node {
+            id: id.into(),
+            r#type: "task".into(),
+            name: None,
+            parent: None,
+            fields,
+            position: None,
+        }
     }
 
     fn base(nodes: Vec<Node>, edges: Vec<Edge>) -> Blueprint {
-        Blueprint { schema: 2, id: "demo".into(), name: "Demo".into(), nodes, edges, body: String::new() }
+        Blueprint {
+            schema: 2,
+            id: "demo".into(),
+            name: "Demo".into(),
+            nodes,
+            edges,
+            body: String::new(),
+        }
     }
 
     #[test]
     fn valid_blueprint_has_no_errors() {
         let bp = base(
             vec![
-                Node { id: "t".into(), r#type: "manual_trigger".into(), name: None, parent: None, fields: serde_json::Map::new(), position: None },
+                Node {
+                    id: "t".into(),
+                    r#type: "manual_trigger".into(),
+                    name: None,
+                    parent: None,
+                    fields: serde_json::Map::new(),
+                    position: None,
+                },
                 task("plan"),
             ],
-            vec![Edge { from: "t".into(), to: "plan".into(), from_port: "out".into(), to_port: "in".into() }],
+            vec![Edge {
+                from: "t".into(),
+                to: "plan".into(),
+                from_port: "out".into(),
+                to_port: "in".into(),
+            }],
         );
         let report = validate(&bp);
         assert!(report.is_valid(), "unexpected: {:?}", report.errors());
@@ -213,11 +278,21 @@ mod tests {
     #[test]
     fn unknown_node_type_is_an_error() {
         let bp = base(
-            vec![Node { id: "x".into(), r#type: "frobnicate".into(), name: None, parent: None, fields: serde_json::Map::new(), position: None }],
+            vec![Node {
+                id: "x".into(),
+                r#type: "frobnicate".into(),
+                name: None,
+                parent: None,
+                fields: serde_json::Map::new(),
+                position: None,
+            }],
             vec![],
         );
         let report = validate(&bp);
-        assert!(report.errors().iter().any(|d| d.code == "unknown_node_type"));
+        assert!(report
+            .errors()
+            .iter()
+            .any(|d| d.code == "unknown_node_type"));
     }
 
     #[test]
@@ -234,7 +309,15 @@ mod tests {
 
     #[test]
     fn edge_to_unknown_node_is_an_error() {
-        let bp = base(vec![task("plan")], vec![Edge { from: "plan".into(), to: "ghost".into(), from_port: "out".into(), to_port: "in".into() }]);
+        let bp = base(
+            vec![task("plan")],
+            vec![Edge {
+                from: "plan".into(),
+                to: "ghost".into(),
+                from_port: "out".into(),
+                to_port: "in".into(),
+            }],
+        );
         let report = validate(&bp);
         assert!(report.errors().iter().any(|d| d.code == "dangling_edge"));
     }
@@ -244,8 +327,18 @@ mod tests {
         let bp = base(
             vec![task("a"), task("b")],
             vec![
-                Edge { from: "a".into(), to: "b".into(), from_port: "out".into(), to_port: "in".into() },
-                Edge { from: "b".into(), to: "a".into(), from_port: "out".into(), to_port: "in".into() },
+                Edge {
+                    from: "a".into(),
+                    to: "b".into(),
+                    from_port: "out".into(),
+                    to_port: "in".into(),
+                },
+                Edge {
+                    from: "b".into(),
+                    to: "a".into(),
+                    from_port: "out".into(),
+                    to_port: "in".into(),
+                },
             ],
         );
         let report = validate(&bp);

--- a/crates/wardian-workflow/src/validate.rs
+++ b/crates/wardian-workflow/src/validate.rs
@@ -1,1 +1,263 @@
-// implemented in a later task
+use crate::blueprint::Blueprint;
+use crate::field_type::FieldType;
+use crate::registry::find_node_type;
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+/// One validation finding. `code` is stable and machine-readable; `message` is
+/// for humans. `node` names the offending node when applicable.
+#[derive(Debug, Clone, Serialize)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub code: &'static str,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node: Option<String>,
+}
+
+impl Diagnostic {
+    fn error(code: &'static str, message: impl Into<String>, node: Option<&str>) -> Self {
+        Self { severity: Severity::Error, code, message: message.into(), node: node.map(str::to_string) }
+    }
+}
+
+/// The result of validating a blueprint.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ValidationReport {
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl ValidationReport {
+    pub fn is_valid(&self) -> bool {
+        !self.diagnostics.iter().any(|d| d.severity == Severity::Error)
+    }
+    pub fn errors(&self) -> Vec<&Diagnostic> {
+        self.diagnostics.iter().filter(|d| d.severity == Severity::Error).collect()
+    }
+}
+
+/// Validate a blueprint against the registry and the structural rules
+/// (DAG-only, declared ports, container parents). Returns every finding so the
+/// builder can surface them all; the engine refuses to run when `is_valid()` is
+/// false.
+pub fn validate(blueprint: &Blueprint) -> ValidationReport {
+    let mut report = ValidationReport::default();
+    let node_ids: HashSet<&str> = blueprint.nodes.iter().map(|n| n.id.as_str()).collect();
+
+    // Duplicate ids.
+    let mut seen: HashSet<&str> = HashSet::new();
+    for node in &blueprint.nodes {
+        if !seen.insert(node.id.as_str()) {
+            report.diagnostics.push(Diagnostic::error(
+                "duplicate_node_id",
+                format!("duplicate node id `{}`", node.id),
+                Some(&node.id),
+            ));
+        }
+    }
+
+    // Per-node: known type + required fields + field-value kind.
+    for node in &blueprint.nodes {
+        let Some(def) = find_node_type(&node.r#type) else {
+            report.diagnostics.push(Diagnostic::error(
+                "unknown_node_type",
+                format!("unknown node type `{}` (see `wardian workflow node-types`)", node.r#type),
+                Some(&node.id),
+            ));
+            continue;
+        };
+
+        for field in &def.fields {
+            let present = node.fields.get(&field.id);
+            if field.required && present.is_none() {
+                report.diagnostics.push(Diagnostic::error(
+                    "missing_required_field",
+                    format!("node `{}` is missing required field `{}`", node.id, field.id),
+                    Some(&node.id),
+                ));
+            }
+            if let Some(value) = present {
+                if let Some(msg) = check_value_kind(&field.field_type, value) {
+                    report.diagnostics.push(Diagnostic::error(
+                        "invalid_field_value",
+                        format!("node `{}` field `{}`: {}", node.id, field.id, msg),
+                        Some(&node.id),
+                    ));
+                }
+            }
+        }
+
+        // Container parents must point at a loop node.
+        if let Some(parent_id) = &node.parent {
+            let parent_is_loop = blueprint
+                .find_node(parent_id)
+                .map(|p| p.r#type == "loop")
+                .unwrap_or(false);
+            if !parent_is_loop {
+                report.diagnostics.push(Diagnostic::error(
+                    "invalid_parent",
+                    format!("node `{}` parent `{}` is not a loop node", node.id, parent_id),
+                    Some(&node.id),
+                ));
+            }
+        }
+    }
+
+    // Edges reference existing nodes.
+    for edge in &blueprint.edges {
+        if !node_ids.contains(edge.from.as_str()) || !node_ids.contains(edge.to.as_str()) {
+            report.diagnostics.push(Diagnostic::error(
+                "dangling_edge",
+                format!("edge `{}` -> `{}` references a missing node", edge.from, edge.to),
+                None,
+            ));
+        }
+    }
+
+    // The top-level graph must be a DAG (loops are containers, not back-edges).
+    if has_cycle(blueprint) {
+        report.diagnostics.push(Diagnostic::error(
+            "cycle_detected",
+            "graph contains a cycle; use a loop container instead of a back-edge",
+            None,
+        ));
+    }
+
+    report
+}
+
+/// Returns a human message when `value` cannot be the given field type.
+/// Only coarse kind checks live here; deep semantic checks (e.g. a valid cron)
+/// belong to later sub-projects.
+fn check_value_kind(field_type: &FieldType, value: &serde_json::Value) -> Option<String> {
+    match field_type {
+        FieldType::Bool => value.is_boolean().then_some(()).map_or(Some("expected a boolean".into()), |_| None),
+        FieldType::Number => value.is_number().then_some(()).map_or(Some("expected a number".into()), |_| None),
+        FieldType::KvMap => value.is_object().then_some(()).map_or(Some("expected an object".into()), |_| None),
+        FieldType::Enum { options } => match value.as_str() {
+            Some(s) if options.iter().any(|o| o == s) => None,
+            Some(s) => Some(format!("`{s}` is not one of {options:?}")),
+            None => Some("expected a string".into()),
+        },
+        // Text-like and ref-like primitives just require a string.
+        _ => match value {
+            serde_json::Value::String(_) => None,
+            _ => Some("expected a string".into()),
+        },
+    }
+}
+
+/// Kahn's algorithm over only the edges between *real* nodes.
+fn has_cycle(blueprint: &Blueprint) -> bool {
+    let mut indegree: HashMap<&str, usize> = blueprint.nodes.iter().map(|n| (n.id.as_str(), 0)).collect();
+    let mut adj: HashMap<&str, Vec<&str>> = HashMap::new();
+    for edge in &blueprint.edges {
+        if indegree.contains_key(edge.from.as_str()) && indegree.contains_key(edge.to.as_str()) {
+            adj.entry(edge.from.as_str()).or_default().push(edge.to.as_str());
+            *indegree.get_mut(edge.to.as_str()).unwrap() += 1;
+        }
+    }
+    let mut queue: Vec<&str> = indegree.iter().filter(|(_, d)| **d == 0).map(|(k, _)| *k).collect();
+    let mut visited = 0usize;
+    while let Some(n) = queue.pop() {
+        visited += 1;
+        if let Some(children) = adj.get(n) {
+            for &c in children {
+                let d = indegree.get_mut(c).unwrap();
+                *d -= 1;
+                if *d == 0 {
+                    queue.push(c);
+                }
+            }
+        }
+    }
+    visited != blueprint.nodes.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blueprint::{Blueprint, Edge, Node};
+
+    fn task(id: &str) -> Node {
+        let mut fields = serde_json::Map::new();
+        fields.insert("agent".into(), serde_json::json!("role:coder"));
+        fields.insert("prompt".into(), serde_json::json!("do it"));
+        Node { id: id.into(), r#type: "task".into(), name: None, parent: None, fields, position: None }
+    }
+
+    fn base(nodes: Vec<Node>, edges: Vec<Edge>) -> Blueprint {
+        Blueprint { schema: 2, id: "demo".into(), name: "Demo".into(), nodes, edges, body: String::new() }
+    }
+
+    #[test]
+    fn valid_blueprint_has_no_errors() {
+        let bp = base(
+            vec![
+                Node { id: "t".into(), r#type: "manual_trigger".into(), name: None, parent: None, fields: serde_json::Map::new(), position: None },
+                task("plan"),
+            ],
+            vec![Edge { from: "t".into(), to: "plan".into(), from_port: "out".into(), to_port: "in".into() }],
+        );
+        let report = validate(&bp);
+        assert!(report.is_valid(), "unexpected: {:?}", report.errors());
+    }
+
+    #[test]
+    fn unknown_node_type_is_an_error() {
+        let bp = base(
+            vec![Node { id: "x".into(), r#type: "frobnicate".into(), name: None, parent: None, fields: serde_json::Map::new(), position: None }],
+            vec![],
+        );
+        let report = validate(&bp);
+        assert!(report.errors().iter().any(|d| d.code == "unknown_node_type"));
+    }
+
+    #[test]
+    fn missing_required_field_is_an_error() {
+        let mut plan = task("plan");
+        plan.fields.remove("prompt");
+        let bp = base(vec![plan], vec![]);
+        let report = validate(&bp);
+        assert!(report
+            .errors()
+            .iter()
+            .any(|d| d.code == "missing_required_field" && d.node.as_deref() == Some("plan")));
+    }
+
+    #[test]
+    fn edge_to_unknown_node_is_an_error() {
+        let bp = base(vec![task("plan")], vec![Edge { from: "plan".into(), to: "ghost".into(), from_port: "out".into(), to_port: "in".into() }]);
+        let report = validate(&bp);
+        assert!(report.errors().iter().any(|d| d.code == "dangling_edge"));
+    }
+
+    #[test]
+    fn cycle_is_an_error_because_graph_must_be_a_dag() {
+        let bp = base(
+            vec![task("a"), task("b")],
+            vec![
+                Edge { from: "a".into(), to: "b".into(), from_port: "out".into(), to_port: "in".into() },
+                Edge { from: "b".into(), to: "a".into(), from_port: "out".into(), to_port: "in".into() },
+            ],
+        );
+        let report = validate(&bp);
+        assert!(report.errors().iter().any(|d| d.code == "cycle_detected"));
+    }
+
+    #[test]
+    fn parent_must_reference_a_loop_node() {
+        let mut child = task("child");
+        child.parent = Some("plan".into());
+        let bp = base(vec![task("plan"), child], vec![]);
+        let report = validate(&bp);
+        assert!(report.errors().iter().any(|d| d.code == "invalid_parent"));
+    }
+}

--- a/crates/wardian-workflow/tests/fixtures/minimal.md
+++ b/crates/wardian-workflow/tests/fixtures/minimal.md
@@ -1,0 +1,20 @@
+---
+schema: 2
+id: minimal
+name: Minimal
+nodes:
+  - id: trigger-1
+    type: manual_trigger
+  - id: plan
+    type: task
+    fields:
+      agent: role:planner
+      prompt: Plan the work
+edges:
+  - from: trigger-1
+    to: plan
+---
+
+# Minimal
+
+A tiny workflow used in tests.

--- a/crates/wardian-workflow/tests/fixtures/pr-review.md
+++ b/crates/wardian-workflow/tests/fixtures/pr-review.md
@@ -1,0 +1,50 @@
+---
+schema: 2
+id: pr-review
+name: PR Review
+nodes:
+  - id: trigger-1
+    type: manual_trigger
+  - id: plan
+    type: task
+    fields:
+      agent: role:planner
+      prompt: Draft a plan for the change
+  - id: loop-1
+    type: loop
+    fields:
+      max_iterations: 3
+  - id: implement
+    type: task
+    parent: loop-1
+    fields:
+      agent: role:coder
+      prompt: Apply the plan
+  - id: test
+    type: shell
+    parent: loop-1
+    fields:
+      command: cargo test
+  - id: ship
+    type: task
+    fields:
+      agent: role:coder
+      prompt: Open the PR
+edges:
+  - from: trigger-1
+    to: plan
+  - from: plan
+    to: loop-1
+  - from: loop-1
+    to: implement
+    from_port: body
+  - from: implement
+    to: test
+  - from: loop-1
+    to: ship
+    from_port: done
+---
+
+# PR Review
+
+Plan, then iterate implement/test inside a loop, then ship.

--- a/crates/wardian-workflow/tests/round_trip.rs
+++ b/crates/wardian-workflow/tests/round_trip.rs
@@ -1,0 +1,17 @@
+use wardian_workflow::{normalize, parse_str, to_string, validate};
+
+const PR_REVIEW: &str = include_str!("fixtures/pr-review.md");
+
+#[test]
+fn pr_review_parses_validates_and_round_trips() {
+    let mut bp = parse_str(PR_REVIEW).expect("parses");
+    normalize(&mut bp);
+
+    let report = validate(&bp);
+    assert!(report.is_valid(), "diagnostics: {:?}", report.errors());
+
+    let text = to_string(&bp).expect("serializes");
+    let mut again = parse_str(&text).expect("re-parses");
+    normalize(&mut again);
+    assert_eq!(bp, again, "round-trip must be stable after normalization");
+}

--- a/docs/workflows/node-reference-v2.md
+++ b/docs/workflows/node-reference-v2.md
@@ -1,0 +1,205 @@
+# Workflow Node Reference
+
+> Generated from the node type registry. Do not edit by hand.
+
+## Task
+
+- **id:** `task`
+- **kind:** agent
+- **category:** Agent
+- **version:** 1
+
+Delegate work to an agent; returns structured output.
+
+### Fields
+
+- `agent` — Agent [agentref (required)]
+- `prompt` — Prompt [prompt (required)]
+- `output_schema` — Output schema [jsonschema]
+
+Outgoing ports: out
+
+## Decision
+
+- **id:** `decision`
+- **kind:** agent
+- **category:** Agent
+- **version:** 1
+
+Agent chooses one of the declared outgoing branches.
+
+### Fields
+
+- `agent` — Agent [agentref (required)]
+- `prompt` — Prompt [prompt (required)]
+- `choices` — Choices [branchport (required), multiple]
+
+Outgoing ports are derived from the `choices` field.
+
+## Branch
+
+- **id:** `branch`
+- **kind:** engine
+- **category:** Control
+- **version:** 1
+
+Deterministic condition on run state.
+
+### Fields
+
+- `condition` — Condition [text (required)]
+
+Outgoing ports: on_true, on_false
+
+## Loop
+
+- **id:** `loop`
+- **kind:** engine
+- **category:** Control
+- **version:** 1
+
+Container: repeats its body subgraph until a bound is hit.
+
+### Fields
+
+- `max_iterations` — Max iterations [number]
+- `until` — Until condition [text]
+
+Outgoing ports: body, done
+
+## Join
+
+- **id:** `join`
+- **kind:** engine
+- **category:** Control
+- **version:** 1
+
+Synchronization barrier; waits for all inbound edges.
+
+_No fields._
+
+Outgoing ports: out
+
+## Shell
+
+- **id:** `shell`
+- **kind:** engine
+- **category:** Action
+- **version:** 1
+
+Run a shell command.
+
+### Fields
+
+- `command` — Command [longtext (required)]
+- `cwd` — Working directory [path]
+
+Outgoing ports: out
+
+## Script
+
+- **id:** `script`
+- **kind:** engine
+- **category:** Action
+- **version:** 1
+
+Run a local script through a selected runtime.
+
+### Fields
+
+- `runtime` — Runtime [enum:python|node|sh (required)]
+- `path` — Script path [path (required)]
+
+Outgoing ports: out
+
+## State
+
+- **id:** `state`
+- **kind:** engine
+- **category:** State
+- **version:** 1
+
+Read or write run or shared storage.
+
+### Fields
+
+- `op` — Operation [enum:get|set|delete (required)]
+- `entries` — Entries [kvmap]
+
+Outgoing ports: out
+
+## Notify
+
+- **id:** `notify`
+- **kind:** engine
+- **category:** State
+- **version:** 1
+
+Send an operator-facing notification.
+
+### Fields
+
+- `message` — Message [prompt (required)]
+
+Outgoing ports: out
+
+## Sub-workflow
+
+- **id:** `sub_workflow`
+- **kind:** engine
+- **category:** Action
+- **version:** 1
+
+Call another workflow blueprint.
+
+### Fields
+
+- `workflow` — Workflow [workflowref (required)]
+
+Outgoing ports: out
+
+## Manual Trigger
+
+- **id:** `manual_trigger`
+- **kind:** trigger
+- **category:** Trigger
+- **version:** 1
+
+Start the workflow on demand.
+
+### Fields
+
+- `input_schema` — Input schema [jsonschema]
+
+Outgoing ports: out
+
+## Scheduled Trigger
+
+- **id:** `scheduled_trigger`
+- **kind:** trigger
+- **category:** Trigger
+- **version:** 1
+
+Start the workflow on a schedule.
+
+### Fields
+
+- `cron` — Schedule [cron (required)]
+
+Outgoing ports: out
+
+## File Watcher
+
+- **id:** `file_watcher`
+- **kind:** trigger
+- **category:** Trigger
+- **version:** 1
+
+Start the workflow on matching file events.
+
+### Fields
+
+- `path` — Watch path [path (required)]
+
+Outgoing ports: out
+

--- a/src/features/workflows/nodeRegistry.schema.json
+++ b/src/features/workflows/nodeRegistry.schema.json
@@ -1,0 +1,444 @@
+{
+  "schema": 2,
+  "node_types": [
+    {
+      "id": "task",
+      "kind": "agent",
+      "category": "Agent",
+      "label": "Task",
+      "icon": "robot",
+      "description": "Delegate work to an agent; returns structured output.",
+      "fields": [
+        {
+          "id": "agent",
+          "kind": "agent_ref",
+          "label": "Agent",
+          "required": true,
+          "multiple": false,
+          "help": "Agent or role to run this task."
+        },
+        {
+          "id": "prompt",
+          "kind": "prompt",
+          "label": "Prompt",
+          "required": true,
+          "multiple": false
+        },
+        {
+          "id": "output_schema",
+          "kind": "json_schema",
+          "label": "Output schema",
+          "required": false,
+          "multiple": false
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "decision",
+      "kind": "agent",
+      "category": "Agent",
+      "label": "Decision",
+      "icon": "git-branch",
+      "description": "Agent chooses one of the declared outgoing branches.",
+      "fields": [
+        {
+          "id": "agent",
+          "kind": "agent_ref",
+          "label": "Agent",
+          "required": true,
+          "multiple": false
+        },
+        {
+          "id": "prompt",
+          "kind": "prompt",
+          "label": "Prompt",
+          "required": true,
+          "multiple": false
+        },
+        {
+          "id": "choices",
+          "kind": "branch_port",
+          "label": "Choices",
+          "required": true,
+          "multiple": true,
+          "help": "Named branches the agent may choose between."
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [],
+      "outputs_from_field": "choices",
+      "version": 1
+    },
+    {
+      "id": "branch",
+      "kind": "engine",
+      "category": "Control",
+      "label": "Branch",
+      "icon": "git-fork",
+      "description": "Deterministic condition on run state.",
+      "fields": [
+        {
+          "id": "condition",
+          "kind": "text",
+          "label": "Condition",
+          "required": true,
+          "multiple": false
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "on_true",
+          "label": "True"
+        },
+        {
+          "id": "on_false",
+          "label": "False"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "loop",
+      "kind": "engine",
+      "category": "Control",
+      "label": "Loop",
+      "icon": "repeat",
+      "description": "Container: repeats its body subgraph until a bound is hit.",
+      "fields": [
+        {
+          "id": "max_iterations",
+          "kind": "number",
+          "label": "Max iterations",
+          "required": false,
+          "multiple": false
+        },
+        {
+          "id": "until",
+          "kind": "text",
+          "label": "Until condition",
+          "required": false,
+          "multiple": false
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "body",
+          "label": "Body"
+        },
+        {
+          "id": "done",
+          "label": "Done"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "join",
+      "kind": "engine",
+      "category": "Control",
+      "label": "Join",
+      "icon": "merge",
+      "description": "Synchronization barrier; waits for all inbound edges.",
+      "fields": [],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "shell",
+      "kind": "engine",
+      "category": "Action",
+      "label": "Shell",
+      "icon": "terminal",
+      "description": "Run a shell command.",
+      "fields": [
+        {
+          "id": "command",
+          "kind": "long_text",
+          "label": "Command",
+          "required": true,
+          "multiple": false
+        },
+        {
+          "id": "cwd",
+          "kind": "path",
+          "label": "Working directory",
+          "required": false,
+          "multiple": false
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "script",
+      "kind": "engine",
+      "category": "Action",
+      "label": "Script",
+      "icon": "file-code",
+      "description": "Run a local script through a selected runtime.",
+      "fields": [
+        {
+          "id": "runtime",
+          "kind": "enum",
+          "options": [
+            "python",
+            "node",
+            "sh"
+          ],
+          "label": "Runtime",
+          "required": true,
+          "multiple": false
+        },
+        {
+          "id": "path",
+          "kind": "path",
+          "label": "Script path",
+          "required": true,
+          "multiple": false
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "state",
+      "kind": "engine",
+      "category": "State",
+      "label": "State",
+      "icon": "database",
+      "description": "Read or write run or shared storage.",
+      "fields": [
+        {
+          "id": "op",
+          "kind": "enum",
+          "options": [
+            "get",
+            "set",
+            "delete"
+          ],
+          "label": "Operation",
+          "required": true,
+          "multiple": false
+        },
+        {
+          "id": "entries",
+          "kind": "kv_map",
+          "label": "Entries",
+          "required": false,
+          "multiple": false
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "notify",
+      "kind": "engine",
+      "category": "State",
+      "label": "Notify",
+      "icon": "bell",
+      "description": "Send an operator-facing notification.",
+      "fields": [
+        {
+          "id": "message",
+          "kind": "prompt",
+          "label": "Message",
+          "required": true,
+          "multiple": false
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "sub_workflow",
+      "kind": "engine",
+      "category": "Action",
+      "label": "Sub-workflow",
+      "icon": "workflow",
+      "description": "Call another workflow blueprint.",
+      "fields": [
+        {
+          "id": "workflow",
+          "kind": "workflow_ref",
+          "label": "Workflow",
+          "required": true,
+          "multiple": false
+        }
+      ],
+      "inputs": [
+        {
+          "id": "in",
+          "label": "In"
+        }
+      ],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "manual_trigger",
+      "kind": "trigger",
+      "category": "Trigger",
+      "label": "Manual Trigger",
+      "icon": "play",
+      "description": "Start the workflow on demand.",
+      "fields": [
+        {
+          "id": "input_schema",
+          "kind": "json_schema",
+          "label": "Input schema",
+          "required": false,
+          "multiple": false
+        }
+      ],
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "scheduled_trigger",
+      "kind": "trigger",
+      "category": "Trigger",
+      "label": "Scheduled Trigger",
+      "icon": "clock",
+      "description": "Start the workflow on a schedule.",
+      "fields": [
+        {
+          "id": "cron",
+          "kind": "cron",
+          "label": "Schedule",
+          "required": true,
+          "multiple": false
+        }
+      ],
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    },
+    {
+      "id": "file_watcher",
+      "kind": "trigger",
+      "category": "Trigger",
+      "label": "File Watcher",
+      "icon": "eye",
+      "description": "Start the workflow on matching file events.",
+      "fields": [
+        {
+          "id": "path",
+          "kind": "path",
+          "label": "Watch path",
+          "required": true,
+          "multiple": false
+        }
+      ],
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "out",
+          "label": "Out"
+        }
+      ],
+      "version": 1
+    }
+  ]
+}


### PR DESCRIPTION
## Description
First sub-project of the Workflow Engine v2 rework (#425): the `wardian-workflow` Rust crate — the single validation gate every workflow editor (agent, builder, CLI) passes through.

**Why:** v1's workflow model is opaque JSON executed by an in-memory, pulse-based, cyclic engine, with node fields implied by scattered code (so agents author by copying old workflows). v2 makes the declarative `.md` blueprint the canonical, inspectable truth and centralizes all parsing/validation/normalization in one library, with a Rust-owned node registry that every other surface is generated from (no drift).

What this crate provides:
- **Blueprint format + round-trip:** `.md` with YAML front-matter (graph) + markdown body, via `serde_norway`. Parse → normalize → serialize is stable.
- **Field-type primitives** + a **Rust-owned Node Type Registry** (Agent steps `task`/`decision`; Engine steps `branch`/`loop`/`join`/`shell`/`script`/`state`/`notify`/`sub_workflow`; triggers). Loops are container nodes (graph stays a DAG).
- **Validation gate:** unknown type, missing required field, invalid field value, dangling edge, cycle (Kahn), and loop-parent rules — `is_valid()` is what the engine will gate runs on.
- **Structural diff** between blueprints.
- **Generated projections:** the builder's `nodeRegistry.schema.json`, the `node-reference-v2.md` doc, and `wardian workflow node-types --json` — all generated from the registry, with a `--check` drift guard.
- **CLI:** `wardian workflow node-types [--json]`, `validate <path>`, `gen-schema`/`gen-docs` (with `--check`).

This is foundation only — the durable engine, builder/run-view, and full CLI are later sub-projects in #425. The new crate is not yet wired into `src-tauri`.

## Related Issues
Part of #425. Advances the spirit of #69 (gating execution of invalid workflows).

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- `cargo test -p wardian-workflow`: 29 unit + 1 integration (`pr_review` round-trips a loop-container fixture, validates clean) — green.
- `cargo test -p wardian-cli`: 83 unit + integration suites — green (includes the new `node-types`/`validate` arg + handler tests).
- `cargo clippy -p wardian-workflow -p wardian-cli -- -D warnings`: clean.
- `cargo check -p Wardian` and `cargo test --workspace`: pass, no regressions.
- Drift guard: `workflow gen-schema --check` / `gen-docs --check` report up-to-date against the committed artifacts.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (generated `docs/workflows/node-reference-v2.md`; spec in a separate branch)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Not applicable — backend/CLI only