### PR TITLE
test(e2e): default visual captures to fullscreen

### DIFF
--- a/docs/developer/native-e2e.md
+++ b/docs/developer/native-e2e.md
@@ -158,12 +158,12 @@ When terminal history exists, the lab also captures `<state>-scrollback-top` and
 Useful tuning variables:
 
 ```bash
-WARDIAN_E2E_RENDERING_WINDOW_WIDTH=1280
-WARDIAN_E2E_RENDERING_WINDOW_HEIGHT=1100
+WARDIAN_E2E_RENDERING_WINDOW_WIDTH=1920
+WARDIAN_E2E_RENDERING_WINDOW_HEIGHT=1080
 WARDIAN_E2E_RENDERING_RESIZED_WIDTH=980
 WARDIAN_E2E_RENDERING_RESIZED_HEIGHT=980
-WARDIAN_E2E_RENDERING_WIDE_WIDTH=1440
-WARDIAN_E2E_RENDERING_WIDE_HEIGHT=1100
+WARDIAN_E2E_RENDERING_WIDE_WIDTH=1920
+WARDIAN_E2E_RENDERING_WIDE_HEIGHT=1080
 WARDIAN_E2E_RENDERING_RAPID_SEQUENCE=1040x900,1320x1040,1160x980,980x980
 WARDIAN_E2E_RENDERING_ROW_HEIGHT=900
 WARDIAN_E2E_TERMINAL_FONT_SIZE=10
@@ -178,6 +178,8 @@ WARDIAN_E2E_RENDERING_CODEX_MODEL=<optional-codex-model>
 WARDIAN_E2E_RENDERING_CLAUDE_MODEL=<optional-claude-model>
 WARDIAN_E2E_RENDERING_OPENCODE_MODEL=opencode/deepseek-v4-flash-free
 ```
+
+The default `initial`, `settled`, and `wide` visual states use a 1920x1080 desktop window so PR evidence resembles a normal fullscreen desktop. Keep the smaller `resized`, `narrow`, rapid-resize, geometry sweep, and outside-terminal sizes when the test is deliberately proving wrapping, cramped layout, or resize behavior.
 
 The lab sends the configured input text as PTY keystrokes and, by default, submits it with carriage return (`\r`). This is intentional: the real-provider run must create actual conversation history before resize, scrollback, clear, pause, and resume evidence is captured. When `WARDIAN_E2E_RENDERING_INPUT_TEXT` is unset, the default prompt asks the provider to print 50 numbered lines from `WARDIAN_SCROLL_001` through `WARDIAN_SCROLL_050`, and the expected response marker defaults to `WARDIAN_SCROLL_050`. For custom deterministic history checks, make the input text ask for a short marker and set `WARDIAN_E2E_RENDERING_EXPECT_RESPONSE_TEXT` to that marker. Set `WARDIAN_E2E_RENDERING_SUBMIT_INPUT=0` only when intentionally inspecting prompt-editing behavior without a completed provider turn.
 

--- a/docs/developer/screenshot-documentation.md
+++ b/docs/developer/screenshot-documentation.md
@@ -41,7 +41,8 @@ Use alt text that describes the visible state. Avoid vague labels such as `Scree
 - Capture real Wardian UI with seeded or sanitized data.
 - Keep screenshots feature-specific. Avoid generic empty-window captures.
 - Hide or avoid local usernames, absolute paths, API keys, provider tokens, and private repository names.
-- Capture the smallest useful app region or viewport that still shows the interaction clearly.
+- For PR visual evidence, prefer a 1920x1080 desktop viewport or native window so the screenshot resembles a normal fullscreen desktop.
+- Use smaller viewports, cropped regions, or component screenshots only when the screenshot is deliberately proving responsive behavior, cramped layout, resize behavior, or a specific detail that would be harder to see fullscreen.
 - Prefer PNG for UI screenshots.
 - Compress large images before committing.
 - Refresh screenshots in the same PR when a visual change makes existing documentation images stale.

--- a/docs/specs/2026-06-01-fullscreen-e2e-visual-defaults.md
+++ b/docs/specs/2026-06-01-fullscreen-e2e-visual-defaults.md
@@ -1,0 +1,31 @@
+# Fullscreen E2E Visual Defaults
+
+- **Status:** Accepted
+- **Date:** 2026-06-01
+- **Decider:** Tan Gemicioglu
+
+## Context
+
+Wardian's automated screenshot and E2E evidence paths historically used a mix of default browser viewport sizes and hand-picked native window sizes such as 1280x720, 1280x1100, 1440x1100, and 980x980. These sizes are useful for deterministic layout coverage, but screenshots used as PR evidence can look slightly different from what users inspect on a normal desktop display.
+
+## Decision
+
+Default visual E2E evidence should use a 1920x1080 desktop viewport or native window unless the test is explicitly about a different size.
+
+Browser E2E now sets Playwright's default viewport to 1920x1080 and keeps environment overrides through `WARDIAN_E2E_VIEWPORT_WIDTH` and `WARDIAN_E2E_VIEWPORT_HEIGHT`.
+
+The real-provider native rendering lab now uses 1920x1080 for its main visual states: `initial`, `settled`, and `wide`. It keeps smaller configured sizes for `narrow`, `resized`, rapid-resize, geometry sweep, outside-terminal parity, and cropped/component evidence because those paths intentionally test wrapping, constrained layouts, terminal geometry, or focused details.
+
+## Consequences
+
+- PR screenshot evidence is closer to a normal fullscreen desktop inspection.
+- Existing resize and cramped-layout coverage is preserved through explicit non-fullscreen probes.
+- CI and local runs can still override dimensions when a display, runner, or remote desktop cannot provide 1920x1080 reliably.
+- Fullscreen defaults may increase screenshot artifact size slightly.
+
+## Verification
+
+The default sizes are covered by focused tests:
+
+- `src/config/e2eViewportDefaults.test.ts` checks the browser E2E viewport default and override knobs.
+- `e2e-native/tests/rendering-audit-options.test.mjs` checks the real-provider rendering lab's main visual default sizes and preserves the deliberate resized dimensions.

--- a/e2e-native/tests/real-provider-rendering-native.test.mjs
+++ b/e2e-native/tests/real-provider-rendering-native.test.mjs
@@ -40,12 +40,12 @@ const auditInputRepeatCount = Math.max(
   1,
   Number.parseInt(process.env.WARDIAN_E2E_RENDERING_INPUT_REPEAT_COUNT ?? "1", 10) || 1,
 );
-const auditWindowWidth = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_WINDOW_WIDTH ?? "1280", 10);
-const auditWindowHeight = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_WINDOW_HEIGHT ?? "1100", 10);
+const auditWindowWidth = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_WINDOW_WIDTH ?? "1920", 10);
+const auditWindowHeight = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_WINDOW_HEIGHT ?? "1080", 10);
 const auditResizedWindowWidth = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_RESIZED_WIDTH ?? "980", 10);
 const auditResizedWindowHeight = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_RESIZED_HEIGHT ?? "980", 10);
-const auditWideWindowWidth = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_WIDE_WIDTH ?? "1440", 10);
-const auditWideWindowHeight = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_WIDE_HEIGHT ?? "1100", 10);
+const auditWideWindowWidth = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_WIDE_WIDTH ?? "1920", 10);
+const auditWideWindowHeight = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_WIDE_HEIGHT ?? "1080", 10);
 const auditStableRowsQuietMs = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_STABLE_ROWS_QUIET_MS ?? "750", 10);
 const auditSettleTimeoutMs = Number.parseInt(process.env.WARDIAN_E2E_RENDERING_SETTLE_TIMEOUT_MS ?? "10000", 10);
 const auditProviderTurnTimeoutMs = Number.parseInt(

--- a/e2e-native/tests/rendering-audit-options.test.mjs
+++ b/e2e-native/tests/rendering-audit-options.test.mjs
@@ -1292,6 +1292,20 @@ test("real-provider Wardian capture records DOM terminal geometry", () => {
   assert.match(testSource, /computedStyle/);
 });
 
+test("real-provider Wardian capture defaults main visual states to 1920x1080", () => {
+  const testSource = fs.readFileSync(
+    path.join(process.cwd(), "e2e-native", "tests", "real-provider-rendering-native.test.mjs"),
+    "utf8",
+  );
+
+  assert.match(testSource, /WARDIAN_E2E_RENDERING_WINDOW_WIDTH \?\? "1920"/);
+  assert.match(testSource, /WARDIAN_E2E_RENDERING_WINDOW_HEIGHT \?\? "1080"/);
+  assert.match(testSource, /WARDIAN_E2E_RENDERING_WIDE_WIDTH \?\? "1920"/);
+  assert.match(testSource, /WARDIAN_E2E_RENDERING_WIDE_HEIGHT \?\? "1080"/);
+  assert.match(testSource, /WARDIAN_E2E_RENDERING_RESIZED_WIDTH \?\? "980"/);
+  assert.match(testSource, /WARDIAN_E2E_RENDERING_RESIZED_HEIGHT \?\? "980"/);
+});
+
 test("real-provider Wardian capture waits for provider input readiness and visible fixed input", () => {
   const testSource = fs.readFileSync(
     path.join(process.cwd(), "e2e-native", "tests", "real-provider-rendering-native.test.mjs"),

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,6 +7,12 @@ const e2ePort = Number.parseInt(process.env.WARDIAN_E2E_PORT ?? "1420", 10);
 const e2eHost = process.env.WARDIAN_E2E_HOST ?? "127.0.0.1";
 const baseURL = process.env.WARDIAN_E2E_BASE_URL ?? `http://${e2eHost}:${e2ePort}`;
 const reuseExistingServer = process.env.WARDIAN_E2E_REUSE_SERVER !== "0";
+const parsedViewportWidth = Number.parseInt(process.env.WARDIAN_E2E_VIEWPORT_WIDTH ?? "1920", 10);
+const parsedViewportHeight = Number.parseInt(process.env.WARDIAN_E2E_VIEWPORT_HEIGHT ?? "1080", 10);
+const e2eViewport = {
+  width: Number.isFinite(parsedViewportWidth) && parsedViewportWidth > 0 ? parsedViewportWidth : 1920,
+  height: Number.isFinite(parsedViewportHeight) && parsedViewportHeight > 0 ? parsedViewportHeight : 1080,
+};
 
 export default defineConfig({
   testDir: "./tests",
@@ -18,6 +24,7 @@ export default defineConfig({
 
   use: {
     baseURL,
+    viewport: e2eViewport,
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
   },

--- a/src/config/e2eViewportDefaults.test.ts
+++ b/src/config/e2eViewportDefaults.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("browser E2E viewport defaults", () => {
+  test("uses a fullscreen desktop viewport by default with env overrides", () => {
+    const config = readFileSync(resolve("e2e/playwright.config.ts"), "utf8");
+
+    expect(config).toContain("WARDIAN_E2E_VIEWPORT_WIDTH");
+    expect(config).toContain("WARDIAN_E2E_VIEWPORT_HEIGHT");
+    expect(config).toContain('?? "1920"');
+    expect(config).toContain('?? "1080"');
+    expect(config).toMatch(/viewport:\s*e2eViewport/);
+  });
+});


### PR DESCRIPTION
## Description
Default automated visual evidence now uses a 1920x1080 desktop surface when the test is not intentionally exercising another size.

This updates browser E2E to set a 1920x1080 viewport with `WARDIAN_E2E_VIEWPORT_WIDTH` / `WARDIAN_E2E_VIEWPORT_HEIGHT` overrides, and updates the native real-provider rendering lab's main visual states to 1920x1080 while preserving the deliberate resized/narrow/rapid geometry probes.

## Related Issues
Fixes #480

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run test -- src/config/e2eViewportDefaults.test.ts` (red before implementation, green after)
- `node --test e2e-native/tests/rendering-audit-options.test.mjs --test-name-pattern "defaults main visual states"` (red before implementation, green after)
- `node --test e2e-native/tests/rendering-audit-options.test.mjs`
- `npm run lint`
- `npm run test`
- `npm run build`
- `cargo check`
- `cargo test`
- `cargo clippy`
- `npm run check:frontend-screenshot` (no frontend app UI changes detected; screenshot evidence not required)
- `npm run docs:check-llms`
- `npm run docs:build`
- `git diff --check`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable