### PR TITLE
test(library): stabilize watcher notifications

### DIFF
--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -1517,13 +1517,42 @@ mod tests {
             }
             observed.push((event.kind, event.paths));
         }
+        drain_fs_events(rx);
+    }
+
+    fn drain_fs_events(rx: &mpsc::Receiver<notify::Event>) {
         while rx.try_recv().is_ok() {}
     }
 
-    fn wait_for_any_fs_event(rx: &mpsc::Receiver<notify::Event>, label: &str) {
-        rx.recv_timeout(Duration::from_secs(10))
-            .unwrap_or_else(|_| panic!("timed out waiting for filesystem event: {}", label));
-        while rx.try_recv().is_ok() {}
+    fn wait_for_fs_remove_event(rx: &mpsc::Receiver<notify::Event>, label: &str) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut observed = Vec::new();
+        loop {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                panic!(
+                    "timed out waiting for filesystem remove event: {}; observed events: {:#?}",
+                    label, observed
+                );
+            };
+            let event = rx.recv_timeout(remaining).unwrap_or_else(|_| {
+                panic!(
+                    "timed out waiting for filesystem remove event: {}; observed events: {:#?}",
+                    label, observed
+                )
+            });
+            if matches!(event.kind, notify::event::EventKind::Remove(_)) {
+                break;
+            }
+            observed.push((event.kind, event.paths));
+        }
+        drain_fs_events(rx);
+    }
+
+    fn wait_for_test_watcher_ready(rx: &mpsc::Receiver<notify::Event>, watched_dir: &Path) {
+        let sentinel = watched_dir.join(".wardian-watch-ready");
+        fs::write(&sentinel, "ready").expect("write watch sentinel");
+        wait_for_fs_event(rx, "watch sentinel create", &sentinel);
+        drain_fs_events(rx);
     }
 
     #[test]
@@ -1531,6 +1560,10 @@ mod tests {
         let temp = tempfile::tempdir().expect("temp dir");
         let skills_dir = temp.path().join("library").join("skills");
         fs::create_dir_all(&skills_dir).expect("skills dir");
+        let existing_skill_dir = skills_dir.join("planner-existing");
+        let existing_skill_file = existing_skill_dir.join("SKILL.md");
+        fs::create_dir_all(&existing_skill_dir).expect("existing skill dir");
+        fs::write(&existing_skill_file, "one").expect("existing skill file");
 
         let targets = discover_skill_watch_targets(&skills_dir).expect("watch targets");
         let (tx, rx) = mpsc::channel::<notify::Event>();
@@ -1545,23 +1578,25 @@ mod tests {
             notify::Watcher::watch(&mut watcher, &target, notify::RecursiveMode::Recursive)
                 .expect("watch target");
         }
+        wait_for_test_watcher_ready(&rx, &skills_dir);
 
-        let skill_dir = skills_dir.join("planner");
-        let skill_file = skill_dir.join("SKILL.md");
-        fs::create_dir_all(&skill_dir).expect("create skill dir");
-        fs::write(&skill_file, "one").expect("write skill");
-        wait_for_fs_event(&rx, "skill create", &skill_dir);
+        let created_skill_dir = skills_dir.join("planner-created");
+        fs::create_dir_all(&created_skill_dir).expect("create skill dir");
+        wait_for_fs_event(&rx, "skill dir create", &created_skill_dir);
 
         let mut file = fs::OpenOptions::new()
             .append(true)
-            .open(&skill_file)
+            .open(&existing_skill_file)
             .expect("open skill for modify");
         file.write_all(b"\ntwo").expect("modify skill");
         file.sync_all().expect("sync skill modify");
-        wait_for_fs_event(&rx, "skill modify", &skill_file);
+        wait_for_fs_event(&rx, "skill modify", &existing_skill_file);
 
-        fs::remove_dir_all(&skill_dir).expect("remove skill");
-        wait_for_any_fs_event(&rx, "skill remove");
+        fs::remove_file(&existing_skill_file).expect("remove skill file");
+        wait_for_fs_remove_event(&rx, "skill file remove");
+
+        fs::remove_dir(&existing_skill_dir).expect("remove skill dir");
+        wait_for_fs_remove_event(&rx, "skill dir remove");
     }
 
     #[test]
@@ -1590,6 +1625,7 @@ mod tests {
             notify::Watcher::watch(&mut watcher, &target, notify::RecursiveMode::Recursive)
                 .expect("watch target");
         }
+        wait_for_test_watcher_ready(&rx, &external_skill);
 
         let external_skill_file = external_skill.join("SKILL.md");
         let mut file = fs::OpenOptions::new()


### PR DESCRIPTION
## Why

The backend CI flaked on `commands::library::tests::recursive_skill_watcher_observes_create_modify_and_remove` with timeouts waiting for filesystem notifications. Reruns sometimes passed, which pointed to test assumptions around real OS filesystem notification delivery rather than a deterministic product regression.

Fixes #451.

## What Changed

- Added a sentinel-based watcher readiness helper so tests wait for the real `notify::recommended_watcher` backend to deliver an event before starting assertions.
- Kept the recursive watcher test on the real OS notification path while avoiding unsupported timing assumptions about immediate file events inside a just-created directory.
- Split recursive coverage so create is asserted on a newly-created skill directory, while modify and remove are asserted on a skill directory that existed before watcher registration.
- Tightened removal coverage to require remove events from the test-scoped watcher instead of accepting any event after deletion.
- Applied the same readiness guard to the linked external-skill watcher test.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml commands::library::tests::recursive_skill_watcher_observes_create_modify_and_remove -- --exact` repeated 10x: passed
- `cargo test --manifest-path src-tauri/Cargo.toml commands::library::tests::linked_skill_watcher_observes_external_target_edits -- --exact` repeated 10x: passed
- `cargo check --manifest-path src-tauri/Cargo.toml`: passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml`: passed
- `cargo test --manifest-path src-tauri/Cargo.toml`: passed, 806 unit tests plus integration tests
- `npm run lint`: passed
- `npm run test`: passed, 102 files / 942 tests
- `npm run build`: passed
- GitHub Actions for PR #452: Linux backend, Windows backend, frontend, security, and codecov all passed

## Notes

- No frontend behavior changed, so no screenshot evidence is required.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` currently reports unrelated rustfmt drift on `origin/main` in files not touched by this PR.
- A stricter exploratory `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` also reports existing lint debt outside this test change.