### PR TITLE
fix(cli): speed up worktree discovery

### DIFF
--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -15,6 +15,7 @@ use wardian_core::identity::AgentIdentity;
 use wardian_core::models::WorkflowDefinition;
 
 const CONTROL_TIMEOUT: Duration = Duration::from_millis(500);
+const CONTROL_GIT_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 const CONTROL_MUTATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct AgentWatchRequest<'a> {
@@ -783,7 +784,7 @@ fn operation_timeout(operation: &ControlOperation) -> Duration {
         | ControlOperation::WorkflowStop
         | ControlOperation::SendMessage
         | ControlOperation::SubmitReply => CONTROL_MUTATION_TIMEOUT,
-        ControlOperation::AgentWorktreeList => CONTROL_TIMEOUT,
+        ControlOperation::AgentWorktreeList => CONTROL_GIT_DISCOVERY_TIMEOUT,
         ControlOperation::Ask { requested, .. } => watch_timeout_for(*requested),
         ControlOperation::AgentWatch { requested, .. } => watch_timeout_for(*requested),
     }
@@ -1091,11 +1092,11 @@ mod tests {
     }
 
     #[test]
-    fn worktree_list_keeps_short_control_timeout() {
-        assert_eq!(
-            operation_timeout(&ControlOperation::AgentWorktreeList),
-            CONTROL_TIMEOUT
-        );
+    fn worktree_list_uses_git_discovery_timeout() {
+        let timeout = operation_timeout(&ControlOperation::AgentWorktreeList);
+
+        assert!(timeout > CONTROL_TIMEOUT);
+        assert!(timeout < CONTROL_MUTATION_TIMEOUT);
     }
 
     #[test]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1317,6 +1317,8 @@ struct DiscoveredGitWorktree {
     worktree_folder: String,
 }
 
+const GIT_WORKTREE_DISCOVERY_CONCURRENCY: usize = 8;
+
 fn is_under_wardian_agent_worktree_root(wardian_home: &std::path::Path, path: &str) -> bool {
     let normalized_home =
         normalize_path_for_prefix_compare(&normalize_existing_workspace_record_path(wardian_home));
@@ -1427,26 +1429,62 @@ fn discover_git_worktrees_for_configs(
     let sources = configs
         .iter()
         .filter_map(source_folder_for_config)
-        .collect::<BTreeSet<_>>();
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
 
+    discover_git_worktrees_for_sources_with(sources, crate::commands::git::list_git_worktrees)
+}
+
+fn discover_git_worktrees_for_sources_with<F>(
+    sources: Vec<String>,
+    list_worktrees: F,
+) -> Vec<DiscoveredGitWorktree>
+where
+    F: Fn(&std::path::Path) -> Result<Vec<crate::commands::git::GitWorktreeInfo>, String> + Sync,
+{
     let mut discovered = BTreeMap::<String, DiscoveredGitWorktree>::new();
-    for source in sources {
-        let source_path = std::path::Path::new(&source);
-        let Ok(worktrees) = crate::commands::git::list_git_worktrees(source_path) else {
-            continue;
-        };
+    for chunk in sources.chunks(GIT_WORKTREE_DISCOVERY_CONCURRENCY) {
+        let entries = std::thread::scope(|scope| {
+            let handles = chunk
+                .iter()
+                .map(|source| {
+                    let source = source.clone();
+                    let list_worktrees = &list_worktrees;
+                    scope.spawn(move || {
+                        let source_path = std::path::Path::new(&source);
+                        let Ok(worktrees) = list_worktrees(source_path) else {
+                            return Vec::new();
+                        };
 
-        for worktree in worktrees {
-            let normalized = normalize_discovered_git_worktree_path(&worktree.path);
-            if workspace_paths_match(&source, &normalized) {
-                continue;
-            }
+                        worktrees
+                            .into_iter()
+                            .filter_map(|worktree| {
+                                let normalized =
+                                    normalize_discovered_git_worktree_path(&worktree.path);
+                                if workspace_paths_match(&source, &normalized) {
+                                    return None;
+                                }
+                                Some(DiscoveredGitWorktree {
+                                    source_folder: source.clone(),
+                                    worktree_folder: normalized,
+                                })
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect::<Vec<_>>();
+
+            handles
+                .into_iter()
+                .flat_map(|handle| handle.join().unwrap_or_default())
+                .collect::<Vec<_>>()
+        });
+
+        for entry in entries {
             discovered
-                .entry(normalized.clone())
-                .or_insert_with(|| DiscoveredGitWorktree {
-                    source_folder: source.clone(),
-                    worktree_folder: normalized,
-                });
+                .entry(entry.worktree_folder.clone())
+                .or_insert(entry);
         }
     }
 
@@ -3149,10 +3187,12 @@ mod tests {
         clone_sanitize_config, clone_unique_name, clone_validate_selected_agent_skills,
         clone_validate_selected_profile_files, codex_provider_session_is_new,
         collect_agent_worktrees, collect_agent_worktrees_with_discovered, detach_agent_for_kill,
-        disable_worktree_config, discover_git_worktrees_for_configs, enable_worktree_config,
+        disable_worktree_config, discover_git_worktrees_for_configs,
+        discover_git_worktrees_for_sources_with, enable_worktree_config,
         ensure_existing_worktree_is_git_registered,
         ensure_provider_available_before_session_bootstrap, find_assignable_worktree,
         flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
+        GIT_WORKTREE_DISCOVERY_CONCURRENCY,
         is_under_wardian_agent_worktree_root, lock_agent_lifecycle, mark_agent_paused_off,
         normalize_clone_folder_override, normalize_discovered_git_worktree_path,
         normalize_existing_workspace_record_path, normalize_spawn_folder,
@@ -4495,6 +4535,41 @@ mod tests {
             &entry.worktree_folder,
             &normalize_workspace_record_path(&repo)
         )));
+    }
+
+    #[test]
+    fn discover_git_worktrees_for_sources_runs_git_discovery_concurrently() {
+        let sources = (0..(GIT_WORKTREE_DISCOVERY_CONCURRENCY * 2 + 1))
+            .map(|index| format!("C:/repo-{index}"))
+            .collect::<Vec<_>>();
+        let active = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let max_active = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let discovered = discover_git_worktrees_for_sources_with(sources, {
+            let active = active.clone();
+            let max_active = max_active.clone();
+            move |source: &std::path::Path| {
+                let current = active.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                max_active.fetch_max(current, std::sync::atomic::Ordering::SeqCst);
+                std::thread::sleep(std::time::Duration::from_millis(25));
+                active.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(vec![crate::commands::git::GitWorktreeInfo {
+                    path: source.join("review"),
+                    branch: None,
+                }])
+            }
+        });
+
+        assert_eq!(discovered.len(), GIT_WORKTREE_DISCOVERY_CONCURRENCY * 2 + 1);
+        assert!(
+            max_active.load(std::sync::atomic::Ordering::SeqCst) > 1,
+            "worktree discovery should not run one git process at a time"
+        );
+        assert!(
+            max_active.load(std::sync::atomic::Ordering::SeqCst)
+                <= GIT_WORKTREE_DISCOVERY_CONCURRENCY,
+            "worktree discovery must not spawn unbounded git processes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
Speeds up `wardian agent worktree list` and avoids false `control_endpoint_timeout` failures when Wardian has many distinct agent workspaces.

What changed:
- Backend Git worktree discovery now dedupes normalized source workspaces as before, then runs `git worktree list --porcelain` in bounded concurrent chunks of 8 instead of serially.
- Existing behavior is preserved for persisted assigned worktrees and discovered unassigned Git worktrees.
- The CLI now uses a dedicated 5s Git-discovery timeout for `AgentWorktreeList`, rather than the 500ms generic control timeout or the full 30s mutation timeout.
- Added tests for concurrent discovery, bounded fanout, existing Git registry discovery, and the CLI timeout classification.

Measured locally before the backend change:
- 25 unique source workspaces produced about 610ms serialized Git discovery.
- Bounded parallel shell measurement of the same Git calls was about 176ms.
- A single `git worktree list --porcelain` call averaged about 27.8ms; the lag was multiplication across repos, not one slow repo.

Wardian-Reviewer result:
- No blocking findings.
- Low test-gap note about proving bounded fanout across more than one chunk was addressed before opening this PR.

## Related Issues
Fixes #454

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Fresh post-review checks:
- `cargo test -p Wardian commands::agent::tests::discover_git_worktrees`
- `cargo test -p wardian-cli live::tests::worktree_list_uses_git_discovery_timeout`
- `git diff --check`

Earlier full local checks on the same implementation before the final test-only review adjustment:
- `cargo test -p Wardian commands::agent::tests::collect_agent_worktrees`
- `cargo check -p Wardian`
- `cargo test -p wardian-cli`
- `cargo clippy -p wardian-cli -- -D warnings`
- `cargo clippy -p Wardian -- -D warnings`

Docs are not applicable: this changes internal backend discovery performance and CLI timeout classification without changing command syntax, output fields, or user-facing workflow behavior.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, or docs are not applicable for this internal performance fix
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable