### PR TITLE
docs: add llms.txt index

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,8 @@ jobs:
           cache: "npm"
       - name: Install dependencies
         run: npm ci
+      - name: Validate llms.txt
+        run: npm run docs:check-llms
       - name: Build VitePress site
         run: npm run docs:build
         env:

--- a/docs/developer/docs-maintenance.md
+++ b/docs/developer/docs-maintenance.md
@@ -26,6 +26,7 @@ Choose the smallest docs surface that matches the change:
 - `docs/developer/` for implementation, testing, publishing, and contributor workflows
 - `docs/specs/` for strategic decisions or behavior that needs design history; specs are repository-internal and excluded from the public docs site
 - `README.md` only when the public overview, installation path, or top-level links change
+- `docs/public/llms.txt` for the agent-readable public docs index served from the docs site root
 
 Keep cross-platform examples POSIX-first with a labeled PowerShell variant when commands differ. Use placeholders such as `<absolute-workspace-path>` instead of personal paths.
 
@@ -52,6 +53,8 @@ Before merging user-facing work, check:
 - The PR body links the issue and lists verification evidence.
 - Release-impacting changes use a Conventional Commit type and scope that Release Please can place in `CHANGELOG.md`.
 - Public overview links in `README.md` and `docs/index.md` still point to the right guide pages and do not point into `docs/specs/` or `docs/research/`.
+- `docs/public/llms.txt` still includes any new or renamed top-level guide, workflow, provider, CLI, or developer docs links.
+- `npm run docs:check-llms` passes after updating `llms.txt`.
 - `npm run docs:build` passes after docs changes.
 
 ## Docs Publication Policy

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,65 @@
+# Wardian Docs
+
+Wardian is a local command center for multi-agent CLI workflows: run provider-backed agents, monitor live terminal sessions, manage reusable skills and prompts, and chain agents into deterministic workflows.
+
+This file is an agent-readable index for the public Wardian documentation. Use the linked pages as the canonical docs source.
+
+## Getting Started
+
+- https://docs.wardian.org/guide/getting-started - Install Wardian, complete first-run setup, verify a provider, spawn the first agent, and inspect the first Queue result.
+- https://docs.wardian.org/guide/ui-overview - Learn the title bar, navigation rail, agent roster, workspace areas, and common app surfaces.
+- https://docs.wardian.org/guide/first-run-troubleshooting - Recover from launch, provider detection, terminal startup, Queue, and CLI setup problems.
+
+## Core Workspace
+
+- https://docs.wardian.org/guide/grid - Use the main agent grid, terminal cards, focused chat mode, and per-agent controls.
+- https://docs.wardian.org/guide/dashboard - Compare live agent health, runtime status, and summary controls.
+- https://docs.wardian.org/guide/watchlists - Group, select, sort, and monitor agents in the roster.
+- https://docs.wardian.org/guide/queue - Review completed agent and workflow results, action-needed items, and notification behavior.
+- https://docs.wardian.org/guide/source-control - Stage, diff, commit, sync, and manage agent worktrees.
+- https://docs.wardian.org/guide/explorer - Browse an agent workspace or Wardian home from the app.
+- https://docs.wardian.org/guide/remote-control - Pair and use the Wardian remote PWA over HTTPS.
+
+## Reuse and Agent Direction
+
+- https://docs.wardian.org/guide/library - Manage reusable prompts, skills, and library item assignment.
+- https://docs.wardian.org/guide/command-panel - Send one-off broadcasts or starred prompts to selected agents.
+- https://docs.wardian.org/guide/class-management - Define agent class blueprints used by spawn and clone flows.
+
+## Workflow Automation
+
+- https://docs.wardian.org/guide/workflows - Build and run visual automations from the Wardian app.
+- https://docs.wardian.org/workflows/ - Start with the workflow mental model, launch behavior, runtime state, and engine loop.
+- https://docs.wardian.org/workflows/building-workflows - Use the workflow canvas, block library, node settings, and variable assistant.
+- https://docs.wardian.org/workflows/node-reference - Reference workflow node types and user-visible behavior.
+- https://docs.wardian.org/workflows/triggers - Understand manual runs, scheduled triggers, and live listeners.
+- https://docs.wardian.org/workflows/agent-assignment - Map workflow roles to direct agents, fresh clones, or reusable assignment modes.
+- https://docs.wardian.org/workflows/troubleshooting - Diagnose common workflow authoring and runtime failures.
+
+## CLI and Agent Communication
+
+- https://docs.wardian.org/guide/cli - Use the Wardian CLI for agent inspection, live control, inter-agent messages, worktree assignment, and workflow commands.
+- https://docs.wardian.org/developer/ipc-events - Understand frontend/backend event contracts and runtime telemetry surfaces.
+- https://docs.wardian.org/developer/tauri-command-reference - Reference Tauri command boundaries used by the UI and native runtime.
+
+## Providers and Runtime
+
+- https://docs.wardian.org/guide/provider-readiness - Verify provider CLIs, authentication, shell PATH, and runtime prerequisites.
+- https://docs.wardian.org/providers - Compare supported providers and user-facing runtime expectations.
+- https://docs.wardian.org/developer/provider-runtimes - Implement or debug provider-specific spawn, resume, and transcript behavior.
+- https://docs.wardian.org/developer/pty-lifecycle - Understand PTY ownership, resize, output buffering, and terminal lifecycle rules.
+
+## Developer Internals
+
+- https://docs.wardian.org/developer/architecture - Read the high-level architecture for frontend, backend, state, and runtime boundaries.
+- https://docs.wardian.org/developer/setup - Set up a development checkout and local verification environment.
+- https://docs.wardian.org/developer/state-management - Understand persisted state, runtime state, and frontend state ownership.
+- https://docs.wardian.org/developer/workflow-engine - Debug or extend deterministic workflow execution.
+- https://docs.wardian.org/developer/native-e2e - Pick the native E2E layer for PTY, invoke, provider, and filesystem behavior.
+- https://docs.wardian.org/developer/docs-maintenance - Maintain public docs, screenshots, and this agent-readable index.
+
+## Project Context
+
+- https://docs.wardian.org/features - Review the public feature overview.
+- https://docs.wardian.org/os-support - Check platform support and OS-specific notes.
+- https://github.com/wardian-app/Wardian - Inspect source, issues, pull requests, and repository-internal specs.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:frontend-screenshot": "node scripts/verify-frontend-screenshot.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
+    "docs:check-llms": "node scripts/verify-llms-txt.mjs",
     "docs:preview": "vitepress preview docs",
     "docs:screenshots": "node scripts/capture-doc-screenshots.mjs",
     "docs:demo-gif": "node scripts/capture-readme-demo.mjs",

--- a/scripts/verify-llms-txt.mjs
+++ b/scripts/verify-llms-txt.mjs
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+const llmsPath = join(repoRoot, "docs", "public", "llms.txt");
+
+const requiredEntries = [
+  ["## Getting Started", "https://docs.wardian.org/guide/getting-started", "docs/guide/getting-started.md"],
+  ["## Core Workspace", "https://docs.wardian.org/guide/grid", "docs/guide/grid.md"],
+  ["## Core Workspace", "https://docs.wardian.org/guide/queue", "docs/guide/queue.md"],
+  ["## Core Workspace", "https://docs.wardian.org/guide/watchlists", "docs/guide/watchlists.md"],
+  ["## Workflow Automation", "https://docs.wardian.org/workflows/", "docs/workflows/index.md"],
+  ["## CLI and Agent Communication", "https://docs.wardian.org/guide/cli", "docs/guide/cli.md"],
+  ["## Providers and Runtime", "https://docs.wardian.org/guide/provider-readiness", "docs/guide/provider-readiness.md"],
+  ["## Developer Internals", "https://docs.wardian.org/developer/architecture", "docs/developer/architecture.md"],
+];
+
+const requiredMaintenanceText = "llms.txt";
+const maintenancePath = join(repoRoot, "docs", "developer", "docs-maintenance.md");
+
+function fail(message) {
+  console.error(message);
+  process.exitCode = 1;
+}
+
+if (!existsSync(llmsPath)) {
+  fail("docs/public/llms.txt is missing.");
+} else {
+  const text = readFileSync(llmsPath, "utf8");
+
+  if (!text.startsWith("# Wardian Docs")) {
+    fail("llms.txt must start with '# Wardian Docs'.");
+  }
+
+  if (text.length > 12000) {
+    fail("llms.txt should stay concise for agent ingestion.");
+  }
+
+  if (/(^|[\s("'`])[A-Za-z]:[\\/]|\\\\Users\\\\|\/Users\//m.test(text)) {
+    fail("llms.txt must not contain local machine paths.");
+  }
+
+  for (const [section, url, sourcePath] of requiredEntries) {
+    if (!text.includes(section)) {
+      fail(`llms.txt is missing required section ${section}.`);
+    }
+
+    if (!text.includes(url)) {
+      fail(`llms.txt is missing required link ${url}.`);
+    }
+
+    if (!existsSync(join(repoRoot, sourcePath))) {
+      fail(`llms.txt source target does not exist: ${sourcePath}.`);
+    }
+  }
+}
+
+const maintenanceText = readFileSync(maintenancePath, "utf8");
+if (!maintenanceText.includes(requiredMaintenanceText)) {
+  fail("docs maintenance guidance must mention llms.txt upkeep.");
+}

--- a/src/config/llmsTxt.test.ts
+++ b/src/config/llmsTxt.test.ts
@@ -1,0 +1,20 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import llmsTxt from "../../docs/public/llms.txt?raw";
+
+describe("llms.txt docs contract", () => {
+  it("keeps the agent-readable docs index valid", () => {
+    expect(() => {
+      execFileSync(process.execPath, ["scripts/verify-llms-txt.mjs"], {
+        cwd: process.cwd(),
+        stdio: "pipe",
+      });
+    }).not.toThrow();
+  });
+
+  it("summarizes Wardian and points agents to canonical docs", () => {
+    expect(llmsTxt).toContain("local command center for multi-agent CLI workflows");
+    expect(llmsTxt).toContain("https://docs.wardian.org/guide/cli");
+    expect(llmsTxt).toContain("https://docs.wardian.org/developer/provider-runtimes");
+  });
+});


### PR DESCRIPTION
## Description
Adds a public `llms.txt` index for Wardian docs at the VitePress site root. The file gives agents a concise product summary and grouped canonical docs links for setup, core app surfaces, workflows, CLI, providers, and developer internals.

The PR also adds a validator script and contract test so required sections and source docs links cannot silently disappear, and wires the check into the docs workflow.

## Related Issues
Fixes #420

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run test -- src/config/llmsTxt.test.ts` (red before `docs/public/llms.txt` existed, green after implementation)
- `npm run docs:check-llms`
- `npm run docs:build`
- verified `docs/.vitepress/dist/llms.txt` exists after build
- `npm run lint`
- `npm run test`
- `npm run build`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo clippy`
- `cd src-tauri && cargo test`

## Screenshots
Not applicable: this is a docs/static text index change with no frontend visual behavior.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable

Note: `npm run test` still prints existing React `act(...)` and mocked provider-readiness warnings from unrelated tests; it exits 0 with 942 tests passing.