### PR TITLE
feat(workflow-v2): live executor — drive real agents + run lifecycle (sub-project 5a)

### DIFF
--- a/docs/specs/2026-05-29-workflow-v2-executor.md
+++ b/docs/specs/2026-05-29-workflow-v2-executor.md
@@ -1,10 +1,12 @@
 # Workflow Engine v2 — Live Executor (sub-project 5a) Design
 
-- **Status:** Proposed
+- **Status:** Implemented (5a)
 - **Date:** 2026-05-29
 - **Part of:** [Workflow Engine v2 epic (#425)]; follows sub-projects 1 (library/registry), 2 (durable engine), 3a (builder), 3b (run view), 4 (CLI).
 
 > **Structure note:** the v2 engine/workflow logic lives as modules in `wardian-core` (`wardian_core::engine`, `wardian_core::workflow`). The live executor lives in `src-tauri` because it owns the agent runtime. Read "executor" as a `src-tauri` impl of the `wardian_core::engine::StepExecutor` trait.
+
+> **Implementation note (5a):** shipped the `src-tauri` live executor, headless/fake runner boundary, output and decision parsing, agent resolution, shell/script/notify/state ops, run/resume/approve/cancel commands, startup interrupted-run logging, and mock-provider end-to-end validation. Deferred scope remains live named-agent routing, visible grouped workers, per-node worktrees, scheduled/event triggers, per-run session continuity, v1 retirement, and UI unification.
 
 ## 1. Problem & goal
 

--- a/docs/specs/2026-05-29-workflow-v2-executor.md
+++ b/docs/specs/2026-05-29-workflow-v2-executor.md
@@ -1,0 +1,74 @@
+# Workflow Engine v2 — Live Executor (sub-project 5a) Design
+
+- **Status:** Proposed
+- **Date:** 2026-05-29
+- **Part of:** [Workflow Engine v2 epic (#425)]; follows sub-projects 1 (library/registry), 2 (durable engine), 3a (builder), 3b (run view), 4 (CLI).
+
+> **Structure note:** the v2 engine/workflow logic lives as modules in `wardian-core` (`wardian_core::engine`, `wardian_core::workflow`). The live executor lives in `src-tauri` because it owns the agent runtime. Read "executor" as a `src-tauri` impl of the `wardian_core::engine::StepExecutor` trait.
+
+## 1. Problem & goal
+
+The v2 durable engine (`wardian_core::engine`) executes a validated blueprint as a resumable run, but every side-effecting step goes through the dependency-inverted `StepExecutor` trait — and the only implementation today is `MockExecutor`. So v2 can author (builder), observe (run view), and mock-execute (CLI), but **nothing drives real agents**. v1's `workflow_engine` is still the only thing that actually runs a workflow against live agents.
+
+**Goal of 5a:** a real `StepExecutor` (`LiveStepExecutor`) in `src-tauri` that drives live work, plus the Tauri commands to launch / resume / cancel a run and pause for approval. This makes v2 actually execute and is the prerequisite for retiring v1 (5c) and unifying the workflow UI (5b).
+
+**Non-goal / explicitly deferred:** live named-agent routing (sending a step to an already-running interactive roster agent over its PTY), per-node git worktrees, scheduled/cron triggers, cross-run concurrency caps, and per-run agent session continuity. See §7.
+
+## 2. Transport: build on `run_headless`, validate it fresh
+
+`src-tauri/src/manager/headless.rs::run_headless_with_options` already spawns a provider in one-shot headless mode (codex `exec --json`, claude `--print`, opencode `run --format json`, antigravity `--print`, **`mock`**), reads its output, and **returns the agent's final response as a value**. It is **request/response, not a PTY** — so it never uses the `ask`/`reply` channels (whose headless behavior is unvalidated). This is the correct transport primitive for headless workers.
+
+**Caveat (explicit):** v1's headless *orchestration* was buggy. We treat `run_headless` as the right building block but **not** as proven, and we do **not** copy v1's patterns. 5a builds a clean executor and validates the primitive end-to-end (mock provider integration test + a gated real-provider smoke). v1's `workflow_engine` headless code is a cautionary reference only.
+
+## 3. Agent resolution (hybrid by reference)
+
+A Task/Decision node's `agent` field resolves as:
+
+- **`role:<x>` / `class:<x>` / `ephemeral`** → spawn a fresh **headless ephemeral worker** for the step via `run_headless` (the default path; this is all of 5a's agent execution). An `AgentConfig` is built from the class/role (provider, class instructions, workspace). Workers are **headless and ephemeral per node** by default; **not** shown in the roster, so a run doesn't flood the Command Center. (A visible/grouped opt-in is a later enhancement, not 5a.)
+- **explicit live agent name** → would route to a running roster agent over its PTY. **Deferred** (§7) — that transport is the genuinely unvalidated one. In 5a, a named reference either runs headless under a derived config or returns a clear "live-agent routing not yet supported" error (decided in the plan).
+
+## 4. `LiveStepExecutor` (the StepExecutor impl)
+
+New module `src-tauri/src/workflow_v2/` with `LiveStepExecutor` implementing `wardian_core::engine::StepExecutor`. Each side-effecting trait method maps to a real action:
+
+- **`run_agent_task`** — resolve `agent` → build `AgentConfig` → `run_headless_with_options(cwd, prompt, session, "json", provider)` → take the returned response → **extract structured output**: if `output_schema` is set, parse/validate JSON (trailing fenced ```json block or whole response); otherwise best-effort parse, falling back to `{"text": <response>}`. Returns `StepOutput(value)` stored at `nodes.<id>.output`.
+- **`run_decision`** — same call, with the prompt appended: "Respond with exactly one of: `<choices>`." Parse the chosen port. If the answer is not a declared choice, **re-prompt once**; if still invalid, fail the node. Returns `ChosenPort`.
+- **`run_shell`** — run `command` in the run workspace cwd via the existing shell util; return `{exit_code, stdout, stderr}`. (No sandbox — local, author-controlled; documented.)
+- **`run_script`** — run `runtime` (`python`/`node`/`sh`) on `path` in the workspace; capture output like shell.
+- **`notify`** — fire an app notification (`tauri-plugin-notification`) and write a run-log line.
+- **`state_op`** — apply `op` (`set`/`merge`/`delete`) with `entries` to the run's `{{storage}}` in the engine `RunState` registry that interpolation reads. (Exact op set pinned in the plan against the engine's storage model.)
+
+**Testability boundary:** the executor calls agents through a small internal `AgentRunner` trait (one method: run a prompt headlessly → response). The real impl wraps `run_headless`; unit tests inject a fake so they never spawn a provider. This keeps the executor logic (resolution, parsing, decision constraint) unit-testable in isolation.
+
+**Workspace:** a run executes in one workspace — an optional blueprint field, else a sensible default (e.g. the run dir or library workspace). No per-node worktrees in 5a.
+
+**Concurrency:** the engine's `drive` loop dispatches runnable nodes **sequentially within a run** (confirmed in `driver.rs`), so the executor never sees concurrent calls from one run. Multiple concurrent runs are allowed; a global cap is deferred.
+
+## 5. Run lifecycle (Tauri commands)
+
+- **`workflow_run_v2(path)`** — load + validate the blueprint (refuse to run if invalid), build a `LiveStepExecutor`, generate a `run_id`, set `run_root = paths::workflow_run_dir(bp.id, run_id)`, and drive `Engine::start_with_id` in a **background tokio task**. Returns the `run_id` immediately; the run proceeds async, writing `events.jsonl` + `state.json` that **Run View (3b) already observes live**.
+- **Approval** — when the engine reaches `AwaitingApproval` it returns and the status persists. `workflow_approve_v2(id, run, granted, note)` resumes via `Engine::grant_approval` / `reject_approval` in a new background task.
+- **`workflow_resume_v2(id, run)`** — resume an interrupted/paused run via `Engine::resume` (completed nodes skipped).
+- **`workflow_cancel_v2(id, run)`** — abort a live run (cancel the background task; mark the run failed/stopped with a reason).
+- **Crash recovery** — on app start, scan `logs/workflows/**` for runs still marked `Running` (their workers are gone) and mark them **interrupted**; Run View surfaces a **Resume** affordance that calls `workflow_resume_v2`. No auto-resume (no surprise re-execution of side-effecting steps at startup).
+
+## 6. Testing
+
+- **Unit** (`wardian-core` unchanged; tests in `src-tauri`): `LiveStepExecutor` with an injected fake `AgentRunner` — agent resolution, output/schema extraction, decision constraint + re-prompt, shell/script/state ops. No real spawn.
+- **Integration (the real validation):** end-to-end run through real `run_headless` with the **`mock` provider** — seed a blueprint in a temp `WARDIAN_HOME`, invoke `workflow_run_v2`, and assert the run dir / `events.jsonl` / terminal `state.json`, and that the CLI `runs`/`run-show` (sub-project 4) read it back. This properly validates the headless primitive that v1 used incorrectly.
+- **Real-provider smoke:** opt-in (one headless codex/claude task), gated like the other real-provider tests.
+
+## 7. Scope boundaries (deferred to later sub-projects)
+
+- **Live named-agent routing** (PTY send/await/capture against a running roster agent) — the unvalidated transport; its own follow-up.
+- **Visible/grouped run workers** in the Command Center (5a workers are headless).
+- **Per-node git worktrees** for isolation.
+- **Scheduled / event triggers** — 5a is manual-run only (`workflow_run_v2`); triggers are later.
+- **Per-run agent session continuity** (resume_session reuse across a run's nodes).
+- **v1 retirement & UI unification** — sub-projects 5b (unified Workflows view, edit↔observe↔run) and 5c (v1→v2 migration, delete v1 engine).
+
+## 8. Risks
+
+- **`run_headless` correctness** under workflow load is unproven → the mock-provider integration test + real-provider smoke are the gate, not assumption.
+- **Structured-output reliability** from free-form agents → schema-validated parse with a re-prompt for decisions and a `{"text": …}` fallback for tasks; brittle prompts are tuned during implementation.
+- **Provider variance** (codex/claude/opencode/antigravity headless output shapes already differ in `run_headless`) → 5a targets the providers `run_headless` already normalizes; per-provider quirks handled there.

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -285,6 +285,7 @@ pub async fn workflow_resume_v2(
 
 /// Grant or reject an approval gate, resuming the run when granted.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn workflow_approve_v2(
     blueprint_id: String,
     run_id: String,

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -1,4 +1,5 @@
 use crate::workflow_engine;
+use crate::workflow_v2::runs;
 use serde_json::Value;
 use tauri::AppHandle;
 use wardian_core::engine::store::{read_checkpoint, read_events};
@@ -158,7 +159,10 @@ pub fn workflow_list_runs() -> Result<Vec<serde_json::Value>, String> {
         return Ok(out);
     }
 
-    for bp in std::fs::read_dir(&root).map_err(|e| e.to_string())?.flatten() {
+    for bp in std::fs::read_dir(&root)
+        .map_err(|e| e.to_string())?
+        .flatten()
+    {
         if !bp.path().is_dir() {
             continue;
         }
@@ -188,14 +192,146 @@ pub fn workflow_list_runs() -> Result<Vec<serde_json::Value>, String> {
 
 /// Read one run: its RunState checkpoint, full event trace, and optional blueprint.
 #[tauri::command]
-pub fn workflow_read_run(blueprint_id: String, run_id: String) -> Result<serde_json::Value, String> {
-    let dir = wardian_core::paths::workflow_run_dir(&blueprint_id, &run_id)
-        .ok_or("no wardian home")?;
+pub fn workflow_read_run(
+    blueprint_id: String,
+    run_id: String,
+) -> Result<serde_json::Value, String> {
+    let dir =
+        wardian_core::paths::workflow_run_dir(&blueprint_id, &run_id).ok_or("no wardian home")?;
     let state = read_checkpoint(&dir).map_err(|e| e.to_string())?;
     let events = read_events(&dir).map_err(|e| e.to_string())?;
     let blueprint = resolve_blueprint(&blueprint_id);
 
     Ok(serde_json::json!({ "state": state, "events": events, "blueprint": blueprint }))
+}
+
+/// Launch a v2 blueprint run headlessly. Validates, then drives the engine in a
+/// background task writing logs/workflows/<id>/<run-id>/. Returns the run id.
+#[tauri::command]
+pub async fn workflow_run_v2(
+    path: String,
+    provider: Option<String>,
+    workspace: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let blueprint = wardian_core::workflow::parse_file(std::path::Path::new(&path))
+        .map_err(|e| e.to_string())?;
+    let report = wardian_core::workflow::validate(&blueprint);
+    if !report.is_valid() {
+        return Ok(serde_json::json!({
+            "ok": false,
+            "diagnostics": report.diagnostics
+        }));
+    }
+
+    let run_id = wardian_core::engine::driver::new_run_id();
+    let run_root =
+        wardian_core::paths::workflow_run_dir(&blueprint.id, &run_id).ok_or("no wardian home")?;
+    let provider = provider.unwrap_or_else(|| "codex".to_string());
+    let workspace = workspace
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| run_root.clone());
+    let blueprint_for_run = blueprint.clone();
+    let run_id_for_run = run_id.clone();
+    let run_root_for_run = run_root.clone();
+
+    tokio::spawn(async move {
+        if let Err(error) = runs::drive_new_run(
+            blueprint_for_run,
+            run_id_for_run,
+            run_root_for_run,
+            workspace,
+            provider,
+        )
+        .await
+        {
+            crate::utils::logging::log_debug(&format!("[workflow-v2] run failed: {error}"));
+        }
+    });
+
+    Ok(serde_json::json!({
+        "ok": true,
+        "run_id": run_id,
+        "blueprint_id": blueprint.id,
+        "run_dir": run_root.to_string_lossy(),
+    }))
+}
+
+/// Resume an interrupted or parked v2 run.
+#[tauri::command]
+pub async fn workflow_resume_v2(
+    blueprint_id: String,
+    run_id: String,
+    blueprint_path: String,
+    provider: Option<String>,
+    workspace: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let blueprint = wardian_core::workflow::parse_file(std::path::Path::new(&blueprint_path))
+        .map_err(|e| e.to_string())?;
+    let run_root =
+        wardian_core::paths::workflow_run_dir(&blueprint_id, &run_id).ok_or("no wardian home")?;
+    let provider = provider.unwrap_or_else(|| "codex".to_string());
+    let workspace = workspace
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| run_root.clone());
+
+    tokio::spawn(async move {
+        if let Err(error) = runs::drive_resume(blueprint, run_root, workspace, provider).await {
+            crate::utils::logging::log_debug(&format!("[workflow-v2] resume failed: {error}"));
+        }
+    });
+
+    Ok(serde_json::json!({ "ok": true, "run_id": run_id }))
+}
+
+/// Grant or reject an approval gate, resuming the run when granted.
+#[tauri::command]
+pub async fn workflow_approve_v2(
+    blueprint_id: String,
+    run_id: String,
+    blueprint_path: String,
+    node: String,
+    granted: bool,
+    actor: String,
+    note: Option<String>,
+    provider: Option<String>,
+    workspace: Option<String>,
+) -> Result<serde_json::Value, String> {
+    let blueprint = wardian_core::workflow::parse_file(std::path::Path::new(&blueprint_path))
+        .map_err(|e| e.to_string())?;
+    let run_root =
+        wardian_core::paths::workflow_run_dir(&blueprint_id, &run_id).ok_or("no wardian home")?;
+
+    let result = if granted {
+        let provider = provider.unwrap_or_else(|| "codex".to_string());
+        let workspace = workspace
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| run_root.clone());
+        let exec = runs::live_executor(workspace, provider);
+        wardian_core::engine::Engine::grant_approval(
+            &blueprint, &run_root, &node, &actor, note, &exec,
+        )
+        .await
+    } else {
+        wardian_core::engine::Engine::reject_approval(&blueprint, &run_root, &node, &actor, note)
+            .await
+    };
+
+    result
+        .map(|_| serde_json::json!({ "ok": true }))
+        .map_err(|e| e.to_string())
+}
+
+/// Record a cancel request for a run. Cooperative cancellation of the live loop
+/// is deferred; the marker gives the UI a durable cancellation request.
+#[tauri::command]
+pub fn workflow_cancel_v2(
+    blueprint_id: String,
+    run_id: String,
+) -> Result<serde_json::Value, String> {
+    let run_root =
+        wardian_core::paths::workflow_run_dir(&blueprint_id, &run_id).ok_or("no wardian home")?;
+    std::fs::write(run_root.join("cancel.marker"), "cancelled").map_err(|e| e.to_string())?;
+    Ok(serde_json::json!({ "ok": true }))
 }
 
 fn resolve_blueprint(id: &str) -> Option<serde_json::Value> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod providers;
 pub mod remote;
 pub mod state;
 pub mod utils;
+mod workflow_v2;
 pub mod workflow_engine;
 pub use wardian_core::models;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ pub mod remote;
 pub mod state;
 pub mod utils;
 pub mod workflow_engine;
-mod workflow_v2;
+pub mod workflow_v2;
 pub use wardian_core::models;
 
 // Tauri's Windows resource contains the Common Controls v6 manifest required by

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -214,6 +214,17 @@ pub fn run() {
 
             start_metrics_supervisor(app.handle().clone());
 
+            if let Some(runs_dir) = wardian_core::paths::workflow_runs_dir() {
+                let interrupted = crate::workflow_v2::runs::scan_interrupted_runs(&runs_dir);
+                if !interrupted.is_empty() {
+                    crate::utils::logging::log_debug(&format!(
+                        "[workflow-v2] {} interrupted run(s) on startup: {:?}",
+                        interrupted.len(),
+                        interrupted
+                    ));
+                }
+            }
+
             tauri::async_runtime::spawn(async move {
                 let state = app_handle.state::<AppState>();
                 #[cfg(windows)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,8 +5,8 @@ pub mod providers;
 pub mod remote;
 pub mod state;
 pub mod utils;
-mod workflow_v2;
 pub mod workflow_engine;
+mod workflow_v2;
 pub use wardian_core::models;
 
 // Tauri's Windows resource contains the Common Controls v6 manifest required by
@@ -452,6 +452,10 @@ pub fn run() {
             commands::workflow::workflow_list_blueprints,
             commands::workflow::workflow_list_runs,
             commands::workflow::workflow_read_run,
+            commands::workflow::workflow_run_v2,
+            commands::workflow::workflow_resume_v2,
+            commands::workflow::workflow_approve_v2,
+            commands::workflow::workflow_cancel_v2,
             commands::library::get_library_tree,
             commands::library::save_library_item,
             commands::library::update_library_metadata,

--- a/src-tauri/src/workflow_v2/mod.rs
+++ b/src-tauri/src/workflow_v2/mod.rs
@@ -1,0 +1,1 @@
+pub mod output;

--- a/src-tauri/src/workflow_v2/mod.rs
+++ b/src-tauri/src/workflow_v2/mod.rs
@@ -1,2 +1,3 @@
 pub mod output;
+pub mod resolve;
 pub mod runner;

--- a/src-tauri/src/workflow_v2/mod.rs
+++ b/src-tauri/src/workflow_v2/mod.rs
@@ -1,3 +1,225 @@
+pub mod ops;
 pub mod output;
 pub mod resolve;
 pub mod runner;
+pub mod runs;
+
+use runner::{AgentRunSpec, AgentRunner};
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
+use wardian_core::engine::{
+    AgentTaskRequest, ChosenPort, DecisionRequest, NotifyRequest, ScriptRequest, ShellRequest,
+    StateRequest, StepError, StepExecutor, StepOutput,
+};
+
+/// The real StepExecutor: drives headless agents and local side effects for one
+/// workflow run.
+pub struct LiveStepExecutor {
+    runner: Arc<dyn AgentRunner>,
+    workspace: PathBuf,
+    default_provider: String,
+}
+
+impl LiveStepExecutor {
+    pub fn new(runner: Arc<dyn AgentRunner>, workspace: PathBuf, default_provider: String) -> Self {
+        Self {
+            runner,
+            workspace,
+            default_provider,
+        }
+    }
+
+    async fn run_prompt(
+        &self,
+        node: &str,
+        agent_ref: &str,
+        prompt: String,
+    ) -> Result<String, StepError> {
+        let resolved = resolve::resolve_agent(agent_ref, &self.workspace, &self.default_provider);
+        if !resolved.is_ephemeral {
+            crate::utils::logging::log_debug(&format!(
+                "[workflow-v2] node {node}: live-agent routing not yet supported; running '{agent_ref}' headless"
+            ));
+        }
+
+        self.runner
+            .run(AgentRunSpec {
+                node: node.to_string(),
+                provider: resolved.provider,
+                cwd: resolved.cwd,
+                prompt,
+                session_id: resolved.session_id,
+                resume_session: resolved.resume_session,
+            })
+            .await
+            .map_err(StepError::new)
+    }
+}
+
+impl StepExecutor for LiveStepExecutor {
+    fn run_agent_task<'life0, 'async_trait>(
+        &'life0 self,
+        req: AgentTaskRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<StepOutput, StepError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move {
+            let response = self.run_prompt(&req.node, &req.agent, req.prompt).await?;
+            Ok(StepOutput(output::extract_structured_output(
+                &response,
+                req.output_schema.as_deref(),
+            )))
+        })
+    }
+
+    fn run_decision<'life0, 'async_trait>(
+        &'life0 self,
+        req: DecisionRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<ChosenPort, StepError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move {
+            let choices_line = format!(
+                "\n\nRespond with exactly one of: {}",
+                req.choices.join(", ")
+            );
+            let response = self
+                .run_prompt(
+                    &req.node,
+                    &req.agent,
+                    format!("{}{}", req.prompt, choices_line),
+                )
+                .await?;
+
+            if let Some(port) = output::parse_decision_port(&response, &req.choices) {
+                return Ok(ChosenPort(port));
+            }
+
+            let strict = format!(
+                "{}\n\nReply with ONLY one of these exact words: {}",
+                req.prompt,
+                req.choices.join(", ")
+            );
+            let response = self.run_prompt(&req.node, &req.agent, strict).await?;
+            output::parse_decision_port(&response, &req.choices)
+                .map(ChosenPort)
+                .ok_or_else(|| {
+                    StepError::new(format!(
+                        "decision node {} did not choose a declared port",
+                        req.node
+                    ))
+                })
+        })
+    }
+
+    fn run_shell<'life0, 'async_trait>(
+        &'life0 self,
+        req: ShellRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<StepOutput, StepError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move { ops::run_shell(&self.workspace, &req).await })
+    }
+
+    fn run_script<'life0, 'async_trait>(
+        &'life0 self,
+        req: ScriptRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<StepOutput, StepError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move { ops::run_script(&self.workspace, &req).await })
+    }
+
+    fn notify<'life0, 'async_trait>(
+        &'life0 self,
+        req: NotifyRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<(), StepError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move { ops::notify(&req) })
+    }
+
+    fn state_op<'life0, 'async_trait>(
+        &'life0 self,
+        req: StateRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<StepOutput, StepError>> + Send + 'async_trait>>
+    where
+        'life0: 'async_trait,
+        Self: 'async_trait,
+    {
+        Box::pin(async move { ops::state_op(&req) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow_v2::runner::FakeAgentRunner;
+    use std::sync::Arc;
+    use wardian_core::engine::executor::{AgentTaskRequest, DecisionRequest, StepExecutor};
+
+    fn exec_with(runner: FakeAgentRunner) -> LiveStepExecutor {
+        LiveStepExecutor::new(
+            Arc::new(runner),
+            std::path::PathBuf::from("."),
+            "mock".into(),
+        )
+    }
+
+    #[tokio::test]
+    async fn agent_task_extracts_structured_output() {
+        let exec =
+            exec_with(FakeAgentRunner::new().with_response("plan", "```json\n{\"go\":true}\n```"));
+        let out = exec
+            .run_agent_task(AgentTaskRequest {
+                node: "plan".into(),
+                agent: "role:Coder".into(),
+                prompt: "p".into(),
+                output_schema: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(out.0["go"], true);
+    }
+
+    #[tokio::test]
+    async fn decision_resolves_to_declared_choice() {
+        let exec = exec_with(FakeAgentRunner::new().with_response("router", "I pick deny"));
+        let port = exec
+            .run_decision(DecisionRequest {
+                node: "router".into(),
+                agent: "role:x".into(),
+                prompt: "p".into(),
+                choices: vec!["approve".into(), "deny".into()],
+            })
+            .await
+            .unwrap();
+        assert_eq!(port.0, "deny");
+    }
+
+    #[tokio::test]
+    async fn decision_fails_when_no_choice_after_reprompt() {
+        let exec = exec_with(FakeAgentRunner::new().with_response("router", "no idea"));
+        let res = exec
+            .run_decision(DecisionRequest {
+                node: "router".into(),
+                agent: "role:x".into(),
+                prompt: "p".into(),
+                choices: vec!["approve".into(), "deny".into()],
+            })
+            .await;
+        assert!(res.is_err());
+    }
+}

--- a/src-tauri/src/workflow_v2/mod.rs
+++ b/src-tauri/src/workflow_v2/mod.rs
@@ -1,1 +1,2 @@
 pub mod output;
+pub mod runner;

--- a/src-tauri/src/workflow_v2/ops.rs
+++ b/src-tauri/src/workflow_v2/ops.rs
@@ -1,20 +1,99 @@
 use std::path::Path;
+use tokio::process::Command;
 use wardian_core::engine::{
     NotifyRequest, ScriptRequest, ShellRequest, StateRequest, StepError, StepOutput,
 };
 
-pub async fn run_shell(_ws: &Path, _req: &ShellRequest) -> Result<StepOutput, StepError> {
-    Ok(StepOutput(serde_json::json!({})))
+/// Run a shell command in the run workspace, or `req.cwd` when supplied.
+/// Captures exit code, stdout, and stderr.
+pub async fn run_shell(ws: &Path, req: &ShellRequest) -> Result<StepOutput, StepError> {
+    let cwd = req.cwd.as_deref().map(Path::new).unwrap_or(ws);
+    let (shell, flag) = if cfg!(windows) {
+        ("cmd", "/C")
+    } else {
+        ("sh", "-c")
+    };
+
+    let output = Command::new(shell)
+        .arg(flag)
+        .arg(&req.command)
+        .current_dir(cwd)
+        .output()
+        .await
+        .map_err(|err| StepError::new(err.to_string()))?;
+
+    Ok(StepOutput(serde_json::json!({
+        "exit_code": output.status.code().unwrap_or(-1),
+        "stdout": String::from_utf8_lossy(&output.stdout),
+        "stderr": String::from_utf8_lossy(&output.stderr),
+    })))
 }
 
-pub async fn run_script(_ws: &Path, _req: &ScriptRequest) -> Result<StepOutput, StepError> {
-    Ok(StepOutput(serde_json::json!({})))
+/// Run `runtime path` in the workspace and capture exit code, stdout, and
+/// stderr.
+pub async fn run_script(ws: &Path, req: &ScriptRequest) -> Result<StepOutput, StepError> {
+    let output = Command::new(&req.runtime)
+        .arg(&req.path)
+        .current_dir(ws)
+        .output()
+        .await
+        .map_err(|err| StepError::new(err.to_string()))?;
+
+    Ok(StepOutput(serde_json::json!({
+        "exit_code": output.status.code().unwrap_or(-1),
+        "stdout": String::from_utf8_lossy(&output.stdout),
+        "stderr": String::from_utf8_lossy(&output.stderr),
+    })))
 }
 
-pub fn notify(_req: &NotifyRequest) -> Result<(), StepError> {
+/// Surface a notify step. 5a logs it; desktop notification wiring is deferred.
+pub fn notify(req: &NotifyRequest) -> Result<(), StepError> {
+    crate::utils::logging::log_debug(&format!(
+        "[workflow-v2] notify {}: {}",
+        req.node, req.message
+    ));
     Ok(())
 }
 
-pub fn state_op(_req: &StateRequest) -> Result<StepOutput, StepError> {
-    Ok(StepOutput(serde_json::json!({})))
+/// State ops return the value that the engine stores as the node output.
+pub fn state_op(req: &StateRequest) -> Result<StepOutput, StepError> {
+    let value = match req.op.as_str() {
+        "set" | "merge" => req.entries.clone(),
+        "delete" => serde_json::json!({}),
+        other => return Err(StepError::new(format!("unknown state op: {other}"))),
+    };
+
+    Ok(StepOutput(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wardian_core::engine::{ShellRequest, StateRequest};
+
+    #[tokio::test]
+    async fn shell_runs_and_reports_exit_code() {
+        let req = ShellRequest {
+            node: "s".into(),
+            command: if cfg!(windows) {
+                "exit 0".into()
+            } else {
+                "true".into()
+            },
+            cwd: None,
+        };
+        let out = run_shell(std::path::Path::new("."), &req).await.unwrap();
+        assert_eq!(out.0["exit_code"], 0);
+    }
+
+    #[test]
+    fn state_set_returns_entries() {
+        let req = StateRequest {
+            node: "st".into(),
+            op: "set".into(),
+            entries: serde_json::json!({"k":"v"}),
+        };
+        let out = state_op(&req).unwrap();
+        assert_eq!(out.0["k"], "v");
+    }
 }

--- a/src-tauri/src/workflow_v2/ops.rs
+++ b/src-tauri/src/workflow_v2/ops.rs
@@ -1,0 +1,20 @@
+use std::path::Path;
+use wardian_core::engine::{
+    NotifyRequest, ScriptRequest, ShellRequest, StateRequest, StepError, StepOutput,
+};
+
+pub async fn run_shell(_ws: &Path, _req: &ShellRequest) -> Result<StepOutput, StepError> {
+    Ok(StepOutput(serde_json::json!({})))
+}
+
+pub async fn run_script(_ws: &Path, _req: &ScriptRequest) -> Result<StepOutput, StepError> {
+    Ok(StepOutput(serde_json::json!({})))
+}
+
+pub fn notify(_req: &NotifyRequest) -> Result<(), StepError> {
+    Ok(())
+}
+
+pub fn state_op(_req: &StateRequest) -> Result<StepOutput, StepError> {
+    Ok(StepOutput(serde_json::json!({})))
+}

--- a/src-tauri/src/workflow_v2/output.rs
+++ b/src-tauri/src/workflow_v2/output.rs
@@ -1,0 +1,93 @@
+//! Pure helpers for turning a headless agent's free-form response into the
+//! structured `nodes.<id>.output` value, and a decision's chosen port.
+
+use serde_json::Value;
+
+/// Extract structured output from a worker response. Tries, in order: a trailing
+/// fenced ```json block, then the whole response as JSON, else wrap as `{"text": ..}`.
+/// `_output_schema` is accepted for future validation; unused parsing-wise in 5a.
+pub fn extract_structured_output(response: &str, _output_schema: Option<&str>) -> Value {
+    if let Some(block) = last_json_block(response) {
+        if let Ok(value) = serde_json::from_str::<Value>(&block) {
+            return value;
+        }
+    }
+
+    let trimmed = response.trim();
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+        return value;
+    }
+
+    serde_json::json!({ "text": response })
+}
+
+/// Find the contents of the last ```json ... ``` fenced block, if any.
+fn last_json_block(s: &str) -> Option<String> {
+    let mut out = None;
+    let mut rest = s;
+
+    while let Some(start) = rest.find("```json") {
+        let after = &rest[start + "```json".len()..];
+        if let Some(end) = after.find("```") {
+            out = Some(after[..end].trim().to_string());
+            rest = &after[end + 3..];
+        } else {
+            break;
+        }
+    }
+
+    out
+}
+
+/// Return the declared choice that appears in the response, case-insensitively,
+/// or None. Prefers the first declared choice that matches.
+pub fn parse_decision_port(response: &str, choices: &[String]) -> Option<String> {
+    let lower = response.to_lowercase();
+    choices
+        .iter()
+        .find(|choice| lower.contains(&choice.to_lowercase()))
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_trailing_json_block() {
+        let resp = "Here is the result:\n```json\n{\"status\":\"ok\",\"n\":3}\n```\n";
+        assert_eq!(
+            extract_structured_output(resp, Some("{}")),
+            json!({"status":"ok","n":3})
+        );
+    }
+
+    #[test]
+    fn extracts_whole_json_response() {
+        assert_eq!(extract_structured_output("{\"a\":1}", None), json!({"a":1}));
+    }
+
+    #[test]
+    fn falls_back_to_text_wrap() {
+        assert_eq!(
+            extract_structured_output("just prose", None),
+            json!({"text":"just prose"})
+        );
+    }
+
+    #[test]
+    fn decision_matches_declared_choice_case_insensitively() {
+        let choices = vec!["approve".to_string(), "deny".to_string()];
+        assert_eq!(
+            parse_decision_port("I choose APPROVE.", &choices),
+            Some("approve".to_string())
+        );
+    }
+
+    #[test]
+    fn decision_returns_none_when_no_choice_present() {
+        let choices = vec!["approve".to_string(), "deny".to_string()];
+        assert_eq!(parse_decision_port("unsure", &choices), None);
+    }
+}

--- a/src-tauri/src/workflow_v2/resolve.rs
+++ b/src-tauri/src/workflow_v2/resolve.rs
@@ -1,0 +1,56 @@
+use std::path::{Path, PathBuf};
+
+/// A resolved agent reference ready to run headlessly.
+#[derive(Debug, Clone)]
+pub struct ResolvedAgent {
+    pub provider: String,
+    pub cwd: PathBuf,
+    pub session_id: String,
+    pub resume_session: Option<String>,
+    /// True for role:/class:/ephemeral workers; false for explicit live agent
+    /// names whose live routing is deferred beyond 5a.
+    pub is_ephemeral: bool,
+}
+
+/// Resolve a blueprint `agent` reference. `role:`/`class:`/`ephemeral` map to a
+/// fresh headless worker on `default_provider`; explicit names are marked as
+/// non-ephemeral so the executor can log the deferred live-routing behavior.
+pub fn resolve_agent(agent_ref: &str, workspace: &Path, default_provider: &str) -> ResolvedAgent {
+    let is_ephemeral = agent_ref.starts_with("role:")
+        || agent_ref.starts_with("class:")
+        || agent_ref == "ephemeral"
+        || agent_ref.is_empty();
+
+    ResolvedAgent {
+        provider: default_provider.to_string(),
+        cwd: workspace.to_path_buf(),
+        session_id: String::new(),
+        resume_session: None,
+        is_ephemeral,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn role_ref_resolves_to_ephemeral_headless_with_default_provider() {
+        let r = resolve_agent("role:Coder", Path::new("/ws"), "codex");
+        assert_eq!(r.provider, "codex");
+        assert!(r.is_ephemeral);
+        assert!(r.session_id.is_empty());
+    }
+
+    #[test]
+    fn class_ref_is_ephemeral() {
+        assert!(resolve_agent("class:Reviewer", Path::new("/ws"), "codex").is_ephemeral);
+    }
+
+    #[test]
+    fn explicit_name_is_not_ephemeral() {
+        let r = resolve_agent("Wardian-Codex", Path::new("/ws"), "codex");
+        assert!(!r.is_ephemeral);
+    }
+}

--- a/src-tauri/src/workflow_v2/runner.rs
+++ b/src-tauri/src/workflow_v2/runner.rs
@@ -1,0 +1,116 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Mutex;
+
+type AgentRunFuture<'a> = Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>>;
+
+/// What the executor needs to run one headless agent prompt.
+#[derive(Debug, Clone)]
+pub struct AgentRunSpec {
+    pub node: String,
+    pub provider: String,
+    pub cwd: PathBuf,
+    pub prompt: String,
+    pub session_id: String,
+    pub resume_session: Option<String>,
+}
+
+/// Boundary between the executor logic and the real headless runtime. Unit tests
+/// inject a fake so they never spawn a provider.
+pub trait AgentRunner: Send + Sync {
+    /// Run the prompt headlessly; return the agent's textual response.
+    fn run(&self, spec: AgentRunSpec) -> AgentRunFuture<'_>;
+}
+
+/// Real runner: drives `manager::headless::run_headless_with_options` and pulls
+/// the `response` field out of the provider-normalized JSON.
+pub struct HeadlessAgentRunner;
+
+impl AgentRunner for HeadlessAgentRunner {
+    fn run(&self, spec: AgentRunSpec) -> AgentRunFuture<'_> {
+        Box::pin(async move {
+            let value =
+                crate::manager::run_headless_with_options(crate::manager::HeadlessRunOptions {
+                    cwd: &spec.cwd,
+                    prompt: &spec.prompt,
+                    wardian_session_id: &spec.session_id,
+                    resume_session: spec.resume_session.as_deref(),
+                    output_format: "json",
+                    provider_name: &spec.provider,
+                    config_override: None,
+                })
+                .await?;
+
+            let response = value
+                .get("response")
+                .and_then(|value| value.as_str())
+                .or_else(|| value.get("text").and_then(|value| value.as_str()))
+                .map(ToString::to_string)
+                .unwrap_or_else(|| value.to_string());
+
+            Ok(response)
+        })
+    }
+}
+
+/// Test double: scripted responses keyed by node id; records call order.
+#[derive(Default)]
+pub struct FakeAgentRunner {
+    responses: HashMap<String, String>,
+    calls: Mutex<Vec<String>>,
+}
+
+impl FakeAgentRunner {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_response(mut self, node: &str, response: &str) -> Self {
+        self.responses.insert(node.into(), response.into());
+        self
+    }
+
+    pub fn calls(&self) -> Vec<String> {
+        self.calls.lock().expect("fake runner calls lock").clone()
+    }
+}
+
+impl AgentRunner for FakeAgentRunner {
+    fn run(&self, spec: AgentRunSpec) -> AgentRunFuture<'_> {
+        Box::pin(async move {
+            self.calls
+                .lock()
+                .expect("fake runner calls lock")
+                .push(spec.node.clone());
+
+            Ok(self
+                .responses
+                .get(&spec.node)
+                .cloned()
+                .unwrap_or_else(|| "{}".into()))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn fake_runner_returns_scripted_response_and_records_calls() {
+        let runner = FakeAgentRunner::new().with_response("plan", "```json\n{\"ok\":true}\n```");
+        let spec = AgentRunSpec {
+            node: "plan".into(),
+            provider: "mock".into(),
+            cwd: std::path::PathBuf::from("."),
+            prompt: "do".into(),
+            session_id: String::new(),
+            resume_session: None,
+        };
+        let out = runner.run(spec).await.unwrap();
+        assert!(out.contains("ok"));
+        assert_eq!(runner.calls(), vec!["plan".to_string()]);
+    }
+}

--- a/src-tauri/src/workflow_v2/runs.rs
+++ b/src-tauri/src/workflow_v2/runs.rs
@@ -1,0 +1,1 @@
+// implemented in Task 6

--- a/src-tauri/src/workflow_v2/runs.rs
+++ b/src-tauri/src/workflow_v2/runs.rs
@@ -1,1 +1,84 @@
-// implemented in Task 6
+use crate::workflow_v2::{runner::HeadlessAgentRunner, LiveStepExecutor};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use wardian_core::engine::store::read_checkpoint;
+use wardian_core::engine::{Engine, RunStatus};
+use wardian_core::workflow::Blueprint;
+
+/// Scan `<runs_dir>/<id>/<run>/state.json` for runs still marked Running.
+/// Returns `(blueprint_id, run_id)` pairs for resume affordances.
+pub fn scan_interrupted_runs(runs_dir: &Path) -> Vec<(String, String)> {
+    let mut interrupted = Vec::new();
+    let Ok(blueprints) = std::fs::read_dir(runs_dir) else {
+        return interrupted;
+    };
+
+    for blueprint in blueprints.flatten().filter(|entry| entry.path().is_dir()) {
+        let Ok(runs) = std::fs::read_dir(blueprint.path()) else {
+            continue;
+        };
+
+        for run in runs.flatten().filter(|entry| entry.path().is_dir()) {
+            if let Ok(Some(state)) = read_checkpoint(&run.path()) {
+                if state.status == RunStatus::Running {
+                    interrupted.push((state.blueprint_id, state.run_id));
+                }
+            }
+        }
+    }
+
+    interrupted
+}
+
+/// Build the live executor for a run in `workspace` with `default_provider`.
+pub fn live_executor(workspace: PathBuf, default_provider: String) -> LiveStepExecutor {
+    LiveStepExecutor::new(Arc::new(HeadlessAgentRunner), workspace, default_provider)
+}
+
+/// Drive a fresh run to completion or pause.
+pub async fn drive_new_run(
+    blueprint: Blueprint,
+    run_id: String,
+    run_root: PathBuf,
+    workspace: PathBuf,
+    default_provider: String,
+) -> Result<(), String> {
+    let exec = live_executor(workspace, default_provider);
+    Engine::start_with_id(&blueprint, run_id, serde_json::json!({}), &run_root, &exec)
+        .await
+        .map(|_| ())
+        .map_err(|err| err.to_string())
+}
+
+/// Resume an interrupted or paused run.
+pub async fn drive_resume(
+    blueprint: Blueprint,
+    run_root: PathBuf,
+    workspace: PathBuf,
+    default_provider: String,
+) -> Result<(), String> {
+    let exec = live_executor(workspace, default_provider);
+    Engine::resume(&blueprint, &run_root, &exec)
+        .await
+        .map(|_| ())
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wardian_core::engine::{RunState, RunStatus};
+
+    #[test]
+    fn scan_interrupted_marks_running_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_root = dir.path().join("wf").join("run-1");
+        std::fs::create_dir_all(&run_root).unwrap();
+        let mut state = RunState::new("run-1", "wf");
+        state.status = RunStatus::Running;
+        wardian_core::engine::store::write_checkpoint(&run_root, &state).unwrap();
+
+        let interrupted = scan_interrupted_runs(dir.path());
+        assert_eq!(interrupted, vec![("wf".to_string(), "run-1".to_string())]);
+    }
+}

--- a/src-tauri/tests/workflow_v2_executor.rs
+++ b/src-tauri/tests/workflow_v2_executor.rs
@@ -1,0 +1,121 @@
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use wardian_core::engine::{driver::new_run_id, Engine, RunStatus};
+
+const DEMO_BLUEPRINT: &str = r#"---
+schema: 2
+id: demo
+name: Demo
+nodes:
+  - id: trigger-1
+    type: manual_trigger
+  - id: plan
+    type: task
+    fields:
+      agent: role:Coder
+      prompt: Return a tiny plan
+edges:
+  - from: trigger-1
+    to: plan
+---
+
+# Demo
+"#;
+
+struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    previous_home: Option<std::ffi::OsString>,
+    previous_session_id: Option<std::ffi::OsString>,
+    previous_mock_scenario: Option<std::ffi::OsString>,
+    previous_mock_delay: Option<std::ffi::OsString>,
+    previous_mock_script: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(home: &std::path::Path, mock_script: &std::path::Path) -> Self {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let lock = LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let guard = Self {
+            _lock: lock,
+            previous_home: std::env::var_os("WARDIAN_HOME"),
+            previous_session_id: std::env::var_os("WARDIAN_SESSION_ID"),
+            previous_mock_scenario: std::env::var_os("WARDIAN_MOCK_SCENARIO"),
+            previous_mock_delay: std::env::var_os("WARDIAN_MOCK_DELAY_MS"),
+            previous_mock_script: std::env::var_os("WARDIAN_MOCK_SCRIPT"),
+        };
+
+        std::env::set_var("WARDIAN_HOME", home);
+        std::env::remove_var("WARDIAN_SESSION_ID");
+        std::env::set_var("WARDIAN_MOCK_SCENARIO", "basic");
+        std::env::set_var("WARDIAN_MOCK_DELAY_MS", "0");
+        std::env::set_var("WARDIAN_MOCK_SCRIPT", mock_script);
+
+        guard
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        restore_env("WARDIAN_HOME", self.previous_home.take());
+        restore_env("WARDIAN_SESSION_ID", self.previous_session_id.take());
+        restore_env("WARDIAN_MOCK_SCENARIO", self.previous_mock_scenario.take());
+        restore_env("WARDIAN_MOCK_DELAY_MS", self.previous_mock_delay.take());
+        restore_env("WARDIAN_MOCK_SCRIPT", self.previous_mock_script.take());
+    }
+}
+
+fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
+    match value {
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
+    }
+}
+
+fn mock_script_path() -> std::path::PathBuf {
+    let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("scripts")
+        .join("mock-agent.cjs");
+    assert!(script.exists(), "mock-agent.cjs not found at {:?}", script);
+    script
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn mock_provider_drives_workflow_v2_run_to_completion() {
+    let home = tempfile::tempdir().unwrap();
+    let workflows_dir = home.path().join("library").join("workflows");
+    std::fs::create_dir_all(&workflows_dir).unwrap();
+    let demo_path = workflows_dir.join("demo.md");
+    std::fs::write(&demo_path, DEMO_BLUEPRINT).unwrap();
+
+    let _env = EnvGuard::set(home.path(), &mock_script_path());
+
+    let blueprint = wardian_core::workflow::parse_file(&demo_path).unwrap();
+    let report = wardian_core::workflow::validate(&blueprint);
+    assert!(report.is_valid(), "diagnostics: {:?}", report.diagnostics);
+
+    let run_id = new_run_id();
+    let run_root = wardian_core::paths::workflow_run_dir(&blueprint.id, &run_id).unwrap();
+    let exec = wardian_app_lib::workflow_v2::runs::live_executor(
+        home.path().to_path_buf(),
+        "mock".into(),
+    );
+
+    let state = Engine::start_with_id(
+        &blueprint,
+        run_id.clone(),
+        serde_json::json!({}),
+        &run_root,
+        &exec,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(state.status, RunStatus::Completed);
+    assert!(run_root.join("events.jsonl").is_file());
+    assert!(run_root.join("state.json").is_file());
+    assert!(state.node_output("plan").is_some());
+}


### PR DESCRIPTION
## Description

Sub-project **5a** of Workflow Engine v2: the **live executor** — a `src-tauri` `LiveStepExecutor` implementing `wardian_core::engine::StepExecutor` that drives real agents and side effects, plus the Tauri commands to run/resume/approve/cancel a v2 run. **This makes v2 actually execute** (until now it could only author, observe, and mock-execute). It writes the durable run that Run View (#438) observes, and is the prerequisite for retiring v1 (5c) and unifying the workflow UI (5b).

Design spec: `docs/specs/2026-05-29-workflow-v2-executor.md`.

### What's included
- **`src-tauri/src/workflow_v2/`**: `LiveStepExecutor` for all six step kinds — agent task (headless `run_headless` → structured-output extraction), decision (choice-constrained with one re-prompt), shell/script (workspace cwd), notify (logged), state (`set`/`merge`/`delete`). A small `AgentRunner` trait (`HeadlessAgentRunner` real / `FakeAgentRunner` test) is the unit-test boundary so the executor logic is tested without spawning a provider. Hybrid agent resolution (`role:`/`class:`/`ephemeral` → fresh headless worker; explicit names noted, live routing deferred).
- **Tauri commands** `workflow_run_v2` / `workflow_resume_v2` / `workflow_approve_v2` / `workflow_cancel_v2` — drive `Engine::start_with_id`/`resume`/`grant_approval`/`reject_approval` in a background task, writing `logs/workflows/<id>/<run-id>/`. Run returns the `run_id` immediately.
- **Crash recovery**: startup scans for runs left `Running` and logs them for a Resume affordance (no auto-resume).

### Transport note (addresses the headless concern)
The executor runs agents via `manager::headless::run_headless` (request/response one-shot), **not** the `ask`/`reply` PTY channels (whose headless behavior is unvalidated). v1's headless *orchestration* was buggy — this is a clean reimplementation that **validates the primitive fresh** rather than copying v1.

## Related Issues
Part of #425 (Workflow Engine v2 epic). Sub-project 5a; 5b (unified UI) and 5c (v1 retirement + migration) follow.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- **Unit:** `workflow_v2` 15/15 (output/decision parsing, runner, resolution, executor agent+decision, shell/state ops, interrupted scan) — via the injected `FakeAgentRunner`, no real spawn.
- **Integration (validation gate):** `tests/workflow_v2_executor.rs` — a real end-to-end run through `run_headless` with the **`mock` provider**, asserting terminal `Completed` + `events.jsonl`/`state.json` written. **Passes (1/1).** This is what validates the headless primitive v1 used incorrectly.
- **Full app suite:** `cargo test -p Wardian` → **814 passed, 0 failed** (no regressions from the new module/commands/startup hook).
- **Lint:** `cargo clippy --workspace -- -D warnings` (CI's exact invocation) → **clean**. (Two benign test-target-only lints appear under `--all-targets` — a conservative `MutexGuard` lint in the test double; not in CI scope. Trivial follow-up.)

## Notes / deferred (per the approved spec)
- **Live named-agent routing** (PTY send/capture to a running roster agent) — the genuinely unvalidated transport; deferred. A named ref currently runs headless under the default provider with a log note.
- **Default provider** is passed per-run (`provider` arg, default `codex`); deriving provider/config per class (`~/.wardian/classes/<Class>`) is a follow-up.
- Also deferred: visible/grouped run workers, per-node worktrees, scheduled triggers, per-run session continuity, cross-run concurrency caps. The Run View Resume button + cancel-loop cooperation are 5b.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (design spec + implementation note)
- [x] My changes generate no new warnings (CI clippy clean)
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- Backend only — no frontend changes, screenshot evidence N/A. -->

---
🤖 Built via Wardian-Codex-copy (subagent-driven, task-by-task) and verified independently. Brainstormed design → committed spec → plan → execution.
