### PR TITLE
fix(cli): honor watchlist spawn position setting

### DIFF
--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -167,9 +167,11 @@ in the right-side roster:
 - **Bottom** appends the newly spawned agent to the end of the global roster
   order.
 
-This setting applies to new visible agents spawned from the Agent Config pane.
-It does not re-sort existing agents on startup, reinterpret manual drag order,
-or override clone/team placement behavior.
+This setting applies to new visible agents spawned from the Agent Config pane
+and to agents created with `wardian agent spawn` while the desktop app is
+running for the same `WARDIAN_HOME`. It does not re-sort existing agents on
+startup, reinterpret manual drag order, or override clone/team placement
+behavior.
 
 ## Terminal
 

--- a/docs/guide/watchlists.md
+++ b/docs/guide/watchlists.md
@@ -53,10 +53,10 @@ Click any column header to sort by that column. Clicking again cycles through as
 Column visibility and sort state are saved to `<wardian-home>/watchlists/prefs.json` and restored on next launch.
 
 New visible agents normally appear at the top of the roster. Change
-**Settings > Watchlist > New agent position** to place newly spawned agents at
-the bottom instead. This setting affects explicit new spawns only; existing
-roster order, manual drag order, clone placement, teams, and custom watchlist
-entries keep their own ordering rules.
+**Settings > Watchlist > New agent position** to place agents spawned from the
+app or with `wardian agent spawn` at the bottom instead. This setting affects
+explicit new spawns only; existing roster order, manual drag order, clone
+placement, teams, and custom watchlist entries keep their own ordering rules.
 
 The CLI can inspect persisted watchlist and team state without starting the desktop app:
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -1082,7 +1082,23 @@ fn resolve_registered_session_name(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AgentOrderPlacement<'a> {
     Top,
+    Bottom,
     After(&'a str),
+}
+
+fn new_agent_order_placement_for_setting(value: &str) -> AgentOrderPlacement<'static> {
+    match value.trim() {
+        "bottom" => AgentOrderPlacement::Bottom,
+        _ => AgentOrderPlacement::Top,
+    }
+}
+
+fn configured_new_agent_order_placement() -> AgentOrderPlacement<'static> {
+    crate::utils::load_app_settings()
+        .map(|settings| {
+            new_agent_order_placement_for_setting(&settings.watchlist_new_agent_position)
+        })
+        .unwrap_or(AgentOrderPlacement::Top)
 }
 
 fn insert_new_agent_order(
@@ -1093,6 +1109,7 @@ fn insert_new_agent_order(
     order.retain(|id| id != session_id);
     match placement {
         AgentOrderPlacement::Top => order.insert(0, session_id.to_string()),
+        AgentOrderPlacement::Bottom => order.push(session_id.to_string()),
         AgentOrderPlacement::After(source_session_id) => {
             let index = order
                 .iter()
@@ -1997,7 +2014,7 @@ pub async fn spawn_agent(
         &app,
         None,
         Some(&session_name),
-        AgentOrderPlacement::Top,
+        configured_new_agent_order_placement(),
     )
     .await;
     if registered.is_err() {
@@ -3228,24 +3245,24 @@ mod tests {
         clone_refresh_profile_system_include_directories, clone_remove_existing_path,
         clone_sanitize_config, clone_unique_name, clone_validate_selected_agent_skills,
         clone_validate_selected_profile_files, codex_provider_session_is_new,
-        collect_agent_worktrees, collect_agent_worktrees_with_discovered, detach_agent_for_kill,
-        disable_worktree_config, discover_git_worktrees_for_configs,
-        discover_git_worktrees_for_sources_with, enable_worktree_config,
-        ensure_existing_worktree_is_git_registered,
+        collect_agent_worktrees, collect_agent_worktrees_with_discovered,
+        configured_new_agent_order_placement, detach_agent_for_kill, disable_worktree_config,
+        discover_git_worktrees_for_configs, discover_git_worktrees_for_sources_with,
+        enable_worktree_config, ensure_existing_worktree_is_git_registered,
         ensure_provider_available_before_session_bootstrap, find_assignable_worktree,
         flatten_clone_file_paths, generated_agent_name, insert_new_agent_order,
         is_under_managed_agent_worktree_root, is_under_wardian_agent_worktree_root,
-        lock_agent_lifecycle, mark_agent_paused_off, normalize_clone_folder_override,
-        normalize_discovered_git_worktree_path, normalize_existing_workspace_record_path,
-        normalize_spawn_folder, normalize_workspace_record_path,
-        persisted_resume_session_for_provider, prepare_agent_for_clear, prepare_clear_config,
-        prepare_restored_config_for_spawn, prepare_resume_config,
-        prepare_resume_config_for_runtime, promote_fresh_provider_session_after_resume,
-        provider_needs_obtain_session_id_on_clear, provider_uses_generated_session_id,
-        reserve_spawn_session_name, resolve_agent_worktree_branch_name,
-        resolve_agent_worktree_path, resolve_requested_spawn_session_name,
-        restore_runtime_state_snapshot_after_resume, sync_resumed_input_sender,
-        take_agent_runtime_for_termination, terminal_cleared_payload,
+        lock_agent_lifecycle, mark_agent_paused_off, new_agent_order_placement_for_setting,
+        normalize_clone_folder_override, normalize_discovered_git_worktree_path,
+        normalize_existing_workspace_record_path, normalize_spawn_folder,
+        normalize_workspace_record_path, persisted_resume_session_for_provider,
+        prepare_agent_for_clear, prepare_clear_config, prepare_restored_config_for_spawn,
+        prepare_resume_config, prepare_resume_config_for_runtime,
+        promote_fresh_provider_session_after_resume, provider_needs_obtain_session_id_on_clear,
+        provider_uses_generated_session_id, reserve_spawn_session_name,
+        resolve_agent_worktree_branch_name, resolve_agent_worktree_path,
+        resolve_requested_spawn_session_name, restore_runtime_state_snapshot_after_resume,
+        sync_resumed_input_sender, take_agent_runtime_for_termination, terminal_cleared_payload,
         validate_assignable_worktree_for_agent, validate_deletable_agent_worktree,
         workspace_paths_match, AgentOrderPlacement, AgentWorktreeSummary, CloneProfileCopyPlan,
         CloneProfileSelection, DiscoveredGitWorktree, GIT_WORKTREE_DISCOVERY_CONCURRENCY,
@@ -4149,6 +4166,67 @@ mod tests {
         insert_new_agent_order(&mut order, "gamma", AgentOrderPlacement::Top);
 
         assert_eq!(order, vec!["gamma", "alpha", "beta"]);
+    }
+
+    #[test]
+    fn fresh_spawn_order_inserts_new_agent_at_bottom() {
+        let mut order = vec!["alpha".to_string(), "beta".to_string()];
+
+        insert_new_agent_order(&mut order, "gamma", AgentOrderPlacement::Bottom);
+
+        assert_eq!(order, vec!["alpha", "beta", "gamma"]);
+    }
+
+    #[test]
+    fn new_agent_order_placement_uses_bottom_setting() {
+        assert_eq!(
+            new_agent_order_placement_for_setting("bottom"),
+            AgentOrderPlacement::Bottom
+        );
+        assert_eq!(
+            new_agent_order_placement_for_setting(" bottom "),
+            AgentOrderPlacement::Bottom
+        );
+    }
+
+    #[test]
+    fn configured_new_agent_order_placement_uses_persisted_bottom_setting() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        let settings_path = temp.path().join("settings").join("app.json");
+        std::fs::create_dir_all(settings_path.parent().expect("parent")).expect("settings dir");
+        std::fs::write(
+            &settings_path,
+            r#"{
+              "schema_version": 2,
+              "overrides": {
+                "watchlist_new_agent_position": "bottom"
+              }
+            }"#,
+        )
+        .expect("write settings");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+        let _home_guard = WardianHomeGuard;
+
+        let placement = configured_new_agent_order_placement();
+
+        assert_eq!(placement, AgentOrderPlacement::Bottom);
+    }
+
+    #[test]
+    fn new_agent_order_placement_defaults_to_top_for_non_bottom_values() {
+        assert_eq!(
+            new_agent_order_placement_for_setting("top"),
+            AgentOrderPlacement::Top
+        );
+        assert_eq!(
+            new_agent_order_placement_for_setting(""),
+            AgentOrderPlacement::Top
+        );
+        assert_eq!(
+            new_agent_order_placement_for_setting("middle"),
+            AgentOrderPlacement::Top
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description
Backend fresh spawns now read the saved `watchlist_new_agent_position` preference before registering the agent order. This makes `wardian agent spawn` honor the same top/bottom placement setting as app-spawned agents, while preserving top as the fallback and clone placement after the source agent.

Updated the settings and watchlist guides to explicitly document that the preference applies to CLI-spawned agents when the desktop app is running for the same `WARDIAN_HOME`.

## Related Issues
Fixes #494

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- Peer review requested from `Wardian-Arch`; follow-up review marked ready to merge.
- `cargo test -p Wardian new_agent_order_placement_uses_bottom_setting` failed before the trim robustness fix and passed after.
- `cargo test -p Wardian configured_new_agent_order_placement_uses_persisted_bottom_setting`
- `cargo test -p Wardian new_agent_order_placement_defaults_to_top_for_non_bottom_values`
- `npm run lint`
- `cargo check`
- `npm run test` (passes; existing React `act(...)` and mocked provider-readiness stderr warnings remain)
- `cargo test`
- `npm run build` (passes; existing Vite large chunk warning remains)
- `cargo clippy`
- `npm run docs:check-llms`
- `npm run docs:build`
- `git diff --check`
- Diff secrets grep for `api key`, `secret`, `token`, `password`, and `.env`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
