### PR TITLE
feat(cli): Workflow Engine v2 thin CLI — exec/runs/replay (sub-project 4)

### DIFF
--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -81,6 +81,35 @@ pub enum WorkflowCommand {
     Validate {
         path: String,
     },
+    /// Execute a v2 blueprint headlessly and write a durable run.
+    Exec {
+        path: String,
+        /// Execution backend. Only `mock` is available until the real executor lands.
+        #[arg(long, default_value = "mock")]
+        executor: String,
+    },
+    /// List v2 runs under <home>/logs/workflows.
+    Runs,
+    /// Show one v2 run's state + event trace.
+    RunShow {
+        blueprint_id: String,
+        run_id: String,
+    },
+    /// Replay a v2 run's event log into its final state (no execution).
+    Replay {
+        blueprint_id: String,
+        run_id: String,
+    },
+    /// Parse a blueprint `.md` and print the structured graph.
+    Parse {
+        path: String,
+    },
+    /// Normalize a blueprint `.md` (print, or --write back in place).
+    Normalize {
+        path: String,
+        #[arg(long)]
+        write: bool,
+    },
     /// Write the node-type JSON schema artifact for the builder.
     GenSchema {
         #[arg(
@@ -370,6 +399,94 @@ mod tests {
         assert!(matches!(
             args.command,
             WorkflowCommand::Validate { ref path } if path == "wf.md"
+        ));
+    }
+
+    #[test]
+    fn parses_workflow_exec_path_with_default_executor() {
+        let cli = Cli::try_parse_from(["wardian", "workflow", "exec", "wf.md"]).unwrap();
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
+        assert!(matches!(
+            args.command,
+            WorkflowCommand::Exec { ref path, ref executor }
+                if path == "wf.md" && executor == "mock"
+        ));
+    }
+
+    #[test]
+    fn parses_workflow_exec_executor() {
+        let cli =
+            Cli::try_parse_from(["wardian", "workflow", "exec", "wf.md", "--executor", "real"])
+                .unwrap();
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
+        assert!(matches!(
+            args.command,
+            WorkflowCommand::Exec { ref path, ref executor }
+                if path == "wf.md" && executor == "real"
+        ));
+    }
+
+    #[test]
+    fn parses_workflow_runs() {
+        let cli = Cli::try_parse_from(["wardian", "workflow", "runs"]).unwrap();
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
+        assert!(matches!(args.command, WorkflowCommand::Runs));
+    }
+
+    #[test]
+    fn parses_workflow_run_show() {
+        let cli = Cli::try_parse_from(["wardian", "workflow", "run-show", "wf", "r1"]).unwrap();
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
+        assert!(matches!(
+            args.command,
+            WorkflowCommand::RunShow { ref blueprint_id, ref run_id }
+                if blueprint_id == "wf" && run_id == "r1"
+        ));
+    }
+
+    #[test]
+    fn parses_workflow_replay() {
+        let cli = Cli::try_parse_from(["wardian", "workflow", "replay", "wf", "r1"]).unwrap();
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
+        assert!(matches!(
+            args.command,
+            WorkflowCommand::Replay { ref blueprint_id, ref run_id }
+                if blueprint_id == "wf" && run_id == "r1"
+        ));
+    }
+
+    #[test]
+    fn parses_workflow_parse() {
+        let cli = Cli::try_parse_from(["wardian", "workflow", "parse", "wf.md"]).unwrap();
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
+        assert!(matches!(
+            args.command,
+            WorkflowCommand::Parse { ref path } if path == "wf.md"
+        ));
+    }
+
+    #[test]
+    fn parses_workflow_normalize_write() {
+        let cli =
+            Cli::try_parse_from(["wardian", "workflow", "normalize", "wf.md", "--write"]).unwrap();
+        let Command::Workflow(args) = cli.command else {
+            panic!("expected Workflow")
+        };
+        assert!(matches!(
+            args.command,
+            WorkflowCommand::Normalize { ref path, write: true } if path == "wf.md"
         ));
     }
 

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -4,7 +4,12 @@ mod errors;
 mod live;
 mod output;
 
-use std::{io::Read as _, time::Duration};
+use std::{
+    fs,
+    io::Read as _,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use args::{
     AgentArgs, AgentCommand, AgentWorktreeCommand, ApprovalArg, AskArgs, Cli, Command,
@@ -383,6 +388,18 @@ fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
         }
         WorkflowCommand::NodeTypes { json } => render_workflow_node_types(json),
         WorkflowCommand::Validate { path } => render_workflow_validate(&path),
+        WorkflowCommand::Exec { path, executor } => render_workflow_exec(&path, &executor),
+        WorkflowCommand::Runs => render_workflow_runs(),
+        WorkflowCommand::RunShow {
+            blueprint_id,
+            run_id,
+        } => render_workflow_run_show(&blueprint_id, &run_id),
+        WorkflowCommand::Replay {
+            blueprint_id,
+            run_id,
+        } => render_workflow_replay(&blueprint_id, &run_id),
+        WorkflowCommand::Parse { path } => render_workflow_parse(&path),
+        WorkflowCommand::Normalize { path, write } => render_workflow_normalize(&path, write),
         WorkflowCommand::GenSchema { out, check } => {
             render_workflow_gen(&out, GenKind::Schema, check)
         }
@@ -408,7 +425,7 @@ fn render_workflow_node_types(json: bool) -> Result<String, CliError> {
 }
 
 fn render_workflow_validate(path: &str) -> Result<String, CliError> {
-    let blueprint = wardian_core::workflow::parse_file(std::path::Path::new(path))
+    let blueprint = wardian_core::workflow::parse_file(Path::new(path))
         .map_err(|e| CliError::generic(e.to_string()))?;
     let report = wardian_core::workflow::validate(&blueprint);
     let body = serde_json::json!({
@@ -418,6 +435,211 @@ fn render_workflow_validate(path: &str) -> Result<String, CliError> {
     });
     serde_json::to_string_pretty(&body)
         .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string()))
+}
+
+fn render_workflow_exec(path: &str, executor: &str) -> Result<String, CliError> {
+    if executor != "mock" {
+        return Err(CliError::backend(
+            ExitCode::Generic,
+            "unsupported_executor",
+            "only 'mock' is available until the real executor lands",
+        ));
+    }
+
+    let blueprint = wardian_core::workflow::parse_file(Path::new(path))
+        .map_err(|e| CliError::generic(e.to_string()))?;
+    let report = wardian_core::workflow::validate(&blueprint);
+    if !report.is_valid() {
+        let body = serde_json::json!({
+            "schema": 1,
+            "ok": false,
+            "diagnostics": report.diagnostics,
+        });
+        return serde_json::to_string_pretty(&body)
+            .map(|json| format!("{json}\n"))
+            .map_err(|e| CliError::generic(e.to_string()));
+    }
+
+    let run_id = wardian_core::engine::driver::new_run_id();
+    let run_root = wardian_core::paths::workflow_run_dir(&blueprint.id, &run_id)
+        .ok_or_else(|| CliError::generic("could not resolve workflow run directory"))?;
+    let runtime = build_workflow_runtime()?;
+    let mock = wardian_core::engine::MockExecutor::new();
+    let state = runtime
+        .block_on(wardian_core::engine::Engine::start_with_id(
+            &blueprint,
+            &run_id,
+            serde_json::json!({}),
+            &run_root,
+            &mock,
+        ))
+        .map_err(|e| CliError::generic(e.to_string()))?;
+
+    let body = serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "run_id": run_id,
+        "blueprint_id": blueprint.id,
+        "status": state.status,
+        "run_dir": run_root,
+        "executor": "mock",
+    });
+    serde_json::to_string_pretty(&body)
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string()))
+}
+
+fn render_workflow_runs() -> Result<String, CliError> {
+    let mut runs = Vec::new();
+    let Some(runs_root) = wardian_core::paths::workflow_runs_dir() else {
+        return render_json(serde_json::json!({ "schema": 1, "runs": runs }));
+    };
+    if !runs_root.exists() {
+        return render_json(serde_json::json!({ "schema": 1, "runs": runs }));
+    }
+
+    for blueprint_entry in fs::read_dir(&runs_root).map_err(|e| CliError::generic(e.to_string()))? {
+        let blueprint_entry = blueprint_entry.map_err(|e| CliError::generic(e.to_string()))?;
+        let blueprint_path = blueprint_entry.path();
+        if !blueprint_path.is_dir() {
+            continue;
+        }
+        for run_entry in
+            fs::read_dir(&blueprint_path).map_err(|e| CliError::generic(e.to_string()))?
+        {
+            let run_entry = run_entry.map_err(|e| CliError::generic(e.to_string()))?;
+            let run_path = run_entry.path();
+            if !run_path.is_dir() {
+                continue;
+            }
+            if let Ok(Some(state)) = wardian_core::engine::store::read_checkpoint(&run_path) {
+                runs.push(serde_json::json!({
+                    "run_id": state.run_id,
+                    "blueprint_id": state.blueprint_id,
+                    "status": state.status,
+                    "node_count": state.nodes.len(),
+                    "failure": state.failure,
+                    "path": run_path,
+                }));
+            }
+        }
+    }
+
+    render_json(serde_json::json!({
+        "schema": 1,
+        "runs": runs,
+    }))
+}
+
+fn render_workflow_run_show(blueprint_id: &str, run_id: &str) -> Result<String, CliError> {
+    let run_root = workflow_run_root(blueprint_id, run_id)?;
+    let state = wardian_core::engine::store::read_checkpoint(&run_root)
+        .map_err(|e| CliError::generic(e.to_string()))?
+        .ok_or_else(|| CliError::generic(format!("state.json not found for run {run_id}")))?;
+    let events = wardian_core::engine::store::read_events(&run_root)
+        .map_err(|e| CliError::generic(e.to_string()))?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "state": state,
+        "events": events,
+    }))
+}
+
+fn render_workflow_replay(blueprint_id: &str, run_id: &str) -> Result<String, CliError> {
+    let blueprint = find_library_blueprint(blueprint_id)?.ok_or_else(|| {
+        CliError::generic(format!(
+            "blueprint {blueprint_id} not found in library/workflows"
+        ))
+    })?;
+    let run_root = workflow_run_root(blueprint_id, run_id)?;
+    let state = wardian_core::engine::Engine::replay(&blueprint, &run_root)
+        .map_err(|e| CliError::generic(e.to_string()))?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "state": state,
+    }))
+}
+
+fn render_workflow_parse(path: &str) -> Result<String, CliError> {
+    let blueprint = wardian_core::workflow::parse_file(Path::new(path))
+        .map_err(|e| CliError::generic(e.to_string()))?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "blueprint": blueprint,
+    }))
+}
+
+fn render_workflow_normalize(path: &str, write: bool) -> Result<String, CliError> {
+    let mut blueprint = wardian_core::workflow::parse_file(Path::new(path))
+        .map_err(|e| CliError::generic(e.to_string()))?;
+    wardian_core::workflow::normalize(&mut blueprint);
+    let normalized = wardian_core::workflow::to_string(&blueprint)
+        .map_err(|e| CliError::generic(e.to_string()))?;
+    if write {
+        fs::write(path, &normalized).map_err(|e| CliError::generic(e.to_string()))?;
+        return render_json(serde_json::json!({
+            "schema": 1,
+            "written": true,
+            "path": path,
+        }));
+    }
+    Ok(normalized)
+}
+
+fn render_json(body: serde_json::Value) -> Result<String, CliError> {
+    serde_json::to_string_pretty(&body)
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string()))
+}
+
+fn workflow_run_root(blueprint_id: &str, run_id: &str) -> Result<PathBuf, CliError> {
+    wardian_core::paths::workflow_run_dir(blueprint_id, run_id)
+        .ok_or_else(|| CliError::generic("could not resolve workflow run directory"))
+}
+
+fn find_library_blueprint(
+    blueprint_id: &str,
+) -> Result<Option<wardian_core::workflow::Blueprint>, CliError> {
+    let Some(home) = wardian_core::paths::wardian_home() else {
+        return Ok(None);
+    };
+    let root = home.join("library").join("workflows");
+    if !root.exists() {
+        return Ok(None);
+    }
+    find_library_blueprint_in_dir(&root, blueprint_id)
+}
+
+fn find_library_blueprint_in_dir(
+    dir: &Path,
+    blueprint_id: &str,
+) -> Result<Option<wardian_core::workflow::Blueprint>, CliError> {
+    for entry in fs::read_dir(dir).map_err(|e| CliError::generic(e.to_string()))? {
+        let entry = entry.map_err(|e| CliError::generic(e.to_string()))?;
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(blueprint) = find_library_blueprint_in_dir(&path, blueprint_id)? {
+                return Ok(Some(blueprint));
+            }
+            continue;
+        }
+        if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            continue;
+        }
+        let blueprint = wardian_core::workflow::parse_file(&path)
+            .map_err(|e| CliError::generic(e.to_string()))?;
+        if blueprint.id == blueprint_id {
+            return Ok(Some(blueprint));
+        }
+    }
+    Ok(None)
+}
+
+fn build_workflow_runtime() -> Result<tokio::runtime::Runtime, CliError> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
         .map_err(|e| CliError::generic(e.to_string()))
 }
 

--- a/crates/wardian-cli/tests/workflow_v2_cli.rs
+++ b/crates/wardian-cli/tests/workflow_v2_cli.rs
@@ -1,0 +1,115 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+const DEMO_BLUEPRINT: &str = r#"---
+schema: 2
+id: demo
+name: Demo
+nodes:
+  - id: trigger-1
+    type: manual_trigger
+  - id: plan
+    type: task
+    fields:
+      agent: role:planner
+      prompt: Plan the demo
+edges:
+  - from: trigger-1
+    to: plan
+---
+
+# Demo
+
+A tiny v2 workflow for CLI round-trip tests.
+"#;
+
+fn bin() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian-cli") {
+        return path.into();
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian_cli") {
+        return path.into();
+    }
+
+    let exe = if cfg!(windows) {
+        "wardian-cli.exe"
+    } else {
+        "wardian-cli"
+    };
+    std::env::current_exe()
+        .unwrap()
+        .parent()
+        .and_then(|deps| deps.parent())
+        .unwrap()
+        .join(exe)
+}
+
+fn seed_demo_workflow(home: &TempDir) -> std::path::PathBuf {
+    let workflows_dir = home.path().join("library").join("workflows");
+    std::fs::create_dir_all(&workflows_dir).unwrap();
+    let path = workflows_dir.join("demo.md");
+    std::fs::write(&path, DEMO_BLUEPRINT).unwrap();
+    path
+}
+
+fn workflow_command(home: &TempDir, args: &[&str]) -> serde_json::Value {
+    let output = Command::new(bin())
+        .args(args)
+        .env("WARDIAN_HOME", home.path())
+        .env_remove("WARDIAN_SESSION_ID")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "status: {:?}\nstderr: {}\nstdout: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn workflow_v2_exec_runs_show_replay_round_trip() {
+    let home = TempDir::new().unwrap();
+    let workflow_path = seed_demo_workflow(&home);
+
+    let exec = workflow_command(
+        &home,
+        &["workflow", "exec", workflow_path.to_str().unwrap()],
+    );
+    assert_eq!(exec["schema"], 1);
+    assert_eq!(exec["ok"], true);
+    assert_eq!(exec["blueprint_id"], "demo");
+    assert_eq!(exec["executor"], "mock");
+    let run_id = exec["run_id"].as_str().unwrap();
+    assert!(!run_id.is_empty());
+
+    let run_dir = home
+        .path()
+        .join("logs")
+        .join("workflows")
+        .join("demo")
+        .join(run_id);
+    assert!(run_dir.is_dir());
+    assert!(run_dir.join("events.jsonl").is_file());
+    assert!(run_dir.join("state.json").is_file());
+
+    let runs = workflow_command(&home, &["workflow", "runs"]);
+    let runs = runs["runs"].as_array().unwrap();
+    assert!(runs.iter().any(|run| {
+        run["blueprint_id"] == "demo" && run["run_id"] == run_id && run["status"] == exec["status"]
+    }));
+
+    let shown = workflow_command(&home, &["workflow", "run-show", "demo", run_id]);
+    let shown_status = shown["state"]["status"].as_str().unwrap();
+    assert!(matches!(
+        shown_status,
+        "completed" | "failed" | "awaiting_approval"
+    ));
+    assert!(!shown["events"].as_array().unwrap().is_empty());
+
+    let replayed = workflow_command(&home, &["workflow", "replay", "demo", run_id]);
+    assert_eq!(replayed["state"]["status"], shown["state"]["status"]);
+}

--- a/crates/wardian-core/src/engine/driver.rs
+++ b/crates/wardian-core/src/engine/driver.rs
@@ -23,8 +23,21 @@ impl Engine {
         run_root: &Path,
         exec: &dyn StepExecutor,
     ) -> crate::engine::Result<RunState> {
+        Self::start_with_id(bp, new_run_id(), trigger, run_root, exec).await
+    }
+
+    /// Start a fresh run with a caller-supplied run id and drive it until it
+    /// completes, fails, or parks on an approval. Returns the resulting
+    /// `RunState`.
+    pub async fn start_with_id(
+        bp: &Blueprint,
+        run_id: impl Into<String>,
+        trigger: serde_json::Value,
+        run_root: &Path,
+        exec: &dyn StepExecutor,
+    ) -> crate::engine::Result<RunState> {
         let g = Graph::new(bp);
-        let mut s = RunState::new(new_run_id(), &bp.id);
+        let mut s = RunState::new(run_id.into(), &bp.id);
         emit(
             run_root,
             &g,
@@ -135,7 +148,48 @@ impl Engine {
     }
 }
 
-fn new_run_id() -> String {
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::MockExecutor;
+
+    #[tokio::test]
+    async fn start_with_id_persists_caller_supplied_run_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let blueprint = Blueprint {
+            schema: 2,
+            id: "wf".into(),
+            name: "Workflow".into(),
+            nodes: vec![Node {
+                id: "t".into(),
+                r#type: "manual_trigger".into(),
+                name: None,
+                parent: None,
+                fields: serde_json::Map::new(),
+                position: None,
+            }],
+            edges: vec![],
+            body: String::new(),
+        };
+        let exec = MockExecutor::new();
+
+        let state = Engine::start_with_id(
+            &blueprint,
+            "run-xyz",
+            serde_json::json!({}),
+            dir.path(),
+            &exec,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(state.run_id, "run-xyz");
+        let checkpoint = read_checkpoint(dir.path()).unwrap().unwrap();
+        assert_eq!(checkpoint.run_id, "run-xyz");
+    }
+}
+
+pub fn new_run_id() -> String {
     format!(
         "{}-{}",
         chrono::Utc::now().timestamp_millis(),

--- a/crates/wardian-core/src/engine/driver.rs
+++ b/crates/wardian-core/src/engine/driver.rs
@@ -148,47 +148,6 @@ impl Engine {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::engine::MockExecutor;
-
-    #[tokio::test]
-    async fn start_with_id_persists_caller_supplied_run_id() {
-        let dir = tempfile::tempdir().unwrap();
-        let blueprint = Blueprint {
-            schema: 2,
-            id: "wf".into(),
-            name: "Workflow".into(),
-            nodes: vec![Node {
-                id: "t".into(),
-                r#type: "manual_trigger".into(),
-                name: None,
-                parent: None,
-                fields: serde_json::Map::new(),
-                position: None,
-            }],
-            edges: vec![],
-            body: String::new(),
-        };
-        let exec = MockExecutor::new();
-
-        let state = Engine::start_with_id(
-            &blueprint,
-            "run-xyz",
-            serde_json::json!({}),
-            dir.path(),
-            &exec,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(state.run_id, "run-xyz");
-        let checkpoint = read_checkpoint(dir.path()).unwrap().unwrap();
-        assert_eq!(checkpoint.run_id, "run-xyz");
-    }
-}
-
 pub fn new_run_id() -> String {
     format!(
         "{}-{}",
@@ -490,5 +449,46 @@ async fn run_side_effect(
         other => Err(StepError::new(format!(
             "no executor for node type `{other}`"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::MockExecutor;
+
+    #[tokio::test]
+    async fn start_with_id_persists_caller_supplied_run_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let blueprint = Blueprint {
+            schema: 2,
+            id: "wf".into(),
+            name: "Workflow".into(),
+            nodes: vec![Node {
+                id: "t".into(),
+                r#type: "manual_trigger".into(),
+                name: None,
+                parent: None,
+                fields: serde_json::Map::new(),
+                position: None,
+            }],
+            edges: vec![],
+            body: String::new(),
+        };
+        let exec = MockExecutor::new();
+
+        let state = Engine::start_with_id(
+            &blueprint,
+            "run-xyz",
+            serde_json::json!({}),
+            dir.path(),
+            &exec,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(state.run_id, "run-xyz");
+        let checkpoint = read_checkpoint(dir.path()).unwrap().unwrap();
+        assert_eq!(checkpoint.run_id, "run-xyz");
     }
 }

--- a/docs/specs/2026-05-29-workflow-v2-cli.md
+++ b/docs/specs/2026-05-29-workflow-v2-cli.md
@@ -1,0 +1,102 @@
+# Workflow v2 CLI Verbs
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Decider:** User
+
+## Context
+
+Wardian now has a Rust workflow v2 blueprint model and deterministic engine in
+`wardian-core`. The CLI needs a thin surface for agents and automation to run a
+blueprint headlessly, inspect durable run artifacts, and normalize or parse
+blueprint Markdown without requiring the desktop app.
+
+The existing workflow CLI verbs remain the app-owned v1 surface:
+`wardian workflow list`, `show`, `run`, and `stop`. Those commands continue to
+coexist with v2 while the desktop app and run view migrate. The new v2 verbs use
+names that avoid overloading v1 `run`.
+
+## Verb Surface
+
+The v2 CLI verbs are:
+
+| Command | Purpose |
+|---|---|
+| `wardian workflow exec <path> [--executor mock]` | Execute a workflow v2 blueprint headlessly and write a durable run. |
+| `wardian workflow runs` | List durable workflow v2 runs from `<wardian-home>/logs/workflows`. |
+| `wardian workflow run-show <blueprint-id> <run-id>` | Show one run's checkpoint state and event trace. |
+| `wardian workflow replay <blueprint-id> <run-id>` | Rebuild final state from the run event log without executing nodes. |
+| `wardian workflow parse <path>` | Parse a blueprint Markdown file and print the structured blueprint JSON. |
+| `wardian workflow normalize <path> [--write]` | Normalize a blueprint and print the Markdown, or write it back in place. |
+
+`exec` rejects non-`mock` executor values with `unsupported_executor` until the
+real executor lands.
+
+## Execution Decision
+
+This slice intentionally supports mock execution only. `exec` validates the
+blueprint, creates a caller-visible run id, and drives
+`Engine::start_with_id(..., &MockExecutor::new())`.
+
+Run artifacts are written to the same durable path the real executor will use:
+
+```text
+<wardian-home>/logs/workflows/<blueprint-id>/<run-id>/events.jsonl
+<wardian-home>/logs/workflows/<blueprint-id>/<run-id>/state.json
+```
+
+When the real workflow executor is ready, it should swap the `MockExecutor`
+implementation at this boundary and keep the run path stable. That preserves
+the `runs`, `run-show`, and `replay` inspection contract for both mock and real
+runs.
+
+`resume` is deferred. The engine already exposes resume primitives, but wiring
+CLI resume against a mock executor is low-value and could imply real provider
+recovery semantics that do not exist yet. Resume should land with the real
+executor and provider-runtime handoff.
+
+## Examples
+
+Bash:
+
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-workflow-v2"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md"
+wardian workflow runs
+wardian workflow run-show demo <run-id>
+wardian workflow replay demo <run-id>
+wardian workflow parse "$WARDIAN_HOME/library/workflows/demo.md"
+wardian workflow normalize "$WARDIAN_HOME/library/workflows/demo.md"
+wardian workflow normalize "$WARDIAN_HOME/library/workflows/demo.md" --write
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_HOME = "$PWD\.tmp\wardian-workflow-v2"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md"
+wardian workflow runs
+wardian workflow run-show demo <run-id>
+wardian workflow replay demo <run-id>
+wardian workflow parse "$env:WARDIAN_HOME\library\workflows\demo.md"
+wardian workflow normalize "$env:WARDIAN_HOME\library\workflows\demo.md"
+wardian workflow normalize "$env:WARDIAN_HOME\library\workflows\demo.md" --write
+```
+
+The v1 app-owned commands remain valid during the migration:
+
+```bash
+wardian workflow list
+wardian workflow show <id-or-name>
+wardian workflow run <id>
+wardian workflow stop <run-instance-id>
+```
+
+PowerShell:
+
+```powershell
+wardian workflow list
+wardian workflow show <id-or-name>
+wardian workflow run <id>
+wardian workflow stop <run-instance-id>
+```


### PR DESCRIPTION
## Description

Sub-project **4** of Workflow Engine v2: the thin **v2 workflow CLI** over `wardian_core::{workflow, engine}`. Adds the run-lifecycle verbs to `wardian workflow`:

- **`exec <blueprint.md> [--executor mock]`** — parse + validate, then drive the engine with the **MockExecutor**, writing a real durable run to `<home>/logs/workflows/<id>/<run-id>/{events.jsonl,state.json}`. Non-`mock` executors error clearly ("real executor not yet available").
- **`runs`** — list v2 runs. **`run-show <id> <run>`** — RunState + event trace. **`replay <id> <run>`** — reconstruct final state from the event log (no execution).
- **`parse <path>`** / **`normalize <path> [--write]`** — blueprint authoring helpers.

`node-types` / `validate` / `gen-schema` / `gen-docs` already shipped in sub-project #1 and are untouched. The existing v1 `run`/`list`/`show`/`stop` (live-app `WorkflowDefinition`) are left intact and coexist; v2 verbs are `exec`/`runs`/`run-show`/`replay`/`parse`/`normalize`.

Also adds a small additive engine helper — `Engine::start_with_id` + `pub fn new_run_id()` — so the CLI can name the on-disk run directory to match the run's id; `start` delegates to it.

## Related Issues
Part of #425 (Workflow Engine v2 epic). Completes the roadmap's sub-project 4 (thin CLI).

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- **Rust unit + integration:** `cargo test -p wardian-cli` (123 incl. new arg-parse tests) and `-p wardian-core` (129+ incl. `start_with_id_persists_caller_supplied_run_id`, `workflow_run_dir_uses_logs_workflows_suffix`) all pass.
- **End-to-end:** `tests/workflow_v2_cli.rs::workflow_v2_exec_runs_show_replay_round_trip` — seeds a temp `WARDIAN_HOME` + blueprint, `exec`s it with the mock executor, then asserts the run dir / `events.jsonl` / `state.json` are written and that `runs` / `run-show` / `replay` round-trip. **Passes.**
- **Lint:** `cargo clippy -p wardian-cli -p wardian-core --all-targets` clean (no warnings).

## Notes for review
- **Mock-only execution (approved scope).** The real `StepExecutor` is a separate later slice; it will swap `MockExecutor` for the live executor at the *same* run path. This makes 3b's Run View demoable against real runs today. `resume` is deferred (low value against the mock).
- **`exec` not `run`** to avoid clashing with the existing v1 `run` verb.
- **⚠️ Merge note:** `paths::workflow_runs_dir`/`workflow_run_dir` are added here AND in PR #438 (3b), identically — whichever of the two merges second drops the duplicate (trivial). Done deliberately so this backend PR could branch off `main` and get full CI rather than stacking.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (new spec `docs/specs/2026-05-29-workflow-v2-cli.md`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Backend/CLI only — no frontend changes, screenshot evidence N/A. -->

---
🤖 Built via Wardian-Codex-copy (subagent-driven, task-by-task) and verified independently. Decisions logged in `.superpowers/judgment-calls-3a-3b.md`.
