### PR TITLE
fix(runtime): silence Windows background process launches

### DIFF
--- a/docs/specs/2026-05-31-silent-windows-process-launches.md
+++ b/docs/specs/2026-05-31-silent-windows-process-launches.md
@@ -1,0 +1,35 @@
+# Silent Windows Process Launches
+
+## Context
+
+Wardian starts many local processes: provider PTYs, headless provider runs, workflow shell steps, git commands, filesystem junction helpers, updater handoff scripts, explorer reveals, and external editor launches. On Windows, console-backed children can briefly show a separate terminal window when they are started without an explicit hidden/no-window policy. That disrupts Wardian's desktop visuals and has led to call-site-specific fixes.
+
+## Goal
+
+All Wardian-owned terminal and background process launches should be silent on Windows by default. Intentional GUI handoffs must keep their visible behavior.
+
+## Process Categories
+
+1. **PTY-backed terminal processes**: managed agents and the standalone user terminal. These use `portable-pty` and must stay attached to ConPTY while preventing an external console window.
+2. **Captured background commands**: provider bootstrap/headless runs, workflow shell and script steps, git, Tailscale status checks, patch scripts, `taskkill`, and junction creation. These should use shared no-window process helpers.
+3. **Intentional GUI handoffs**: `explorer`, `open`, `xdg-open`, external editors, and the Windows update handoff. These should remain explicit and should not be accidentally reclassified as background-only launches.
+
+## Design
+
+Wardian already patches `portable-pty` through `vendor/portable-pty`. Keep that Windows ConPTY patch focused on `STARTF_USESHOWWINDOW` and `SW_HIDE`; native validation showed that adding `CREATE_NO_WINDOW` to ConPTY child creation prevents the standalone user terminal from operating correctly. This is the PTY-specific boundary: ConPTY children remain hidden through the startup window hint, while non-PTY background process launches use `CREATE_NO_WINDOW`.
+
+For non-PTY processes, keep `src-tauri/src/utils/process.rs` as the central launcher policy. Captured commands should use `new_silent_command` or `new_silent_std_command` so `stdout` and `stderr` capture semantics stay intact while Windows uses `CREATE_NO_WINDOW`. Fire-and-forget commands should use `new_headless_command` or `new_headless_std_command`, which build on the same silent policy and explicitly null standard handles. Call sites that already need path-candidate fidelity can apply the shared silent-command policy functions to an existing `Command`. Existing GUI handoff call sites remain direct or use their existing handoff-specific flags so the refactor does not suppress user-visible file manager or editor behavior.
+
+## Non-Goals
+
+- Do not change provider arguments, current working directories, environment variables, stdout/stderr capture, or process lifecycle semantics.
+- Do not hide or redirect intentional GUI actions.
+- Do not introduce a new PTY abstraction unless `portable-pty` exposes a stable creation-flag API later.
+
+## Verification
+
+- Unit tests for the centralized Windows process flag helpers, launch specs, and captured stdout/stderr behavior.
+- Existing Rust tests around provider launch argument construction and shell selection.
+- Native user-terminal smoke to prove the ConPTY path still runs commands after the process-creation policy change.
+- `cargo check`, `cargo test`, and `cargo clippy` in `src-tauri`.
+- Frontend validation remains unchanged because this is backend/runtime infrastructure only.

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1,5 +1,6 @@
 use crate::state::AppState;
 use crate::utils::fs::create_directory_link;
+use crate::utils::process::apply_silent_std_command_policy;
 use notify::Watcher;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -114,11 +115,7 @@ fn build_git_command(program: &Path, cwd: &str, args: &[&str]) -> Command {
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_ASKPASS", "echo");
 
-    #[cfg(target_os = "windows")]
-    {
-        use std::os::windows::process::CommandExt;
-        command.creation_flags(0x08000000);
-    }
+    apply_silent_std_command_policy(&mut command);
 
     command
 }
@@ -1058,7 +1055,11 @@ mod tests {
             .to_string_lossy()
             .replace('\\', "\\\\");
         let tracked_config = format!("[build]\ntarget-dir = \"{expected_target}\"\n");
-        std::fs::write(workspace.join(".cargo").join("config.toml"), &tracked_config).unwrap();
+        std::fs::write(
+            workspace.join(".cargo").join("config.toml"),
+            &tracked_config,
+        )
+        .unwrap();
 
         let cwd = workspace.to_str().unwrap();
         run_git(cwd, &["init"]).unwrap();

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -416,7 +416,7 @@ fn link_skill_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
         _ => dst.to_path_buf(),
     };
 
-    let output = std::process::Command::new("cmd")
+    let output = crate::utils::process::new_silent_std_command("cmd")
         .args(["/C", "mklink", "/J"])
         .arg(&dst)
         .arg(&src)

--- a/src-tauri/src/commands/patch.rs
+++ b/src-tauri/src/commands/patch.rs
@@ -1,6 +1,5 @@
 use crate::manager::log_debug;
 use std::path::PathBuf;
-use std::process::Command;
 use tauri::{AppHandle, Manager};
 
 fn node_entrypoint_path(path: PathBuf) -> PathBuf {
@@ -69,15 +68,8 @@ pub async fn run_gemini_patch(app: AppHandle) -> Result<String, String> {
 
     let node_resource_path = node_entrypoint_path(resource_path);
 
-    #[allow(unused_mut)]
-    let mut cmd = Command::new("node");
+    let mut cmd = crate::utils::process::new_silent_std_command("node");
     cmd.arg(&node_resource_path);
-
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000);
-    }
 
     let output = cmd
         .output()

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -319,10 +319,11 @@ fn spawn_windows_update_handoff(
 
 fn windows_update_handoff_creation_flags() -> u32 {
     const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
     const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x0100_0000;
 
-    CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB
+    CREATE_NEW_PROCESS_GROUP
+        | crate::utils::process::windows_silent_process_creation_flags()
+        | CREATE_BREAKAWAY_FROM_JOB
 }
 
 #[cfg(test)]

--- a/src-tauri/src/remote/setup_check.rs
+++ b/src-tauri/src/remote/setup_check.rs
@@ -165,7 +165,7 @@ pub async fn load_remote_setup_check() -> RemoteSetupCheckResult {
 }
 
 async fn run_tailscale_json(args: &[&str]) -> Result<String, String> {
-    let mut command = tokio::process::Command::new("tailscale");
+    let mut command = crate::utils::process::new_silent_command("tailscale");
     command.args(args);
     command.kill_on_drop(true);
     let output = tokio::time::timeout(TAILSCALE_TIMEOUT, command.output())

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -877,10 +877,8 @@ pub(crate) fn create_directory_link(
             link.to_string_lossy(),
             target.to_string_lossy()
         );
-        let mut cmd = std::process::Command::new("cmd");
-        cmd.raw_arg("/c")
-            .raw_arg(&command)
-            .creation_flags(0x08000000);
+        let mut cmd = crate::utils::process::new_silent_std_command("cmd");
+        cmd.raw_arg("/c").raw_arg(&command);
         let output = cmd.output().map_err(|e| e.to_string())?;
         if output.status.success() {
             Ok(())

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -6,6 +6,30 @@ static APP_PROCESS_SUPERVISOR: OnceLock<AppProcessSupervisor> = OnceLock::new();
 #[cfg(windows)]
 static APP_PROCESS_SUPERVISOR_ERROR: OnceLock<String> = OnceLock::new();
 
+pub(crate) fn windows_create_no_window_flag() -> u32 {
+    0x0800_0000
+}
+
+pub(crate) fn windows_silent_process_creation_flags() -> u32 {
+    windows_create_no_window_flag()
+}
+
+pub(crate) fn apply_silent_tokio_command_policy(cmd: &mut tokio::process::Command) {
+    #[cfg(windows)]
+    {
+        cmd.creation_flags(windows_silent_process_creation_flags());
+    }
+}
+
+pub(crate) fn apply_silent_std_command_policy(cmd: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        cmd.creation_flags(windows_silent_process_creation_flags());
+    }
+}
+
 #[cfg(windows)]
 #[derive(Debug)]
 struct AppProcessSupervisor {
@@ -42,20 +66,27 @@ pub fn headless_command_spec(program: &str) -> HeadlessCommandSpec {
 
 pub fn new_headless_command(program: &str) -> tokio::process::Command {
     use std::process::Stdio;
+
+    let mut cmd = new_silent_command(program);
+
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+
+    cmd
+}
+
+pub fn new_silent_command(program: &str) -> tokio::process::Command {
     use tokio::process::Command;
 
     let spec = headless_command_spec(program);
     let mut cmd = Command::new(&spec.program);
     cmd.args(&spec.args);
 
-    cmd.stdin(Stdio::null());
-    cmd.stdout(Stdio::null());
-    cmd.stderr(Stdio::null());
-
     #[cfg(target_os = "windows")]
     {
         if spec.use_no_window {
-            cmd.creation_flags(0x08000000);
+            apply_silent_tokio_command_policy(&mut cmd);
         }
     }
 
@@ -65,20 +96,24 @@ pub fn new_headless_command(program: &str) -> tokio::process::Command {
 pub fn new_headless_std_command(program: &str) -> std::process::Command {
     use std::process::Stdio;
 
-    let spec = headless_command_spec(program);
-    let mut cmd = std::process::Command::new(&spec.program);
-    cmd.args(&spec.args);
+    let mut cmd = new_silent_std_command(program);
 
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::null());
     cmd.stderr(Stdio::null());
 
+    cmd
+}
+
+pub fn new_silent_std_command(program: &str) -> std::process::Command {
+    let spec = headless_command_spec(program);
+    let mut cmd = std::process::Command::new(&spec.program);
+    cmd.args(&spec.args);
+
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
-
         if spec.use_no_window {
-            cmd.creation_flags(0x08000000);
+            apply_silent_std_command_policy(&mut cmd);
         }
     }
 
@@ -318,7 +353,7 @@ pub fn force_kill_process_tree(pid: u32) -> Result<(), String> {
         return Ok(());
     }
 
-    let output = new_headless_std_command("taskkill.exe")
+    let output = new_silent_std_command("taskkill.exe")
         .args(["/PID", &pid.to_string(), "/T", "/F"])
         .output()
         .map_err(|err| format!("taskkill failed to launch for {}: {}", pid, err))?;
@@ -343,7 +378,29 @@ pub fn force_kill_process_tree(pid: u32) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{headless_command_spec, new_headless_std_command};
+    use super::{
+        headless_command_spec, new_headless_std_command, new_silent_command, new_silent_std_command,
+    };
+
+    fn captured_output_command() -> (String, Vec<String>) {
+        if cfg!(target_os = "windows") {
+            (
+                "cmd".to_string(),
+                vec![
+                    "/C".to_string(),
+                    "echo wardian_stdout&& echo wardian_stderr 1>&2".to_string(),
+                ],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec![
+                    "-c".to_string(),
+                    "printf '%s\\n' wardian_stdout; printf '%s\\n' wardian_stderr >&2".to_string(),
+                ],
+            )
+        }
+    }
 
     #[test]
     fn wraps_cmd_shims_for_headless_windows_execution() {
@@ -378,6 +435,42 @@ mod tests {
         } else {
             assert_eq!(cmd.get_program().to_string_lossy(), "example.cmd");
         }
+    }
+
+    #[test]
+    fn silent_std_command_preserves_captured_stdout_and_stderr() {
+        let (program, args) = captured_output_command();
+        let output = new_silent_std_command(&program)
+            .args(args)
+            .output()
+            .expect("silent std command should run");
+
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("wardian_stdout"));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("wardian_stderr"));
+    }
+
+    #[tokio::test]
+    async fn silent_tokio_command_preserves_captured_stdout_and_stderr() {
+        let (program, args) = captured_output_command();
+        let output = new_silent_command(&program)
+            .args(args)
+            .output()
+            .await
+            .expect("silent tokio command should run");
+
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("wardian_stdout"));
+        assert!(String::from_utf8_lossy(&output.stderr).contains("wardian_stderr"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_silent_process_creation_flags_include_no_window() {
+        assert_eq!(
+            super::windows_silent_process_creation_flags() & super::windows_create_no_window_flag(),
+            super::windows_create_no_window_flag()
+        );
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/workflow_v2/ops.rs
+++ b/src-tauri/src/workflow_v2/ops.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use tokio::process::Command;
 use wardian_core::engine::{
     NotifyRequest, ScriptRequest, ShellRequest, StateRequest, StepError, StepOutput,
 };
@@ -14,7 +13,8 @@ pub async fn run_shell(ws: &Path, req: &ShellRequest) -> Result<StepOutput, Step
         ("sh", "-c")
     };
 
-    let output = Command::new(shell)
+    let mut command = crate::utils::process::new_silent_command(shell);
+    let output = command
         .arg(flag)
         .arg(&req.command)
         .current_dir(cwd)
@@ -32,7 +32,8 @@ pub async fn run_shell(ws: &Path, req: &ShellRequest) -> Result<StepOutput, Step
 /// Run `runtime path` in the workspace and capture exit code, stdout, and
 /// stderr.
 pub async fn run_script(ws: &Path, req: &ScriptRequest) -> Result<StepOutput, StepError> {
-    let output = Command::new(&req.runtime)
+    let mut command = crate::utils::process::new_silent_command(&req.runtime);
+    let output = command
         .arg(&req.path)
         .current_dir(ws)
         .output()

--- a/vendor/portable-pty/README.wardian.md
+++ b/vendor/portable-pty/README.wardian.md
@@ -1,6 +1,6 @@
 # Wardian patch
 
-This is `portable-pty` 0.9.0 with a small Windows-only ConPTY startup hint:
+This is `portable-pty` 0.9.0 with a small Windows-only ConPTY startup patch:
 `STARTF_USESHOWWINDOW` + `SW_HIDE` is set when creating PTY child processes.
 
 Wardian uses visible embedded PTYs for CLI providers. Some Windows CLI launches

--- a/vendor/portable-pty/src/win/psuedocon.rs
+++ b/vendor/portable-pty/src/win/psuedocon.rs
@@ -32,6 +32,10 @@ pub const PSEUDOCONSOLE_WIN32_INPUT_MODE: DWORD = 0x4;
 #[allow(dead_code)]
 pub const PSEUDOCONSOLE_PASSTHROUGH_MODE: DWORD = 0x8;
 
+fn conpty_child_process_creation_flags() -> DWORD {
+    EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT
+}
+
 shared_library!(ConPtyFuncs,
     pub fn CreatePseudoConsole(
         size: COORD,
@@ -147,7 +151,7 @@ impl PsuedoCon {
                 ptr::null_mut(),
                 ptr::null_mut(),
                 0,
-                EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+                conpty_child_process_creation_flags(),
                 cmd.environment_block().as_mut_slice().as_mut_ptr() as *mut _,
                 cwd.as_ref()
                     .map(|c| c.as_slice().as_ptr())
@@ -176,5 +180,26 @@ impl PsuedoCon {
         Ok(WinChild {
             proc: Mutex::new(proc),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn conpty_child_process_creation_flags_preserve_extended_startup_info() {
+        assert_ne!(
+            super::conpty_child_process_creation_flags() & super::EXTENDED_STARTUPINFO_PRESENT,
+            0
+        );
+    }
+
+    #[test]
+    fn conpty_child_process_creation_flags_do_not_create_no_window() {
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+        assert_eq!(
+            super::conpty_child_process_creation_flags() & CREATE_NO_WINDOW,
+            0
+        );
     }
 }


### PR DESCRIPTION
## Description
Centralizes Windows silent process launch policy for Wardian-owned background and captured process launches. Captured commands now use shared silent helpers that preserve stdout/stderr capture, while true headless launches keep null stdio semantics.

The PR also documents the PTY boundary: ConPTY launches keep the vendored `SW_HIDE` startup hint and explicitly avoid `CREATE_NO_WINDOW`, because native validation showed that flag breaks standalone user-terminal behavior. Intentional GUI handoffs such as file manager/editor launches remain visible.

## Related Issues
Fixes #470

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] Staged diff secrets scan for common credential/key patterns
- [x] `cd src-tauri && cargo test silent_`
- [x] `cd src-tauri && cargo test windows_update_handoff_breaks_away_from_app_supervisor_job`
- [x] `cd src-tauri && cargo test`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo clippy`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run tauri -- build --debug --no-bundle`
- [x] Native harness smoke with isolated `WARDIAN_E2E_NATIVE_HOME`
- [x] Native user-terminal smoke with isolated `WARDIAN_E2E_NATIVE_HOME`
- [x] Reviewer agent final pass: no blocking findings; ready to merge

Notes: `cargo check --target x86_64-unknown-linux-gnu` was attempted from Windows, but the run stopped in `libdbus-sys` because cross `pkg-config`/DBus sysroot is not configured locally. Direct `portable-pty` manifest testing was also attempted, but Cargo refuses because the vendored crate sits under the root workspace without being a workspace member.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable