### PR TITLE
fix(agents): stabilize action-needed status transitions

### DIFF
--- a/docs/specs/2026-05-31-claude-status-transition-consistency.md
+++ b/docs/specs/2026-05-31-claude-status-transition-consistency.md
@@ -1,0 +1,50 @@
+# Provider Status Transition Consistency
+
+- **Status:** Implemented
+- **Date:** 2026-05-31
+- **Decider:** User
+
+## Context
+
+Wardian status labels drive roster state, CLI wait/watch behavior, mailbox
+delivery, and action-needed alerts. Real provider CLIs expose status evidence
+through different live surfaces: structured stream JSON, transcript JSONL,
+permission hooks, and terminal prompts. The status label must prefer the earliest
+explicit action-required or completion evidence without allowing generic activity
+to erase an unresolved action-needed state.
+
+## Decision
+
+Wardian applies provider PTY stream status events as live status evidence for
+providers whose terminal output is the earliest source of truth. For Claude and
+Codex stream events, generic `Generating` and `UserQuery` activity does not
+overwrite an existing `Action Needed` status. Explicit `ActionRequired` still
+moves the agent to `Action Needed`, and explicit `ModelResponse` or
+`TurnCompleted` clears it to `Idle`.
+
+Telemetry log parsing is also allowed to clear a stale Claude `Action Needed`
+status when the transcript later shows a definitive idle state. Initial log
+replay remains metadata-only and does not emit status transitions.
+
+Wardian approval actions are delivered to live PTYs when the target is currently
+`Action Needed`. Provider-specific approval keys are used for known interactive
+prompts, so Codex and Antigravity accept actions submit the highlighted default
+with Enter instead of queueing a literal approval message.
+
+Antigravity workspace trust and permission prompts are parsed from terminal text
+as `ActionRequired` events. This lets the roster and CLI move to `Action Needed`
+while the trust gate is visible, before any JSON transcript evidence exists.
+
+## Consequences
+
+- Claude, Codex, and Antigravity action-needed labels can update from the live
+  stream path instead of waiting for a later log or hook observation.
+- Generic progress or generation events no longer hide an unresolved
+  action-needed state.
+- If the live watcher misses the clearing transition, telemetry can still
+  recover from stale action-needed once the transcript records completion.
+- CLI approval actions can unblock real provider prompts and move the agent back
+  through `Processing` toward `Idle`.
+- Antigravity trust prompts are treated as first-class action-needed gates.
+- Existing duplicate suppression in `set_agent_status` continues to collapse
+  repeated observations from PTY, hook, and transcript sources.

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -764,7 +764,9 @@ async fn deliver_message_to_target(
             || matches!(queue_policy, QueuePolicy::MailboxOnly)
         {
             decide_delivery_route(&info.status, input_mode, queue_policy, approval_action)
-        } else if provider_input_has_known_not_ready_state(state, &info.uuid).await {
+        } else if provider_input_has_known_not_ready_state(state, &info.uuid).await
+            && !provider_idle_status_allows_live_delivery(&info, queue_policy)
+        {
             match queue_policy {
                 QueuePolicy::QueueIfBusy => DeliveryRoute::Mailbox {
                     runtime_state: "provider_input_not_ready",
@@ -810,11 +812,17 @@ async fn deliver_message_to_target(
                     let profile = crate::utils::delivery_profile::delivery_profile(&info.provider);
                     let delivery_lock = state.delivery_lock_for(&info.uuid).await;
                     let _delivery_guard = delivery_lock.lock().await;
-                    let payload_cursor =
-                        codex_payload_echo_cursor(state, &info.provider, &info.uuid).await;
-                    let result = match wait_for_terminal_ready_for_control_send(state, &info).await
+                    let result = if let (MessageInputMode::ApprovalAction, Some(action)) =
+                        (input_mode, approval_action)
                     {
-                        Ok(()) => {
+                        submit_approval_action_via_sender(&tx, &info.provider, action)
+                            .await
+                            .map_err(|error| error.to_string())
+                    } else {
+                        let payload_cursor =
+                            codex_payload_echo_cursor(state, &info.provider, &info.uuid).await;
+                        match wait_for_terminal_ready_for_control_send(state, &info).await {
+                            Ok(()) => {
                             let wait_uuid = info.uuid.clone();
                             let wait_provider = info.provider.clone();
                             let wait_prompt = outbound_message.clone();
@@ -837,9 +845,15 @@ async fn deliver_message_to_target(
                             .map_err(|error| error.to_string())
                         }
                         Err(error) => Err(error),
+                        }
                     };
                     match result {
                         Ok(outcome) => {
+                            if input_mode == MessageInputMode::ApprovalAction
+                                && matches!(approval_action, Some(ApprovalAction::Accept))
+                            {
+                                mark_approval_accept_started(app, state, &info.uuid).await;
+                            }
                             delivered += 1;
                             let detail = DeliveryDetail {
                                 uuid: info.uuid,
@@ -920,6 +934,15 @@ async fn deliver_message_to_target(
     Ok(delivery)
 }
 
+fn provider_idle_status_allows_live_delivery(
+    info: &DeliveryTargetInfo,
+    queue_policy: QueuePolicy,
+) -> bool {
+    matches!(queue_policy, QueuePolicy::LiveOnly)
+        && info.provider == "claude"
+        && info.status == "idle"
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DeliveryRoute {
     Live,
@@ -931,11 +954,15 @@ fn decide_delivery_route(
     status: &str,
     input_mode: MessageInputMode,
     queue_policy: QueuePolicy,
-    _approval_action: Option<&ApprovalAction>,
+    approval_action: Option<&ApprovalAction>,
 ) -> DeliveryRoute {
     if input_mode == MessageInputMode::ApprovalAction {
-        return DeliveryRoute::Reject {
-            failure: "unsupported_approval_shape",
+        return if approval_action.is_some() && status == "action_required" {
+            DeliveryRoute::Live
+        } else {
+            DeliveryRoute::Reject {
+                failure: "not_input_ready",
+            }
         };
     }
     if matches!(queue_policy, QueuePolicy::MailboxOnly) {
@@ -956,12 +983,7 @@ fn decide_delivery_route(
             QueuePolicy::MailboxOnly => unreachable!("handled above"),
         },
         "action_required" => {
-            if input_mode == MessageInputMode::ApprovalAction {
-                DeliveryRoute::Reject {
-                    failure: "unsupported_approval_shape",
-                }
-            } else if matches!(queue_policy, QueuePolicy::QueueIfBusy)
-                && input_mode == MessageInputMode::Message
+            if matches!(queue_policy, QueuePolicy::QueueIfBusy) && input_mode == MessageInputMode::Message
             {
                 DeliveryRoute::Mailbox {
                     runtime_state: "target_action_required",
@@ -983,6 +1005,71 @@ fn decide_delivery_route(
         _ => DeliveryRoute::Reject {
             failure: "not_input_ready",
         },
+    }
+}
+
+fn approval_action_bytes(provider: &str, action: &ApprovalAction) -> Vec<u8> {
+    match action {
+        ApprovalAction::Accept => {
+            if provider.eq_ignore_ascii_case("codex")
+                || provider.eq_ignore_ascii_case("antigravity")
+            {
+                b"\r".to_vec()
+            } else {
+                b"y\r".to_vec()
+            }
+        }
+        ApprovalAction::Reject => {
+            if provider.eq_ignore_ascii_case("codex") {
+                b"\x1b".to_vec()
+            } else {
+                b"n\r".to_vec()
+            }
+        }
+        ApprovalAction::Select { option } => {
+            let mut bytes = option.as_bytes().to_vec();
+            bytes.push(b'\r');
+            bytes
+        }
+        ApprovalAction::FreeText { text } => {
+            let mut bytes = text.as_bytes().to_vec();
+            bytes.push(b'\r');
+            bytes
+        }
+    }
+}
+
+async fn submit_approval_action_via_sender(
+    tx: &tokio::sync::mpsc::Sender<Vec<u8>>,
+    provider: &str,
+    action: &ApprovalAction,
+) -> Result<crate::utils::delivery_transaction::TerminalDeliveryOutcome, String> {
+    let bytes = approval_action_bytes(provider, action);
+    tx.send(bytes)
+        .await
+        .map_err(|_| "input channel closed".to_string())?;
+    Ok(
+        crate::utils::delivery_transaction::TerminalDeliveryOutcome {
+            delivery_state: "submit_sent_unverified".to_string(),
+            delivery_phase: "approval_key_sent".to_string(),
+            observed_state: Some("bytes_sent".to_string()),
+            reason: None,
+        },
+    )
+}
+
+async fn mark_approval_accept_started(app: Option<&AppHandle>, state: &AppState, session_id: &str) {
+    let Some(app) = app else {
+        return;
+    };
+    let current_status = {
+        let agents = state.agents.lock().await;
+        agents
+            .get(session_id)
+            .map(|agent| agent.current_status.clone())
+    };
+    if let Some(current_status) = current_status {
+        manager::set_agent_status(app, session_id, &current_status, "Processing...");
     }
 }
 
@@ -3316,7 +3403,7 @@ mod tests {
     }
 
     #[test]
-    fn delivery_route_rejects_structured_approval_action_shape() {
+    fn delivery_route_sends_approval_action_when_action_required() {
         let approval_action = ApprovalAction::Accept;
         let route = decide_delivery_route(
             "action_required",
@@ -3327,14 +3414,12 @@ mod tests {
 
         assert_eq!(
             route,
-            DeliveryRoute::Reject {
-                failure: "unsupported_approval_shape"
-            }
+            DeliveryRoute::Live
         );
     }
 
     #[test]
-    fn delivery_route_rejects_approval_action_without_payload() {
+    fn delivery_route_rejects_approval_action_without_action_required_status() {
         let route = decide_delivery_route(
             "idle",
             MessageInputMode::ApprovalAction,
@@ -3345,13 +3430,13 @@ mod tests {
         assert_eq!(
             route,
             DeliveryRoute::Reject {
-                failure: "unsupported_approval_shape"
+                failure: "not_input_ready"
             }
         );
     }
 
     #[test]
-    fn delivery_route_rejects_idle_structured_approval_action_shape() {
+    fn delivery_route_rejects_idle_approval_action() {
         let approval_action = ApprovalAction::Accept;
         let route = decide_delivery_route(
             "idle",
@@ -3363,13 +3448,13 @@ mod tests {
         assert_eq!(
             route,
             DeliveryRoute::Reject {
-                failure: "unsupported_approval_shape"
+                failure: "not_input_ready"
             }
         );
     }
 
     #[test]
-    fn delivery_route_rejects_mailbox_only_structured_approval_action_shape() {
+    fn delivery_route_rejects_mailbox_only_approval_action_when_not_action_required() {
         let approval_action = ApprovalAction::Accept;
         let route = decide_delivery_route(
             "processing",
@@ -3381,7 +3466,7 @@ mod tests {
         assert_eq!(
             route,
             DeliveryRoute::Reject {
-                failure: "unsupported_approval_shape"
+                failure: "not_input_ready"
             }
         );
     }
@@ -3775,6 +3860,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn approval_action_delivery_sends_provider_approval_key() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "codex".to_string();
+            *agent.current_status.lock().unwrap() = "Action Needed".to_string();
+        }
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let delivery = deliver_message_to_target(
+            None,
+            &state,
+            "CoderOne",
+            "",
+            None,
+            MessageInputMode::ApprovalAction,
+            QueuePolicy::QueueIfBusy,
+            Some(&ApprovalAction::Accept),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+        assert_eq!(delivery[0].runtime_state, "live_pty_available");
+        assert_eq!(delivery[0].delivery_state, "submit_sent_unverified");
+        assert_eq!(
+            delivery[0].delivery_phase.as_deref(),
+            Some("approval_key_sent")
+        );
+    }
+
+    #[tokio::test]
     async fn mailbox_drain_submits_next_pending_message_when_target_is_idle() {
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -3895,6 +4020,51 @@ mod tests {
         assert_eq!(delivery[0].runtime_state, "provider_input_not_ready");
         assert_eq!(delivery[0].delivery_state, "queued");
         assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn claude_idle_status_allows_live_delivery_despite_stale_readiness() {
+        let state = AppState::new();
+        insert_test_agent(&state, "agent-1", "ClaudeOne", "Coder").await;
+        {
+            let agents = state.agents.lock().await;
+            let agent = agents.get("agent-1").unwrap();
+            agent.config.lock().unwrap().provider = "claude".to_string();
+            *agent.current_status.lock().unwrap() = "Idle".to_string();
+        }
+        state
+            .interactions
+            .record_provider_input_state(
+                "agent-1",
+                4,
+                wardian_core::control::ProviderInputReadiness::Busy,
+                None,
+            )
+            .await;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        state
+            .input_senders
+            .write()
+            .unwrap()
+            .insert("agent-1".to_string(), tx);
+
+        let delivery = deliver_message_to_target(
+            None,
+            &state,
+            "ClaudeOne",
+            "queued work",
+            None,
+            MessageInputMode::Message,
+            QueuePolicy::LiveOnly,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(rx.recv().await.unwrap(), b"queued work".to_vec());
+        assert_eq!(rx.recv().await.unwrap(), b"\r".to_vec());
+        assert_eq!(delivery[0].runtime_state, "live_pty_available");
     }
 
     #[tokio::test]

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -376,32 +376,85 @@ pub(crate) fn apply_agent_event(
     init_timestamp: &std::sync::Arc<std::sync::Mutex<Option<String>>>,
     current_status: &std::sync::Arc<std::sync::Mutex<String>>,
 ) {
-    match event {
+    apply_agent_event_with_policy(
+        app,
+        session_id,
+        event,
+        query_count,
+        init_timestamp,
+        current_status,
+        ProviderStatusEventPolicy::Normal,
+    );
+}
+
+pub(crate) fn apply_agent_event_with_policy(
+    app: &AppHandle,
+    session_id: &str,
+    event: AgentEvent,
+    query_count: &std::sync::Arc<std::sync::Mutex<usize>>,
+    init_timestamp: &std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    current_status: &std::sync::Arc<std::sync::Mutex<String>>,
+    policy: ProviderStatusEventPolicy,
+) {
+    match &event {
         AgentEvent::UserQuery => {
             if let Ok(mut count) = query_count.lock() {
                 *count += 1;
             }
-            set_agent_status(app, session_id, current_status, "Processing...");
-        }
-        AgentEvent::Generating => {
-            set_agent_status(app, session_id, current_status, "Processing...");
         }
         AgentEvent::Init { timestamp, .. } => {
             if let Ok(mut ts) = init_timestamp.lock() {
-                *ts = timestamp;
+                *ts = timestamp.clone();
             }
         }
-        AgentEvent::ModelResponse => {
-            set_agent_status(app, session_id, current_status, "Idle");
+        _ => {}
+    }
+    apply_agent_status_event_with_policy(app, session_id, event, current_status, policy);
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProviderStatusEventPolicy {
+    Normal,
+    PreserveActionRequired,
+}
+
+pub(crate) fn provider_status_from_event(
+    current_status: &str,
+    event: &AgentEvent,
+    policy: ProviderStatusEventPolicy,
+) -> Option<&'static str> {
+    match event {
+        AgentEvent::UserQuery | AgentEvent::Generating => {
+            if policy == ProviderStatusEventPolicy::PreserveActionRequired
+                && wardian_core::identity::normalize_status(current_status) == "action_required"
+            {
+                None
+            } else {
+                Some("Processing...")
+            }
         }
-        AgentEvent::TurnCompleted => {
-            set_agent_status(app, session_id, current_status, "Idle");
+        AgentEvent::ModelResponse | AgentEvent::TurnCompleted => Some("Idle"),
+        AgentEvent::ActionRequired { .. } => Some("Action Needed"),
+        AgentEvent::Init { .. } | AgentEvent::Unknown => None,
+    }
+}
+
+pub(crate) fn apply_agent_status_event_with_policy(
+    app: &AppHandle,
+    session_id: &str,
+    event: AgentEvent,
+    current_status: &std::sync::Arc<std::sync::Mutex<String>>,
+    policy: ProviderStatusEventPolicy,
+) {
+    let current = current_status
+        .lock()
+        .map(|status| status.clone())
+        .unwrap_or_default();
+    if let Some(next_status) = provider_status_from_event(&current, &event, policy) {
+        set_agent_status(app, session_id, current_status, next_status);
+        if matches!(event, AgentEvent::TurnCompleted) {
             emit_agent_turn_completed(app, session_id);
         }
-        AgentEvent::ActionRequired { .. } => {
-            set_agent_status(app, session_id, current_status, "Action Needed");
-        }
-        AgentEvent::Unknown => {}
     }
 }
 
@@ -411,22 +464,13 @@ pub(crate) fn apply_agent_status_event(
     event: AgentEvent,
     current_status: &std::sync::Arc<std::sync::Mutex<String>>,
 ) {
-    match event {
-        AgentEvent::UserQuery | AgentEvent::Generating => {
-            set_agent_status(app, session_id, current_status, "Processing...");
-        }
-        AgentEvent::ModelResponse => {
-            set_agent_status(app, session_id, current_status, "Idle");
-        }
-        AgentEvent::TurnCompleted => {
-            set_agent_status(app, session_id, current_status, "Idle");
-            emit_agent_turn_completed(app, session_id);
-        }
-        AgentEvent::ActionRequired { .. } => {
-            set_agent_status(app, session_id, current_status, "Action Needed");
-        }
-        AgentEvent::Init { .. } | AgentEvent::Unknown => {}
-    }
+    apply_agent_status_event_with_policy(
+        app,
+        session_id,
+        event,
+        current_status,
+        ProviderStatusEventPolicy::Normal,
+    );
 }
 
 /// On macOS, GUI apps inherit a minimal PATH that excludes Homebrew, npm globals,
@@ -1113,6 +1157,27 @@ mod tests {
             "Action Needed"
         );
         assert_eq!(*agent.query_count.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn status_event_policy_preserves_action_needed_until_explicit_completion() {
+        assert_eq!(
+            provider_status_from_event(
+                "Action Needed",
+                &AgentEvent::Generating,
+                ProviderStatusEventPolicy::PreserveActionRequired,
+            ),
+            None
+        );
+
+        assert_eq!(
+            provider_status_from_event(
+                "Action Needed",
+                &AgentEvent::ModelResponse,
+                ProviderStatusEventPolicy::PreserveActionRequired,
+            ),
+            Some("Idle")
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -19,9 +19,12 @@ use super::codex::{
 };
 use super::opencode::{opencode_interactive_env, opencode_status_from_title};
 use super::{
-    apply_agent_event, apply_agent_status_event, apply_terminal_identity_env, debug_preview_bytes,
-    extract_terminal_titles, finalize_interactive_spawn_args, interactive_provider_args,
-    interactive_provider_cwd, interactive_provider_launch, set_agent_status,
+    apply_agent_event, apply_agent_event_with_policy, apply_agent_status_event,
+    apply_agent_status_event_with_policy, apply_terminal_identity_env, debug_preview_bytes,
+    extract_terminal_titles,
+    finalize_interactive_spawn_args, interactive_provider_args, interactive_provider_cwd,
+    interactive_provider_launch, provider_status_from_event, set_agent_status,
+    ProviderStatusEventPolicy,
 };
 use crate::providers::gemini::gemini_status_from_title;
 
@@ -174,6 +177,26 @@ fn save_agent_state_after_session_capture(app: &AppHandle) {
 
 fn should_cleanup_stale_session_processes_before_spawn(is_restored: bool) -> bool {
     !is_restored
+}
+
+fn pty_status_event_policy_for_provider(provider_name: &str) -> ProviderStatusEventPolicy {
+    if provider_name == "claude" || provider_name == "codex" {
+        ProviderStatusEventPolicy::PreserveActionRequired
+    } else {
+        ProviderStatusEventPolicy::Normal
+    }
+}
+
+fn line_event_status_for_pty_provider(
+    provider_name: &str,
+    current_status: &str,
+    event: &AgentEvent,
+) -> Option<&'static str> {
+    provider_status_from_event(
+        current_status,
+        event,
+        pty_status_event_policy_for_provider(provider_name),
+    )
 }
 
 fn filter_ignored_conversation_id(
@@ -583,29 +606,23 @@ pub async fn spawn_agent(
                     // Use a simple line-based approach for stream-json events
                     for line in text.lines() {
                         if let Some(event) = pty_provider.parse_output(line) {
-                            match event {
-                                AgentEvent::Init {
+                            if provider_name_for_pty == "claude" {
+                                if let AgentEvent::Init {
                                     session_id,
                                     timestamp,
-                                } => {
+                                } = &event
+                                {
                                     if let Some(ts) = timestamp {
                                         let mut it = init_timestamp_clone.lock().unwrap();
                                         if it.is_none() {
-                                            *it = Some(ts);
+                                            *it = Some(ts.clone());
                                         }
                                     }
                                     if !session_id.trim().is_empty() {
                                         let needs_save = {
                                             let mut config = config_lock_clone.lock().unwrap();
-                                            if capture_codex_init_resume_session(
-                                                &provider_name_for_pty,
-                                                &session_id,
-                                                &mut config,
-                                            ) {
-                                                true
-                                            } else if provider_name_for_pty != "codex"
-                                                && config.resume_session.as_deref()
-                                                    != Some(&session_id)
+                                            if config.resume_session.as_deref()
+                                                != Some(session_id.as_str())
                                             {
                                                 config.resume_session = Some(session_id.clone());
                                                 true
@@ -618,8 +635,6 @@ pub async fn spawn_agent(
                                                 "[Wardian] Session ID mapped for {}: {}",
                                                 sid_for_pty, session_id
                                             ));
-
-                                            // Notify UI that metadata (resume_session ID) has changed
                                             let _ = pty_emit_app.emit("agents-updated", ());
                                             let _ = pty_emit_app.emit(
                                                 "agent-pty-output-ready",
@@ -629,39 +644,77 @@ pub async fn spawn_agent(
                                         }
                                     }
                                 }
-                                AgentEvent::ActionRequired { message: _ } => {
-                                    set_agent_status(
-                                        &pty_app,
-                                        &sid_for_pty,
-                                        &current_status_clone,
-                                        "Action Needed",
-                                    );
+                                apply_agent_status_event_with_policy(
+                                    &pty_app,
+                                    &sid_for_pty,
+                                    event,
+                                    &current_status_clone,
+                                    ProviderStatusEventPolicy::PreserveActionRequired,
+                                );
+                                continue;
+                            }
+
+                            if let AgentEvent::Init {
+                                session_id,
+                                timestamp,
+                            } = &event
+                            {
+                                if let Some(ts) = timestamp {
+                                    let mut it = init_timestamp_clone.lock().unwrap();
+                                    if it.is_none() {
+                                        *it = Some(ts.clone());
+                                    }
                                 }
-                                AgentEvent::ModelResponse => {
-                                    set_agent_status(
-                                        &pty_app,
-                                        &sid_for_pty,
-                                        &current_status_clone,
-                                        "Idle",
-                                    );
+                                if !session_id.trim().is_empty() {
+                                    let needs_save = {
+                                        let mut config = config_lock_clone.lock().unwrap();
+                                        if capture_codex_init_resume_session(
+                                            &provider_name_for_pty,
+                                            session_id,
+                                            &mut config,
+                                        ) {
+                                            true
+                                        } else if provider_name_for_pty != "codex"
+                                            && config.resume_session.as_deref()
+                                                != Some(session_id.as_str())
+                                        {
+                                            config.resume_session = Some(session_id.clone());
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    };
+                                    if needs_save {
+                                        log_debug(&format!(
+                                            "[Wardian] Session ID mapped for {}: {}",
+                                            sid_for_pty, session_id
+                                        ));
+
+                                        // Notify UI that metadata (resume_session ID) has changed
+                                        let _ = pty_emit_app.emit("agents-updated", ());
+                                        let _ = pty_emit_app.emit(
+                                            "agent-pty-output-ready",
+                                            serde_json::json!({ "session_id": sid_for_pty }),
+                                        );
+                                        save_agent_state_after_session_capture(&pty_emit_app);
+                                    }
                                 }
-                                AgentEvent::TurnCompleted => {
-                                    set_agent_status(
-                                        &pty_app,
-                                        &sid_for_pty,
-                                        &current_status_clone,
-                                        "Idle",
-                                    );
-                                }
-                                AgentEvent::UserQuery | AgentEvent::Generating => {
-                                    set_agent_status(
-                                        &pty_app,
-                                        &sid_for_pty,
-                                        &current_status_clone,
-                                        "Processing...",
-                                    );
-                                }
-                                _ => {}
+                            }
+                            let current = current_status_clone
+                                .lock()
+                                .map(|status| status.clone())
+                                .unwrap_or_default();
+                            if let Some(next_status) = line_event_status_for_pty_provider(
+                                &provider_name_for_pty,
+                                &current,
+                                &event,
+                            ) {
+                                set_agent_status(
+                                    &pty_app,
+                                    &sid_for_pty,
+                                    &current_status_clone,
+                                    next_status,
+                                );
                             }
                         }
                     }
@@ -815,18 +868,22 @@ pub async fn spawn_agent(
                                             }
                                         }
 
-                                        // Claude uses a dedicated log watcher for status, so
-                                        // only capture Init timestamps from its PTY JSON.
-                                        if provider_name_for_pty != "claude" {
-                                            apply_agent_event(
-                                                &pty_app,
-                                                &sid_for_pty,
-                                                event,
-                                                &query_count_clone,
-                                                &init_timestamp_clone,
-                                                &current_status_clone,
-                                            );
-                                        }
+                                        let status_policy = if provider_name_for_pty == "claude"
+                                            || provider_name_for_pty == "codex"
+                                        {
+                                            ProviderStatusEventPolicy::PreserveActionRequired
+                                        } else {
+                                            ProviderStatusEventPolicy::Normal
+                                        };
+                                        apply_agent_event_with_policy(
+                                            &pty_app,
+                                            &sid_for_pty,
+                                            event,
+                                            &query_count_clone,
+                                            &init_timestamp_clone,
+                                            &current_status_clone,
+                                            status_policy,
+                                        );
                                     }
                                     let _ = pty_emit_app.emit("agent-json-event", serde_json::json!({ "session_id": sid_out, "data": parsed }));
                                     let consumed = stream.byte_offset();
@@ -960,13 +1017,14 @@ pub async fn spawn_agent(
                                         }
                                     }
                                     if let Some(event) = watcher_provider.parse_output(&raw_line) {
-                                        apply_agent_event(
+                                        apply_agent_event_with_policy(
                                             &watcher_app,
                                             &watcher_session,
                                             event,
                                             &watcher_query_count,
                                             &watcher_init_timestamp,
                                             &watcher_current_status,
+                                            ProviderStatusEventPolicy::PreserveActionRequired,
                                         );
                                     }
                                     let _ = watcher_app.emit(
@@ -1488,6 +1546,32 @@ mod tests {
     fn restored_spawns_skip_stale_process_scan() {
         assert!(!should_cleanup_stale_session_processes_before_spawn(true));
         assert!(should_cleanup_stale_session_processes_before_spawn(false));
+    }
+
+    #[test]
+    fn codex_line_status_preserves_action_needed_until_completion() {
+        assert_eq!(
+            line_event_status_for_pty_provider(
+                "codex",
+                "Idle",
+                &AgentEvent::ActionRequired {
+                    message: "approve command".to_string(),
+                },
+            ),
+            Some("Action Needed")
+        );
+        assert_eq!(
+            line_event_status_for_pty_provider("codex", "Action Needed", &AgentEvent::Generating),
+            None
+        );
+        assert_eq!(
+            line_event_status_for_pty_provider(
+                "codex",
+                "Action Needed",
+                &AgentEvent::TurnCompleted,
+            ),
+            Some("Idle")
+        );
     }
 
     #[test]

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -414,6 +414,16 @@ fn set_snapshot_status_from_log(snap: &AgentSnapshot, next_status: &str, is_init
     set_snapshot_status(snap, next_status);
 }
 
+fn apply_claude_log_status(
+    snap: &AgentSnapshot,
+    lines: &[serde_json::Value],
+    is_initial_replay: bool,
+) {
+    if let Some(status) = claude_status_from_log(lines) {
+        set_snapshot_status_from_log(snap, &status, is_initial_replay);
+    }
+}
+
 fn record_opencode_assistant_text(snap: &AgentSnapshot, session_id: &str, text: &str) {
     let text = text.trim();
     if text.is_empty() {
@@ -1005,19 +1015,7 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                                         }
                                     }
 
-                                    let current_status_snap =
-                                        snap.current_status.lock().unwrap().clone();
-                                    if !current_status_snap.starts_with("Action Required")
-                                        && !current_status_snap.starts_with("Action Needed")
-                                    {
-                                        if let Some(status) = claude_status_from_log(&lines) {
-                                            set_snapshot_status_from_log(
-                                                snap,
-                                                &status,
-                                                is_initial_log_replay,
-                                            );
-                                        }
-                                    }
+                                    apply_claude_log_status(snap, &lines, is_initial_log_replay);
                                 }
                                 "opencode" => {
                                     let mut status = snap.current_status.lock().unwrap().clone();
@@ -1473,6 +1471,38 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("idle")
         );
+    }
+
+    #[test]
+    fn claude_log_status_can_clear_stale_action_needed() {
+        let snap = test_snapshot("Action Needed");
+        let lines = vec![
+            serde_json::json!({
+                "type": "user",
+                "message": { "role": "user", "content": "Run a tool" }
+            }),
+            serde_json::json!({
+                "type": "system",
+                "subtype": "permission_request",
+                "tool_name": "Bash"
+            }),
+            serde_json::json!({
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [{
+                        "type": "tool_result",
+                        "tool_use_id": "tool-1",
+                        "content": "ok"
+                    }]
+                }
+            }),
+            serde_json::json!({ "type": "system", "subtype": "turn_duration" }),
+        ];
+
+        super::apply_claude_log_status(&snap, &lines, false);
+
+        assert_eq!(*snap.current_status.lock().unwrap(), "Idle");
     }
 
     #[test]

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -207,6 +207,16 @@ impl AgentProvider for AntigravityProvider {
     }
 
     fn parse_output(&self, line: &str) -> Option<AgentEvent> {
+        let trimmed = line.trim();
+        if trimmed.contains("Do you trust the contents of this project?")
+            || trimmed.contains("requires permission to read, edit, and execute files here")
+            || trimmed.contains("Requesting permission for:")
+        {
+            return Some(AgentEvent::ActionRequired {
+                message: "Antigravity permission required".to_string(),
+            });
+        }
+
         let parsed: serde_json::Value = serde_json::from_str(line).ok()?;
         match parsed.get("type").and_then(|value| value.as_str()) {
             Some("USER_INPUT") => Some(AgentEvent::UserQuery),
@@ -345,6 +355,17 @@ mod tests {
                 .unwrap(),
             AgentEvent::TurnCompleted
         );
+    }
+
+    #[test]
+    fn parse_output_detects_workspace_trust_prompt_as_action_required() {
+        let provider = make_provider();
+        let line = "Do you trust the contents of this project? Antigravity CLI requires permission to read, edit, and execute files here.";
+
+        assert!(matches!(
+            provider.parse_output(line),
+            Some(AgentEvent::ActionRequired { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Description
Stabilizes Wardian agent status transitions for real provider action gates.

This PR:
- preserves unresolved `Action Needed` states until explicit completion events instead of allowing generic activity to clear them;
- applies live status evidence from Claude/Codex streams and Codex log replay with the same action-preserving policy;
- sends provider-specific approval bytes for live `action_required` targets;
- lets Claude idle status bypass stale provider-input readiness only for live-only sends;
- detects Antigravity trust/permission terminal prompts as `ActionRequired`;
- documents the provider status transition decision in `docs/specs/`.

Wardian-Reviewer completed final packaging review with no findings and marked the branch clear for PR.

## Related Issues
Fixes #472

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Real-provider E2E was run with isolated `WARDIAN_HOME` and temp workspaces so existing Wardian agents were not affected.

Real-provider artifacts:
- Codex: `target/status-probe/real-codex-action-2026-05-31T23-12-46-975Z.json`
  - observed `idle -> processing -> action_required`, approval accepted, then `processing -> idle`, placeholder file written.
- Antigravity: `target/status-probe/real-antigravity-trust-2026-05-31T23-24-07-590Z.json`
  - observed trust prompt become `action_required`, approval accepted, then `processing -> idle`.
- Claude: `target/status-probe/real-claude-action2-2026-05-31T23-20-54-103Z.json`
  - observed `idle -> processing -> idle`, placeholder file written; local Claude completed without a permission gate, but the stale-readiness live-send bug was reproduced and fixed.

Fresh verification after rebasing onto current `origin/main`:
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo test` (804 lib tests plus integration/doc test suites)
- `npm run lint`
- `npm run test` (101 files / 911 tests; existing React `act(...)` and mocked readiness warnings only)
- `npm run build`
- `git diff --check origin/main...HEAD`
- committed-patch secrets scan returned no matches

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable