### PR TITLE
fix(ci): use release please PR output for lock sync

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,17 +26,12 @@ jobs:
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs }}
         run: |
           set -euo pipefail
 
           release_branch="$(
-            gh pr list \
-              --repo "$GITHUB_REPOSITORY" \
-              --state open \
-              --base main \
-              --label "autorelease: pending" \
-              --json headRefName \
-              --jq '.[0].headRefName'
+            node -e 'const prs = JSON.parse(process.env.RELEASE_PLEASE_PRS || "[]"); console.log(prs[0]?.headBranchName ?? "");'
           )"
 
           if [ -z "$release_branch" ] || [ "$release_branch" = "null" ]; then

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -29,7 +29,9 @@ describe("release workflow contract", () => {
     expect(releasePleaseWorkflow).toContain("steps.release.outputs.prs_created == 'true'");
     expect(releasePleaseWorkflow).toContain("actions/checkout@v4");
     expect(releasePleaseWorkflow).toContain("fetch-depth: 0");
-    expect(releasePleaseWorkflow).toContain("--label \"autorelease: pending\"");
+    expect(releasePleaseWorkflow).toContain("RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs }}");
+    expect(releasePleaseWorkflow).toContain("headBranchName");
+    expect(releasePleaseWorkflow).not.toContain("gh pr list");
     expect(releasePleaseWorkflow).toContain("cargo metadata --format-version 1 --no-deps");
     expect(releasePleaseWorkflow).toContain("git add Cargo.lock");
     expect(releasePleaseWorkflow).toContain("chore: sync release Cargo.lock");


### PR DESCRIPTION
## Description
Fixes the Release Please workflow lockfile sync step by reading the release PR branch from `steps.release.outputs.prs` instead of querying immediately for an `autorelease: pending` PR label. The failing main run created PR #443 successfully, but the follow-up label-based `gh pr list` returned no branch.

## Related Issues
Fixes #444

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npx --yes yaml-lint .github/workflows/release-please.yml`
- Node extraction smoke test with sample Release Please `prs` JSON
- `npm run lint`
- `npm run test -- src/config/releaseWorkflow.test.ts`
- `npm run test`
- `npm run build`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo clippy`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable

Notes: no user-facing docs, code comments, or screenshot evidence are needed; this is an internal CI workflow fix.