### PR TITLE
fix(remote): restore workflow list compatibility

### DIFF
--- a/src-tauri/src/remote/gateway.rs
+++ b/src-tauri/src/remote/gateway.rs
@@ -103,6 +103,7 @@ fn remote_router(app: AppHandle, config: RemoteGatewayConfig) -> Router {
         .route("/remote/api/auth/challenge", post(create_auth_challenge))
         .route("/remote/api/auth/session", post(create_auth_session))
         .route("/remote/api/agents", get(list_remote_agents))
+        .route("/remote/api/workflows", get(list_remote_workflows))
         .route(
             "/remote/api/agents/{session_id}/chat",
             get(load_remote_agent_chat),
@@ -593,6 +594,31 @@ async fn list_remote_agents(
         GatewayAuditEvent::accepted("roster_read", "list_agents"),
     );
     Ok(Json(serde_json::json!({ "agents": agents })))
+}
+
+async fn list_remote_workflows(
+    State(ctx): State<RemoteGatewayContext>,
+    headers: HeaderMap,
+) -> Result<Json<serde_json::Value>, RemoteGatewayError> {
+    let origin = require_audited_request_boundary(&ctx.config, &headers, false, "list_workflows")?;
+    let session = require_audited_remote_session(
+        &ctx,
+        &headers,
+        &origin,
+        "workflow_read",
+        "list_workflows",
+    )
+    .await?;
+    audit_gateway_event(
+        &session,
+        &origin,
+        GatewayAuditEvent::accepted("workflow_read", "list_workflows"),
+    );
+    Ok(Json(remote_workflow_compat_empty_list_response()))
+}
+
+fn remote_workflow_compat_empty_list_response() -> serde_json::Value {
+    serde_json::json!({ "workflows": [] })
 }
 
 async fn load_remote_agent_chat(
@@ -2155,6 +2181,14 @@ mod tests {
         assert_eq!(response.csrf_nonce, "csrf-1");
         assert!(response.expires_at.ends_with('Z'));
         assert!(response.absolute_expires_at.ends_with('Z'));
+    }
+
+    #[test]
+    fn remote_workflow_compat_empty_list_preserves_v1_shape() {
+        assert_eq!(
+            remote_workflow_compat_empty_list_response(),
+            serde_json::json!({ "workflows": [] })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
Restores backend compatibility for cached remote mobile bundles that still call `GET /remote/api/workflows` during startup.

The live desktop was reachable over Tailscale and remote auth/session bootstrap succeeded, but the running backend returned 404 for `/remote/api/workflows`. Fresh frontend bundles now tolerate that 404, but cached PWA bundles can still treat it as a fatal bootstrap error and show `Desktop unreachable`.

This PR adds an authenticated, audited compatibility endpoint that returns the previous empty workflow-list shape:

```json
{ "workflows": [] }
```

It does not restore the old workflow run/stop APIs.

Agent review: `Wardian-Reviewer` reported no Critical or Important findings. A suggested route-level test was evaluated, but the direct handler setup depends on process-global `WARDIAN_HOME`/Tauri app state and was flaky under parallel `cargo test`; the PR keeps the deterministic response-shape test and follows the existing audited remote-read route pattern.

## Related Issues
Fixes #465

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Red/green:
- Red: `cargo test remote::gateway::tests::remote_workflow_compat_empty_list_preserves_v1_shape` failed before implementation because the compatibility response helper did not exist.
- Green: `cargo test remote::gateway::tests::remote_workflow_compat_empty_list_preserves_v1_shape` passed after implementation.

Verification run:
- `cargo test remote::gateway::tests::` passed, 29 tests.
- `npm run test -- src/features/remote/RemoteMobileApp.test.tsx -t "keeps the remote shell usable when workflow listing is unavailable"` passed.
- `npm run lint` passed.
- `npm run test` passed, 101 files / 911 tests.
- `npm run build` passed.
- `cargo clippy` passed.
- `cargo test` passed.
- `cargo check` passed.
- `npm run check:frontend-screenshot -- origin/main HEAD` passed; no frontend files changed.

Live investigation evidence before the fix:
- `http://127.0.0.1:41241/remote/api/health` returned 200.
- `https://inanna.tailb6e29a.ts.net/remote/api/health` returned 200.
- `/remote/api/workflows` returned 404 locally and through Tailscale.
- Audit logs showed accepted remote `session_read` and `roster_read` entries from the phone session, so Tailscale and remote auth were not the failing layer.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, or no new hard-to-understand logic was introduced
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable because this is backend-only