### PR TITLE
fix(ci): publish frontend Codecov coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,3 +15,14 @@ comment:
   layout: "reach,diff,flags"
   behavior: default
   require_changes: true
+
+flags:
+  frontend:
+    paths:
+      - src/
+    carryforward: false
+  backend:
+    paths:
+      - src-tauri/
+      - crates/
+    carryforward: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Wardian CI
+name: tests
 
 on:
   push:
@@ -47,10 +47,8 @@ jobs:
       - name: Unit Tests
         run: npm run test
       - name: Coverage Report
-        if: github.event_name == 'pull_request'
         run: npm run test:coverage
       - name: Upload Frontend Coverage
-        if: github.event_name == 'pull_request'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@
 
 **Local command center for multi-agent CLI workflows** — see every session, collect completed work in a queue, and give agents a CLI surface for coordinating and controlling Wardian.
 
-[![CI](https://github.com/wardian-app/Wardian/actions/workflows/ci.yml/badge.svg)](https://github.com/wardian-app/Wardian/actions/workflows/ci.yml)
-[![Frontend Coverage](https://codecov.io/gh/wardian-app/Wardian/branch/main/graph/badge.svg?flag=frontend&label=frontend%20coverage)](https://codecov.io/gh/wardian-app/Wardian)
-[![Backend Coverage](https://codecov.io/gh/wardian-app/Wardian/branch/main/graph/badge.svg?flag=backend&label=backend%20coverage)](https://codecov.io/gh/wardian-app/Wardian)
+[![tests](https://github.com/wardian-app/Wardian/actions/workflows/ci.yml/badge.svg)](https://github.com/wardian-app/Wardian/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/wardian-app/Wardian/branch/main/graph/badge.svg)](https://codecov.io/gh/wardian-app/Wardian)
 [![Release](https://img.shields.io/github/v/release/wardian-app/Wardian?label=release)](https://github.com/wardian-app/Wardian/releases/latest)
 [![Downloads](https://img.shields.io/github/downloads/wardian-app/Wardian/total?label=downloads)](https://github.com/wardian-app/Wardian/releases)
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-555)

--- a/src/config/ciWorkflow.test.ts
+++ b/src/config/ciWorkflow.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import ciWorkflow from "../../.github/workflows/ci.yml?raw";
+import codecovConfig from "../../.codecov.yml?raw";
+import readme from "../../README.md?raw";
 
 describe("CI workflow contract", () => {
   it("runs test jobs on main branch pushes as well as pull requests", () => {
@@ -11,5 +13,28 @@ describe("CI workflow contract", () => {
     expect(ciWorkflow).toContain("cargo test --workspace");
     expect(ciWorkflow).toContain("cargo check --workspace");
     expect(ciWorkflow).toContain("cargo llvm-cov --workspace --lcov --output-path coverage/rust-lcov.info");
+  });
+
+  it("uploads frontend coverage on main branch pushes for Codecov branch badges", () => {
+    expect(ciWorkflow).toMatch(/- name: Coverage Report\s+run: npm run test:coverage/);
+    expect(ciWorkflow).toMatch(
+      /- name: Upload Frontend Coverage\s+uses: codecov\/codecov-action@v4\s+with:\s+files: \.\/coverage\/lcov\.info\s+flags: frontend/,
+    );
+  });
+
+  it("advertises one combined Codecov badge in the README", () => {
+    const badgeUrls = readme.match(
+      /https:\/\/codecov\.io\/gh\/wardian-app\/Wardian\/branch\/main\/graph\/badge\.svg[^\)]*/g,
+    );
+
+    expect(badgeUrls).toHaveLength(1);
+    expect(badgeUrls?.[0]).not.toContain("flag=");
+    expect(readme).not.toContain("flag=frontend");
+    expect(readme).not.toContain("flag=backend");
+  });
+
+  it("declares frontend and backend Codecov flags with scoped paths", () => {
+    expect(codecovConfig).toMatch(/flags:\s+frontend:\s+paths:\s+- src\//);
+    expect(codecovConfig).toMatch(/backend:\s+paths:\s+- src-tauri\/\s+- crates\//);
   });
 });


### PR DESCRIPTION
## Description
Fixes Codecov coverage reporting so the README can use one combined coverage badge for both frontend and backend coverage.

The frontend coverage upload now runs on `main` pushes as well as PRs, matching the backend coverage behavior. The Codecov config also declares explicit frontend/backend flag path mappings, and the README now uses a single unflagged Codecov badge. The GitHub Actions workflow is renamed from `Wardian CI` to `tests` so the native workflow badge displays the shorter lowercase label.

## Related Issues
Fixes #432

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run test -- src/config/ciWorkflow.test.ts` initially failed for the missing main-branch frontend upload, two flag-specific badges, and missing Codecov flag paths; passed after the fix.
- `npm run lint`
- `npm run test` - 88 files / 909 tests passed. Existing React `act(...)` and provider-readiness stderr appeared in unrelated tests.
- `npm run build` - passed with existing Vite large chunk warning.
- `npm run test:coverage` - passed and generated `coverage/lcov.info`.
- `git diff --check`
- Staged diff secret scan for obvious key/token patterns returned no matches.

Subagent review: `codecov-coverage-review` found no Critical or Important issues and assessed the patch as ready to merge.

Docs maintenance: user docs are not applicable because this changes CI coverage publication and README badges only; no app/user workflow changes.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable