### PR TITLE
fix(release): sync Cargo lockfile in release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,7 +41,7 @@ jobs:
 
           git fetch origin "$release_branch"
           git checkout -B "$release_branch" "origin/$release_branch"
-          cargo metadata --format-version 1 --no-deps > /dev/null
+          cargo update --workspace
 
           if git diff --quiet -- Cargo.lock; then
             echo "Cargo.lock already matches release manifests."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Wardian"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -5678,7 +5678,7 @@ dependencies = [
 
 [[package]]
 name = "wardian-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "rusqlite",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "wardian-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -19,7 +19,7 @@ describe("release workflow contract", () => {
     expect(releasePleaseWorkflow).toContain("steps.release.outputs.tag_name");
   });
 
-  it("keeps Rust workspace crate versions in the Release Please bump set", () => {
+  it("syncs Cargo.lock after Release Please bumps Rust workspace versions", () => {
     expect(releasePleaseConfig.packages["."]["extra-files"]).toContainEqual({
       type: "toml",
       path: "Cargo.toml",
@@ -32,7 +32,10 @@ describe("release workflow contract", () => {
     expect(releasePleaseWorkflow).toContain("RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs }}");
     expect(releasePleaseWorkflow).toContain("headBranchName");
     expect(releasePleaseWorkflow).not.toContain("gh pr list");
-    expect(releasePleaseWorkflow).toContain("cargo metadata --format-version 1 --no-deps");
+    expect(releasePleaseWorkflow).not.toContain("npm install --package-lock-only");
+    expect(releasePleaseWorkflow).not.toContain("cargo metadata --format-version 1 --no-deps");
+    expect(releasePleaseWorkflow).toContain("cargo update --workspace");
+    expect(releasePleaseWorkflow).toContain("git diff --quiet -- Cargo.lock");
     expect(releasePleaseWorkflow).toContain("git add Cargo.lock");
     expect(releasePleaseWorkflow).toContain("chore: sync release Cargo.lock");
   });


### PR DESCRIPTION
## Description
Release PR automation now uses `cargo update --workspace` after Release Please updates Rust version manifests. The previous `cargo metadata --format-version 1 --no-deps` step can report success without rewriting `Cargo.lock`, which left Wardian workspace package versions stale on release PRs.

This also syncs the current `Cargo.lock` workspace package versions from `0.3.7` to `0.3.8`.

## Related Issues
Fixes #468

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] Temporary worktree probe of the open Release Please branch: `cargo update --workspace` changes only Wardian workspace package versions in `Cargo.lock` from `0.3.7` to `0.3.9`
- [x] `npm run test -- src/config/releaseWorkflow.test.ts` fails before the workflow change and passes after it
- [x] `npm run lint`
- [x] Earlier full pre-PR verification on this branch before the review correction: `npm run test`, `npm run build`, `cd src-tauri && cargo clippy`, `cd src-tauri && cargo test`, `cd src-tauri && cargo check`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, or docs are not applicable for this internal release CI fix
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable