### PR TITLE
fix(engine): submit Codex prompts after echo

### DIFF
--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -1,3 +1,4 @@
+use crate::manager;
 use crate::state::{AppState, MailboxMessageDraft};
 use std::{
     fmt,
@@ -20,6 +21,7 @@ use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
 
 const STRUCTURED_ASK_INLINE_MESSAGE_MAX_BYTES: usize = 4096;
 const STRUCTURED_ASK_REQUESTS_DIR: &str = "requests";
+const CODEX_PAYLOAD_ECHO_TIMEOUT_MS: u64 = 750;
 
 #[cfg(windows)]
 pub(crate) type ControlEndpointClaim = tokio::net::windows::named_pipe::NamedPipeServer;
@@ -848,13 +850,28 @@ async fn deliver_message_to_target(
                     let profile = crate::utils::delivery_profile::delivery_profile(&info.provider);
                     let delivery_lock = state.delivery_lock_for(&info.uuid).await;
                     let _delivery_guard = delivery_lock.lock().await;
+                    let payload_cursor =
+                        codex_payload_echo_cursor(state, &info.provider, &info.uuid).await;
                     let result = match wait_for_terminal_ready_for_control_send(state, &info).await
                     {
                         Ok(()) => {
-                            crate::utils::terminal_input::submit_prompt_with_outcome_via_sender(
+                            let wait_uuid = info.uuid.clone();
+                            let wait_provider = info.provider.clone();
+                            let wait_prompt = outbound_message.clone();
+                            crate::utils::terminal_input::submit_prompt_with_outcome_via_sender_after_payload(
                                 &tx,
                                 &outbound_message,
                                 &info.provider,
+                                || async move {
+                                    wait_for_codex_payload_echo_before_submit(
+                                        state,
+                                        &wait_provider,
+                                        &wait_uuid,
+                                        payload_cursor.as_deref(),
+                                        &wait_prompt,
+                                    )
+                                    .await;
+                                },
                             )
                             .await
                             .map_err(|error| error.to_string())
@@ -1281,6 +1298,90 @@ async fn wait_for_terminal_output(
     ))
 }
 
+async fn codex_payload_echo_cursor(
+    state: &AppState,
+    provider: &str,
+    session_id: &str,
+) -> Option<String> {
+    if provider != "codex" {
+        return None;
+    }
+
+    let watch_state = {
+        let agents = state.agents.lock().await;
+        agents.get(session_id)?.watch_state.clone()
+    };
+    watch_state.lock().ok().map(|guard| guard.latest_cursor())
+}
+
+async fn wait_for_codex_payload_echo_before_submit(
+    state: &AppState,
+    provider: &str,
+    session_id: &str,
+    since_cursor: Option<&str>,
+    prompt: &str,
+) {
+    if provider != "codex" {
+        return;
+    }
+
+    let Some(since_cursor) = since_cursor else {
+        return;
+    };
+
+    if let Err(error) =
+        wait_for_codex_prompt_echo_since(
+            state,
+            session_id,
+            since_cursor,
+            prompt,
+            CODEX_PAYLOAD_ECHO_TIMEOUT_MS,
+        )
+        .await
+    {
+        manager::log_debug(&format!(
+            "[Wardian] [{session_id}] Codex prompt echo wait before submit did not complete: {error}"
+        ));
+    }
+}
+
+async fn wait_for_codex_prompt_echo_since(
+    state: &AppState,
+    session_id: &str,
+    since_cursor: &str,
+    prompt: &str,
+    timeout_ms: u64,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    while started.elapsed() < std::time::Duration::from_millis(timeout_ms) {
+        let watch_state = {
+            let agents = state.agents.lock().await;
+            agents
+                .get(session_id)
+                .ok_or_else(|| format!("Agent {} not found or is off", session_id))?
+                .watch_state
+                .clone()
+        };
+        let output = watch_state
+            .lock()
+            .map_err(|_| format!("Agent {} watch state lock poisoned", session_id))?
+            .snapshot_since(Some(since_cursor), Some(16 * 1024))
+            .map(|snapshot| snapshot.output.text)
+            .map_err(|error| format!("watch state error: {}", error.code()))?;
+
+        if codex_output_has_prompt_echo(&output, prompt) {
+            return Ok(());
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+
+    Err(format!(
+        "Timed out waiting for {} Codex prompt echo before submit",
+        session_id
+    ))
+}
+
 fn codex_output_has_ready_prompt(output: &str) -> bool {
     let cleaned = strip_ansi_controls(output).replace('\r', "\n");
     let mut trailing_metadata_lines = 0usize;
@@ -1298,6 +1399,28 @@ fn codex_output_has_ready_prompt(output: &str) -> bool {
         return false;
     }
     false
+}
+
+fn codex_output_has_prompt_echo(output: &str, prompt: &str) -> bool {
+    let Some(token) = codex_prompt_echo_token(prompt) else {
+        return false;
+    };
+    normalize_codex_prompt_echo_text(output).contains(&token)
+}
+
+fn codex_prompt_echo_token(prompt: &str) -> Option<String> {
+    let first_line = prompt.lines().map(str::trim).find(|line| !line.is_empty())?;
+    let prefix: String = first_line.chars().take(96).collect();
+    let token = normalize_codex_prompt_echo_text(&prefix);
+    (!token.is_empty()).then_some(token)
+}
+
+fn normalize_codex_prompt_echo_text(text: &str) -> String {
+    strip_ansi_controls(text)
+        .replace('\r', "\n")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn codex_ready_prompt_trailing_metadata_line(line: &str) -> bool {
@@ -2566,6 +2689,7 @@ async fn drain_next_mailbox_message_for_idle_agent(
         .get(session_id)
         .cloned();
     let profile = crate::utils::delivery_profile::delivery_profile(&info.provider);
+    let payload_cursor = codex_payload_echo_cursor(state, &info.provider, session_id).await;
     let detail = match sender {
         Some(tx) => {
             let result = match wait_for_terminal_ready_for_control_send(state, &info).await {
@@ -2585,6 +2709,9 @@ async fn drain_next_mailbox_message_for_idle_agent(
                         profile: Some(profile.provider.clone()),
                         error: None,
                     };
+                    let wait_provider = info.provider.clone();
+                    let wait_uuid = session_id.to_string();
+                    let wait_prompt = record.body.clone();
                     crate::utils::terminal_input::submit_prompt_with_outcome_via_sender_after_payload(
                         &tx,
                         &record.body,
@@ -2593,6 +2720,14 @@ async fn drain_next_mailbox_message_for_idle_agent(
                             let submit_started = submit_started.clone();
                             async move {
                                 record_delivery_attempt(state, &submit_started).await;
+                                wait_for_codex_payload_echo_before_submit(
+                                    state,
+                                    &wait_provider,
+                                    &wait_uuid,
+                                    payload_cursor.as_deref(),
+                                    &wait_prompt,
+                                )
+                                .await;
                             }
                         },
                     )
@@ -2983,6 +3118,13 @@ mod tests {
         );
     }
 
+    fn expected_terminal_chunks(provider: &str, prompt: &str) -> Vec<Vec<u8>> {
+        let chunks =
+            crate::utils::terminal_input::provider_submit_chunks(provider, prompt).unwrap();
+        assert_eq!(chunks.len(), 2);
+        chunks
+    }
+
     fn sample_workflow(id: &str, name: &str, nodes: Vec<WorkflowNode>) -> WorkflowDefinition {
         WorkflowDefinition {
             id: id.to_string(),
@@ -3024,7 +3166,7 @@ mod tests {
         let chunks =
             crate::utils::terminal_input::provider_submit_chunks("codex", "hello\nworld").unwrap();
 
-        assert_eq!(chunks[0], b"hello\nworld".to_vec());
+        assert_eq!(chunks[0], b"\x1b[200~hello\nworld\x1b[201~".to_vec());
         assert_eq!(chunks[1], b"\r".to_vec());
     }
 
@@ -3078,6 +3220,22 @@ mod tests {
         ));
         assert!(!codex_output_has_ready_prompt(
             "\r\n› Previous prompt\r\n  gpt-5.5 high · Context 100% left · D:\\Development\\Wardian• Working...\r\n"
+        ));
+    }
+
+    #[test]
+    fn codex_prompt_echo_detects_payload_visible_after_send() {
+        assert!(codex_output_has_prompt_echo(
+            "\r\n› From Test: Ping. Reply with exactly: pong\r\n\r\n  Wardian request id: ask_123\r\n",
+            "From Test: Ping. Reply with exactly: pong\n\nWardian request id: ask_123"
+        ));
+    }
+
+    #[test]
+    fn codex_prompt_echo_rejects_output_without_current_payload() {
+        assert!(!codex_output_has_prompt_echo(
+            "\r\n› Explain this codebase\r\n\r\n  gpt-5.5 high · Context 100% left · ~\r\n",
+            "From Test: Ping. Reply with exactly: pong\n\nWardian request id: ask_123"
         ));
     }
 
@@ -3528,8 +3686,9 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(rx.recv().await.unwrap(), b"hello".to_vec());
-        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+        let expected = expected_terminal_chunks("codex", "hello");
+        assert_eq!(rx.recv().await.unwrap(), expected[0]);
+        assert_eq!(rx.recv().await.unwrap(), expected[1]);
         {
             let agents = state.agents.lock().await;
             let agent = agents.get("agent-1").unwrap();
@@ -3740,8 +3899,9 @@ mod tests {
             .unwrap()
             .expect("drained message");
 
-        assert_eq!(rx.recv().await.unwrap(), b"queued work".to_vec());
-        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+        let expected = expected_terminal_chunks("codex", "queued work");
+        assert_eq!(rx.recv().await.unwrap(), expected[0]);
+        assert_eq!(rx.recv().await.unwrap(), expected[1]);
         assert_eq!(drained.runtime_state, "mailbox_drain");
         assert_eq!(drained.delivery_state, "submit_sent_unverified");
         assert_eq!(drained.message_id.as_deref(), Some(message_id.as_str()));
@@ -3866,8 +4026,9 @@ mod tests {
             .unwrap()
             .expect("drained message");
 
-        assert_eq!(rx.recv().await.unwrap(), b"queued work".to_vec());
-        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+        let expected = expected_terminal_chunks("codex", "queued work");
+        assert_eq!(rx.recv().await.unwrap(), expected[0]);
+        assert_eq!(rx.recv().await.unwrap(), expected[1]);
         assert_eq!(drained.runtime_state, "mailbox_drain");
         assert_eq!(drained.delivery_state, "submit_sent_unverified");
         assert_eq!(drained.message_id.as_deref(), Some(message_id.as_str()));
@@ -4160,8 +4321,9 @@ mod tests {
 
         assert_eq!(drained.delivery_state, "submit_sent_unverified");
         assert!(blocked.is_none());
-        assert_eq!(rx.try_recv().unwrap(), b"first queued work".to_vec());
-        assert_eq!(rx.try_recv().unwrap(), b"\r".to_vec());
+        let expected = expected_terminal_chunks("codex", "first queued work");
+        assert_eq!(rx.try_recv().unwrap(), expected[0]);
+        assert_eq!(rx.try_recv().unwrap(), expected[1]);
         assert!(rx.try_recv().is_err());
         let input_state = state
             .interactions
@@ -4413,7 +4575,8 @@ mod tests {
             payload = rx.recv() => payload.expect("payload"),
             attempt = &mut drain => panic!("drain completed before payload was observed: {attempt:?}"),
         };
-        assert_eq!(payload, b"queued work".to_vec());
+        let expected = expected_terminal_chunks("codex", "queued work");
+        assert_eq!(payload, expected[0]);
         drop(rx);
 
         let attempt = drain.await.unwrap().expect("drain attempt");

--- a/src-tauri/src/utils/delivery_profile.rs
+++ b/src-tauri/src/utils/delivery_profile.rs
@@ -35,10 +35,10 @@ pub fn delivery_profile(provider: &str) -> DeliveryProfile {
         "codex" => DeliveryProfile {
             provider: normalized,
             submit_key: SubmitKey::CarriageReturn,
-            submit_delay_ms: 150,
+            submit_delay_ms: 0,
             bracketed_paste: BracketedPasteProfile {
                 enabled: true,
-                min_bytes: 2048,
+                min_bytes: 1,
             },
             input_ready_markers: &["›", "Use /skills"],
             busy_markers: &["esc to interrupt", "Working"],
@@ -106,14 +106,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn codex_profile_uses_short_submit_delay_and_return_key() {
+    fn codex_profile_uses_immediate_bracketed_paste_and_return_key() {
         let profile = delivery_profile("codex");
 
         assert_eq!(profile.provider, "codex");
         assert_eq!(profile.submit_key, SubmitKey::CarriageReturn);
-        assert!(profile.submit_delay_ms >= 150);
-        assert!(profile.submit_delay_ms < 1000);
+        assert_eq!(profile.submit_delay_ms, 0);
         assert!(profile.bracketed_paste.enabled);
+        assert_eq!(profile.bracketed_paste.min_bytes, 1);
     }
 
     #[test]

--- a/src-tauri/src/utils/delivery_transaction.rs
+++ b/src-tauri/src/utils/delivery_transaction.rs
@@ -67,7 +67,8 @@ pub fn bracketed_paste_bytes(prompt: &str) -> Vec<u8> {
 }
 
 pub fn plan_terminal_payload(profile: &DeliveryProfile, prompt: &str) -> TerminalPayloadPlan {
-    let use_bracketed_paste = profile.bracketed_paste.enabled
+    let use_bracketed_paste = !prompt.is_empty()
+        && profile.bracketed_paste.enabled
         && (prompt.contains('\n') || prompt.len() >= profile.bracketed_paste.min_bytes);
     let payload_kind = if use_bracketed_paste {
         PayloadKind::BracketedPaste
@@ -160,14 +161,24 @@ mod tests {
     }
 
     #[test]
-    fn plan_uses_literal_for_short_single_line() {
+    fn plan_uses_bracketed_paste_for_short_codex_input() {
         let profile = delivery_profile("codex");
         let plan = plan_terminal_payload(&profile, "hello");
 
-        assert_eq!(plan.payload_kind, PayloadKind::Literal);
-        assert_eq!(plan.payload_bytes, b"hello".to_vec());
+        assert_eq!(plan.payload_kind, PayloadKind::BracketedPaste);
+        assert_eq!(plan.payload_bytes, b"\x1b[200~hello\x1b[201~".to_vec());
         assert_eq!(plan.submit_key, b"\r".to_vec());
         assert_eq!(plan.submit_delay_ms, profile.submit_delay_ms);
+    }
+
+    #[test]
+    fn plan_keeps_empty_prompt_empty_when_bracketed_paste_threshold_is_zero() {
+        let mut profile = delivery_profile("codex");
+        profile.bracketed_paste.min_bytes = 0;
+        let plan = plan_terminal_payload(&profile, "");
+
+        assert_eq!(plan.payload_kind, PayloadKind::Literal);
+        assert!(plan.payload_bytes.is_empty());
     }
 
     #[test]
@@ -238,7 +249,7 @@ mod tests {
 
     #[tokio::test]
     async fn submit_transaction_marks_submit_key_failure_as_unsafe_to_retry() {
-        let profile = zero_delay_profile("codex");
+        let profile = zero_delay_profile("antigravity");
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1);
 
         let submit =

--- a/src-tauri/src/utils/terminal_input.rs
+++ b/src-tauri/src/utils/terminal_input.rs
@@ -16,10 +16,8 @@ pub fn provider_submit_chunks(provider_name: &str, prompt: &str) -> Result<Vec<V
     }
 
     let profile = crate::utils::delivery_profile::delivery_profile(provider_name);
-    Ok(vec![
-        normalized.into_bytes(),
-        profile.submit_key.bytes().to_vec(),
-    ])
+    let plan = crate::utils::delivery_transaction::plan_terminal_payload(&profile, &normalized);
+    Ok(vec![plan.payload_bytes, plan.submit_key])
 }
 
 pub async fn submit_prompt_chunks_via_sender(
@@ -178,9 +176,12 @@ mod tests {
     }
 
     #[test]
-    fn legacy_submit_chunks_keep_codex_multiline_literal() {
-        let chunks = provider_submit_chunks("codex", "hello\nworld").expect("chunks");
+    fn provider_submit_chunks_reports_codex_bracketed_paste_payload() {
+        let chunks = provider_submit_chunks("codex", "hello").expect("chunks");
 
-        assert_eq!(chunks, vec![b"hello\nworld".to_vec(), b"\r".to_vec()]);
+        assert_eq!(
+            chunks,
+            vec![b"\x1b[200~hello\x1b[201~".to_vec(), b"\r".to_vec()]
+        );
     }
 }


### PR DESCRIPTION
## Description
Fixes Codex prompt delivery on Windows by waiting for Codex to visibly echo the delivered payload before sending the submit key. This keeps Codex interactions delay-free in the normal path while avoiding the race where Enter arrives before bracketed paste is committed.

Changes included:
- Use bracketed paste for Codex prompt payloads, including short prompts.
- For live and mailbox Codex delivery, capture the watch cursor before payload send and wait for the prompt echo after that cursor before submitting.
- Add regression coverage for Codex payload planning and prompt-echo detection.

## Related Issues
Fixes #430

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] `cargo check -p Wardian`
- [x] `cargo clippy -p Wardian -- -D warnings`
- [x] `cargo test -p Wardian` (773 unit tests + 7 mock provider e2e tests passed after rebasing onto `origin/main`)
- [x] `npm run lint`
- [x] `npm run test` (88 files, 906 tests passed; existing mocked-readiness/React act stderr warnings only)
- [x] `npm run build`
- [x] `git diff --check`
- [x] Manual native Codex smoke: `wardian ask EchoTarget "Ping. Reply with exactly: pong" --timeout 3m` returned structured reply body `pong` instead of leaving the prompt in the Codex composer.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, or documentation is not applicable
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable