### PR TITLE
chore: scrub personal paths/names from tracked files

### DIFF
--- a/docs/specs/2026-05-30-workflow-v2-schedule-invoker.md
+++ b/docs/specs/2026-05-30-workflow-v2-schedule-invoker.md
@@ -8,7 +8,7 @@
 
 ## 1. Goal & scope
 
-Give v2 the ability to run blueprints on a schedule — the parity gap that made the 5c migration lossy (every Trident + heartbeat workflow was scheduled). A persisted schedule fires real v2 runs via 6a's `workflow_run_v2` path at the right times, survives app restart, and supports the same cadences v1 had.
+Give v2 the ability to run blueprints on a schedule — the parity gap that made the 5c migration lossy (most migrated workflows were scheduled). A persisted schedule fires real v2 runs via 6a's `workflow_run_v2` path at the right times, survives app restart, and supports the same cadences v1 had.
 
 **In scope (6b):**
 1. A `WorkflowSchedule` entity (wardian-core) = invocation context + `ScheduleDefinition` + runtime fields.

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -3190,13 +3190,13 @@ mod tests {
             "\r\n›\u{1b}[22m Write tests for @filename"
         ));
         assert!(codex_output_has_ready_prompt(
-            "\r\n› Explain this codebase\r\n\r\n  gpt-5.5 high · Context 100% left · D:\\Trading\\trident\r\n"
+            "\r\n› Explain this codebase\r\n\r\n  gpt-5.5 high · Context 100% left · C:\\projects\\example\r\n"
         ));
         assert!(codex_output_has_ready_prompt(
             "\r\n› Working on test coverage\r\n"
         ));
         assert!(codex_output_has_ready_prompt(
-            "\r\n› Explain this codebase\r\n\r\n  gpt-5.5 high · Context 100% left · D:\\Processing\\trident\r\n"
+            "\r\n› Explain this codebase\r\n\r\n  gpt-5.5 high · Context 100% left · C:\\projects\\sample\r\n"
         ));
         assert!(!codex_output_has_ready_prompt("Booting MCP server"));
     }


### PR DESCRIPTION
## Description
Removes two incidental references to local/personal specifics from tracked files (no secrets were involved):

- `src-tauri/src/control.rs` — codex ready-prompt test fixtures hard-coded real local paths (`D:\Trading\trident`, `D:\Processing\trident`); replaced with generic `C:\projects\example` / `C:\projects\sample`. The test asserts the `›` ready-prompt marker, not the path, so behavior is unchanged.
- `docs/specs/2026-05-30-workflow-v2-schedule-invoker.md` — reworded a line that named a private workflow suite to a generic phrasing.

History is intentionally **not** rewritten (these are a project name + local path, not credentials).

## Type of Change
- [x] Chore / hygiene

## How Has This Been Tested?
- `cargo test -p Wardian --lib codex_ready_prompt` → 3 passed (fixtures still detect the ready prompt)

## Checklist
- [x] No secrets/credentials involved
- [x] No behavior change