### PR TITLE
fix(explorer): refresh file tree from filesystem changes

### DIFF
--- a/docs/developer/explorer-sidebar.md
+++ b/docs/developer/explorer-sidebar.md
@@ -11,12 +11,14 @@ The Explorer Sidebar is a dedicated panel found in the Wardian sidebar (`Sidebar
 This is the main container component for the file explorer tab.
 - **Root Resolution**: It queries the backend command `get_explorer_root(sessionId)` to identify which path to render.
 - **File Click Action**: It receives file selections from `FileTree` and routes them through the Settings-backed `explorerFileClickAction` preference. Preview mode uses `read_file_preview`; external mode reuses `open_in_external_editor`.
+- **Filesystem Watch Refresh**: While mounted, the panel subscribes to `explorer-changed`, starts `explorer_watch` for the current root after the listener is ready, and calls `explorer_unwatch` on cleanup. Matching events increment a refresh token and carry changed paths down to `FileTree`.
 - **Context Menu Context**: Provides right-click operations tailored to `FileTree` items (Open Preview, Open in External App, Reveal in OS, Copy Absolute Path, Delete).
 - **Preview Modal**: Implements a themed modal overlay to securely display raw text file contents queried from the OS.
 
 ### 2. `FileTree.tsx`
 A recursive, lazy-loading component responsible for accurately representing nested directory structures.
 - **Lazy Loading**: Instead of indexing the entire workspace at once, it fetches child nodes only when a directory is expanded, ensuring optimal performance for large projects.
+- **Targeted Refresh**: Each mounted tree refetches its directory when the refresh token changes and one of the changed paths directly affects that directory. Expanded state stays local to the component, so refreshes do not collapse the visible tree.
 - **Theming**: Integrates seamlessly with Wardian typography and spacing. Nested items have fixed padding metrics to align correctly underneath parent elements without succumbing to horizontal flex contraction (`shrink-0`). Directory rows use only their expansion chevron; file rows use `lucide-react` icons with colors mapped explicitly to `wardian-*` CSS variables based on file extensions.
 
 ### 3. Backend Commands (`src-tauri/src/commands/fs.rs`)
@@ -27,6 +29,7 @@ The file system operations strictly enforce security and platform agnosticism:
 - `reveal_in_explorer`: OS-specific `std::process::Command` routing to invoke `explorer`, `open`, or `xdg-open`.
 - `open_in_external_editor`: Opens a path with the Settings-selected external app mode (`system`, `vscode`, or `custom`) by spawning the platform command in Rust.
 - `delete_file`: Recursively deletes a directory or permanently removes a file string.
+- `explorer_watch` / `explorer_unwatch`: Manage debounced recursive filesystem watchers for active explorer roots. Watchers are reference-counted by root and exclude high-churn folders such as `.git`, `node_modules`, `target`, `.venv`, `dist`, `build`, `.next`, `.turbo`, `.cache`, and `.wardian/tmp`.
 
 ## Technical Decisions
 - **`Option<String>` vs Strict Strings**: Using `null` / `Option` for Session IDs enables elegant toggling between global and localized modes without parallel commands.

--- a/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
+++ b/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
@@ -1,0 +1,39 @@
+# Explorer Filesystem Watch Refresh
+
+* **Status:** Accepted
+* **Date:** 2026-06-02
+* **Decider:** User, Codex
+
+## Context
+
+The Explorer sidebar lazy-loads directory contents with `get_directory_tree`.
+Mounted directory components only refetch when their `path` changes, so files
+created, deleted, renamed, or modified by agents, terminals, editors, and other
+external processes can leave the visible tree stale.
+
+Polling would work, but developer tools generally model file updates as
+filesystem events. VS Code uses recursive and non-recursive watchers with
+deduplication and excludes, falling back to polling only in limited missing-path
+cases. Obsidian exposes vault create, modify, delete, and rename events to
+plugins.
+
+## Decision
+
+Explorer will use a backend Tauri filesystem watcher for the active explorer
+root. The watcher emits debounced `explorer-changed` events with the root and
+changed paths. The frontend subscribes while the Explorer panel is mounted and
+refreshes only mounted lazy tree branches affected by the event.
+
+The watcher excludes high-churn implementation folders such as `.git`,
+`node_modules`, `target`, `.venv`, `dist`, `build`, `.next`, `.turbo`,
+`.cache`, and `.wardian/tmp`.
+
+## Consequences
+
+* Visible explorer directories update without manual tab switching or polling.
+* Expanded folders and scroll position are preserved because the root tree is
+  not remounted for ordinary refreshes.
+* Idle CPU cost is lower than polling, with a small watcher handle and memory
+  cost while Explorer is mounted.
+* Large generated-file bursts are debounced and partially filtered, but watcher
+  behavior can still vary across platforms and network filesystems.

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1,8 +1,19 @@
-use serde::Deserialize;
+use crate::state::{AppState, ExplorerWatchRegistration};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Emitter};
 use wardian_core::models::AgentConfig;
 use wardian_core::models::FileNode;
+
+const EXPLORER_WATCH_DEBOUNCE_MS: u64 = 150;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExplorerChangedPayload {
+    pub root_path: String,
+    pub changed_paths: Vec<String>,
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ExternalEditorLaunchSettings {
@@ -14,6 +25,69 @@ pub struct ExternalEditorLaunchSettings {
 struct ExternalEditorLaunchSpec {
     program: String,
     args: Vec<String>,
+}
+
+fn normalize_explorer_watch_key(path: &Path) -> Result<String, String> {
+    let absolute = match path.canonicalize() {
+        Ok(path) => path,
+        Err(_) if path.is_absolute() => path.to_path_buf(),
+        Err(error) => {
+            let current_dir = std::env::current_dir().map_err(|cwd_error| {
+                format!(
+                    "Failed to resolve explorer watch root {}: {}; current_dir failed: {}",
+                    path.display(),
+                    error,
+                    cwd_error
+                )
+            })?;
+            current_dir.join(path)
+        }
+    };
+    let normalized = absolute.to_string_lossy().replace('\\', "/");
+    Ok(if cfg!(windows) {
+        normalized.to_lowercase()
+    } else {
+        normalized
+    })
+}
+
+fn is_explorer_watch_excluded(path: &Path) -> bool {
+    let mut previous: Option<String> = None;
+    for segment in path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+    {
+        let lower = segment.to_ascii_lowercase();
+        if matches!(
+            lower.as_str(),
+            ".git"
+                | "node_modules"
+                | "target"
+                | ".venv"
+                | "dist"
+                | "build"
+                | ".next"
+                | ".turbo"
+                | ".cache"
+        ) {
+            return true;
+        }
+        if previous.as_deref() == Some(".wardian") && lower == "tmp" {
+            return true;
+        }
+        previous = Some(lower);
+    }
+    false
+}
+
+fn event_paths(event: notify::Event) -> Vec<PathBuf> {
+    let mut paths = BTreeSet::new();
+    for path in event.paths {
+        if !is_explorer_watch_excluded(&path) {
+            paths.insert(path);
+        }
+    }
+    paths.into_iter().collect()
 }
 
 fn resolve_agent_visible_workspace(config: &AgentConfig) -> String {
@@ -92,6 +166,122 @@ pub async fn get_directory_tree(path: String) -> Result<Vec<FileNode>, String> {
     nodes.sort_by(|a, b| b.is_dir.cmp(&a.is_dir).then(a.name.cmp(&b.name)));
 
     Ok(nodes)
+}
+
+#[tauri::command]
+pub async fn explorer_watch(
+    root_path: String,
+    app: AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let root = PathBuf::from(&root_path);
+    if !root.is_dir() {
+        return Err(format!(
+            "Explorer watch root does not exist or is not a directory: {}",
+            root_path
+        ));
+    }
+
+    let watch_key = normalize_explorer_watch_key(&root)?;
+    let mut registrations = state.explorer_watchers.lock().await;
+    if let Some(registration) = registrations.get_mut(&watch_key) {
+        registration.ref_count += 1;
+        return Ok(());
+    }
+
+    let canonical_root = root.canonicalize().map_err(|e| {
+        format!(
+            "Failed to resolve explorer watch root {}: {}",
+            root.display(),
+            e
+        )
+    })?;
+    let emitted_root = root_path.clone();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Vec<PathBuf>>();
+
+    let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if let Ok(event) = res {
+            let paths = event_paths(event);
+            if !paths.is_empty() {
+                let _ = tx.send(paths);
+            }
+        }
+    })
+    .map_err(|e| e.to_string())?;
+
+    notify::Watcher::watch(
+        &mut watcher,
+        &canonical_root,
+        notify::RecursiveMode::Recursive,
+    )
+    .map_err(|e| e.to_string())?;
+
+    registrations.insert(
+        watch_key,
+        ExplorerWatchRegistration {
+            watcher,
+            ref_count: 1,
+        },
+    );
+    drop(registrations);
+
+    let app_handle = app.clone();
+    tokio::spawn(async move {
+        loop {
+            let Some(first_paths) = rx.recv().await else {
+                break;
+            };
+            let mut changed_paths = BTreeSet::new();
+            changed_paths.extend(first_paths);
+
+            loop {
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(EXPLORER_WATCH_DEBOUNCE_MS),
+                    rx.recv(),
+                )
+                .await
+                {
+                    Ok(Some(paths)) => {
+                        changed_paths.extend(paths);
+                    }
+                    Ok(None) => return,
+                    Err(_) => break,
+                }
+            }
+
+            let payload = ExplorerChangedPayload {
+                root_path: emitted_root.clone(),
+                changed_paths: changed_paths
+                    .into_iter()
+                    .map(|path| path.to_string_lossy().into_owned())
+                    .collect(),
+            };
+            let _ = app_handle.emit("explorer-changed", payload);
+        }
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn explorer_unwatch(
+    root_path: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<(), String> {
+    let root = PathBuf::from(&root_path);
+    let watch_key = normalize_explorer_watch_key(&root)?;
+    let mut registrations = state.explorer_watchers.lock().await;
+    let Some(registration) = registrations.get_mut(&watch_key) else {
+        return Ok(());
+    };
+
+    if registration.ref_count > 1 {
+        registration.ref_count -= 1;
+    } else {
+        registrations.remove(&watch_key);
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -428,5 +618,39 @@ mod tests {
         assert!(!terminal_link_target_exists(
             missing_path.to_string_lossy().into_owned()
         ));
+    }
+
+    #[test]
+    fn explorer_watch_excludes_high_churn_paths() {
+        assert!(is_explorer_watch_excluded(Path::new("/repo/.git/index")));
+        assert!(is_explorer_watch_excluded(Path::new(
+            "/repo/node_modules/pkg/index.js"
+        )));
+        assert!(is_explorer_watch_excluded(Path::new(
+            "/repo/target/debug/app"
+        )));
+        assert!(is_explorer_watch_excluded(Path::new(
+            "/repo/.wardian/tmp/cache"
+        )));
+        assert!(!is_explorer_watch_excluded(Path::new("/repo/src/main.ts")));
+    }
+
+    #[test]
+    fn explorer_watch_key_normalizes_existing_paths() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let key = normalize_explorer_watch_key(temp.path()).expect("watch key");
+
+        assert!(!key.contains('\\'));
+        assert!(key.contains('/'));
+    }
+
+    #[test]
+    fn explorer_watch_key_normalizes_missing_absolute_paths() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let missing = temp.path().join("deleted-before-unwatch");
+        let key = normalize_explorer_watch_key(&missing).expect("watch key");
+
+        assert!(!key.contains('\\'));
+        assert!(key.ends_with("/deleted-before-unwatch"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -411,6 +411,8 @@ pub fn run() {
             commands::fs::validate_directory_path,
             commands::fs::get_explorer_root,
             commands::fs::get_directory_tree,
+            commands::fs::explorer_watch,
+            commands::fs::explorer_unwatch,
             commands::fs::delete_file,
             commands::fs::reveal_in_explorer,
             commands::fs::open_in_external_editor,

--- a/src-tauri/src/state/app_state.rs
+++ b/src-tauri/src/state/app_state.rs
@@ -15,6 +15,11 @@ pub struct LibraryWatchRegistration {
     pub watched_paths: Vec<PathBuf>,
 }
 
+pub struct ExplorerWatchRegistration {
+    pub watcher: notify::RecommendedWatcher,
+    pub ref_count: usize,
+}
+
 pub struct AppState {
     // Map of session_id to ActiveAgent
     pub agents: Mutex<HashMap<String, ActiveAgent>>,
@@ -40,6 +45,8 @@ pub struct AppState {
     pub git_watchers: Mutex<HashMap<String, notify::RecommendedWatcher>>,
     // Active library watchers keyed by library type, shared by mounted UI consumers
     pub library_watchers: Mutex<HashMap<String, LibraryWatchRegistration>>,
+    // Active explorer root watchers keyed by normalized root path
+    pub explorer_watchers: Mutex<HashMap<String, ExplorerWatchRegistration>>,
     // Single standalone terminal session for the human user.
     pub user_terminal: Mutex<Option<crate::state::UserTerminalSession>>,
     // Live-only structured ask/reply requests keyed by backend-owned request id.
@@ -123,6 +130,7 @@ impl Default for AppState {
             workflow_schedules_paused: std::sync::atomic::AtomicBool::new(false),
             git_watchers: Mutex::new(HashMap::new()),
             library_watchers: Mutex::new(HashMap::new()),
+            explorer_watchers: Mutex::new(HashMap::new()),
             user_terminal: Mutex::new(None),
             ask_requests: Mutex::new(HashMap::new()),
             interactions: InteractionState::default(),

--- a/src-tauri/src/state/mod.rs
+++ b/src-tauri/src/state/mod.rs
@@ -9,7 +9,7 @@ pub mod user_terminal;
 
 pub use active_agent::ActiveAgent;
 pub use agent_watch::AgentWatchState;
-pub use app_state::{AppState, LibraryWatchRegistration};
+pub use app_state::{AppState, ExplorerWatchRegistration, LibraryWatchRegistration};
 pub use interactions::InteractionState;
 pub use mailbox::{
     MailboxDeliveryPhase, MailboxMessageDraft, MailboxMessageRecord, MailboxMessageStatus,

--- a/src/features/explorer/ExplorerPanel.test.tsx
+++ b/src/features/explorer/ExplorerPanel.test.tsx
@@ -281,7 +281,7 @@ describe('ExplorerPanel', () => {
     let handler: ((event: { payload: { root_path: string; changed_paths: string[] } }) => void) | undefined;
     mockListen.mockImplementation(async (_event, callback) => {
       handler = callback as typeof handler;
-      return vi.fn();
+      return () => {};
     });
     vi.mocked(invoke).mockImplementation(async (command) => {
       if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
@@ -310,7 +310,7 @@ describe('ExplorerPanel', () => {
     let handler: ((event: { payload: { root_path: string; changed_paths: string[] } }) => void) | undefined;
     mockListen.mockImplementation(async (_event, callback) => {
       handler = callback as typeof handler;
-      return vi.fn();
+      return () => {};
     });
     vi.mocked(invoke).mockImplementation(async (command) => {
       if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';

--- a/src/features/explorer/ExplorerPanel.test.tsx
+++ b/src/features/explorer/ExplorerPanel.test.tsx
@@ -1,23 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import type React from 'react';
 import { ExplorerPanel } from './ExplorerPanel';
 import type { AgentConfig } from '../../types';
 import { useSettingsStore } from '../../store/useSettingsStore';
+import { ConfirmProvider } from '../../components/ConfirmDialog';
+
+const mockListen = vi.mocked(listen);
 
 vi.mock('./FileTree', () => ({
   FileTree: ({
     path,
     onContextMenu,
     onSelect,
+    refreshToken,
+    changedPaths,
   }: {
     path: string;
     onContextMenu?: (event: React.MouseEvent, node: unknown) => void;
     onSelect?: (path: string, isDir: boolean) => void;
+    refreshToken?: number;
+    changedPaths?: string[];
   }) => (
     <div data-testid="file-tree">
+      <output data-testid="file-tree-refresh-token">{refreshToken ?? 0}</output>
+      <output data-testid="file-tree-changed-paths">{(changedPaths ?? []).join('|')}</output>
       <button
         type="button"
         data-testid="mock-file-row"
@@ -45,6 +55,7 @@ vi.mock('./FileTree', () => ({
 describe('ExplorerPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockListen.mockResolvedValue(vi.fn());
     useSettingsStore.setState({
       externalEditor: 'system',
       externalEditorCustomExecutable: '',
@@ -240,5 +251,169 @@ describe('ExplorerPanel', () => {
       expect(vi.mocked(invoke).mock.calls.length).toBeGreaterThan(callsBeforeRerender);
       expect(invoke).toHaveBeenCalledWith('get_explorer_root', { sessionId: 'agent-1' });
     });
+  });
+
+  it('starts the explorer watcher only after the change listener is ready', async () => {
+    const unlisten = vi.fn();
+    let resolveListen: ((value: typeof unlisten) => void) | undefined;
+    mockListen.mockReturnValue(new Promise((resolve) => {
+      resolveListen = resolve;
+    }));
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
+      if (command === 'git_status') return { files: [] };
+      return null;
+    });
+
+    render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
+
+    expect(await screen.findByTestId('file-tree')).toBeInTheDocument();
+    expect(invoke).not.toHaveBeenCalledWith('explorer_watch', { rootPath: 'C:\\Users\\test\\repo' });
+
+    resolveListen?.(unlisten);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('explorer_watch', { rootPath: 'C:\\Users\\test\\repo' });
+    });
+  });
+
+  it('passes matching explorer change events to FileTree refresh props', async () => {
+    let handler: ((event: { payload: { root_path: string; changed_paths: string[] } }) => void) | undefined;
+    mockListen.mockImplementation(async (_event, callback) => {
+      handler = callback as typeof handler;
+      return vi.fn();
+    });
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
+      if (command === 'git_status') return { files: [] };
+      return null;
+    });
+
+    render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
+
+    expect(await screen.findByTestId('file-tree-refresh-token')).toHaveTextContent('0');
+
+    await act(async () => {
+      handler?.({
+        payload: {
+          root_path: 'C:\\Users\\test\\repo',
+          changed_paths: ['C:\\Users\\test\\repo\\src\\new-file.ts'],
+        },
+      });
+    });
+
+    expect(await screen.findByTestId('file-tree-refresh-token')).toHaveTextContent('1');
+    expect(screen.getByTestId('file-tree-changed-paths')).toHaveTextContent('C:\\Users\\test\\repo\\src\\new-file.ts');
+  });
+
+  it('ignores explorer change events from other roots', async () => {
+    let handler: ((event: { payload: { root_path: string; changed_paths: string[] } }) => void) | undefined;
+    mockListen.mockImplementation(async (_event, callback) => {
+      handler = callback as typeof handler;
+      return vi.fn();
+    });
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
+      if (command === 'git_status') return { files: [] };
+      return null;
+    });
+
+    render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
+
+    expect(await screen.findByTestId('file-tree-refresh-token')).toHaveTextContent('0');
+
+    await act(async () => {
+      handler?.({
+        payload: {
+          root_path: 'D:\\Other\\repo',
+          changed_paths: ['D:\\Other\\repo\\src\\new-file.ts'],
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('file-tree-refresh-token')).toHaveTextContent('0');
+    });
+  });
+
+  it('stops the explorer watcher and listener on unmount', async () => {
+    const unlisten = vi.fn();
+    mockListen.mockResolvedValue(unlisten);
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
+      if (command === 'git_status') return { files: [] };
+      return null;
+    });
+
+    const { unmount } = render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('explorer_watch', { rootPath: 'C:\\Users\\test\\repo' });
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(unlisten).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith('explorer_unwatch', { rootPath: 'C:\\Users\\test\\repo' });
+    });
+  });
+
+  it('unwatches after a pending explorer watcher resolves if unmounted first', async () => {
+    const unlisten = vi.fn();
+    let resolveWatch: (() => void) | undefined;
+    mockListen.mockResolvedValue(unlisten);
+    vi.mocked(invoke).mockImplementation((command) => {
+      if (command === 'get_explorer_root') return Promise.resolve('C:\\Users\\test\\repo');
+      if (command === 'git_status') return Promise.resolve({ files: [] });
+      if (command === 'explorer_watch') {
+        return new Promise((resolve) => {
+          resolveWatch = () => resolve(null);
+        });
+      }
+      return Promise.resolve(null);
+    });
+
+    const { unmount } = render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('explorer_watch', { rootPath: 'C:\\Users\\test\\repo' });
+    });
+
+    unmount();
+
+    expect(invoke).not.toHaveBeenCalledWith('explorer_unwatch', { rootPath: 'C:\\Users\\test\\repo' });
+
+    await act(async () => {
+      resolveWatch?.();
+    });
+
+    await waitFor(() => {
+      expect(unlisten).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith('explorer_unwatch', { rootPath: 'C:\\Users\\test\\repo' });
+    });
+  });
+
+  it('refreshes the tree after deleting a file without remounting FileTree', async () => {
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
+      if (command === 'git_status') return { files: [] };
+      if (command === 'delete_file') return null;
+      return null;
+    });
+
+    render(
+      <ConfirmProvider>
+        <ExplorerPanel selectedAgentIds={new Set()} agents={[]} />
+      </ConfirmProvider>,
+    );
+
+    const tree = await screen.findByTestId('mock-file-row');
+    await userEvent.pointer({ keys: '[MouseRight]', target: tree });
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Confirm' }));
+
+    expect(await screen.findByTestId('file-tree-refresh-token')).toHaveTextContent('1');
+    expect(screen.getByTestId('file-tree-changed-paths')).toHaveTextContent('C:\\Users\\test\\repo\\notes.md');
   });
 });

--- a/src/features/explorer/ExplorerPanel.tsx
+++ b/src/features/explorer/ExplorerPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { writeText } from '@tauri-apps/plugin-clipboard-manager';
 import { FolderOpen } from 'lucide-react';
 import { FileTree, FileNode } from './FileTree';
@@ -11,6 +12,16 @@ interface ExplorerPanelProps {
   selectedAgentIds: Set<string>;
   agents: AgentConfig[];
 }
+
+interface ExplorerChangedEvent {
+  root_path: string;
+  changed_paths: string[];
+}
+
+const normalizeComparablePath = (path: string): string => {
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/g, '');
+  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+};
 
 const externalEditorLabel = (editor: string) => {
   switch (editor) {
@@ -53,7 +64,8 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
   // Preview Modal State
   const [previewContent, setPreviewContent] = useState<string | null>(null);
   const [previewTitle, setPreviewTitle] = useState<string | null>(null);
-  const [refreshKey, setRefreshKey] = useState(0);
+  const [refreshToken, setRefreshToken] = useState(0);
+  const [changedPaths, setChangedPaths] = useState<string[]>([]);
   const [externalOpenError, setExternalOpenError] = useState<string | null>(null);
 
   const selectedAgentId = selectedAgentIds.size === 1 ? Array.from(selectedAgentIds)[0] : null;
@@ -97,6 +109,43 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
     poll();
     const id = setInterval(poll, 3000);
     return () => { isMounted = false; clearInterval(id); };
+  }, [rootPath]);
+
+  useEffect(() => {
+    if (!rootPath) return;
+
+    let disposed = false;
+    let watchActive = false;
+    const unlistenPromise = listen<ExplorerChangedEvent>('explorer-changed', (event) => {
+      if (normalizeComparablePath(event.payload.root_path) !== normalizeComparablePath(rootPath)) {
+        return;
+      }
+      setChangedPaths(event.payload.changed_paths);
+      setRefreshToken((current) => current + 1);
+    });
+
+    void unlistenPromise
+      .then(async () => {
+        if (disposed) return;
+        await invoke('explorer_watch', { rootPath });
+        watchActive = true;
+        if (disposed) {
+          watchActive = false;
+          invoke('explorer_unwatch', { rootPath }).catch(() => {});
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to watch explorer root:', err);
+      });
+
+    return () => {
+      disposed = true;
+      if (watchActive) {
+        watchActive = false;
+        invoke('explorer_unwatch', { rootPath }).catch(() => {});
+      }
+      unlistenPromise.then((fn) => fn()).catch(() => {});
+    };
   }, [rootPath]);
 
   useEffect(() => {
@@ -206,7 +255,8 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
       if (await confirm(`Are you sure you want to delete ${activeNode.name}?`)) {
         try {
           await invoke('delete_file', { path: activeNode.path });
-          setRefreshKey(prev => prev + 1); // trigger remount of root FileTree
+          setChangedPaths([activeNode.path]);
+          setRefreshToken((current) => current + 1);
         } catch (err) {
           console.error("Delete failed:", err);
           alert(`Failed to delete: ${err}`);
@@ -251,13 +301,14 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
       <div className="flex-1 overflow-auto w-full relative min-h-0 -mx-3 px-3">
         {rootPath ? (
           <FileTree
-            key={refreshKey}
             path={rootPath}
             onContextMenu={handleContextMenu}
             onSelect={handleFileSelect}
             gitStatusMap={gitStatusMap}
             changedDirectories={changedDirectories}
             explorerRoot={rootPath}
+            refreshToken={refreshToken}
+            changedPaths={changedPaths}
           />
         ) : (
           <div className="text-sm text-wardian-text-muted animate-pulse border border-transparent">Mapping directory...</div>

--- a/src/features/explorer/FileTree.test.tsx
+++ b/src/features/explorer/FileTree.test.tsx
@@ -87,4 +87,94 @@ describe('FileTree Component', () => {
     expect(directoryRow?.querySelectorAll('svg')).toHaveLength(1);
     expect(fileRow?.querySelectorAll('svg')).toHaveLength(1);
   });
+
+  it('refetches an expanded directory when a refresh event affects that directory', async () => {
+    const rootNodes = [
+      { name: 'src', path: '/test/src', is_dir: true, extension: null },
+    ];
+    const initialSrcNodes = [
+      { name: 'before.ts', path: '/test/src/before.ts', is_dir: false, extension: 'ts' },
+    ];
+    const refreshedSrcNodes = [
+      { name: 'after.ts', path: '/test/src/after.ts', is_dir: false, extension: 'ts' },
+    ];
+    let srcReads = 0;
+
+    vi.mocked(invoke).mockImplementation(async (_command, args) => {
+      const path = (args as { path: string }).path;
+      if (path === '/test') return rootNodes;
+      if (path === '/test/src') {
+        srcReads += 1;
+        return srcReads === 1 ? initialSrcNodes : refreshedSrcNodes;
+      }
+      return [];
+    });
+
+    const { rerender } = render(
+      <FileTree
+        path="/test"
+        explorerRoot="/test"
+        refreshToken={0}
+        changedPaths={[]}
+      />,
+    );
+
+    await userEvent.click(await screen.findByText('src'));
+    expect(await screen.findByText('before.ts')).toBeInTheDocument();
+
+    rerender(
+      <FileTree
+        path="/test"
+        explorerRoot="/test"
+        refreshToken={1}
+        changedPaths={['/test/src/after.ts']}
+      />,
+    );
+
+    expect(await screen.findByText('after.ts')).toBeInTheDocument();
+    expect(screen.queryByText('before.ts')).not.toBeInTheDocument();
+    expect(screen.getByText('src')).toBeInTheDocument();
+  });
+
+  it('does not refetch an expanded directory when a refresh event is unrelated', async () => {
+    const rootNodes = [
+      { name: 'src', path: '/test/src', is_dir: true, extension: null },
+    ];
+    const srcNodes = [
+      { name: 'before.ts', path: '/test/src/before.ts', is_dir: false, extension: 'ts' },
+    ];
+
+    vi.mocked(invoke).mockImplementation(async (_command, args) => {
+      const path = (args as { path: string }).path;
+      if (path === '/test') return rootNodes;
+      if (path === '/test/src') return srcNodes;
+      return [];
+    });
+
+    const { rerender } = render(
+      <FileTree
+        path="/test"
+        explorerRoot="/test"
+        refreshToken={0}
+        changedPaths={[]}
+      />,
+    );
+
+    await userEvent.click(await screen.findByText('src'));
+    expect(await screen.findByText('before.ts')).toBeInTheDocument();
+
+    const callsBeforeRefresh = vi.mocked(invoke).mock.calls.length;
+    rerender(
+      <FileTree
+        path="/test"
+        explorerRoot="/test"
+        refreshToken={1}
+        changedPaths={['/test/docs/readme.md']}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(vi.mocked(invoke).mock.calls.length).toBe(callsBeforeRefresh);
+    });
+  });
 });

--- a/src/features/explorer/FileTree.tsx
+++ b/src/features/explorer/FileTree.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { ChevronRight, ChevronDown, File, FileText, Image, Code } from 'lucide-react';
 
@@ -17,6 +17,8 @@ export interface FileTreeProps {
   gitStatusMap?: Record<string, string>;
   changedDirectories?: Set<string>;
   explorerRoot?: string;
+  refreshToken?: number;
+  changedPaths?: string[];
 }
 
 const GIT_STATUS_COLORS: Record<string, string> = {
@@ -34,6 +36,18 @@ function toRelativePath(nodePath: string, root: string): string {
   return n.startsWith(r) ? n.slice(r.length).replace(/^\//, '') : n;
 }
 
+function normalizePathForCompare(path: string): string {
+  const normalized = path.replace(/\\/g, '/').replace(/\/+$/g, '');
+  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function pathAffectsDirectory(changedPath: string, directoryPath: string): boolean {
+  const changed = normalizePathForCompare(changedPath);
+  const directory = normalizePathForCompare(directoryPath);
+  const changedParent = changed.includes('/') ? changed.slice(0, changed.lastIndexOf('/')) : '';
+  return changed === directory || changedParent === directory;
+}
+
 const getFileIcon = (extension: string | null) => {
   if (!extension) return <File className="w-4 h-4 text-wardian-text-muted shrink-0" />;
   const ext = extension.toLowerCase();
@@ -46,34 +60,58 @@ const getFileIcon = (extension: string | null) => {
   return <FileText className="w-4 h-4 text-wardian-text-muted shrink-0" />;
 }
 
-export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMenu, depth = 0, gitStatusMap, changedDirectories, explorerRoot }) => {
+export const FileTree: React.FC<FileTreeProps> = ({
+  path,
+  onSelect,
+  onContextMenu,
+  depth = 0,
+  gitStatusMap,
+  changedDirectories,
+  explorerRoot,
+  refreshToken = 0,
+  changedPaths = [],
+}) => {
   const [nodes, setNodes] = useState<FileNode[]>([]);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const fetchTree = useCallback(async (isMounted: () => boolean, showLoading: boolean) => {
+    if (showLoading) {
+      setLoading(true);
+    }
+    try {
+      const result = await invoke<FileNode[]>('get_directory_tree', { path });
+      if (isMounted()) {
+        setNodes(result);
+        setError(null);
+      }
+    } catch (err) {
+      if (isMounted()) {
+        setError(String(err));
+        console.error("Failed to load directory tree for", path, err);
+      }
+    } finally {
+      if (isMounted() && showLoading) setLoading(false);
+    }
+  }, [path]);
+
   useEffect(() => {
     let isMounted = true;
-    const fetchTree = async () => {
-      setLoading(true);
-      try {
-        const result = await invoke<FileNode[]>('get_directory_tree', { path });
-        if (isMounted) {
-          setNodes(result);
-          setError(null);
-        }
-      } catch (err) {
-        if (isMounted) {
-          setError(String(err));
-          console.error("Failed to load directory tree for", path, err);
-        }
-      } finally {
-        if (isMounted) setLoading(false);
-      }
-    };
-    fetchTree();
+    void fetchTree(() => isMounted, true);
     return () => { isMounted = false; };
-  }, [path]);
+  }, [fetchTree]);
+
+  useEffect(() => {
+    if (refreshToken === 0) return;
+    if (!changedPaths.some((changedPath) => pathAffectsDirectory(changedPath, path))) {
+      return;
+    }
+
+    let isMounted = true;
+    void fetchTree(() => isMounted, false);
+    return () => { isMounted = false; };
+  }, [changedPaths, fetchTree, path, refreshToken]);
 
   const toggleFolder = (nodePath: string) => {
     setExpanded(prev => ({ ...prev, [nodePath]: !prev[nodePath] }));
@@ -152,6 +190,8 @@ export const FileTree: React.FC<FileTreeProps> = ({ path, onSelect, onContextMen
                 gitStatusMap={gitStatusMap}
                 changedDirectories={changedDirectories}
                 explorerRoot={explorerRoot}
+                refreshToken={refreshToken}
+                changedPaths={changedPaths}
               />
             )}
           </React.Fragment>


### PR DESCRIPTION
## Description
Refreshes the Explorer sidebar from backend filesystem watcher events instead of relying on remount-style manual refreshes.

- Adds `explorer_watch` / `explorer_unwatch` Tauri commands with recursive notify watching, ref-counted registrations, debounce, and high-churn path exclusions.
- Wires `ExplorerPanel` to listen before watching, filter events to the active root, and refresh expanded `FileTree` directories only when affected paths change.
- Documents the watcher design and adds regression coverage for targeted refresh and in-flight watcher cleanup.

## Related Issues
Fixes #490

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run lint` exited 0.
- `npm run test -- src/features/explorer/ExplorerPanel.test.tsx src/features/explorer/FileTree.test.tsx` exited 0: 2 files / 19 tests.
- `npm run test` exited 0. Existing unrelated React `act(...)` warnings and provider-readiness test logs were still emitted.
- `npm run build` exited 0. Vite emitted the existing chunk-size warning.
- `cd src-tauri && cargo test commands::fs::tests` exited 0: 14 tests.
- `cd src-tauri && cargo check` exited 0.
- `cd src-tauri && cargo clippy` exited 0.
- `cd src-tauri && cargo test --lib -- --test-threads=1 --nocapture` exited 0: 847 tests.
- `cd src-tauri && cargo test --bins` exited 0.
- `cd src-tauri && cargo test --tests` exited 0: lib tests plus integration tests passed.
- `cd src-tauri && cargo test --doc` exited 0.
- `npm run docs:check-llms` exited 0.
- `npm run docs:build` exited 0.
- `PR_BODY=<this PR body> npm run check:frontend-screenshot -- origin/main HEAD` exited 0.
- Wardian-Reviewer re-review found no blocking issues after the in-flight watcher cleanup race fix.

Note: two plain `cargo test` invocations hung silently in the harness after the rebase; stale cargo/test processes were stopped, then the same coverage was run split by target as listed above and passed.

## Screenshots
![explorer-tree](https://raw.githubusercontent.com/wardian-app/Wardian/fix/explorer-tab-file-change-refresh/docs/assets/screenshots/explorer/workspace-tree.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable