### PR TITLE
fix(agent): ignore stale status after clear

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -192,9 +192,8 @@ fn prepare_agent_for_clear(agent: &mut ActiveAgent) -> PreparedAgentClear {
     if let Ok(mut title) = agent.terminal_title.lock() {
         title.clear();
     }
-    if let Ok(mut status) = agent.current_status.lock() {
-        *status = "Processing...".to_string();
-    }
+    agent.current_status =
+        std::sync::Arc::new(std::sync::Mutex::new("Processing...".to_string()));
     if let Ok(mut count) = agent.query_count.lock() {
         *count = 0;
     }
@@ -5199,6 +5198,7 @@ mod tests {
         let (tx, _rx) = tokio::sync::mpsc::channel(1);
         active.stdin_tx = Some(tx);
         active.process_id = Some(12345);
+        let runtime_status = active.current_status.clone();
         active.output_buffer.lock().unwrap().push_str("old output");
         *active.terminal_title.lock().unwrap() = "Old Title".to_string();
         *active.current_status.lock().unwrap() = "Idle".to_string();
@@ -5231,6 +5231,10 @@ mod tests {
         );
         assert_eq!(active.process_id, None);
         assert!(active.stdin_tx.is_none());
+        assert!(
+            !Arc::ptr_eq(&runtime_status, &active.current_status),
+            "clear must detach stale runtime status writers before replacement spawn"
+        );
         assert_eq!(active.output_buffer.lock().unwrap().as_str(), "");
         assert_eq!(active.terminal_title.lock().unwrap().as_str(), "");
         assert_eq!(

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -168,17 +168,29 @@ pub(crate) fn set_agent_status(
             let observed_at =
                 chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
-            // Phase 2: Persist status change to SQLite
-            let _ = wardian_core::db::update_agent_status(session_id, next_status, None);
-
             let status_app = app.clone();
             let status_session_id = session_id.to_string();
             let status = next_status.to_string();
+            let current_status = current_status.clone();
             let status_sequence = app
                 .state::<AppState>()
                 .next_status_observation_sequence(session_id);
             tauri::async_runtime::spawn(async move {
                 let state = status_app.state::<AppState>();
+                if !status_arc_belongs_to_current_agent(&state, &status_session_id, &current_status)
+                    .await
+                {
+                    log_debug(&format!(
+                        "[Wardian] Ignoring stale status '{}' for replaced session {}",
+                        status, status_session_id
+                    ));
+                    return;
+                }
+
+                // Phase 2: Persist status change to SQLite after confirming the
+                // reporting runtime still owns the active agent slot.
+                let _ = wardian_core::db::update_agent_status(&status_session_id, &status, None);
+
                 record_provider_input_from_status_state(
                     &state,
                     &status_session_id,
@@ -217,6 +229,17 @@ pub(crate) fn set_agent_status(
             });
         }
     }
+}
+
+async fn status_arc_belongs_to_current_agent(
+    state: &AppState,
+    session_id: &str,
+    current_status: &std::sync::Arc<std::sync::Mutex<String>>,
+) -> bool {
+    let agents = state.agents.lock().await;
+    agents
+        .get(session_id)
+        .is_some_and(|agent| std::sync::Arc::ptr_eq(&agent.current_status, current_status))
 }
 
 async fn record_provider_input_from_status_state(
@@ -1065,6 +1088,38 @@ mod tests {
             "Action Needed"
         );
         assert_eq!(*agent.query_count.lock().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn stale_runtime_status_arc_is_not_current_after_agent_replacement() {
+        let state = AppState::new();
+        let old_agent = test_active_agent("Idle");
+        let old_status = old_agent.current_status.clone();
+        {
+            let mut config = old_agent.config.lock().unwrap();
+            config.session_id = "agent-1".to_string();
+        }
+        state
+            .agents
+            .lock()
+            .await
+            .insert("agent-1".to_string(), old_agent);
+
+        let new_agent = test_active_agent("Idle");
+        {
+            let mut config = new_agent.config.lock().unwrap();
+            config.session_id = "agent-1".to_string();
+        }
+        state
+            .agents
+            .lock()
+            .await
+            .insert("agent-1".to_string(), new_agent);
+
+        assert!(
+            !status_arc_belongs_to_current_agent(&state, "agent-1", &old_status).await,
+            "late status events from a cleared runtime must not update the replacement agent"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description
Fixes a CLI-triggered clear/join lifecycle race where stale runtime status writers from a cleared agent session could still publish status/readiness side effects for the replacement session.

What changed:
- `set_agent_status` now verifies that the reporting `current_status` Arc still belongs to the active agent before updating SQLite, provider-input readiness, watch state, frontend status, or mailbox drain behavior.
- `prepare_agent_for_clear` now swaps in a fresh visible status Arc during clear preparation, detaching old PTY/log watcher status writers before the replacement runtime is spawned.
- Added regression coverage for both stale status ownership after replacement and the clear preparation detach behavior.

Review result: Wardian-Reviewer re-reviewed the implementation after the race-window fix and reported no blocking findings. It noted a non-blocking lifecycle edge where very early replacement-runtime events can still be dropped before the new active agent is installed; current recovery remains through later readiness/status observations.

## Related Issues
Fixes #439

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- RED check before implementation: `cargo test -p Wardian commands::agent::tests::prepare_agent_for_clear_resets_visible_runtime_without_terminating_inline` failed on the new stale Arc assertion.
- `cargo test -p Wardian commands::agent::tests::prepare_agent_for_clear_resets_visible_runtime_without_terminating_inline`
- `cargo test -p Wardian manager::tests::stale_runtime_status_arc_is_not_current_after_agent_replacement`
- `cargo test -p Wardian manager::tests::`
- `npm run lint`
- `npm run test` (passed: 95 files, 924 tests; existing React `act(...)` and readiness stderr warnings observed)
- `npm run build` (passed; existing Vite chunk-size warning observed)
- `cargo check -p Wardian`
- `cargo clippy -p Wardian -- -D warnings`
- `cargo test -p Wardian` (passed: 774 unit tests + 7 mock provider e2e tests)
- `git diff --check`

Docs are not applicable: this is an internal backend lifecycle fix with no CLI surface, UI behavior, or public workflow change.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, or docs are not applicable for this internal lifecycle fix
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable