### PR TITLE
Fix live-agent workflow completion and monitor history UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace -- --test-threads=1
       - name: Check Compilation
         run: cargo check --workspace
 

--- a/crates/wardian-core/src/engine/core.rs
+++ b/crates/wardian-core/src/engine/core.rs
@@ -171,6 +171,28 @@ pub fn enter_loop(g: &Graph, s: &mut RunState, loop_id: &str) {
 
 /// For each Running loop whose body is fully terminal, evaluate its bound and
 /// either start the next iteration or finish (pulse `done`).
+fn resolve_u32_field(
+    fields: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    registry: &serde_json::Value,
+    default: u32,
+) -> u32 {
+    let Some(value) = fields.get(key) else {
+        return default;
+    };
+
+    if let Some(n) = value.as_u64() {
+        return u32::try_from(n).unwrap_or(u32::MAX);
+    }
+
+    value
+        .as_str()
+        .and_then(|template| crate::engine::interpolate::resolve(template, registry).ok())
+        .and_then(|resolved| resolved.trim().parse::<u64>().ok())
+        .map(|n| u32::try_from(n).unwrap_or(u32::MAX))
+        .unwrap_or(default)
+}
+
 pub fn advance_loops(g: &Graph, s: &mut RunState) {
     let loop_ids: Vec<String> = g
         .blueprint()
@@ -198,9 +220,9 @@ pub fn advance_loops(g: &Graph, s: &mut RunState) {
         let iter = *s.loop_iter.get(&lp).unwrap_or(&0);
         let loop_node = g.blueprint().find_node(&lp);
         let max = loop_node
-            .and_then(|nd| nd.fields.get("max_iterations"))
-            .and_then(|v| v.as_u64())
-            .unwrap_or(1) as u32;
+            .map(|nd| resolve_u32_field(&nd.fields, "max_iterations", &s.registry, 1))
+            .unwrap_or(1)
+            .max(1);
         let until_met = loop_node
             .and_then(|nd| nd.fields.get("until"))
             .and_then(|v| v.as_str())
@@ -463,6 +485,109 @@ mod tests {
         advance_loops(&g, &mut s);
         assert_eq!(s.status_or_pending("lp"), NodeStatus::Completed);
         assert!(step(&g, &s).contains(&"ship".to_string())); // done port delivered
+    }
+
+    #[test]
+    fn loop_uses_interpolated_max_iterations_from_trigger_output() {
+        let mut lp = loop_node("lp", 1);
+        lp.fields.insert(
+            "max_iterations".into(),
+            serde_json::json!("{{trigger.output.n}}"),
+        );
+        let blueprint = bp(
+            vec![
+                node("t", "manual_trigger"),
+                lp,
+                child("b", "lp"),
+                node("ship", "task"),
+            ],
+            vec![
+                edge("t", "out", "lp"),
+                edge("lp", "body", "b"),
+                edge("lp", "done", "ship"),
+            ],
+        );
+        let g = Graph::new(&blueprint);
+        let mut s = RunState::new("r", "wf");
+        s.set_trigger(serde_json::json!({ "n": 3 }));
+        complete(&g, &mut s, "t", serde_json::json!({}));
+        enter_loop(&g, &mut s, "lp");
+
+        complete(&g, &mut s, "b", serde_json::json!({}));
+        advance_loops(&g, &mut s);
+        assert_eq!(s.loop_iter["lp"], 1);
+        assert_eq!(s.status_or_pending("b"), NodeStatus::Pending);
+
+        complete(&g, &mut s, "b", serde_json::json!({}));
+        advance_loops(&g, &mut s);
+        assert_eq!(s.loop_iter["lp"], 2);
+        assert_eq!(s.status_or_pending("b"), NodeStatus::Pending);
+
+        complete(&g, &mut s, "b", serde_json::json!({}));
+        advance_loops(&g, &mut s);
+        assert_eq!(s.status_or_pending("lp"), NodeStatus::Completed);
+        assert!(step(&g, &s).contains(&"ship".to_string()));
+    }
+
+    #[test]
+    fn loop_keeps_integer_literal_max_iterations_behavior() {
+        let blueprint = bp(
+            vec![
+                node("t", "manual_trigger"),
+                loop_node("lp", 2),
+                child("b", "lp"),
+                node("ship", "task"),
+            ],
+            vec![
+                edge("t", "out", "lp"),
+                edge("lp", "body", "b"),
+                edge("lp", "done", "ship"),
+            ],
+        );
+        let g = Graph::new(&blueprint);
+        let mut s = RunState::new("r", "wf");
+        complete(&g, &mut s, "t", serde_json::json!({}));
+        enter_loop(&g, &mut s, "lp");
+
+        complete(&g, &mut s, "b", serde_json::json!({}));
+        advance_loops(&g, &mut s);
+        assert_eq!(s.loop_iter["lp"], 1);
+
+        complete(&g, &mut s, "b", serde_json::json!({}));
+        advance_loops(&g, &mut s);
+        assert_eq!(s.status_or_pending("lp"), NodeStatus::Completed);
+    }
+
+    #[test]
+    fn unresolved_loop_max_iterations_template_falls_back_to_default() {
+        let mut lp = loop_node("lp", 2);
+        lp.fields.insert(
+            "max_iterations".into(),
+            serde_json::json!("{{trigger.output.missing}}"),
+        );
+        let blueprint = bp(
+            vec![
+                node("t", "manual_trigger"),
+                lp,
+                child("b", "lp"),
+                node("ship", "task"),
+            ],
+            vec![
+                edge("t", "out", "lp"),
+                edge("lp", "body", "b"),
+                edge("lp", "done", "ship"),
+            ],
+        );
+        let g = Graph::new(&blueprint);
+        let mut s = RunState::new("r", "wf");
+        complete(&g, &mut s, "t", serde_json::json!({}));
+        enter_loop(&g, &mut s, "lp");
+
+        complete(&g, &mut s, "b", serde_json::json!({}));
+        advance_loops(&g, &mut s);
+
+        assert_eq!(s.status_or_pending("lp"), NodeStatus::Completed);
+        assert!(step(&g, &s).contains(&"ship".to_string()));
     }
 
     #[test]

--- a/crates/wardian-core/src/engine/core.rs
+++ b/crates/wardian-core/src/engine/core.rs
@@ -196,14 +196,20 @@ pub fn advance_loops(g: &Graph, s: &mut RunState) {
         }
 
         let iter = *s.loop_iter.get(&lp).unwrap_or(&0);
-        let max = g
-            .blueprint()
-            .find_node(&lp)
+        let loop_node = g.blueprint().find_node(&lp);
+        let max = loop_node
             .and_then(|nd| nd.fields.get("max_iterations"))
             .and_then(|v| v.as_u64())
             .unwrap_or(1) as u32;
+        let until_met = loop_node
+            .and_then(|nd| nd.fields.get("until"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|condition| !condition.is_empty())
+            .map(|condition| lookup_truthy(&s.registry, condition))
+            .unwrap_or(false);
 
-        if iter + 1 < max {
+        if !until_met && iter + 1 < max {
             // Snapshot this iteration's outputs as `prev`, then reset the body.
             for b in &body {
                 if let Some(out) = s.node_output(b).cloned() {
@@ -235,6 +241,23 @@ pub fn advance_loops(g: &Graph, s: &mut RunState) {
             s.set_node_status(&lp, NodeStatus::Completed);
             deliver_from_port(g, s, &lp, "done");
         }
+    }
+}
+
+pub(crate) fn lookup_truthy(registry: &serde_json::Value, path: &str) -> bool {
+    let mut cur = registry;
+    for seg in path.split('.') {
+        match cur.get(seg) {
+            Some(v) => cur = v,
+            None => return false,
+        }
+    }
+    match cur {
+        serde_json::Value::Bool(b) => *b,
+        serde_json::Value::Null => false,
+        serde_json::Value::String(s) => !s.is_empty(),
+        serde_json::Value::Number(n) => n.as_f64().map(|f| f != 0.0).unwrap_or(false),
+        _ => true,
     }
 }
 
@@ -440,6 +463,73 @@ mod tests {
         advance_loops(&g, &mut s);
         assert_eq!(s.status_or_pending("lp"), NodeStatus::Completed);
         assert!(step(&g, &s).contains(&"ship".to_string())); // done port delivered
+    }
+
+    #[test]
+    fn loop_exits_early_when_until_condition_is_truthy() {
+        let mut lp = loop_node("lp", 5);
+        lp.fields
+            .insert("until".into(), serde_json::json!("nodes.b.output.done"));
+        let blueprint = bp(
+            vec![
+                node("t", "manual_trigger"),
+                lp,
+                child("b", "lp"),
+                node("ship", "task"),
+            ],
+            vec![
+                edge("t", "out", "lp"),
+                edge("lp", "body", "b"),
+                edge("lp", "done", "ship"),
+            ],
+        );
+        let g = Graph::new(&blueprint);
+        let mut s = RunState::new("r", "wf");
+        complete(&g, &mut s, "t", serde_json::json!({}));
+        enter_loop(&g, &mut s, "lp");
+
+        complete(&g, &mut s, "b", serde_json::json!({ "done": true }));
+        advance_loops(&g, &mut s);
+
+        assert_eq!(s.loop_iter["lp"], 0);
+        assert_eq!(s.status_or_pending("lp"), NodeStatus::Completed);
+        assert!(step(&g, &s).contains(&"ship".to_string()));
+    }
+
+    #[test]
+    fn loop_continues_until_max_when_until_condition_is_false() {
+        let mut lp = loop_node("lp", 2);
+        lp.fields
+            .insert("until".into(), serde_json::json!("nodes.b.output.done"));
+        let blueprint = bp(
+            vec![
+                node("t", "manual_trigger"),
+                lp,
+                child("b", "lp"),
+                node("ship", "task"),
+            ],
+            vec![
+                edge("t", "out", "lp"),
+                edge("lp", "body", "b"),
+                edge("lp", "done", "ship"),
+            ],
+        );
+        let g = Graph::new(&blueprint);
+        let mut s = RunState::new("r", "wf");
+        complete(&g, &mut s, "t", serde_json::json!({}));
+        enter_loop(&g, &mut s, "lp");
+
+        complete(&g, &mut s, "b", serde_json::json!({ "done": false }));
+        advance_loops(&g, &mut s);
+
+        assert_eq!(s.loop_iter["lp"], 1);
+        assert_eq!(s.status_or_pending("b"), NodeStatus::Pending);
+
+        complete(&g, &mut s, "b", serde_json::json!({ "done": false }));
+        advance_loops(&g, &mut s);
+
+        assert_eq!(s.status_or_pending("lp"), NodeStatus::Completed);
+        assert!(step(&g, &s).contains(&"ship".to_string()));
     }
 
     #[test]

--- a/crates/wardian-core/src/engine/driver.rs
+++ b/crates/wardian-core/src/engine/driver.rs
@@ -354,29 +354,12 @@ fn eval_branch(s: &RunState, node: &Node) -> crate::engine::Result<String> {
         .get("condition")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    let truthy = lookup_truthy(&s.registry, cond);
+    let truthy = core::lookup_truthy(&s.registry, cond);
     Ok(if truthy {
         "on_true".into()
     } else {
         "on_false".into()
     })
-}
-
-fn lookup_truthy(registry: &serde_json::Value, path: &str) -> bool {
-    let mut cur = registry;
-    for seg in path.split('.') {
-        match cur.get(seg) {
-            Some(v) => cur = v,
-            None => return false,
-        }
-    }
-    match cur {
-        serde_json::Value::Bool(b) => *b,
-        serde_json::Value::Null => false,
-        serde_json::Value::String(s) => !s.is_empty(),
-        serde_json::Value::Number(n) => n.as_f64().map(|f| f != 0.0).unwrap_or(false),
-        _ => true,
-    }
 }
 
 /// Interpolate the node's string fields and call the matching executor method.

--- a/crates/wardian-core/src/workflow/validate.rs
+++ b/crates/wardian-core/src/workflow/validate.rs
@@ -31,6 +31,15 @@ impl Diagnostic {
             node: node.map(str::to_string),
         }
     }
+
+    fn warning(code: &'static str, message: impl Into<String>, node: Option<&str>) -> Self {
+        Self {
+            severity: Severity::Warning,
+            code,
+            message: message.into(),
+            node: node.map(str::to_string),
+        }
+    }
 }
 
 /// The result of validating a blueprint.
@@ -101,6 +110,16 @@ pub fn validate(blueprint: &Blueprint) -> ValidationReport {
                 ));
             }
             if let Some(value) = present {
+                if node.r#type == "loop" && field.id == "max_iterations" {
+                    if let Some(msg) = check_loop_max_iterations(value) {
+                        report.diagnostics.push(Diagnostic::warning(
+                            "invalid_loop_max_iterations",
+                            format!("node `{}` field `max_iterations`: {}", node.id, msg),
+                            Some(&node.id),
+                        ));
+                    }
+                    continue;
+                }
                 if let Some(msg) = check_value_kind(&field.field_type, value) {
                     report.diagnostics.push(Diagnostic::error(
                         "invalid_field_value",
@@ -154,6 +173,28 @@ pub fn validate(blueprint: &Blueprint) -> ValidationReport {
     }
 
     report
+}
+
+fn check_loop_max_iterations(value: &serde_json::Value) -> Option<String> {
+    if let Some(n) = value.as_u64() {
+        return (n == 0).then_some("expected a positive integer or a {{...}} template".into());
+    }
+
+    if let Some(template) = value.as_str() {
+        return (!is_single_template(template))
+            .then_some("expected a positive integer or a single {{...}} template".into());
+    }
+
+    Some("expected a positive integer or a {{...}} template".into())
+}
+
+fn is_single_template(value: &str) -> bool {
+    let trimmed = value.trim();
+    if !trimmed.starts_with("{{") || !trimmed.ends_with("}}") {
+        return false;
+    }
+    let inner = trimmed[2..trimmed.len() - 2].trim();
+    !inner.is_empty() && !inner.contains("{{") && !inner.contains("}}")
 }
 
 /// Returns a human message when `value` cannot be the given field type.
@@ -232,6 +273,19 @@ mod tests {
         Node {
             id: id.into(),
             r#type: "task".into(),
+            name: None,
+            parent: None,
+            fields,
+            position: None,
+        }
+    }
+
+    fn loop_node(max_iterations: serde_json::Value) -> Node {
+        let mut fields = serde_json::Map::new();
+        fields.insert("max_iterations".into(), max_iterations);
+        Node {
+            id: "lp".into(),
+            r#type: "loop".into(),
             name: None,
             parent: None,
             fields,
@@ -352,5 +406,58 @@ mod tests {
         let bp = base(vec![task("plan"), child], vec![]);
         let report = validate(&bp);
         assert!(report.errors().iter().any(|d| d.code == "invalid_parent"));
+    }
+
+    #[test]
+    fn loop_max_iterations_accepts_template_string() {
+        let bp = base(
+            vec![loop_node(serde_json::json!(
+                "{{trigger.output.max_cycles}}"
+            ))],
+            vec![],
+        );
+
+        let report = validate(&bp);
+
+        assert!(
+            report.is_valid(),
+            "unexpected errors: {:?}",
+            report.errors()
+        );
+        assert!(!report
+            .diagnostics
+            .iter()
+            .any(|d| { d.code == "invalid_field_value" && d.node.as_deref() == Some("lp") }));
+    }
+
+    #[test]
+    fn loop_max_iterations_warns_for_malformed_template_string() {
+        let bp = base(
+            vec![loop_node(serde_json::json!("{{trigger.output.max_cycles"))],
+            vec![],
+        );
+
+        let report = validate(&bp);
+
+        assert!(report.diagnostics.iter().any(|d| {
+            d.severity == Severity::Warning
+                && d.code == "invalid_loop_max_iterations"
+                && d.node.as_deref() == Some("lp")
+        }));
+        assert!(report.is_valid());
+    }
+
+    #[test]
+    fn loop_max_iterations_warns_for_non_positive_literal() {
+        let bp = base(vec![loop_node(serde_json::json!(0))], vec![]);
+
+        let report = validate(&bp);
+
+        assert!(report.diagnostics.iter().any(|d| {
+            d.severity == Severity::Warning
+                && d.code == "invalid_loop_max_iterations"
+                && d.node.as_deref() == Some("lp")
+        }));
+        assert!(report.is_valid());
     }
 }

--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -16,22 +16,28 @@ This document captures the practical runtime differences between Wardian's suppo
 - Provider delivery profiles are responsible for translating Wardian input into the provider's native submit behavior, including short prompts, pasted multiline prompts, long prompts, slash-command-shaped text, and inputs that already end with a newline.
 - Delivery recognizers must fail closed. If Wardian cannot recognize that a provider prompt is ready, that a paste bracket has settled, or that a command was submitted, it should avoid sending more input instead of guessing and corrupting the provider TUI state.
 - Approval prompt state must be fresh. A stale recognizer hit, old transcript event, or previous terminal buffer line must not keep an agent in `action_required` or trigger a delivery retry for a new turn.
+- On Windows, provider adapters should prefer direct native executables or a
+  direct `node <script.js>` launch resolved from an npm `.cmd` shim. Shell-wrap
+  only when shell dispatch is required, such as extensionless OpenCode shims.
 
 ## Quick Comparison
 
 | Provider | Working root | Instruction file | Skill model | Session identity |
 | --- | --- | --- | --- | --- |
-| Gemini | Real target workspace | `GEMINI.md` | Patched CLI can discover skills from include directories | Discovered from provider output |
+| Gemini | Projected habitat workspace for headless runs | `GEMINI.md` | Patched CLI can discover skills from include directories | Discovered from provider output |
 | Antigravity | Real target workspace | `AGENTS.md` | `--add-dir` roots expose Wardian context | Discovered from conversation cache and transcript path |
 | Claude | Real target workspace | `CLAUDE.md` | `.claude/skills` points at Wardian's `.agents/skills` | Wardian assigns `--session-id` up front |
-| Codex | Real target workspace via `--cd` | `AGENTS.md` | Per-agent `CODEX_HOME/skills` under habitat | Discovered from provider output, then adopted |
-| OpenCode | Real target workspace | `AGENTS.md` plus injected runtime config | `skills.paths` built from Wardian include roots | Discovered from provider output |
+| Codex | Real target workspace via `--cd`; habitat-backed `CODEX_HOME` | `AGENTS.md` | Per-agent `CODEX_HOME/skills` under habitat | Discovered from provider output, then adopted |
+| OpenCode | Habitat command root with real workspace passed as `--dir` | `AGENTS.md` plus injected runtime config | `skills.paths` built from Wardian include roots | Discovered from provider output |
 
 ## Gemini
 
 ### Working-root model
 
-Gemini runs directly in the real target workspace. Wardian does not project a habitat workspace for Gemini.
+Gemini headless runs use a projected habitat workspace so shared, class, and
+agent instructions and skills can be materialized outside Wardian's hidden state
+tree. The real target workspace remains the author-facing workspace, but the
+provider process runs from the habitat workspace path during headless execution.
 
 ### Instruction and skill discovery
 
@@ -47,8 +53,8 @@ Gemini runs directly in the real target workspace. Wardian does not project a ha
 
 ### Practical implications
 
-- Gemini is the least habitat-dependent provider.
-- Regressions here are usually about CLI patch drift, include-directory handling, or event parsing, not workspace projection.
+- Gemini regressions are usually about habitat projection, CLI patch drift,
+  include-directory handling, or event parsing.
 
 ## Antigravity
 
@@ -204,7 +210,7 @@ Codex commentary events like `agent_message` should not be used as hard status t
 
 ### Working-root model
 
-OpenCode runs directly in the real target workspace. Wardian does not use a projected workspace for OpenCode.
+OpenCode uses a Wardian habitat as the provider command root when projected context is available. The real target workspace remains the project directory and is passed to `opencode run` explicitly with `--dir`.
 
 ### Instruction and skill discovery
 
@@ -224,11 +230,15 @@ This is how OpenCode sees Wardian-managed class and agent context without forcin
 
 ### Practical implications
 
-- OpenCode is closer to Gemini than Codex on workspace handling: it wants the real repo as `cwd`.
+- OpenCode is closer to Gemini than Codex on workspace handling: Wardian launches from the habitat command root while passing the real repo with `--dir`.
 - OpenCode is closer to Codex than Gemini on instruction naming: it consumes `AGENTS.md` directly.
 - If OpenCode stops seeing Wardian skills or class instructions, inspect the generated `OPENCODE_CONFIG_CONTENT` first.
 - If interactive spawn works but telemetry is thin, that is expected today; OpenCode does not expose one stable per-session JSONL path the way Claude and Codex do.
-- On Windows, Wardian should prefer a native `opencode.exe` or packaged OpenCode binary over `.cmd`/script shims during PATH resolution. If only a shim exists, interactive launch must wrap it through `cmd /d /c ...` because direct PTY spawning does not get shell dispatch semantics.
+- On Windows, Wardian should prefer a native `opencode.exe` or packaged
+  OpenCode binary over `.cmd`/script shims during PATH resolution. If only an
+  extensionless or script shim exists, interactive and headless launch must wrap
+  it through `cmd /d /c ...` because direct process spawning does not get shell
+  dispatch semantics.
 
 ## Choosing Where to Debug
 

--- a/docs/developer/workflow-engine.md
+++ b/docs/developer/workflow-engine.md
@@ -66,9 +66,13 @@ Template fields resolve against this registry before each node executes.
    state.
 5. Observe and Monitor refresh durable run state through `workflow_read_run`.
 
-Resume and human approval use the same durable run records:
+Resume, startup recovery, and human approval use the same durable run records:
 
-- `workflow_resume` resumes an interrupted run;
+- `workflow_resume` resumes an explicitly resumed durable run, such as one
+  parked before more work is dispatched;
+- app startup marks runs that were still `running` at process exit as `failed`
+  with an interruption reason, because their worker tasks and provider
+  processes are no longer owned by the new app process;
 - `workflow_approve` grants or rejects an approval gate;
 - `workflow_cancel` writes a cancellation marker for a live run.
 
@@ -85,6 +89,15 @@ resolver:
 
 Headless execution uses the provider adapters behind
 `run_headless_with_options`, with structured output parsed into node outputs.
+
+Active-agent execution uses the visible agent PTY, but completion is still an
+explicit structured contract. Wardian creates a task interaction for the
+workflow node, appends a `wardian reply <request-id> --status ... --stdin`
+instruction to the delivered prompt, and waits for that reply before completing
+the node. Terminal `idle` status alone is not completion; it only allows Wardian
+to check transcript-marker compatibility for agents that echoed the reply
+command instead of submitting it through the control endpoint. `blocked` and
+`failed` replies fail the node with the reply body as the diagnostic.
 
 ## Old Workflow System
 

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -38,16 +38,22 @@ The **Run** button opens a launch dialog for the current blueprint. Use **Run no
 
 Manual input parameters appear in the dialog when the blueprint's entry trigger defines an input schema.
 
-## Monitoring Schedules
+## Monitoring Workflow Activity
 
-Monitor shows every saved schedule with inline controls:
+Monitor shows a unified activity feed for workflow schedules and runs. Use the
+tabs to switch between all activity, items needing attention, running work,
+scheduled work, and history.
+
+The top counters call out due-soon schedules and attention states. Schedule
+rows expose the current Monitor actions:
 
 - **Pause** or **Resume** changes whether the schedule fires on its cadence.
 - **Run now** launches the scheduled invoker immediately.
 - **Edit** reopens the schedule form.
-- **Remove** deletes the schedule without deleting the blueprint.
 
-Monitor also lists active and recent runs so you can jump directly into Observe.
+Active and recent runs appear in the same feed so you can jump directly into
+Observe. Older history is paged separately to keep the main feed focused on the
+latest run per blueprint.
 
 ## Important Limits
 

--- a/docs/specs/2026-05-29-workflow-executor.md
+++ b/docs/specs/2026-05-29-workflow-executor.md
@@ -6,7 +6,7 @@
 
 > **Structure note:** the workflow engine/workflow logic lives as modules in `wardian-core` (`wardian_core::engine`, `wardian_core::workflow`). The live executor lives in `src-tauri` because it owns the agent runtime. Read "executor" as a `src-tauri` impl of the `wardian_core::engine::StepExecutor` trait.
 
-> **Implementation note (5a):** shipped the `src-tauri` live executor, headless/fake runner boundary, output and decision parsing, agent resolution, shell/script/notify/state ops, run/resume/approve/cancel commands, startup interrupted-run logging, and mock-provider end-to-end validation. Deferred scope remains live named-agent routing, visible grouped workers, per-node worktrees, scheduled/event triggers, per-run session continuity, old workflow system retirement, and UI unification.
+> **Implementation note (5a):** shipped the `src-tauri` live executor, headless/fake runner boundary, output and decision parsing, agent resolution, shell/script/notify/state ops, run/resume/approve/cancel commands, startup interrupted-run reconciliation, and mock-provider end-to-end validation. Deferred scope remains live named-agent routing, visible grouped workers, per-node worktrees, scheduled/event triggers, per-run session continuity, old workflow system retirement, and UI unification.
 
 ## 1. Problem & goal
 
@@ -50,9 +50,9 @@ New module `src-tauri/src/workflow/` with `LiveStepExecutor` implementing `wardi
 
 - **`workflow_run(path)`** — load + validate the blueprint (refuse to run if invalid), build a `LiveStepExecutor`, generate a `run_id`, set `run_root = paths::workflow_run_dir(bp.id, run_id)`, and drive `Engine::start_with_id` in a **background tokio task**. Returns the `run_id` immediately; the run proceeds async, writing `events.jsonl` + `state.json` that **Run View (3b) already observes live**.
 - **Approval** — when the engine reaches `AwaitingApproval` it returns and the status persists. `workflow_approve(id, run, granted, note)` resumes via `Engine::grant_approval` / `reject_approval` in a new background task.
-- **`workflow_resume(id, run)`** — resume an interrupted/paused run via `Engine::resume` (completed nodes skipped).
+- **`workflow_resume(id, run)`** — resume an explicitly selected durable run via `Engine::resume` (completed nodes skipped).
 - **`workflow_cancel(id, run)`** — abort a live run (cancel the background task; mark the run failed/stopped with a reason).
-- **Crash recovery** — on app start, scan `logs/workflows/**` for runs still marked `Running` (their workers are gone) and mark them **interrupted**; Run View surfaces a **Resume** affordance that calls `workflow_resume`. No auto-resume (no surprise re-execution of side-effecting steps at startup).
+- **Crash recovery** — on app start, scan `logs/workflows/**` for runs still marked `Running` and mark them **failed** with an interruption reason. The new app process no longer owns the old background tasks or provider processes, so startup does not silently resume or leave those runs displayed as active.
 
 ## 6. Testing
 

--- a/docs/specs/2026-05-29-workflow-unified-view.md
+++ b/docs/specs/2026-05-29-workflow-unified-view.md
@@ -37,7 +37,7 @@ Switching Edit ↔ Observe does **not** reset the builder store (edit-in-progres
 
 - **Run button** → a **launch dialog**: a **provider** field defaulting to the agents' default provider — read `default_provider` from `useSettingsStore` and resolve via the same `resolveEffectiveProvider(providerReadiness, defaultProvider)` agent spawn uses (respects provider readiness), overridable per-run — plus an optional **workspace** field. On confirm, call `workflow_run(path, provider, workspace)`, switch to **Observe**, and open the returned run live.
 - **Live updates:** while the observed run's status is `Running`, the run store refreshes `workflow_read_run` on a short interval (poll) so the DAG/timeline update as the run progresses; polling stops at a terminal status.
-- **Lifecycle controls (Observe):** **Resume** (`workflow_resume`), **Approve / Reject** for an `awaiting_approval` node (`workflow_approve`), **Cancel** (`workflow_cancel`). A run with status `Running` but no active progress (the 5a startup-scan "interrupted" case) is shown with a **Resume** affordance.
+- **Lifecycle controls (Observe):** **Resume** (`workflow_resume`), **Approve / Reject** for an `awaiting_approval` node (`workflow_approve`), **Cancel** (`workflow_cancel`). Startup reconciliation now marks runs left `Running` by a previous app process as `Failed` with an interruption reason instead of presenting them as still active.
 
 ## 5. Components & files
 

--- a/docs/specs/2026-06-01-workflow-agent-session-semantics.md
+++ b/docs/specs/2026-06-01-workflow-agent-session-semantics.md
@@ -326,8 +326,12 @@ For each task/decision node:
      resume;
    - agent + current conversation + busy -> apply busy policy.
 4. Execute the route.
-5. Parse output using existing workflow task/decision output semantics.
-6. Release leases and update schedule/run status.
+5. For the live/open route, create a task interaction and require the target
+   agent to answer with `wardian reply <request-id> --status ... --stdin`.
+   Terminal `idle` is not completion by itself; it only enables transcript
+   marker compatibility checks. `blocked` and `failed` replies fail the node.
+6. Parse output using existing workflow task/decision output semantics.
+7. Release leases and update schedule/run status.
 
 ## 11. UI Placement
 

--- a/docs/workflows/node-reference-v2.md
+++ b/docs/workflows/node-reference-v2.md
@@ -62,8 +62,11 @@ Container: repeats its body subgraph until a bound is hit.
 
 ### Fields
 
-- `max_iterations` — Max iterations [number]
-- `until` — Until condition [text]
+- `max_iterations` — Max iterations [number or `{{registry.path}}` template].
+  Runtime clamps the resolved value to at least `1`; malformed templates warn
+  during validation and fall back at runtime.
+- `until` — Registry dot path checked for truthiness before another body pulse,
+  for example `trigger.output.stop` or `nodes.review.output.done`.
 
 Outgoing ports: body, done
 
@@ -187,4 +190,3 @@ Entry point. Runs on demand or when an invoker fires it.
 - `input_schema` — Input schema [jsonschema]
 
 Outgoing ports: out
-

--- a/docs/workflows/node-reference-v2.md
+++ b/docs/workflows/node-reference-v2.md
@@ -62,7 +62,7 @@ Container: repeats its body subgraph until a bound is hit.
 
 ### Fields
 
-- `max_iterations` — Max iterations [number or `{{registry.path}}` template].
+- `max_iterations` — Max iterations [number or `&#123;&#123;registry.path&#125;&#125;` template].
   Runtime clamps the resolved value to at least `1`; malformed templates warn
   during validation and fall back at runtime.
 - `until` — Registry dot path checked for truthiness before another body pulse,

--- a/docs/workflows/node-reference.md
+++ b/docs/workflows/node-reference.md
@@ -171,7 +171,7 @@ Behavior:
 
 - supports `count` mode and `conditional` mode
 - accepts `max_iterations` as a positive integer or as a single registry
-  template such as `{{trigger.output.limit}}`
+  template such as `&#123;&#123;trigger.output.limit&#125;&#125;`
 - resolves `until` as a dot path against the run registry, such as
   `nodes.review.output.done`
 - treats truthy `until` values as the signal to stop before another body pulse

--- a/docs/workflows/node-reference.md
+++ b/docs/workflows/node-reference.md
@@ -170,12 +170,19 @@ Use it for repeated execution.
 Behavior:
 
 - supports `count` mode and `conditional` mode
+- accepts `max_iterations` as a positive integer or as a single registry
+  template such as `{{trigger.output.limit}}`
+- resolves `until` as a dot path against the run registry, such as
+  `nodes.review.output.done`
+- treats truthy `until` values as the signal to stop before another body pulse
 - emits `body` while continuing and `done` when finished
 - stores iterator state in workflow runtime data
 
 Common pitfall:
 
 - forgetting to bound the loop correctly, which can create confusing repeated behavior
+- malformed `max_iterations` templates warn during validation and fall back at
+  runtime instead of invalidating the whole blueprint
 
 ### Wait
 

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -604,7 +604,9 @@ mod tests {
         let file_path = temp.path().join("notes");
         fs::write(&file_path, "test").expect("write file");
 
-        assert!(terminal_link_target_exists(file_path.to_string_lossy().into_owned()));
+        assert!(terminal_link_target_exists(
+            file_path.to_string_lossy().into_owned()
+        ));
         assert!(terminal_link_target_exists(
             temp.path().to_string_lossy().into_owned()
         ));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -214,10 +214,10 @@ pub fn run() {
             start_metrics_supervisor(app.handle().clone());
 
             if let Some(runs_dir) = wardian_core::paths::workflow_runs_dir() {
-                let interrupted = crate::workflow::runs::scan_interrupted_runs(&runs_dir);
+                let interrupted = crate::workflow::runs::fail_interrupted_runs(&runs_dir);
                 if !interrupted.is_empty() {
                     crate::utils::logging::log_debug(&format!(
-                        "[workflow] {} interrupted run(s) on startup: {:?}",
+                        "[workflow] marked {} interrupted run(s) failed on startup: {:?}",
                         interrupted.len(),
                         interrupted
                     ));

--- a/src-tauri/src/manager/headless.rs
+++ b/src-tauri/src/manager/headless.rs
@@ -1,4 +1,5 @@
 use crate::providers::antigravity::AntigravityProvider;
+use crate::providers::codex::CodexProvider;
 use crate::providers::opencode::OpenCodeProvider;
 use crate::providers::ProviderFactory;
 use crate::utils::fs::*;
@@ -25,14 +26,26 @@ pub(crate) fn headless_provider_launch(
     provider_args: &[String],
 ) -> Result<crate::utils::shell::ShellLaunchSpec, String> {
     #[cfg(windows)]
-    if provider_name == "opencode" {
-        let cmd_host = std::env::var("ComSpec").unwrap_or_else(|_| "cmd.exe".to_string());
-        let mut fragments = vec![quote_cmd_arg(bin)];
-        fragments.extend(provider_args.iter().map(|arg| quote_cmd_arg(arg)));
-        return Ok(crate::utils::shell::ShellLaunchSpec {
-            executable: cmd_host,
-            args: vec!["/d".to_string(), "/c".to_string(), fragments.join(" ")],
-        });
+    {
+        let lower_bin = bin.to_ascii_lowercase();
+        if provider_name == "opencode" && !lower_bin.ends_with(".exe") {
+            let cmd_host = std::env::var("ComSpec").unwrap_or_else(|_| "cmd.exe".to_string());
+            let mut fragments = vec![quote_cmd_arg(bin)];
+            fragments.extend(provider_args.iter().map(|arg| quote_cmd_arg(arg)));
+            return Ok(crate::utils::shell::ShellLaunchSpec {
+                executable: cmd_host,
+                args: vec!["/d".to_string(), "/c".to_string(), fragments.join(" ")],
+            });
+        }
+        if !lower_bin.ends_with(".cmd")
+            && !lower_bin.ends_with(".bat")
+            && !lower_bin.ends_with(".ps1")
+        {
+            return Ok(crate::utils::shell::ShellLaunchSpec {
+                executable: bin.to_string(),
+                args: provider_args.to_vec(),
+            });
+        }
     }
 
     #[cfg(not(windows))]
@@ -103,6 +116,14 @@ pub(crate) fn headless_provider_args(
         "codex" => {
             provider_args.push("--cd".to_string());
             provider_args.push(provider_cwd.to_string_lossy().to_string());
+            if let Some(config) = config_override {
+                CodexProvider::new().append_common_args(&mut provider_args, config, true);
+                if let Some(custom) = config.custom_args.as_ref() {
+                    if let Some(parsed) = shlex::split(custom) {
+                        provider_args.extend(parsed);
+                    }
+                }
+            }
             provider_args.push("exec".to_string());
             if let Some(resume_id) = resume_session.filter(|s| !s.trim().is_empty()) {
                 provider_args.push("resume".to_string());
@@ -112,6 +133,22 @@ pub(crate) fn headless_provider_args(
             provider_args.push(prompt.to_string());
         }
         "claude" => {
+            if let Some(config) = config_override {
+                let mut config = config.clone();
+                config.resume_session = resume_session.map(str::to_string);
+                let spawn_args = strip_flag_value_pairs(
+                    strip_flag_value_pairs(
+                        strip_flag_value_pairs(
+                            provider.get_spawn_args(&config, resume_session.is_some()),
+                            "--session-id",
+                        ),
+                        "--resume",
+                    ),
+                    "--input-format",
+                );
+                let spawn_args = strip_flag_value_pairs(spawn_args, "--output-format");
+                provider_args.extend(spawn_args);
+            }
             provider_args.push("--print".to_string());
             provider_args.push("--output-format".to_string());
             provider_args.push(output_format.to_string());
@@ -248,14 +285,9 @@ pub async fn run_headless_with_options(
         config_override,
         persisted_config.as_ref(),
     )?;
-    let persisted_provider_config =
-        if matches!(provider_name, "gemini" | "opencode" | "antigravity") {
-            config_override
-                .cloned()
-                .or_else(|| persisted_config.clone())
-        } else {
-            None
-        };
+    let effective_provider_config = config_override
+        .cloned()
+        .or_else(|| persisted_config.clone());
     let (bin, _) = provider.get_executable();
     let claude_hook = if provider_name == "claude" {
         ensure_claude_permission_hook(wardian_session_id).ok()
@@ -270,7 +302,7 @@ pub async fn run_headless_with_options(
         prompt,
         output_format,
         resume_session,
-        persisted_provider_config.as_ref(),
+        effective_provider_config.as_ref(),
     );
     if let Some(hook) = claude_hook.as_ref() {
         if provider_name == "claude" {
@@ -286,7 +318,7 @@ pub async fn run_headless_with_options(
     }
     apply_headless_identity_env(&mut cmd, wardian_session_id);
     super::apply_managed_cli_path_to_process(&mut cmd);
-    if let Some(config) = persisted_config.as_ref() {
+    if let Some(config) = effective_provider_config.as_ref() {
         for (key, value) in super::worktree_build_env(config) {
             cmd.env(key, value);
         }
@@ -307,7 +339,7 @@ pub async fn run_headless_with_options(
             cwd,
             &provider_context.class_name,
             opencode_scope_session,
-            persisted_provider_config.as_ref(),
+            effective_provider_config.as_ref(),
         )? {
             cmd.env(key, value);
         }
@@ -827,6 +859,58 @@ mod tests {
         assert!(!args.contains(&"ses_source".to_string()));
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn node_headless_launch_uses_direct_process_args() {
+        let args = vec![
+            "provider.js".to_string(),
+            "--cd".to_string(),
+            "D:/Development/Wardian".to_string(),
+            "exec".to_string(),
+            "--json".to_string(),
+            "first line\nsecond line".to_string(),
+        ];
+
+        let spec = headless_provider_launch("gemini", "node", &args).unwrap();
+
+        assert_eq!(spec.executable, "node");
+        assert_eq!(spec.args, args);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn opencode_exe_headless_launch_uses_direct_process_args() {
+        let args = vec![
+            "run".to_string(),
+            "--print-logs".to_string(),
+            "first line\nsecond line".to_string(),
+        ];
+
+        let spec = headless_provider_launch("opencode", "C:/tools/opencode.exe", &args).unwrap();
+
+        assert_eq!(spec.executable, "C:/tools/opencode.exe");
+        assert_eq!(spec.args, args);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn opencode_extensionless_headless_launch_uses_cmd_host_on_windows() {
+        let args = vec![
+            "run".to_string(),
+            "--print-logs".to_string(),
+            "first line\nsecond line".to_string(),
+        ];
+
+        let spec = headless_provider_launch("opencode", "C:/nvm4w/nodejs/opencode", &args)
+            .expect("launch spec");
+
+        assert!(spec.executable.ends_with("cmd.exe") || spec.executable == "cmd.exe");
+        assert_eq!(spec.args[0], "/d");
+        assert_eq!(spec.args[1], "/c");
+        assert!(spec.args[2].contains("C:/nvm4w/nodejs/opencode"));
+        assert!(spec.args[2].contains("first line\nsecond line"));
+    }
+
     #[test]
     fn claude_fresh_headless_args_omit_resume_flag() {
         let provider = crate::providers::ProviderFactory::resolve("claude").unwrap();
@@ -842,6 +926,90 @@ mod tests {
 
         assert!(args.contains(&"--print".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn codex_headless_args_include_assigned_profile_config() {
+        let provider = crate::providers::ProviderFactory::resolve("codex").unwrap();
+        let config = AgentConfig {
+            provider: "codex".into(),
+            model: Some("gpt-test".into()),
+            include_directories: Some(vec!["/workspace/docs".into()]),
+            provider_config: wardian_core::models::ProviderConfig::Codex(
+                wardian_core::models::CodexProviderConfig {
+                    sandbox_mode: Some("workspace-write".into()),
+                    approval_policy: Some("on-request".into()),
+                    profile: Some("review".into()),
+                    full_auto: Some(false),
+                    ..Default::default()
+                },
+            ),
+            ..Default::default()
+        };
+
+        let args = headless_provider_args(
+            "codex",
+            provider.as_ref(),
+            Path::new("/workspace"),
+            "task",
+            "json",
+            None,
+            Some(&config),
+        );
+
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"gpt-test".to_string()));
+        assert!(args.contains(&"--sandbox".to_string()));
+        assert!(args.contains(&"workspace-write".to_string()));
+        assert!(args.contains(&"--ask-for-approval".to_string()));
+        assert!(args.contains(&"on-request".to_string()));
+        assert!(args.contains(&"--profile".to_string()));
+        assert!(args.contains(&"review".to_string()));
+        assert!(args.contains(&"--add-dir".to_string()));
+        assert!(args.contains(&"/workspace/docs".to_string()));
+        assert!(args.contains(&"exec".to_string()));
+        assert!(args.contains(&"--json".to_string()));
+    }
+
+    #[test]
+    fn claude_headless_args_include_assigned_profile_config_without_session_reuse() {
+        let provider = crate::providers::ProviderFactory::resolve("claude").unwrap();
+        let config = AgentConfig {
+            session_id: "visible-agent".into(),
+            provider: "claude".into(),
+            model: Some("claude-test".into()),
+            include_directories: Some(vec!["/workspace/docs".into()]),
+            provider_config: wardian_core::models::ProviderConfig::Claude(
+                wardian_core::models::ClaudeProviderConfig {
+                    permission_mode: Some("acceptEdits".into()),
+                    max_turns: Some(4),
+                    ..Default::default()
+                },
+            ),
+            ..Default::default()
+        };
+
+        let args = headless_provider_args(
+            "claude",
+            provider.as_ref(),
+            Path::new("/workspace"),
+            "task",
+            "text",
+            None,
+            Some(&config),
+        );
+
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"claude-test".to_string()));
+        assert!(args.contains(&"--add-dir".to_string()));
+        assert!(args.contains(&"/workspace/docs".to_string()));
+        assert!(args.contains(&"--permission-mode".to_string()));
+        assert!(args.contains(&"acceptEdits".to_string()));
+        assert!(args.contains(&"--max-turns".to_string()));
+        assert!(args.contains(&"4".to_string()));
+        assert!(args.contains(&"--print".to_string()));
+        assert!(!args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"visible-agent".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/manager/headless.rs
+++ b/src-tauri/src/manager/headless.rs
@@ -51,6 +51,44 @@ pub struct HeadlessRunOptions<'a> {
     pub config_override: Option<&'a AgentConfig>,
 }
 
+#[derive(Debug)]
+struct HeadlessProviderContext {
+    class_name: String,
+    command_cwd: std::path::PathBuf,
+    args_cwd: std::path::PathBuf,
+    habitat_root: Option<std::path::PathBuf>,
+}
+
+fn headless_provider_context(
+    provider_name: &str,
+    cwd: &std::path::Path,
+    wardian_session_id: &str,
+    config_override: Option<&AgentConfig>,
+    persisted_config: Option<&AgentConfig>,
+) -> Result<HeadlessProviderContext, String> {
+    let class_name = config_override
+        .or(persisted_config)
+        .map(|config| config.agent_class.trim().to_string())
+        .filter(|class_name| !class_name.is_empty())
+        .unwrap_or_default();
+    let habitat_root =
+        prepare_provider_habitat(provider_name, cwd, &class_name, Some(wardian_session_id))?;
+    let command_cwd =
+        super::interactive_provider_cwd(provider_name, cwd, habitat_root.as_deref(), None);
+    let args_cwd = if provider_name == "opencode" {
+        cwd.to_path_buf()
+    } else {
+        command_cwd.clone()
+    };
+
+    Ok(HeadlessProviderContext {
+        class_name,
+        command_cwd,
+        args_cwd,
+        habitat_root,
+    })
+}
+
 pub(crate) fn headless_provider_args(
     provider_name: &str,
     provider: &dyn AgentProvider,
@@ -86,6 +124,25 @@ pub(crate) fn headless_provider_args(
         "mock" => {
             provider_args.push("--print".to_string());
             provider_args.push(prompt.to_string());
+        }
+        "gemini" => {
+            if let Some(config) = config_override {
+                let mut config = config.clone();
+                config.resume_session = resume_session.map(str::to_string);
+                let spawn_args = provider.get_spawn_args(&config, resume_session.is_some());
+                let spawn_args = strip_flag_value_pairs(spawn_args, "--session-id");
+                let spawn_args = strip_flag_value_pairs(spawn_args, "--resume");
+                let spawn_args = strip_flag_value_pairs(spawn_args, "--output-format");
+                provider_args.extend(spawn_args);
+            }
+            provider_args.push("-p".to_string());
+            provider_args.push(prompt.to_string());
+            provider_args.push("--output-format".to_string());
+            provider_args.push(output_format.to_string());
+            if let Some(resume_id) = resume_session.filter(|s| !s.trim().is_empty()) {
+                provider_args.push("--resume".to_string());
+                provider_args.push(resume_id.to_string());
+            }
         }
         "opencode" => {
             provider_args.push("run".to_string());
@@ -183,16 +240,22 @@ pub async fn run_headless_with_options(
     let config_override = options.config_override;
     let provider = ProviderFactory::resolve(provider_name)?;
     crate::providers::readiness::ensure_provider_available_for_launch(provider_name)?;
-    let habitat_root = prepare_provider_habitat(provider_name, cwd, "", Some(wardian_session_id))?;
-    let provider_cwd = cwd.to_path_buf();
     let persisted_config = persisted_agent_config(wardian_session_id);
-    let persisted_provider_config = if matches!(provider_name, "opencode" | "antigravity") {
-        config_override
-            .cloned()
-            .or_else(|| persisted_config.clone())
-    } else {
-        None
-    };
+    let provider_context = headless_provider_context(
+        provider_name,
+        cwd,
+        wardian_session_id,
+        config_override,
+        persisted_config.as_ref(),
+    )?;
+    let persisted_provider_config =
+        if matches!(provider_name, "gemini" | "opencode" | "antigravity") {
+            config_override
+                .cloned()
+                .or_else(|| persisted_config.clone())
+        } else {
+            None
+        };
     let (bin, _) = provider.get_executable();
     let claude_hook = if provider_name == "claude" {
         ensure_claude_permission_hook(wardian_session_id).ok()
@@ -203,7 +266,7 @@ pub async fn run_headless_with_options(
     let mut provider_args = headless_provider_args(
         provider_name,
         provider.as_ref(),
-        &provider_cwd,
+        &provider_context.args_cwd,
         prompt,
         output_format,
         resume_session,
@@ -229,24 +292,20 @@ pub async fn run_headless_with_options(
         }
     }
     if provider_name == "codex" {
-        if let Some(root) = habitat_root.as_ref() {
+        if let Some(root) = provider_context.habitat_root.as_ref() {
             cmd.env("CODEX_HOME", habitat_codex_home(root));
         }
     } else if provider_name == "claude" {
         cmd.env("CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD", "1");
     } else if provider_name == "opencode" {
-        let class_name = persisted_provider_config
-            .as_ref()
-            .map(|config| config.agent_class.as_str())
-            .unwrap_or("");
         let opencode_scope_session = if resume_session.is_some() {
             resume_session
         } else {
             (!wardian_session_id.trim().is_empty()).then_some(wardian_session_id)
         };
         for (key, value) in opencode_env(
-            &provider_cwd,
-            class_name,
+            cwd,
+            &provider_context.class_name,
             opencode_scope_session,
             persisted_provider_config.as_ref(),
         )? {
@@ -270,7 +329,7 @@ pub async fn run_headless_with_options(
     #[cfg(target_os = "macos")]
     cmd.env("PATH", macos_extended_path());
 
-    cmd.current_dir(&provider_cwd)
+    cmd.current_dir(&provider_context.command_cwd)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
@@ -282,7 +341,7 @@ pub async fn run_headless_with_options(
         } else {
             wardian_session_id
         },
-        cwd.display(),
+        provider_context.command_cwd.display(),
         prompt.len(),
         output_format
     ));
@@ -744,7 +803,7 @@ fn apply_headless_identity_env(cmd: &mut tokio::process::Command, wardian_sessio
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     #[test]
     fn bootstrap_session_prompt_uses_intro_prompt_for_providers_that_need_bootstrap() {
         assert_eq!(session_bootstrap_prompt(), "Introduce yourself");
@@ -783,6 +842,49 @@ mod tests {
 
         assert!(args.contains(&"--print".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn gemini_headless_args_include_config_without_session_reuse() {
+        let provider = crate::providers::ProviderFactory::resolve("gemini").unwrap();
+        let config = AgentConfig {
+            session_id: "wardian-agent".into(),
+            resume_session: Some("provider-session".into()),
+            system_include_directories: Some(vec!["C:/wardian/common".into()]),
+            include_directories: Some(vec!["C:/workspace/docs".into()]),
+            model: Some("gemini-test-model".into()),
+            provider_config: wardian_core::models::ProviderConfig::Gemini(
+                wardian_core::models::GeminiProviderConfig {
+                    output_format: Some("text".into()),
+                    ..Default::default()
+                },
+            ),
+            ..Default::default()
+        };
+
+        let args = headless_provider_args(
+            "gemini",
+            provider.as_ref(),
+            Path::new("D:/Development/Wardian"),
+            "task",
+            "json",
+            None,
+            Some(&config),
+        );
+
+        assert!(args.contains(&"--include-directories".to_string()));
+        assert!(args.contains(&"C:/wardian/common,C:/workspace/docs".to_string()));
+        assert!(args.contains(&"--model".to_string()));
+        assert!(args.contains(&"gemini-test-model".to_string()));
+        assert!(!args.contains(&"--session-id".to_string()));
+        assert!(!args.contains(&"wardian-agent".to_string()));
+        assert!(!args.contains(&"--resume".to_string()));
+        assert!(!args.contains(&"provider-session".to_string()));
+        let output_format_index = args
+            .iter()
+            .position(|arg| arg == "--output-format")
+            .expect("output format flag");
+        assert_eq!(args[output_format_index + 1], "json");
     }
 
     #[test]
@@ -850,6 +952,97 @@ mod tests {
         assert!(args.contains(&"--dangerously-skip-permissions".to_string()));
         assert!(!args.contains(&"--output-format".to_string()));
         assert!(!args.contains(&"--resume".to_string()));
+    }
+
+    #[test]
+    fn gemini_headless_context_projects_persisted_class_skills() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let previous_home = std::env::var_os("WARDIAN_HOME");
+        let wardian_home = tempfile::tempdir().expect("wardian home");
+        let workspace = tempfile::tempdir().expect("workspace");
+        let class_skill = wardian_home
+            .path()
+            .join("classes")
+            .join("Personal Assistant")
+            .join(".agents")
+            .join("skills")
+            .join("gws");
+        std::fs::create_dir_all(&class_skill).expect("create class skill");
+        std::fs::write(class_skill.join("SKILL.md"), "gws skill").expect("write class skill");
+        std::env::set_var("WARDIAN_HOME", wardian_home.path());
+
+        let persisted = AgentConfig {
+            session_id: "agent-1".into(),
+            agent_class: "Personal Assistant".into(),
+            provider: "gemini".into(),
+            ..Default::default()
+        };
+        let context = headless_provider_context(
+            "gemini",
+            workspace.path(),
+            "agent-1",
+            None,
+            Some(&persisted),
+        )
+        .expect("headless context");
+
+        let expected_habitat = wardian_home
+            .path()
+            .join("agents")
+            .join("agent-1")
+            .join("habitat");
+        assert_eq!(context.habitat_root, Some(expected_habitat.clone()));
+        assert_eq!(context.command_cwd, expected_habitat.join("workspace"));
+        assert_eq!(context.args_cwd, context.command_cwd);
+        assert!(expected_habitat.join("GEMINI.md").is_file());
+        assert!(expected_habitat
+            .join(".agents")
+            .join("skills")
+            .join("gws")
+            .join("SKILL.md")
+            .is_file());
+
+        match previous_home {
+            Some(value) => std::env::set_var("WARDIAN_HOME", value),
+            None => std::env::remove_var("WARDIAN_HOME"),
+        }
+    }
+
+    #[test]
+    fn opencode_headless_context_keeps_real_workspace_as_run_dir() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let previous_home = std::env::var_os("WARDIAN_HOME");
+        let wardian_home = tempfile::tempdir().expect("wardian home");
+        let workspace = tempfile::tempdir().expect("workspace");
+        std::env::set_var("WARDIAN_HOME", wardian_home.path());
+
+        let persisted = AgentConfig {
+            session_id: "agent-1".into(),
+            agent_class: "Builder".into(),
+            provider: "opencode".into(),
+            ..Default::default()
+        };
+        let context = headless_provider_context(
+            "opencode",
+            workspace.path(),
+            "agent-1",
+            None,
+            Some(&persisted),
+        )
+        .expect("headless context");
+
+        let expected_habitat = wardian_home
+            .path()
+            .join("agents")
+            .join("agent-1")
+            .join("habitat");
+        assert_eq!(context.command_cwd, expected_habitat);
+        assert_eq!(context.args_cwd, PathBuf::from(workspace.path()));
+
+        match previous_home {
+            Some(value) => std::env::set_var("WARDIAN_HOME", value),
+            None => std::env::remove_var("WARDIAN_HOME"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/providers/antigravity.rs
+++ b/src-tauri/src/providers/antigravity.rs
@@ -113,6 +113,15 @@ impl AgentProvider for AntigravityProvider {
                     for name in ["agy.exe", "agy.cmd", "agy.bat", "agy"] {
                         let candidate = path.join(name);
                         if candidate.is_file() {
+                            if !name.eq_ignore_ascii_case("agy.exe") {
+                                if let Some(launch) =
+                                    crate::providers::npm::node_launch_from_npm_cmd_shim(
+                                        &path, "agy",
+                                    )
+                                {
+                                    return launch;
+                                }
+                            }
                             return (candidate.to_string_lossy().to_string(), vec![]);
                         }
                     }
@@ -275,6 +284,45 @@ mod tests {
     #[test]
     fn instruction_filename_is_agents_md() {
         assert_eq!(make_provider().get_instruction_filename(), "AGENTS.md");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_path_resolution_prefers_node_entrypoint_over_cmd_shim() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let previous_path = std::env::var_os("PATH");
+        let temp = tempfile::tempdir().unwrap();
+        let agy_js = temp
+            .path()
+            .join("node_modules")
+            .join("@google")
+            .join("antigravity")
+            .join("bin")
+            .join("agy.js");
+        std::fs::create_dir_all(agy_js.parent().unwrap()).unwrap();
+        std::fs::write(
+            temp.path().join("agy.cmd"),
+            r#"@ECHO off
+SET dp0=%~dp0
+"%dp0%\node.exe" "%dp0%\node_modules\@google\antigravity\bin\agy.js" %*
+"#,
+        )
+        .unwrap();
+        std::fs::write(&agy_js, "console.log('agy')").unwrap();
+
+        unsafe {
+            std::env::set_var("PATH", temp.path());
+        }
+
+        let (executable, args) = AntigravityProvider::new().get_executable();
+
+        assert_eq!(executable, "node");
+        assert_eq!(args, vec![agy_js.to_string_lossy().to_string()]);
+
+        match previous_path {
+            Some(value) => unsafe { std::env::set_var("PATH", value) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
     }
 
     #[test]

--- a/src-tauri/src/providers/claude.rs
+++ b/src-tauri/src/providers/claude.rs
@@ -136,6 +136,12 @@ impl AgentProvider for ClaudeProvider {
                     });
 
                 for path in std::env::split_paths(&paths) {
+                    if let Some(launch) =
+                        crate::providers::npm::node_launch_from_npm_cmd_shim(&path, "claude")
+                    {
+                        return launch;
+                    }
+
                     let direct = path.join("claude");
                     if direct.exists() {
                         return (direct.to_string_lossy().to_string(), vec![]);
@@ -150,7 +156,14 @@ impl AgentProvider for ClaudeProvider {
             }
 
             if let Some(appdata) = dirs::data_dir() {
-                let npm_claude = appdata.join("npm").join("claude.cmd");
+                let npm_dir = appdata.join("npm");
+                if let Some(launch) =
+                    crate::providers::npm::node_launch_from_npm_cmd_shim(&npm_dir, "claude")
+                {
+                    return launch;
+                }
+
+                let npm_claude = npm_dir.join("claude.cmd");
                 if npm_claude.exists() {
                     return (npm_claude.to_string_lossy().to_string(), vec![]);
                 }
@@ -392,6 +405,44 @@ mod tests {
     fn instruction_filename_is_claude_md() {
         let p = make_provider();
         assert_eq!(p.get_instruction_filename(), "CLAUDE.md");
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_path_resolution_prefers_node_entrypoint_over_cmd_shim() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let previous_path = std::env::var_os("PATH");
+        let temp = tempfile::tempdir().unwrap();
+        let claude_js = temp
+            .path()
+            .join("node_modules")
+            .join("@anthropic-ai")
+            .join("claude-code")
+            .join("cli.js");
+        std::fs::create_dir_all(claude_js.parent().unwrap()).unwrap();
+        std::fs::write(
+            temp.path().join("claude.cmd"),
+            r#"@ECHO off
+SET dp0=%~dp0
+"%dp0%\node.exe" "%dp0%\node_modules\@anthropic-ai\claude-code\cli.js" %*
+"#,
+        )
+        .unwrap();
+        std::fs::write(&claude_js, "console.log('claude')").unwrap();
+
+        unsafe {
+            std::env::set_var("PATH", temp.path());
+        }
+
+        let (executable, args) = ClaudeProvider::new().get_executable();
+
+        assert_eq!(executable, "node");
+        assert_eq!(args, vec![claude_js.to_string_lossy().to_string()]);
+
+        match previous_path {
+            Some(value) => unsafe { std::env::set_var("PATH", value) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
     }
 
     #[test]

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -17,21 +17,33 @@ impl CodexProvider {
     }
 
     #[cfg(target_os = "windows")]
-    fn find_windows_codex_in_paths<I>(paths: I, path_exts: &[String]) -> Option<String>
+    fn windows_codex_node_launch(path: &std::path::Path) -> Option<(String, Vec<String>)> {
+        crate::providers::npm::node_launch_from_npm_cmd_shim(path, "codex")
+    }
+
+    #[cfg(target_os = "windows")]
+    fn find_windows_codex_in_paths<I>(
+        paths: I,
+        path_exts: &[String],
+    ) -> Option<(String, Vec<String>)>
     where
         I: IntoIterator<Item = std::path::PathBuf>,
     {
         for path in paths {
+            if let Some(launch) = Self::windows_codex_node_launch(&path) {
+                return Some(launch);
+            }
+
             for ext in path_exts {
                 let candidate = path.join(format!("codex{ext}"));
                 if candidate.exists() {
-                    return Some(candidate.to_string_lossy().to_string());
+                    return Some((candidate.to_string_lossy().to_string(), vec![]));
                 }
             }
 
             let powershell = path.join("codex.ps1");
             if powershell.exists() {
-                return Some(powershell.to_string_lossy().to_string());
+                return Some((powershell.to_string_lossy().to_string(), vec![]));
             }
         }
 
@@ -94,7 +106,12 @@ impl CodexProvider {
         Some("Approval required".to_string())
     }
 
-    fn append_common_args(&self, args: &mut Vec<String>, config: &AgentConfig, is_exec_mode: bool) {
+    pub(crate) fn append_common_args(
+        &self,
+        args: &mut Vec<String>,
+        config: &AgentConfig,
+        is_exec_mode: bool,
+    ) {
         let codex = config.codex_config();
         if let Some(ref model) = config.model {
             args.push("--model".into());
@@ -239,10 +256,10 @@ impl AgentProvider for CodexProvider {
                         vec![".exe".to_string(), ".cmd".to_string(), ".bat".to_string()]
                     });
 
-                if let Some(executable) =
+                if let Some((executable, args)) =
                     Self::find_windows_codex_in_paths(std::env::split_paths(&paths), &path_exts)
                 {
-                    return (executable, vec![]);
+                    return (executable, args);
                 }
             }
 
@@ -626,7 +643,7 @@ mod tests {
         std::fs::write(temp.path().join("codex.ps1"), "echo test").unwrap();
 
         let path_exts = vec![".exe".to_string(), ".cmd".to_string(), ".bat".to_string()];
-        let executable =
+        let (executable, args) =
             CodexProvider::find_windows_codex_in_paths([temp.path().to_path_buf()], &path_exts)
                 .unwrap();
 
@@ -634,6 +651,38 @@ mod tests {
             executable,
             temp.path().join("codex.ps1").to_string_lossy().to_string()
         );
+        assert!(args.is_empty());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_path_resolution_prefers_node_codex_entrypoint_over_cmd_shim() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_js = temp
+            .path()
+            .join("node_modules")
+            .join("@openai")
+            .join("codex")
+            .join("bin")
+            .join("codex.js");
+        std::fs::create_dir_all(codex_js.parent().unwrap()).unwrap();
+        std::fs::write(
+            temp.path().join("codex.cmd"),
+            r#"@ECHO off
+SET dp0=%~dp0
+"%dp0%\node.exe" "%dp0%\node_modules\@openai\codex\bin\codex.js" %*
+"#,
+        )
+        .unwrap();
+        std::fs::write(&codex_js, "console.log('codex')").unwrap();
+
+        let path_exts = vec![".cmd".to_string()];
+        let (executable, args) =
+            CodexProvider::find_windows_codex_in_paths([temp.path().to_path_buf()], &path_exts)
+                .unwrap();
+
+        assert_eq!(executable, "node");
+        assert_eq!(args, vec![codex_js.to_string_lossy().to_string()]);
     }
 
     #[test]

--- a/src-tauri/src/providers/gemini.rs
+++ b/src-tauri/src/providers/gemini.rs
@@ -44,6 +44,13 @@ impl AgentProvider for GeminiProvider {
         // 1. Try bare command in PATH
         if let Some(paths) = std::env::var_os("PATH") {
             for path in std::env::split_paths(&paths) {
+                #[cfg(target_os = "windows")]
+                if let Some(launch) =
+                    crate::providers::npm::node_launch_from_npm_cmd_shim(&path, "gemini")
+                {
+                    return launch;
+                }
+
                 let full_path = path.join(exe_name);
                 if full_path.exists() {
                     return (exe_name.to_string(), vec![]);
@@ -54,14 +61,20 @@ impl AgentProvider for GeminiProvider {
         // 2. Robust Fallback
         if cfg!(target_os = "windows") {
             if let Some(appdata) = dirs::data_dir() {
-                let npm_gemini = appdata.join("npm").join("gemini.cmd");
+                let npm_dir = appdata.join("npm");
+                if let Some(launch) =
+                    crate::providers::npm::node_launch_from_npm_cmd_shim(&npm_dir, "gemini")
+                {
+                    return launch;
+                }
+
+                let npm_gemini = npm_dir.join("gemini.cmd");
                 if npm_gemini.exists() {
                     return (npm_gemini.to_string_lossy().to_string(), vec![]);
                 }
 
                 // Legacy index.js lookup
-                let index_js = appdata
-                    .join("npm")
+                let index_js = npm_dir
                     .join("node_modules")
                     .join("@google")
                     .join("gemini-cli")
@@ -288,6 +301,45 @@ mod tests {
             assert!(bin == "node" || binary_name.eq_ignore_ascii_case("gemini.cmd"));
         } else {
             assert_eq!(bin, "gemini");
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_path_resolution_prefers_node_entrypoint_over_cmd_shim() {
+        let _lock = crate::utils::wardian_test_env_lock();
+        let previous_path = std::env::var_os("PATH");
+        let temp = tempfile::tempdir().unwrap();
+        let gemini_js = temp
+            .path()
+            .join("node_modules")
+            .join("@google")
+            .join("gemini-cli")
+            .join("bundle")
+            .join("gemini.js");
+        std::fs::create_dir_all(gemini_js.parent().unwrap()).unwrap();
+        std::fs::write(
+            temp.path().join("gemini.cmd"),
+            r#"@ECHO off
+SET dp0=%~dp0
+"%dp0%\node.exe" "%dp0%\node_modules\@google\gemini-cli\bundle\gemini.js" %*
+"#,
+        )
+        .unwrap();
+        std::fs::write(&gemini_js, "console.log('gemini')").unwrap();
+
+        unsafe {
+            std::env::set_var("PATH", temp.path());
+        }
+
+        let (executable, args) = GeminiProvider::new().get_executable();
+
+        assert_eq!(executable, "node");
+        assert_eq!(args, vec![gemini_js.to_string_lossy().to_string()]);
+
+        match previous_path {
+            Some(value) => unsafe { std::env::set_var("PATH", value) },
+            None => unsafe { std::env::remove_var("PATH") },
         }
     }
 

--- a/src-tauri/src/providers/mod.rs
+++ b/src-tauri/src/providers/mod.rs
@@ -5,6 +5,7 @@ pub mod codex;
 pub mod factory;
 pub mod gemini;
 pub mod mock;
+pub mod npm;
 pub mod opencode;
 pub mod readiness;
 pub mod transcript;

--- a/src-tauri/src/providers/npm.rs
+++ b/src-tauri/src/providers/npm.rs
@@ -1,0 +1,69 @@
+#[cfg(target_os = "windows")]
+/// Resolve an npm-generated `.cmd` shim to a direct `node <script.js>` launch.
+///
+/// Provider adapters should use this before returning a Windows npm CLI shim.
+/// Launching the JavaScript entrypoint directly keeps headless provider argv
+/// stable and avoids shell quoting/windowing behavior from `cmd.exe` shims.
+pub fn node_launch_from_npm_cmd_shim(
+    base_dir: &std::path::Path,
+    command_name: &str,
+) -> Option<(String, Vec<String>)> {
+    let shim = base_dir.join(format!("{command_name}.cmd"));
+    let content = std::fs::read_to_string(shim).ok()?;
+    let script = npm_cmd_shim_script_path(&content)?;
+    let script = base_dir.join(script);
+    if !script.is_file() {
+        return None;
+    }
+
+    let local_node = base_dir.join("node.exe");
+    let executable = if local_node.is_file() {
+        local_node.to_string_lossy().to_string()
+    } else {
+        "node".to_string()
+    };
+    Some((executable, vec![script.to_string_lossy().to_string()]))
+}
+
+#[cfg(not(target_os = "windows"))]
+/// Non-Windows providers do not use npm `.cmd` shims.
+pub fn node_launch_from_npm_cmd_shim(
+    _base_dir: &std::path::Path,
+    _command_name: &str,
+) -> Option<(String, Vec<String>)> {
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn npm_cmd_shim_script_path(content: &str) -> Option<std::path::PathBuf> {
+    for quoted in content.split('"').skip(1).step_by(2) {
+        let normalized = quoted.replace('/', "\\");
+        let lower = normalized.to_ascii_lowercase();
+        let Some(rest) = lower.strip_prefix("%dp0%\\") else {
+            continue;
+        };
+        if !rest.ends_with(".js") {
+            continue;
+        }
+        let original_rest = &normalized["%dp0%\\".len()..];
+        return Some(std::path::PathBuf::from(original_rest));
+    }
+    None
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_node_script_from_npm_cmd_shim() {
+        let content = r#"@ECHO off
+"%dp0%\node.exe" "%dp0%\node_modules\package\bin\tool.js" %*
+"#;
+
+        assert_eq!(
+            npm_cmd_shim_script_path(content).unwrap(),
+            std::path::PathBuf::from("node_modules\\package\\bin\\tool.js")
+        );
+    }
+}

--- a/src-tauri/src/providers/transcript.rs
+++ b/src-tauri/src/providers/transcript.rs
@@ -27,11 +27,11 @@ fn extract_codex(raw_line: &str) -> Option<WatchTranscriptMessage> {
     };
     let payload_type = payload.get("type").and_then(|value| value.as_str())?;
     let role = payload.get("role").and_then(|value| value.as_str());
-    let is_assistant = role == Some("assistant")
-        || matches!(
-            payload_type,
-            "agent_message" | "assistant_message" | "message"
-        );
+    let is_assistant = match role {
+        Some("assistant" | "model") => true,
+        Some(_) => false,
+        None => matches!(payload_type, "agent_message" | "assistant_message"),
+    };
     if !is_assistant {
         return None;
     }
@@ -313,6 +313,11 @@ mod tests {
         assert!(
             extract_transcript_message("mock", r#"{"type":"user","content":"hello"}"#).is_none()
         );
+        assert!(extract_transcript_message(
+            "codex",
+            r#"{"type":"response_item","payload":{"type":"message","role":"user","content":"wardian reply wf_test --status done --stdin\nprompt echo"}}"#
+        )
+        .is_none());
         assert!(extract_transcript_message(
             "codex",
             r#"{"type":"response_item","payload":{"type":"function_call","arguments":"{}"}}"#

--- a/src-tauri/src/state/interactions.rs
+++ b/src-tauri/src/state/interactions.rs
@@ -209,17 +209,19 @@ impl InteractionState {
         let (structured_reply, completed_task, reply_record) = {
             let mut records = self.records.lock().await;
             let task = records.get_mut(task_id).ok_or("not_found")?;
-            if task.status == InteractionStatus::Completed {
+            if task.status != InteractionStatus::AwaitingReply {
                 return Err("duplicate_reply");
             }
-            if let Some(source) = source_session_id {
-                if !task
-                    .target_session_ids
-                    .iter()
-                    .any(|target| target == source)
-                {
-                    return Err("unauthorized");
-                }
+            let source_session_id = source_session_id
+                .map(str::trim)
+                .filter(|source| !source.is_empty())
+                .ok_or("unauthorized")?;
+            if !task
+                .target_session_ids
+                .iter()
+                .any(|target| target == source_session_id)
+            {
+                return Err("unauthorized");
             }
             let target_session_id = task
                 .target_session_ids
@@ -233,7 +235,7 @@ impl InteractionState {
             let reply = InteractionRecord {
                 id: new_interaction_id(),
                 kind: InteractionKind::Reply,
-                sender_session_id: source_session_id.map(str::to_string),
+                sender_session_id: Some(source_session_id.to_string()),
                 target_session_ids: task.sender_session_id.iter().cloned().collect(),
                 status: InteractionStatus::Completed,
                 trigger_policy: InteractionTriggerPolicy::NotifyOnly,
@@ -250,7 +252,7 @@ impl InteractionState {
                 status,
                 body: body.to_string(),
                 target_session_id,
-                source_session_id: source_session_id.map(str::to_string),
+                source_session_id: Some(source_session_id.to_string()),
                 replied_at: now,
             };
             let completed_task = task.clone();
@@ -258,6 +260,68 @@ impl InteractionState {
             (structured_reply, completed_task, reply)
         };
         let _ = wardian_core::db::upsert_interaction_record(&completed_task);
+        let _ = wardian_core::db::upsert_interaction_record(&reply_record);
+        let _ = wardian_core::db::upsert_structured_reply(&structured_reply);
+        self.replies
+            .lock()
+            .await
+            .insert(task_id.to_string(), structured_reply.clone());
+        Ok(structured_reply)
+    }
+
+    pub async fn fail_task_with_reply(
+        &self,
+        task_id: &str,
+        target_session_id: &str,
+        body: &str,
+    ) -> Result<StructuredReply, &'static str> {
+        let now = now_rfc3339_millis();
+        let (structured_reply, failed_task, reply_record) = {
+            let mut records = self.records.lock().await;
+            let task = records.get_mut(task_id).ok_or("not_found")?;
+            if task.status != InteractionStatus::AwaitingReply {
+                return Err("duplicate_reply");
+            }
+            if !task
+                .target_session_ids
+                .iter()
+                .any(|target| target == target_session_id)
+            {
+                return Err("unauthorized");
+            }
+
+            task.status = InteractionStatus::Failed;
+            task.updated_at = now.clone();
+            task.completed_at = Some(now.clone());
+
+            let reply = InteractionRecord {
+                id: new_interaction_id(),
+                kind: InteractionKind::Reply,
+                sender_session_id: None,
+                target_session_ids: task.sender_session_id.iter().cloned().collect(),
+                status: InteractionStatus::Completed,
+                trigger_policy: InteractionTriggerPolicy::NotifyOnly,
+                body_ref: InteractionBodyRef::Inline {
+                    body: body.to_string(),
+                },
+                parent_interaction_id: Some(task_id.to_string()),
+                created_at: now.clone(),
+                updated_at: now.clone(),
+                completed_at: Some(now.clone()),
+            };
+            let structured_reply = StructuredReply {
+                request_id: task_id.to_string(),
+                status: ReplyStatus::Failed,
+                body: body.to_string(),
+                target_session_id: target_session_id.to_string(),
+                source_session_id: None,
+                replied_at: now,
+            };
+            let failed_task = task.clone();
+            records.insert(reply.id.clone(), reply.clone());
+            (structured_reply, failed_task, reply)
+        };
+        let _ = wardian_core::db::upsert_interaction_record(&failed_task);
         let _ = wardian_core::db::upsert_interaction_record(&reply_record);
         let _ = wardian_core::db::upsert_structured_reply(&structured_reply);
         self.replies
@@ -558,5 +622,72 @@ mod reply_tests {
         assert_eq!(reply.body, "blocked");
         assert_eq!(reply.target_session_id, "agent-1");
         assert_eq!(reply.source_session_id.as_deref(), Some("agent-1"));
+    }
+
+    #[tokio::test]
+    async fn reply_requires_target_source_session() {
+        let state = InteractionState::default();
+        let task = state
+            .create_task(
+                None,
+                "agent-1".to_string(),
+                InteractionBodyRef::Inline {
+                    body: "review".to_string(),
+                },
+            )
+            .await;
+
+        let originless = state
+            .complete_task_with_reply(&task.id, None, ReplyStatus::Done, "spoofed")
+            .await
+            .unwrap_err();
+        assert_eq!(originless, "unauthorized");
+
+        let foreign = state
+            .complete_task_with_reply(&task.id, Some("agent-2"), ReplyStatus::Done, "spoofed")
+            .await
+            .unwrap_err();
+        assert_eq!(foreign, "unauthorized");
+
+        assert_eq!(
+            state.interaction(&task.id).await.unwrap().status,
+            InteractionStatus::AwaitingReply
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_task_records_terminal_reply_and_rejects_late_reply() {
+        let state = InteractionState::default();
+        let task = state
+            .create_task(
+                None,
+                "agent-1".to_string(),
+                InteractionBodyRef::Inline {
+                    body: "review".to_string(),
+                },
+            )
+            .await;
+
+        let failed = state
+            .fail_task_with_reply(&task.id, "agent-1", "timed out")
+            .await
+            .unwrap();
+
+        assert_eq!(failed.status, ReplyStatus::Failed);
+        assert_eq!(failed.source_session_id, None);
+        assert_eq!(
+            state.interaction(&task.id).await.unwrap().status,
+            InteractionStatus::Failed
+        );
+        assert_eq!(
+            state.structured_reply(&task.id).await.unwrap().body,
+            "timed out"
+        );
+
+        let late = state
+            .complete_task_with_reply(&task.id, Some("agent-1"), ReplyStatus::Done, "late")
+            .await
+            .unwrap_err();
+        assert_eq!(late, "duplicate_reply");
     }
 }

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -173,7 +173,7 @@ pub fn ensure_claude_permission_hook(
 pub fn resolve_system_include_directories(class_name: &str, session_id: &str) -> Vec<String> {
     let mut dirs = Vec::new();
     if let Some(app_dir) = get_wardian_home() {
-        let class_path = app_dir.join("classes").join(class_name);
+        let class_path = safe_class_dir(&app_dir, class_name);
         let common_path = app_dir.join("common");
         let agent_path = app_dir.join("agents").join(session_id);
 
@@ -187,7 +187,7 @@ pub fn resolve_system_include_directories(class_name: &str, session_id: &str) ->
         if common_path.exists() {
             dirs.push(common_path.to_string_lossy().to_string());
         }
-        if class_path.exists() {
+        if let Some(class_path) = class_path.filter(|path| path.exists()) {
             dirs.push(class_path.to_string_lossy().to_string());
         }
         if agent_path.exists() {
@@ -195,6 +195,20 @@ pub fn resolve_system_include_directories(class_name: &str, session_id: &str) ->
         }
     }
     dirs
+}
+
+fn safe_class_dir(wardian_home: &std::path::Path, class_name: &str) -> Option<std::path::PathBuf> {
+    let trimmed = class_name.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let mut components = std::path::Path::new(trimmed).components();
+    match (components.next(), components.next()) {
+        (Some(std::path::Component::Normal(name)), None) => {
+            Some(wardian_home.join("classes").join(name))
+        }
+        _ => None,
+    }
 }
 
 pub fn project_antigravity_include_directories(session_id: &str, dirs: Vec<String>) -> Vec<String> {
@@ -400,9 +414,7 @@ pub fn resolve_opencode_runtime_roots(
             push_unique(common_dir);
         }
 
-        let trimmed_class = class_name.trim();
-        if !trimmed_class.is_empty() {
-            let class_dir = wardian_home.join("classes").join(trimmed_class);
+        if let Some(class_dir) = safe_class_dir(&wardian_home, class_name) {
             if class_dir.exists() {
                 push_unique(class_dir);
             }
@@ -706,16 +718,16 @@ fn write_habitat_instruction_files(
     session_id: Option<&str>,
 ) -> Result<(), String> {
     let common_agents = wardian_home.join("common").join("AGENTS.md");
-    let class_agents = wardian_home
-        .join("classes")
-        .join(class_name)
-        .join("AGENTS.md");
+    let class_agents = safe_class_dir(wardian_home, class_name).map(|path| path.join("AGENTS.md"));
     let agent_agents = session_id
         .filter(|sid| !sid.trim().is_empty())
         .map(|sid| wardian_home.join("agents").join(sid).join("AGENTS.md"));
 
     let mut sections = Vec::new();
-    let mut candidates = vec![("Common", common_agents), ("Class", class_agents)];
+    let mut candidates = vec![("Common", common_agents)];
+    if let Some(class_agents) = class_agents {
+        candidates.push(("Class", class_agents));
+    }
     if let Some(agent_agents) = agent_agents {
         candidates.push(("Agent", agent_agents));
     }
@@ -724,8 +736,7 @@ fn write_habitat_instruction_files(
             if let Ok(content) = std::fs::read_to_string(&path) {
                 if !content.trim().is_empty() {
                     sections.push(format!(
-                        "## {label}\nSource: {}\n\n{}\n",
-                        path.to_string_lossy(),
+                        "## {label}\nSource: {label}\n\n{}\n",
                         content.trim()
                     ));
                 }
@@ -763,14 +774,12 @@ fn build_habitat_skill_projection(
     }
     std::fs::create_dir_all(&merged_skills).map_err(|e| e.to_string())?;
 
-    let mut sources = vec![
-        wardian_home.join("common").join(".agents").join("skills"),
-        wardian_home
-            .join("classes")
-            .join(class_name)
-            .join(".agents")
-            .join("skills"),
-    ];
+    let mut sources = vec![wardian_home.join("common").join(".agents").join("skills")];
+    if let Some(class_skills) =
+        safe_class_dir(wardian_home, class_name).map(|path| path.join(".agents").join("skills"))
+    {
+        sources.push(class_skills);
+    }
     if let Some(session_id) = session_id.filter(|sid| !sid.trim().is_empty()) {
         sources.push(
             wardian_home
@@ -1043,10 +1052,12 @@ pub fn validate_workspace_path(path: &std::path::Path) -> Result<std::path::Path
 #[cfg(test)]
 mod tests {
     use super::{
-        build_opencode_runtime_config, create_directory_link, ensure_claude_permission_hook,
-        habitat_root_for_session, project_antigravity_include_directories,
-        projected_link_matches_target, provider_uses_projected_workspace,
-        resolve_opencode_runtime_roots, sync_codex_agent_home, sync_opencode_config_dir,
+        build_habitat_skill_projection, build_opencode_runtime_config, create_directory_link,
+        ensure_claude_permission_hook, habitat_root_for_session,
+        project_antigravity_include_directories, projected_link_matches_target,
+        provider_uses_projected_workspace, resolve_opencode_runtime_roots,
+        resolve_system_include_directories, sync_codex_agent_home, sync_opencode_config_dir,
+        write_habitat_instruction_files,
     };
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1088,6 +1099,40 @@ mod tests {
         assert!(provider_uses_projected_workspace("codex"));
         assert!(provider_uses_projected_workspace("gemini"));
         assert!(provider_uses_projected_workspace("opencode"));
+    }
+
+    #[test]
+    fn habitat_instruction_files_use_stable_source_labels() {
+        let wardian_home = unique_temp_dir("habitat-source-labels-home");
+        let habitat_root = unique_temp_dir("habitat-source-labels-root");
+        let common = wardian_home.join("common");
+        let class = wardian_home.join("classes").join("Builder");
+        let agent = wardian_home.join("agents").join("agent-1");
+        std::fs::create_dir_all(&common).expect("create common");
+        std::fs::create_dir_all(&class).expect("create class");
+        std::fs::create_dir_all(&agent).expect("create agent");
+        std::fs::create_dir_all(&habitat_root).expect("create habitat");
+        std::fs::write(common.join("AGENTS.md"), "common instructions").expect("write common");
+        std::fs::write(class.join("AGENTS.md"), "class instructions").expect("write class");
+        std::fs::write(agent.join("AGENTS.md"), "agent instructions").expect("write agent");
+
+        write_habitat_instruction_files(&wardian_home, &habitat_root, "Builder", Some("agent-1"))
+            .expect("write habitat instructions");
+
+        let agents_md =
+            std::fs::read_to_string(habitat_root.join("AGENTS.md")).expect("read AGENTS.md");
+        assert!(agents_md.contains("Source: Common"));
+        assert!(agents_md.contains("Source: Class"));
+        assert!(agents_md.contains("Source: Agent"));
+        assert!(!agents_md.contains(&wardian_home.to_string_lossy().to_string()));
+        assert!(!agents_md.contains("agent-1/AGENTS.md"));
+        assert_eq!(
+            std::fs::read_to_string(habitat_root.join("GEMINI.md")).expect("read GEMINI.md"),
+            "@AGENTS.md\n"
+        );
+
+        let _ = std::fs::remove_dir_all(&wardian_home);
+        let _ = std::fs::remove_dir_all(&habitat_root);
     }
 
     #[test]
@@ -1547,6 +1592,60 @@ mod tests {
         unsafe { std::env::remove_var("WARDIAN_HOME") };
 
         assert_eq!(roots, vec![common, class_dir, agent_dir]);
+
+        let _ = std::fs::remove_dir_all(&wardian_home);
+    }
+
+    #[test]
+    fn class_projection_rejects_path_traversal_components() {
+        let wardian_home = unique_temp_dir("class-projection-traversal");
+        let outside = wardian_home.join("outside-class");
+        let habitat_root = wardian_home.join("agents").join("ses_123").join("habitat");
+
+        std::fs::create_dir_all(outside.join(".agents").join("skills").join("outside-skill"))
+            .expect("create outside skill");
+        std::fs::write(outside.join("AGENTS.md"), "outside class instructions")
+            .expect("write outside agents");
+        std::fs::create_dir_all(&habitat_root).expect("create habitat");
+
+        write_habitat_instruction_files(
+            &wardian_home,
+            &habitat_root,
+            "../outside-class",
+            Some("ses_123"),
+        )
+        .expect("write habitat instructions");
+        build_habitat_skill_projection(
+            &wardian_home,
+            &habitat_root,
+            "../outside-class",
+            Some("ses_123"),
+        )
+        .expect("build skill projection");
+
+        let agents_md =
+            std::fs::read_to_string(habitat_root.join("AGENTS.md")).expect("read agents");
+        assert!(!agents_md.contains("outside class instructions"));
+        assert!(!habitat_root
+            .join(".agents")
+            .join("skills")
+            .join("outside-skill")
+            .exists());
+
+        let _ = std::fs::remove_dir_all(&wardian_home);
+    }
+
+    #[test]
+    fn system_include_directories_ignore_traversal_class_names() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let wardian_home = unique_temp_dir("system-include-traversal");
+        std::fs::create_dir_all(wardian_home.join("outside-class")).expect("create outside class");
+        unsafe { std::env::set_var("WARDIAN_HOME", wardian_home.to_string_lossy().to_string()) };
+
+        let dirs = resolve_system_include_directories("../outside-class", "ses_123");
+
+        unsafe { std::env::remove_var("WARDIAN_HOME") };
+        assert!(!dirs.iter().any(|dir| dir.contains("outside-class")));
 
         let _ = std::fs::remove_dir_all(&wardian_home);
     }

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -102,7 +102,7 @@ pub fn resolve_cwd(folder: &str, agent_id: &str) -> std::path::PathBuf {
 }
 
 pub fn provider_uses_projected_workspace(provider: &str) -> bool {
-    matches!(provider, "codex" | "opencode")
+    matches!(provider, "codex" | "gemini" | "opencode")
 }
 
 pub fn prepare_provider_habitat(
@@ -1083,11 +1083,11 @@ mod tests {
     }
 
     #[test]
-    fn only_codex_and_opencode_use_projected_workspaces() {
+    fn codex_gemini_and_opencode_use_projected_workspaces() {
         assert!(!provider_uses_projected_workspace("claude"));
         assert!(provider_uses_projected_workspace("codex"));
+        assert!(provider_uses_projected_workspace("gemini"));
         assert!(provider_uses_projected_workspace("opencode"));
-        assert!(!provider_uses_projected_workspace("gemini"));
     }
 
     #[test]

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -133,6 +133,7 @@ impl LiveStepExecutor {
                 resume_session: resolved.resume_session.clone(),
                 is_live: resolved.is_live,
                 is_input_ready: resolved.is_input_ready,
+                config: resolved.config.clone(),
             };
             return self
                 .run_agent_binding_prompt(
@@ -158,6 +159,7 @@ impl LiveStepExecutor {
                 prompt,
                 session_id: resolved.session_id,
                 resume_session: resolved.resume_session,
+                config_override: resolved.config,
             })
             .await
             .map_err(StepError::new)
@@ -188,6 +190,7 @@ impl LiveStepExecutor {
                         prompt,
                         session_id: String::new(),
                         resume_session: None,
+                        config_override: None,
                     })
                     .await
                     .map_err(StepError::new)
@@ -274,8 +277,9 @@ impl LiveStepExecutor {
                         provider: agent.provider.clone(),
                         cwd: agent.cwd.clone(),
                         prompt,
-                        session_id: agent.session_id.clone(),
+                        session_id: fresh_background_session_id(&self.owner_id, node),
                         resume_session: None,
+                        config_override: agent.config.clone(),
                     })
                     .await
                     .map_err(StepError::new)
@@ -328,16 +332,20 @@ impl LiveStepExecutor {
                 prompt,
                 session_id: agent.session_id.clone(),
                 resume_session: Some(resume_session),
+                config_override: agent.config.clone(),
             })
             .await;
 
-        if let Err(error) = release_background_resume_lease(&lease.owner_kind, &lease.owner_id) {
-            crate::utils::logging::log_debug(&format!(
-                "[workflow] failed to release background resume lease: {error}"
-            ));
+        let release_result = release_background_resume_lease(&lease.owner_kind, &lease.owner_id);
+        match (result, release_result) {
+            (Ok(_), Err(error)) => Err(StepError::new(format!(
+                "background resume completed but failed to release conversation lease: {error}"
+            ))),
+            (Err(run_error), Err(release_error)) => Err(StepError::new(format!(
+                "{run_error}; additionally failed to release conversation lease: {release_error}"
+            ))),
+            (result, Ok(())) => result.map_err(StepError::new),
         }
-
-        result.map_err(StepError::new)
     }
 }
 
@@ -359,6 +367,33 @@ fn prompt_for_agent_task(prompt: String, output_schema: Option<&str>) -> String 
     format!(
         "{prompt}\n\nWorkflow output contract:\nRespond with valid JSON that satisfies this output_schema. Return only the JSON object, or put the final JSON object in a trailing fenced ```json block.\noutput_schema:\n{schema}"
     )
+}
+
+fn fresh_background_session_id(owner_id: &str, node: &str) -> String {
+    format!(
+        "workflow-bg-{}-{}",
+        sanitize_session_component(owner_id),
+        sanitize_session_component(node)
+    )
+}
+
+fn sanitize_session_component(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches('-');
+    if trimmed.is_empty() {
+        "unknown".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn acquire_background_resume_lease(
@@ -503,7 +538,7 @@ mod tests {
     use std::sync::Mutex;
     use wardian_core::engine::executor::{AgentTaskRequest, DecisionRequest, StepExecutor};
     use wardian_core::models::{
-        AgentConversationMode, BusyPolicy, WorkflowAssignments, WorkflowRoleAssignment,
+        AgentConfig, AgentConversationMode, BusyPolicy, WorkflowAssignments, WorkflowRoleAssignment,
     };
 
     fn exec_with(runner: FakeAgentRunner) -> LiveStepExecutor {
@@ -652,6 +687,7 @@ mod tests {
                 resume_session: Some("provider-session".to_string()),
                 is_live: true,
                 is_input_ready: true,
+                config: None,
             },
         );
 
@@ -703,6 +739,7 @@ mod tests {
                 resume_session: Some("provider-session".to_string()),
                 is_live: false,
                 is_input_ready: false,
+                config: None,
             },
         );
 
@@ -733,6 +770,91 @@ mod tests {
             Some(value) => std::env::set_var("WARDIAN_HOME", value),
             None => std::env::remove_var("WARDIAN_HOME"),
         }
+    }
+
+    #[tokio::test]
+    async fn fresh_background_assigned_agent_does_not_reuse_live_session_identity() {
+        struct IdentityCheckingRunner;
+
+        impl AgentRunner for IdentityCheckingRunner {
+            fn run(
+                &self,
+                spec: AgentRunSpec,
+            ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+                Box::pin(async move {
+                    assert_ne!(
+                        spec.session_id, "agent-123",
+                        "fresh background runs must not reuse the visible agent identity"
+                    );
+                    assert!(
+                        spec.session_id.contains("workflow-bg"),
+                        "fresh background runs should get a workflow-scoped identity"
+                    );
+                    assert!(
+                        spec.resume_session.is_none(),
+                        "fresh background runs must not resume the visible provider conversation"
+                    );
+                    let config = spec
+                        .config_override
+                        .expect("fresh background should keep the assigned agent profile");
+                    assert_eq!(config.session_id, "agent-123");
+                    assert_eq!(config.provider, "gemini");
+                    Ok("{\"ok\":true}".to_string())
+                })
+            }
+        }
+
+        let mut assignments = WorkflowAssignments::new();
+        assignments.insert(
+            "Coder".to_string(),
+            WorkflowRoleAssignment::Agent {
+                agent_id: "agent-123".to_string(),
+                conversation: AgentConversationMode::FreshBackground,
+                busy_policy: BusyPolicy::Fail,
+            },
+        );
+
+        let mut agent_catalog = HashMap::new();
+        agent_catalog.insert(
+            "agent-123".to_string(),
+            AgentBinding {
+                session_id: "agent-123".to_string(),
+                provider: "gemini".to_string(),
+                cwd: PathBuf::from("/agent-workspace"),
+                resume_session: Some("provider-session".to_string()),
+                is_live: true,
+                is_input_ready: true,
+                config: Some(AgentConfig {
+                    session_id: "agent-123".to_string(),
+                    provider: "gemini".to_string(),
+                    folder: "/agent-workspace".to_string(),
+                    ..AgentConfig::default()
+                }),
+            },
+        );
+
+        let exec = LiveStepExecutor::new_with_assignments_and_live_runner(
+            Arc::new(IdentityCheckingRunner),
+            None,
+            PathBuf::from("/run-workspace"),
+            "codex".into(),
+            HashMap::new(),
+            assignments,
+            agent_catalog,
+        )
+        .with_owner_id("run-456".to_string());
+
+        let out = exec
+            .run_agent_task(AgentTaskRequest {
+                node: "plan".into(),
+                agent: "role:Coder".into(),
+                prompt: "return json".into(),
+                output_schema: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(out.0["ok"], true);
     }
 
     #[tokio::test]
@@ -783,6 +905,7 @@ mod tests {
                 resume_session: Some("provider-session".to_string()),
                 is_live: false,
                 is_input_ready: false,
+                config: None,
             },
         );
 
@@ -842,6 +965,7 @@ mod tests {
                 resume_session: None,
                 is_live: false,
                 is_input_ready: false,
+                config: None,
             },
         );
 
@@ -893,6 +1017,7 @@ mod tests {
                 resume_session: None,
                 is_live: false,
                 is_input_ready: false,
+                config: None,
             },
         );
 

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -349,6 +349,18 @@ fn assignment_role_name(agent_ref: &str) -> String {
         .to_string()
 }
 
+fn prompt_for_agent_task(prompt: String, output_schema: Option<&str>) -> String {
+    let Some(schema) = output_schema
+        .map(str::trim)
+        .filter(|schema| !schema.is_empty())
+    else {
+        return prompt;
+    };
+    format!(
+        "{prompt}\n\nWorkflow output contract:\nRespond with valid JSON that satisfies this output_schema. Return only the JSON object, or put the final JSON object in a trailing fenced ```json block.\noutput_schema:\n{schema}"
+    )
+}
+
 fn acquire_background_resume_lease(
     agent: &AgentBinding,
     resume_session: &str,
@@ -388,7 +400,8 @@ impl StepExecutor for LiveStepExecutor {
         Self: 'async_trait,
     {
         Box::pin(async move {
-            let response = self.run_prompt(&req.node, &req.agent, req.prompt).await?;
+            let prompt = prompt_for_agent_task(req.prompt, req.output_schema.as_deref());
+            let response = self.run_prompt(&req.node, &req.agent, prompt).await?;
             output::extract_structured_output(&response, req.output_schema.as_deref())
                 .map(StepOutput)
                 .map_err(StepError::new)
@@ -487,6 +500,7 @@ mod tests {
     use super::*;
     use crate::workflow::runner::{FakeAgentRunner, FakeLiveAgentRunner};
     use std::sync::Arc;
+    use std::sync::Mutex;
     use wardian_core::engine::executor::{AgentTaskRequest, DecisionRequest, StepExecutor};
     use wardian_core::models::{
         AgentConversationMode, BusyPolicy, WorkflowAssignments, WorkflowRoleAssignment,
@@ -548,6 +562,47 @@ mod tests {
             .expect_err("schema-bound agent task should require declared fields");
 
         assert!(err.0.contains("reason"));
+    }
+
+    #[tokio::test]
+    async fn agent_task_with_schema_instructs_background_agents_to_return_json() {
+        struct PromptCapturingRunner {
+            prompt: Mutex<Option<String>>,
+        }
+
+        impl AgentRunner for PromptCapturingRunner {
+            fn run(
+                &self,
+                spec: AgentRunSpec,
+            ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + '_>> {
+                *self.prompt.lock().expect("prompt lock") = Some(spec.prompt);
+                Box::pin(async { Ok(r#"{"decision":"buy","reason":"breakout"}"#.to_string()) })
+            }
+        }
+
+        let runner = Arc::new(PromptCapturingRunner {
+            prompt: Mutex::new(None),
+        });
+        let exec = LiveStepExecutor::new(
+            runner.clone(),
+            std::path::PathBuf::from("."),
+            "mock".into(),
+            HashMap::new(),
+            HashMap::new(),
+        );
+
+        exec.run_agent_task(AgentTaskRequest {
+            node: "plan".into(),
+            agent: "role:Coder".into(),
+            prompt: "analyze".into(),
+            output_schema: Some(r#"{"decision":"string","reason":"string"}"#.into()),
+        })
+        .await
+        .unwrap();
+
+        let prompt = runner.prompt.lock().expect("prompt lock").clone().unwrap();
+        assert!(prompt.contains("Respond with valid JSON"));
+        assert!(prompt.contains(r#"{"decision":"string","reason":"string"}"#));
     }
 
     #[tokio::test]

--- a/src-tauri/src/workflow/resolve.rs
+++ b/src-tauri/src/workflow/resolve.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use wardian_core::models::workflow::{AgentConversationMode, BusyPolicy};
+use wardian_core::models::AgentConfig;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct AgentBinding {
     pub session_id: String,
     pub provider: String,
@@ -10,6 +11,7 @@ pub struct AgentBinding {
     pub resume_session: Option<String>,
     pub is_live: bool,
     pub is_input_ready: bool,
+    pub config: Option<AgentConfig>,
 }
 
 /// A resolved agent reference ready to run headlessly.
@@ -19,6 +21,7 @@ pub struct ResolvedAgent {
     pub cwd: PathBuf,
     pub session_id: String,
     pub resume_session: Option<String>,
+    pub config: Option<AgentConfig>,
     /// True for role:/class:/ephemeral workers; false for explicit live agent
     /// names whose live routing is deferred beyond 5a.
     pub is_ephemeral: bool,
@@ -108,6 +111,7 @@ pub fn resolve_agent_with_catalog(
                 cwd: workspace.to_path_buf(),
                 session_id: String::new(),
                 resume_session: None,
+                config: None,
                 is_ephemeral,
                 is_live: false,
                 is_input_ready: false,
@@ -120,6 +124,7 @@ pub fn resolve_agent_with_catalog(
                 cwd: agent.cwd.clone(),
                 session_id: agent.session_id.clone(),
                 resume_session: agent.resume_session.clone(),
+                config: agent.config.clone(),
                 is_ephemeral: false,
                 is_live: agent.is_live,
                 is_input_ready: agent.is_input_ready,
@@ -133,6 +138,7 @@ pub fn resolve_agent_with_catalog(
             cwd: agent.cwd.clone(),
             session_id: agent.session_id.clone(),
             resume_session: agent.resume_session.clone(),
+            config: agent.config.clone(),
             is_ephemeral: false,
             is_live: agent.is_live,
             is_input_ready: agent.is_input_ready,
@@ -144,6 +150,7 @@ pub fn resolve_agent_with_catalog(
         cwd: workspace.to_path_buf(),
         session_id: String::new(),
         resume_session: None,
+        config: None,
         is_ephemeral,
         is_live: false,
         is_input_ready: false,
@@ -210,6 +217,7 @@ mod tests {
                 resume_session: Some("provider-session-456".to_string()),
                 is_live: true,
                 is_input_ready: true,
+                config: None,
             },
         );
 
@@ -244,6 +252,7 @@ mod tests {
                 resume_session: Some("provider-session-456".to_string()),
                 is_live: false,
                 is_input_ready: false,
+                config: None,
             },
         );
 

--- a/src-tauri/src/workflow/runner.rs
+++ b/src-tauri/src/workflow/runner.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::sync::Mutex;
 use std::time::Duration;
 use tauri::Manager;
+use wardian_core::control::{InteractionBodyRef, ProviderInputReadiness, ReplyStatus};
 
 type AgentRunFuture<'a> = Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>>;
 type LiveAgentRunFuture<'a> = Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>>;
@@ -129,19 +130,42 @@ async fn run_live_agent_prompt(
         .map_err(|_| format!("Agent {} watch state lock poisoned", spec.session_id))?
         .latest_cursor();
 
+    let task = state
+        .interactions
+        .create_task(
+            None,
+            spec.session_id.clone(),
+            InteractionBodyRef::Inline {
+                body: spec.prompt.clone(),
+            },
+        )
+        .await;
+    {
+        let mut guard = watch_state
+            .lock()
+            .map_err(|_| format!("Agent {} watch state lock poisoned", spec.session_id))?;
+        guard.push_event(
+            "request",
+            serde_json::json!({
+                "request_id": &task.id,
+                "target_session_id": &spec.session_id,
+                "status": "pending",
+                "created_at": &task.created_at,
+                "workflow_node": &spec.node,
+            }),
+        );
+    }
+
     if should_mark_processing {
         crate::manager::set_agent_status(app, &spec.session_id, &current_status, "Processing...");
     }
     state
         .interactions
-        .start_provider_input_generation(
-            &spec.session_id,
-            wardian_core::control::ProviderInputReadiness::Busy,
-            None,
-        )
+        .start_provider_input_generation(&spec.session_id, ProviderInputReadiness::Busy, None)
         .await;
 
-    crate::utils::terminal_input::submit_prompt_via_sender(&tx, &spec.prompt, &provider_name)
+    let prompt = prompt_with_structured_reply_instruction(&spec.prompt, &task.id);
+    crate::utils::terminal_input::submit_prompt_via_sender(&tx, &prompt, &provider_name)
         .await
         .map_err(|error| {
             format!(
@@ -150,9 +174,18 @@ async fn run_live_agent_prompt(
             )
         })?;
 
-    let snapshot =
-        wait_for_live_agent_completion(watch_state, initial_cursor, spec.timeout).await?;
-    let response = live_agent_response_from_snapshot(&snapshot);
+    let reply =
+        wait_for_live_agent_reply(&state, watch_state, initial_cursor, &task.id, spec.timeout)
+            .await?;
+    let response = match reply.status {
+        ReplyStatus::Done => reply.body,
+        ReplyStatus::Blocked | ReplyStatus::Failed => {
+            return Err(format!(
+                "live agent {} returned {:?} for workflow node {}: {}",
+                spec.session_id, reply.status, spec.node, reply.body
+            ));
+        }
+    };
     if response.trim().is_empty() {
         Err(format!(
             "live agent {} completed workflow node {} without readable output",
@@ -163,6 +196,46 @@ async fn run_live_agent_prompt(
     }
 }
 
+fn prompt_with_structured_reply_instruction(prompt: &str, request_id: &str) -> String {
+    format!(
+        "{prompt}\n\nWardian workflow request id: {request_id}\nWhen this workflow node is fully complete, respond with:\nwardian reply {request_id} --status done --stdin\nUse --status blocked or --status failed if you cannot complete it. Put the final workflow output on stdin."
+    )
+}
+
+async fn wait_for_live_agent_reply(
+    app_state: &crate::state::AppState,
+    watch_state: std::sync::Arc<Mutex<crate::state::AgentWatchState>>,
+    since: String,
+    request_id: &str,
+    timeout: Duration,
+) -> Result<wardian_core::control::StructuredReply, String> {
+    let started = std::time::Instant::now();
+    loop {
+        if let Some(reply) = app_state.interactions.structured_reply(request_id).await {
+            return Ok(reply);
+        }
+        let snapshot = {
+            let guard = watch_state
+                .lock()
+                .map_err(|_| "watch state lock poisoned".to_string())?;
+            guard
+                .snapshot_since(Some(&since), Some(128 * 1024))
+                .map_err(|error| format!("watch state error: {}", error.code()))?
+        };
+        if let Some(error) = live_agent_terminal_failure(&snapshot) {
+            return Err(error);
+        }
+        let elapsed = started.elapsed();
+        if elapsed >= timeout {
+            return Err(format!(
+                "timed out waiting for live agent workflow reply {request_id}"
+            ));
+        }
+        tokio::time::sleep((timeout - elapsed).min(Duration::from_millis(25))).await;
+    }
+}
+
+#[cfg(test)]
 async fn wait_for_live_agent_completion(
     state: std::sync::Arc<Mutex<crate::state::AgentWatchState>>,
     since: String,
@@ -185,16 +258,8 @@ async fn wait_for_live_agent_completion(
                 .map_err(|error| format!("watch state error: {}", error.code()))?
         };
 
-        if let Some(status) = latest_terminal_status(&snapshot) {
-            match status.as_str() {
-                "idle" => return Ok(snapshot),
-                "action_required" | "off" | "error" => {
-                    return Err(format!(
-                        "live agent reached {status} before completing workflow node"
-                    ));
-                }
-                _ => {}
-            }
+        if let Some(error) = live_agent_terminal_failure(&snapshot) {
+            return Err(error);
         }
 
         let elapsed = started.elapsed();
@@ -210,6 +275,17 @@ async fn wait_for_live_agent_completion(
     }
 }
 
+fn live_agent_terminal_failure(
+    snapshot: &crate::state::agent_watch::WatchSnapshot,
+) -> Option<String> {
+    latest_terminal_status(snapshot).and_then(|status| match status.as_str() {
+        "action_required" | "off" | "error" => Some(format!(
+            "live agent reached {status} before completing workflow node"
+        )),
+        _ => None,
+    })
+}
+
 fn latest_terminal_status(snapshot: &crate::state::agent_watch::WatchSnapshot) -> Option<String> {
     snapshot.events.iter().rev().find_map(|event| {
         (event.kind == "status")
@@ -217,25 +293,6 @@ fn latest_terminal_status(snapshot: &crate::state::agent_watch::WatchSnapshot) -
             .flatten()
             .map(wardian_core::identity::normalize_status)
     })
-}
-
-fn live_agent_response_from_snapshot(
-    snapshot: &crate::state::agent_watch::WatchSnapshot,
-) -> String {
-    snapshot
-        .transcript
-        .messages
-        .iter()
-        .rev()
-        .find(|message| {
-            !message.text.trim().is_empty() && !matches!(message.role.as_str(), "user" | "human")
-        })
-        .map(|message| message.text.clone())
-        .or_else(|| {
-            (!snapshot.transcript.latest_text.trim().is_empty())
-                .then(|| snapshot.transcript.latest_text.clone())
-        })
-        .unwrap_or_else(|| snapshot.output.text.clone())
 }
 
 /// Test double: scripted responses keyed by node id; records call order.
@@ -322,6 +379,7 @@ impl LiveAgentRunner for FakeLiveAgentRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn fake_runner_returns_scripted_response_and_records_calls() {
@@ -337,5 +395,85 @@ mod tests {
         let out = runner.run(spec).await.unwrap();
         assert!(out.contains("ok"));
         assert_eq!(runner.calls(), vec!["plan".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn live_agent_wait_does_not_complete_on_idle_status_alone() {
+        let state = Arc::new(Mutex::new(crate::state::AgentWatchState::new(
+            "agent-1".to_string(),
+            16,
+            4096,
+        )));
+        let since = state.lock().expect("watch state lock").latest_cursor();
+        {
+            let mut guard = state.lock().expect("watch state lock");
+            guard.push_output(b"stale terminal repaint text");
+            guard.push_event("status", serde_json::json!({ "status": "idle" }));
+        }
+
+        let result = wait_for_live_agent_completion(state, since, Duration::from_millis(10)).await;
+
+        assert_eq!(
+            result.expect_err("idle status alone must not complete a live workflow node"),
+            "timed out waiting for live agent workflow node to complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_agent_reply_wait_completes_only_after_structured_reply() {
+        let app_state = crate::state::AppState::new();
+        let watch_state = Arc::new(Mutex::new(crate::state::AgentWatchState::new(
+            "agent-1".to_string(),
+            16,
+            4096,
+        )));
+        let since = watch_state
+            .lock()
+            .expect("watch state lock")
+            .latest_cursor();
+        {
+            let mut guard = watch_state.lock().expect("watch state lock");
+            guard.push_output(b"stale terminal repaint text");
+            guard.push_event("status", serde_json::json!({ "status": "idle" }));
+        }
+        let task = app_state
+            .interactions
+            .create_task_with_id(
+                "wf_test_reply".to_string(),
+                None,
+                "agent-1".to_string(),
+                InteractionBodyRef::Inline {
+                    body: "write the file".to_string(),
+                },
+            )
+            .await;
+        let task_id = task.id.clone();
+
+        let wait = wait_for_live_agent_reply(
+            &app_state,
+            watch_state,
+            since,
+            &task_id,
+            Duration::from_secs(1),
+        );
+        let complete = async {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            app_state
+                .interactions
+                .complete_task_with_reply(
+                    &task_id,
+                    Some("agent-1"),
+                    ReplyStatus::Done,
+                    "{\"ok\":true}",
+                )
+                .await
+                .expect("complete workflow task")
+        };
+
+        let (reply, _) = tokio::join!(wait, complete);
+
+        let reply = reply.expect("structured reply should complete workflow node");
+        assert_eq!(reply.status, ReplyStatus::Done);
+        assert_eq!(reply.body, "{\"ok\":true}");
     }
 }

--- a/src-tauri/src/workflow/runner.rs
+++ b/src-tauri/src/workflow/runner.rs
@@ -5,7 +5,10 @@ use std::pin::Pin;
 use std::sync::Mutex;
 use std::time::Duration;
 use tauri::Manager;
-use wardian_core::control::{InteractionBodyRef, ProviderInputReadiness, ReplyStatus};
+use wardian_core::control::{
+    InteractionBodyRef, ProviderInputReadiness, ProviderReadyEvidence, ReplyStatus,
+};
+use wardian_core::models::AgentConfig;
 
 type AgentRunFuture<'a> = Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>>;
 type LiveAgentRunFuture<'a> = Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>>;
@@ -19,6 +22,7 @@ pub struct AgentRunSpec {
     pub prompt: String,
     pub session_id: String,
     pub resume_session: Option<String>,
+    pub config_override: Option<AgentConfig>,
 }
 
 /// What the executor needs to route one prompt into an already-running agent.
@@ -38,7 +42,9 @@ pub trait AgentRunner: Send + Sync {
 }
 
 /// Boundary for active-agent execution. Unlike headless runs, this uses the
-/// existing live PTY and waits for the agent's next terminal status transition.
+/// existing live PTY and completes only through the structured `wardian reply`
+/// contract. Idle terminal status is not completion; it is only a signal that
+/// transcript marker compatibility can be checked.
 pub trait LiveAgentRunner: Send + Sync {
     fn run_live(&self, spec: LiveAgentRunSpec) -> LiveAgentRunFuture<'_>;
 }
@@ -58,7 +64,7 @@ impl AgentRunner for HeadlessAgentRunner {
                     resume_session: spec.resume_session.as_deref(),
                     output_format: "json",
                     provider_name: &spec.provider,
-                    config_override: None,
+                    config_override: spec.config_override.as_ref(),
                 })
                 .await?;
 
@@ -140,7 +146,7 @@ async fn run_live_agent_prompt(
             },
         )
         .await;
-    {
+    if let Err(error) = (|| {
         let mut guard = watch_state
             .lock()
             .map_err(|_| format!("Agent {} watch state lock poisoned", spec.session_id))?;
@@ -154,32 +160,76 @@ async fn run_live_agent_prompt(
                 "workflow_node": &spec.node,
             }),
         );
+        Ok::<(), String>(())
+    })() {
+        fail_live_workflow_task(
+            &state,
+            &watch_state,
+            &task.id,
+            &spec.session_id,
+            &error,
+            false,
+        )
+        .await;
+        return Err(error);
     }
 
     if should_mark_processing {
         crate::manager::set_agent_status(app, &spec.session_id, &current_status, "Processing...");
     }
-    state
+    let provider_input = state
         .interactions
         .start_provider_input_generation(&spec.session_id, ProviderInputReadiness::Busy, None)
         .await;
 
     let prompt = prompt_with_structured_reply_instruction(&spec.prompt, &task.id);
-    crate::utils::terminal_input::submit_prompt_via_sender(&tx, &prompt, &provider_name)
-        .await
-        .map_err(|error| {
-            format!(
-                "failed to submit workflow node {} to live agent {}: {error}",
-                spec.node, spec.session_id
-            )
-        })?;
+    if let Err(error) =
+        crate::utils::terminal_input::submit_prompt_via_sender(&tx, &prompt, &provider_name).await
+    {
+        let message = format!(
+            "failed to submit workflow node {} to live agent {}: {error}",
+            spec.node, spec.session_id
+        );
+        fail_live_workflow_task(
+            &state,
+            &watch_state,
+            &task.id,
+            &spec.session_id,
+            &message,
+            true,
+        )
+        .await;
+        return Err(message);
+    }
 
-    let reply =
-        wait_for_live_agent_reply(&state, watch_state, initial_cursor, &task.id, spec.timeout)
-            .await?;
+    let reply = match wait_for_live_agent_reply(
+        &state,
+        watch_state.clone(),
+        initial_cursor,
+        &task.id,
+        &spec.session_id,
+        spec.timeout,
+    )
+    .await
+    {
+        Ok(reply) => reply,
+        Err(error) => {
+            fail_live_workflow_task(
+                &state,
+                &watch_state,
+                &task.id,
+                &spec.session_id,
+                &error,
+                true,
+            )
+            .await;
+            return Err(error);
+        }
+    };
     let response = match reply.status {
         ReplyStatus::Done => reply.body,
         ReplyStatus::Blocked | ReplyStatus::Failed => {
+            release_live_agent_provider_input(&state, &spec.session_id).await;
             return Err(format!(
                 "live agent {} returned {:?} for workflow node {}: {}",
                 spec.session_id, reply.status, spec.node, reply.body
@@ -187,10 +237,21 @@ async fn run_live_agent_prompt(
         }
     };
     if response.trim().is_empty() {
+        release_live_agent_provider_input(&state, &spec.session_id).await;
         Err(format!(
             "live agent {} completed workflow node {} without readable output",
             spec.session_id, spec.node
         ))
+    } else if let Err(error) = wait_for_live_agent_provider_ready(
+        &state,
+        &spec.session_id,
+        provider_input.generation,
+        Duration::from_secs(30),
+    )
+    .await
+    {
+        release_live_agent_provider_input(&state, &spec.session_id).await;
+        Err(error)
     } else {
         Ok(response)
     }
@@ -202,11 +263,108 @@ fn prompt_with_structured_reply_instruction(prompt: &str, request_id: &str) -> S
     )
 }
 
+async fn fail_live_workflow_task(
+    app_state: &crate::state::AppState,
+    watch_state: &std::sync::Arc<Mutex<crate::state::AgentWatchState>>,
+    request_id: &str,
+    target_session_id: &str,
+    reason: &str,
+    release_provider_input: bool,
+) {
+    if release_provider_input {
+        release_live_agent_provider_input(app_state, target_session_id).await;
+    }
+
+    let Ok(reply) = app_state
+        .interactions
+        .fail_task_with_reply(request_id, target_session_id, reason)
+        .await
+    else {
+        return;
+    };
+
+    if let Ok(mut guard) = watch_state.lock() {
+        guard.push_event(
+            "reply",
+            serde_json::json!({
+                "request_id": reply.request_id,
+                "status": reply.status,
+                "target_session_id": reply.target_session_id,
+                "source_session_id": reply.source_session_id,
+                "replied_at": reply.replied_at,
+            }),
+        );
+    }
+}
+
+async fn release_live_agent_provider_input(
+    app_state: &crate::state::AppState,
+    target_session_id: &str,
+) {
+    if let Some(generation) = app_state
+        .interactions
+        .current_provider_input_generation(target_session_id)
+        .await
+    {
+        app_state
+            .interactions
+            .record_provider_input_state(
+                target_session_id,
+                generation,
+                ProviderInputReadiness::Unknown,
+                None,
+            )
+            .await;
+    }
+}
+
+async fn wait_for_live_agent_provider_ready(
+    app_state: &crate::state::AppState,
+    target_session_id: &str,
+    generation: u64,
+    timeout: Duration,
+) -> Result<(), String> {
+    let started = std::time::Instant::now();
+    loop {
+        if let Some(input_state) = app_state
+            .interactions
+            .provider_input_state(target_session_id)
+            .await
+        {
+            if input_state.generation >= generation
+                && input_state.state == ProviderInputReadiness::Ready
+                && input_state.ready_evidence == Some(ProviderReadyEvidence::ProviderEvent)
+            {
+                return Ok(());
+            }
+            if input_state.generation >= generation
+                && matches!(
+                    input_state.state,
+                    ProviderInputReadiness::ActionRequired | ProviderInputReadiness::Unavailable
+                )
+            {
+                return Err(format!(
+                    "live agent {target_session_id} did not return to input-ready state after workflow reply"
+                ));
+            }
+        }
+
+        let elapsed = started.elapsed();
+        if elapsed >= timeout {
+            return Err(format!(
+                "timed out waiting for live agent {target_session_id} to return to input-ready state"
+            ));
+        }
+        tokio::time::sleep((timeout - elapsed).min(Duration::from_millis(25))).await;
+    }
+}
+
 async fn wait_for_live_agent_reply(
     app_state: &crate::state::AppState,
     watch_state: std::sync::Arc<Mutex<crate::state::AgentWatchState>>,
     since: String,
     request_id: &str,
+    target_session_id: &str,
     timeout: Duration,
 ) -> Result<wardian_core::control::StructuredReply, String> {
     let started = std::time::Instant::now();
@@ -225,6 +383,17 @@ async fn wait_for_live_agent_reply(
         if let Some(error) = live_agent_terminal_failure(&snapshot) {
             return Err(error);
         }
+        if latest_terminal_status(&snapshot).as_deref() == Some("idle") {
+            if let Some((status, body)) = structured_reply_marker(&snapshot, request_id) {
+                return app_state
+                    .interactions
+                    .complete_task_with_reply(request_id, Some(target_session_id), status, &body)
+                    .await
+                    .map_err(|error| {
+                        format!("failed to record live agent workflow reply {request_id}: {error}")
+                    });
+            }
+        }
         let elapsed = started.elapsed();
         if elapsed >= timeout {
             return Err(format!(
@@ -235,8 +404,54 @@ async fn wait_for_live_agent_reply(
     }
 }
 
+fn structured_reply_marker(
+    snapshot: &crate::state::agent_watch::WatchSnapshot,
+    request_id: &str,
+) -> Option<(ReplyStatus, String)> {
+    snapshot
+        .transcript
+        .messages
+        .iter()
+        .rev()
+        .filter(|message| matches!(message.role.as_str(), "assistant" | "model"))
+        .find_map(|message| parse_structured_reply_marker(&message.text, request_id))
+}
+
+fn parse_structured_reply_marker(text: &str, request_id: &str) -> Option<(ReplyStatus, String)> {
+    let marker = format!("wardian reply {request_id}");
+    let lines = text.lines().collect::<Vec<_>>();
+    let marker_line_index = lines.iter().position(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with(&marker)
+            && trimmed
+                .get(marker.len()..)
+                .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with(' '))
+    })?;
+    let command = lines[marker_line_index].trim();
+    if !command.contains("--stdin") {
+        return None;
+    }
+    let status = if command.contains("--status blocked") {
+        ReplyStatus::Blocked
+    } else if command.contains("--status failed") {
+        ReplyStatus::Failed
+    } else if command.contains("--status done") {
+        ReplyStatus::Done
+    } else {
+        return None;
+    };
+    let leading_body = lines[..marker_line_index].join("\n").trim().to_string();
+    let trailing_body = lines[marker_line_index + 1..].join("\n");
+    let body = if leading_body.is_empty() {
+        trailing_body.trim().to_string()
+    } else {
+        leading_body
+    };
+    (!body.is_empty()).then_some((status, body))
+}
+
 #[cfg(test)]
-async fn wait_for_live_agent_completion(
+async fn wait_for_live_agent_status_transition_for_regression(
     state: std::sync::Arc<Mutex<crate::state::AgentWatchState>>,
     since: String,
     timeout: Duration,
@@ -391,6 +606,7 @@ mod tests {
             prompt: "do".into(),
             session_id: String::new(),
             resume_session: None,
+            config_override: None,
         };
         let out = runner.run(spec).await.unwrap();
         assert!(out.contains("ok"));
@@ -411,7 +627,12 @@ mod tests {
             guard.push_event("status", serde_json::json!({ "status": "idle" }));
         }
 
-        let result = wait_for_live_agent_completion(state, since, Duration::from_millis(10)).await;
+        let result = wait_for_live_agent_status_transition_for_regression(
+            state,
+            since,
+            Duration::from_millis(10),
+        )
+        .await;
 
         assert_eq!(
             result.expect_err("idle status alone must not complete a live workflow node"),
@@ -454,6 +675,7 @@ mod tests {
             watch_state,
             since,
             &task_id,
+            "agent-1",
             Duration::from_secs(1),
         );
         let complete = async {
@@ -475,5 +697,206 @@ mod tests {
         let reply = reply.expect("structured reply should complete workflow node");
         assert_eq!(reply.status, ReplyStatus::Done);
         assert_eq!(reply.body, "{\"ok\":true}");
+    }
+
+    #[tokio::test]
+    async fn live_agent_reply_wait_accepts_explicit_transcript_marker_after_idle() {
+        let app_state = crate::state::AppState::new();
+        let watch_state = Arc::new(Mutex::new(crate::state::AgentWatchState::new(
+            "agent-1".to_string(),
+            16,
+            4096,
+        )));
+        let since = watch_state
+            .lock()
+            .expect("watch state lock")
+            .latest_cursor();
+        let task = app_state
+            .interactions
+            .create_task_with_id(
+                "wf_test_marker".to_string(),
+                None,
+                "agent-1".to_string(),
+                InteractionBodyRef::Inline {
+                    body: "write the file".to_string(),
+                },
+            )
+            .await;
+        let task_id = task.id.clone();
+        {
+            let mut guard = watch_state.lock().expect("watch state lock");
+            guard.push_transcript(wardian_core::control::WatchTranscriptMessage {
+                role: "assistant".to_string(),
+                text: format!(
+                    "Final workflow output\n\nwardian reply {task_id} --status done --stdin"
+                ),
+                provider: "gemini".to_string(),
+                turn_id: None,
+                source: Some("gemini_log".to_string()),
+            });
+            guard.push_event("status", serde_json::json!({ "status": "idle" }));
+        }
+
+        let reply = wait_for_live_agent_reply(
+            &app_state,
+            watch_state,
+            since,
+            &task_id,
+            "agent-1",
+            Duration::from_secs(1),
+        )
+        .await
+        .expect("marker should complete workflow task");
+
+        assert_eq!(reply.status, ReplyStatus::Done);
+        assert_eq!(reply.body, "Final workflow output");
+        assert!(app_state
+            .interactions
+            .structured_reply(&task_id)
+            .await
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn live_agent_failure_cleanup_closes_task_and_releases_input_generation() {
+        let app_state = crate::state::AppState::new();
+        let watch_state = Arc::new(Mutex::new(crate::state::AgentWatchState::new(
+            "agent-1".to_string(),
+            16,
+            4096,
+        )));
+        let task = app_state
+            .interactions
+            .create_task_with_id(
+                "wf_test_cleanup".to_string(),
+                None,
+                "agent-1".to_string(),
+                InteractionBodyRef::Inline {
+                    body: "write the file".to_string(),
+                },
+            )
+            .await;
+        app_state
+            .interactions
+            .start_provider_input_generation("agent-1", ProviderInputReadiness::Busy, None)
+            .await;
+
+        fail_live_workflow_task(
+            &app_state,
+            &watch_state,
+            &task.id,
+            "agent-1",
+            "timed out",
+            true,
+        )
+        .await;
+
+        assert_eq!(
+            app_state
+                .interactions
+                .interaction(&task.id)
+                .await
+                .unwrap()
+                .status,
+            wardian_core::control::InteractionStatus::Failed
+        );
+        assert_eq!(
+            app_state
+                .interactions
+                .structured_reply(&task.id)
+                .await
+                .unwrap()
+                .status,
+            ReplyStatus::Failed
+        );
+        assert_eq!(
+            app_state
+                .interactions
+                .provider_input_state("agent-1")
+                .await
+                .unwrap()
+                .state,
+            ProviderInputReadiness::Unknown
+        );
+        let snapshot = watch_state
+            .lock()
+            .expect("watch state lock")
+            .snapshot_since(None, None)
+            .expect("watch snapshot");
+        assert!(snapshot.events.iter().any(|event| {
+            event.kind == "reply"
+                && event
+                    .payload
+                    .get("request_id")
+                    .and_then(|value| value.as_str())
+                    == Some("wf_test_cleanup")
+                && event.payload.get("status").and_then(|value| value.as_str()) == Some("failed")
+        }));
+    }
+
+    #[tokio::test]
+    async fn live_agent_success_waits_for_provider_ready_evidence() {
+        let app_state = crate::state::AppState::new();
+        let input = app_state
+            .interactions
+            .start_provider_input_generation("agent-1", ProviderInputReadiness::Busy, None)
+            .await;
+
+        let wait = wait_for_live_agent_provider_ready(
+            &app_state,
+            "agent-1",
+            input.generation,
+            Duration::from_secs(1),
+        );
+        let ready = async {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            app_state
+                .interactions
+                .record_provider_input_state(
+                    "agent-1",
+                    input.generation,
+                    ProviderInputReadiness::Ready,
+                    Some(ProviderReadyEvidence::ProviderEvent),
+                )
+                .await;
+        };
+
+        let (result, _) = tokio::join!(wait, ready);
+
+        result.expect("provider event readiness should release live workflow delivery");
+    }
+
+    #[test]
+    fn structured_reply_marker_requires_body_and_status() {
+        assert!(parse_structured_reply_marker(
+            "wardian reply wf_test --status done --stdin",
+            "wf_test"
+        )
+        .is_none());
+        assert!(
+            parse_structured_reply_marker("body\nwardian reply wf_test --stdin", "wf_test")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn structured_reply_marker_accepts_body_after_command() {
+        let (status, body) = parse_structured_reply_marker(
+            "wardian reply wf_test --status done --stdin\nSummary written.",
+            "wf_test",
+        )
+        .expect("marker-first reply should parse");
+
+        assert_eq!(status, ReplyStatus::Done);
+        assert_eq!(body, "Summary written.");
+    }
+
+    #[test]
+    fn structured_reply_marker_ignores_embedded_command_text() {
+        assert!(parse_structured_reply_marker(
+            "Please run wardian reply wf_test --status done --stdin after the work.\nSummary.",
+            "wf_test",
+        )
+        .is_none());
     }
 }

--- a/src-tauri/src/workflow/runs.rs
+++ b/src-tauri/src/workflow/runs.rs
@@ -9,7 +9,8 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use wardian_core::engine::store::read_checkpoint;
+use wardian_core::engine::event::{Event, EventKind};
+use wardian_core::engine::store::{append_event, read_checkpoint, read_events, write_checkpoint};
 use wardian_core::engine::{Engine, RunStatus};
 use wardian_core::models::{
     AgentConfig, InvocationKind, WorkflowAssignments, WorkflowRoleAssignment,
@@ -28,7 +29,7 @@ pub struct WorkflowRunInvocation {
 }
 
 /// Scan `<runs_dir>/<id>/<run>/state.json` for runs still marked Running.
-/// Returns `(blueprint_id, run_id)` pairs for resume affordances.
+/// Returns `(blueprint_id, run_id)` pairs for diagnostics and tests.
 pub fn scan_interrupted_runs(runs_dir: &Path) -> Vec<(String, String)> {
     let mut interrupted = Vec::new();
     let Ok(blueprints) = std::fs::read_dir(runs_dir) else {
@@ -46,6 +47,64 @@ pub fn scan_interrupted_runs(runs_dir: &Path) -> Vec<(String, String)> {
                     interrupted.push((state.blueprint_id, state.run_id));
                 }
             }
+        }
+    }
+
+    interrupted
+}
+
+pub fn fail_interrupted_runs(runs_dir: &Path) -> Vec<(String, String)> {
+    let mut interrupted = Vec::new();
+    let Ok(blueprints) = std::fs::read_dir(runs_dir) else {
+        return interrupted;
+    };
+
+    for blueprint in blueprints.flatten().filter(|entry| entry.path().is_dir()) {
+        let Ok(runs) = std::fs::read_dir(blueprint.path()) else {
+            continue;
+        };
+
+        for run in runs.flatten().filter(|entry| entry.path().is_dir()) {
+            let run_root = run.path();
+            let Ok(Some(mut state)) = read_checkpoint(&run_root) else {
+                continue;
+            };
+            if state.status != RunStatus::Running {
+                continue;
+            }
+            let message = "workflow run interrupted by application restart".to_string();
+            let events = read_events(&run_root).unwrap_or_default();
+            let event_next_seq = events
+                .iter()
+                .map(|event| event.seq + 1)
+                .max()
+                .unwrap_or(state.next_seq);
+            let already_recorded = events.iter().any(|event| {
+                matches!(
+                    &event.kind,
+                    EventKind::RunFailed { error } if error == &message
+                )
+            });
+            if !already_recorded {
+                let event = Event::new(
+                    state.next_seq,
+                    EventKind::RunFailed {
+                        error: message.clone(),
+                    },
+                );
+                if append_event(&run_root, &event).is_err() {
+                    continue;
+                }
+                state.next_seq = event.seq + 1;
+            } else {
+                state.next_seq = state.next_seq.max(event_next_seq);
+            }
+            state.status = RunStatus::Failed;
+            state.failure = Some(message);
+            if write_checkpoint(&run_root, &state).is_err() {
+                continue;
+            }
+            interrupted.push((state.blueprint_id, state.run_id));
         }
     }
 
@@ -294,6 +353,7 @@ fn agent_binding_from_config(
         resume_session: config.resume_session.clone(),
         is_live,
         is_input_ready,
+        config: Some(config.clone()),
     })
 }
 
@@ -565,6 +625,70 @@ edges:
 
         let interrupted = scan_interrupted_runs(dir.path());
         assert_eq!(interrupted, vec![("wf".to_string(), "run-1".to_string())]);
+    }
+
+    #[test]
+    fn fail_interrupted_runs_marks_running_checkpoint_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_root = dir.path().join("wf").join("run-1");
+        std::fs::create_dir_all(&run_root).unwrap();
+        let mut state = RunState::new("run-1", "wf");
+        state.status = RunStatus::Running;
+        wardian_core::engine::store::write_checkpoint(&run_root, &state).unwrap();
+
+        let interrupted = fail_interrupted_runs(dir.path());
+
+        assert_eq!(interrupted, vec![("wf".to_string(), "run-1".to_string())]);
+        let state = wardian_core::engine::store::read_checkpoint(&run_root)
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.status, RunStatus::Failed);
+        assert_eq!(
+            state.failure.as_deref(),
+            Some("workflow run interrupted by application restart")
+        );
+        let events = read_events(&run_root).unwrap();
+        assert!(matches!(
+            events.last().map(|event| &event.kind),
+            Some(EventKind::RunFailed { .. })
+        ));
+    }
+
+    #[test]
+    fn fail_interrupted_runs_does_not_duplicate_existing_restart_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_root = dir.path().join("wf").join("run-1");
+        std::fs::create_dir_all(&run_root).unwrap();
+        let mut state = RunState::new("run-1", "wf");
+        state.status = RunStatus::Running;
+        wardian_core::engine::store::write_checkpoint(&run_root, &state).unwrap();
+        wardian_core::engine::store::append_event(
+            &run_root,
+            &Event::new(
+                0,
+                EventKind::RunFailed {
+                    error: "workflow run interrupted by application restart".to_string(),
+                },
+            ),
+        )
+        .unwrap();
+
+        let interrupted = fail_interrupted_runs(dir.path());
+
+        assert_eq!(interrupted, vec![("wf".to_string(), "run-1".to_string())]);
+        let events = read_events(&run_root).unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event.kind, EventKind::RunFailed { .. }))
+                .count(),
+            1
+        );
+        let state = wardian_core::engine::store::read_checkpoint(&run_root)
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.next_seq, 1);
+        assert_eq!(state.status, RunStatus::Failed);
     }
 
     #[test]

--- a/src/features/workflows/RunLaunchDialog.test.tsx
+++ b/src/features/workflows/RunLaunchDialog.test.tsx
@@ -278,6 +278,34 @@ describe('RunLaunchDialog', () => {
     ));
   });
 
+  it('wraps temporary provider choices inside the role assignment picker', async () => {
+    const blueprint: Blueprint = {
+      schema: 2,
+      id: 'wf',
+      name: 'Workflow',
+      nodes: [
+        { id: 'heartbeat', type: 'task', fields: { agent: 'role:reasoning_gate', prompt: 'Check in.' } },
+      ],
+      edges: [],
+    };
+
+    render(
+      <RunLaunchDialog
+        path="/x/wf.md"
+        blueprint={blueprint}
+        onLaunched={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /change reasoning_gate assignment/i })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /change reasoning_gate assignment/i }));
+
+    const temporaryOptions = screen.getByTestId('temporary-provider-options');
+    expect(temporaryOptions).toHaveClass('flex-wrap');
+    expect(screen.getByRole('button', { name: /new temporary antigravity/i })).toHaveClass('max-w-full');
+  });
+
   it('lets each workflow role choose its own fresh provider', async () => {
     const blueprint: Blueprint = {
       schema: 2,

--- a/src/features/workflows/RunLaunchDialog.tsx
+++ b/src/features/workflows/RunLaunchDialog.tsx
@@ -591,8 +591,8 @@ function RoleAssignmentPicker({
                 >
                   <span className="flex min-w-0 items-center justify-between gap-2">
                     <span className="truncate text-left font-bold">{agent.session_name || agent.session_id}</span>
-                    <span className="shrink-0 rounded border border-wardian-border px-1 py-0.5 text-[9px] uppercase text-muted">
-                      {agent.is_off ? 'off' : 'idle'}
+                    <span className="shrink-0 rounded border border-wardian-border px-1 py-0.5 text-[9px] text-muted">
+                      {agent.is_off ? 'Off' : 'Idle'}
                     </span>
                   </span>
                   <span className="truncate text-left text-[10px] text-muted">
@@ -620,7 +620,7 @@ function RoleAssignmentPicker({
 function PickerGroup({ title, children }: { title: string; children: ReactNode }) {
   return (
     <div className="mb-2 last:mb-0">
-      <div className="mb-1 text-[10px] font-bold uppercase text-muted">{title}</div>
+      <div className="mb-1 text-[10px] font-bold text-muted">{title}</div>
       {children}
     </div>
   );

--- a/src/features/workflows/RunLaunchDialog.tsx
+++ b/src/features/workflows/RunLaunchDialog.tsx
@@ -559,14 +559,14 @@ function RoleAssignmentPicker({
         autoFocus
       />
       <PickerGroup title="Temporary agents">
-        <div className="grid grid-cols-2 gap-1">
+        <div data-testid="temporary-provider-options" className="flex min-w-0 flex-wrap gap-1">
           {providerOptions.map((option) => {
             const target = providerTarget(option.value);
             return (
               <button
                 key={option.value}
                 type="button"
-                className={pickerButtonClass(target === selectedTarget)}
+                className={`${pickerButtonClass(target === selectedTarget)} max-w-full flex-[1_1_8.75rem]`}
                 disabled={!option.available}
                 onClick={() => onSelect(target)}
               >
@@ -627,7 +627,7 @@ function PickerGroup({ title, children }: { title: string; children: ReactNode }
 }
 
 function pickerButtonClass(selected: boolean) {
-  return `min-w-0 rounded border px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 ${
+  return `flex min-w-0 flex-col overflow-hidden rounded border px-2 py-1 text-xs disabled:cursor-not-allowed disabled:opacity-50 ${
     selected
       ? 'border-[var(--color-wardian-accent)] bg-[color-mix(in_srgb,var(--color-wardian-accent),transparent_88%)] text-primary'
       : 'border-wardian-border bg-[var(--color-wardian-bg)] text-primary hover:border-[var(--color-wardian-accent)]'

--- a/src/features/workflows/ScheduleEditor.tsx
+++ b/src/features/workflows/ScheduleEditor.tsx
@@ -34,7 +34,7 @@ interface ScheduleEditorProps {
 
 const inputClass = "w-full bg-[var(--color-wardian-input-bg)] border border-wardian-border rounded-lg px-3 py-1.5 text-[11px] text-[var(--color-wardian-text)] outline-none focus:border-[var(--color-wardian-accent)]/50 transition-colors";
 const selectClass = inputClass + " cursor-pointer";
-const labelClass = "text-[11px] font-bold text-muted-neutral tracking-wide";
+const labelClass = "text-[11px] font-bold text-muted-neutral";
 
 export const ScheduleEditor: React.FC<ScheduleEditorProps> = ({ value, onChange, compact }) => {
   const schedType = value.schedule_type || 'interval';

--- a/src/features/workflows/builder/BuilderCanvas.tsx
+++ b/src/features/workflows/builder/BuilderCanvas.tsx
@@ -195,7 +195,7 @@ const BuilderNode = memo(({ data, selected }: NodeProps<Node<BuilderNodeData>>) 
       {renderHandles('target', portsFor(def?.inputs ?? []), Position.Left)}
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[9px] font-bold tracking-wide text-muted">{def?.label ?? node.type}</span>
+          <span className="text-[9px] font-bold text-muted">{def?.label ?? node.type}</span>
           {hasDiagnostics && (
             <span className="text-[9px] font-bold text-[var(--color-wardian-error)]">Error</span>
           )}
@@ -236,7 +236,7 @@ const LoopGroupNode = memo(({ data, selected }: NodeProps<Node<BuilderNodeData>>
           : 'border-wardian-border'
     }`}>
       {renderHandles('target', portsFor(def?.inputs ?? []), Position.Left)}
-      <div className="text-[10px] font-bold tracking-wide text-muted">{def?.label ?? 'Loop'}</div>
+      <div className="text-[10px] font-bold text-muted">{def?.label ?? 'Loop'}</div>
       <div className="mt-1 text-sm font-bold text-[var(--color-wardian-text)]">{node.name ?? node.id}</div>
       {renderHandles('source', outputPorts(node, def?.outputs ?? [], def?.outputs_from_field), Position.Right)}
     </div>

--- a/src/features/workflows/builder/BuilderToolbar.tsx
+++ b/src/features/workflows/builder/BuilderToolbar.tsx
@@ -18,17 +18,17 @@ export function BuilderToolbar() {
           onChange={(event) => blueprint && setBlueprint({ ...blueprint, name: event.target.value })}
           className="min-w-[220px] rounded-md border border-wardian-border bg-[var(--color-wardian-bg)] px-3 py-1.5 text-sm font-bold text-[var(--color-wardian-text)] outline-none focus:ring-1 focus:ring-[var(--color-wardian-accent)]"
         />
-        <span className="text-[10px] font-bold tracking-wide text-muted">{dirty ? 'Unsaved changes' : 'Saved state'}</span>
+        <span className="text-[10px] font-bold text-muted">{dirty ? 'Unsaved changes' : 'Saved state'}</span>
       </div>
       <div className="flex items-center gap-3">
-        <span className={`text-[10px] font-bold tracking-wide ${invalid ? 'text-[var(--color-wardian-error)]' : 'text-[var(--color-wardian-success)]'}`}>
+        <span className={`text-[10px] font-bold ${invalid ? 'text-[var(--color-wardian-error)]' : 'text-[var(--color-wardian-success)]'}`}>
           {invalid ? `${diagnostics.length} issue${diagnostics.length === 1 ? '' : 's'}` : 'Valid'}
         </span>
         <button
           type="button"
           disabled={!blueprint || invalid}
           onClick={() => void save()}
-          className="rounded-md border border-wardian-border bg-[var(--color-wardian-accent)] px-4 py-1.5 text-[11px] font-bold text-black transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded-md border border-wardian-border bg-[var(--color-wardian-accent)] px-4 py-1.5 text-[11px] font-bold text-[var(--color-wardian-bg)] transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
         >
           Save
         </button>

--- a/src/features/workflows/builder/NodeConfigForm.test.tsx
+++ b/src/features/workflows/builder/NodeConfigForm.test.tsx
@@ -33,4 +33,29 @@ describe('NodeConfigForm', () => {
     expect(prompt).toHaveClass('min-h-[132px]');
     expect(prompt).toHaveClass('w-full');
   });
+  it('shows templated loop max iterations as editable text', () => {
+    const onChange = vi.fn();
+    const loopNode: BlueprintNode = {
+      id: 'loop-1',
+      type: 'loop',
+      fields: {
+        max_iterations: '{{trigger.output.max_cycles}}',
+        until: 'nodes.agent-arbiter.output.converged',
+      },
+    };
+
+    render(<NodeConfigForm node={loopNode} onChange={onChange} />);
+
+    const maxIterations = screen.getByLabelText(/Max iterations/i) as HTMLInputElement;
+    expect(maxIterations).toHaveAttribute('type', 'text');
+    expect(maxIterations).toHaveValue('{{trigger.output.max_cycles}}');
+
+    fireEvent.change(maxIterations, { target: { value: '7' } });
+
+    expect(onChange).toHaveBeenCalledWith('max_iterations', 7);
+
+    fireEvent.change(maxIterations, { target: { value: '{{trigger.output.review_cap}}' } });
+
+    expect(onChange).toHaveBeenLastCalledWith('max_iterations', '{{trigger.output.review_cap}}');
+  });
 });

--- a/src/features/workflows/builder/NodeConfigForm.tsx
+++ b/src/features/workflows/builder/NodeConfigForm.tsx
@@ -18,7 +18,7 @@ function FieldInput({ field, value, onChange }: { field: FieldDef; value: unknow
   const id = `field-${field.id}`;
   const str = (value as string) ?? '';
   const label = (
-    <label htmlFor={id} className="flex min-w-0 items-center gap-1 text-[10px] font-bold uppercase tracking-wide text-muted">
+    <label htmlFor={id} className="flex min-w-0 items-center gap-1 text-[10px] font-bold text-muted">
       <span className="truncate">{field.label}</span>
       {field.required ? <span className="text-[var(--color-wardian-error)]">*</span> : null}
     </label>

--- a/src/features/workflows/builder/NodeConfigForm.tsx
+++ b/src/features/workflows/builder/NodeConfigForm.tsx
@@ -8,13 +8,23 @@ export function NodeConfigForm({ node, onChange }: { node: BlueprintNode; onChan
   return (
     <div className="grid gap-3" data-testid="node-config-form">
       {def.fields.map((f) => (
-        <FieldInput key={f.id} field={f} value={node.fields?.[f.id]} onChange={(v) => onChange(f.id, v)} />
+        <FieldInput key={f.id} nodeType={node.type} field={f} value={node.fields?.[f.id]} onChange={(v) => onChange(f.id, v)} />
       ))}
     </div>
   );
 }
 
-function FieldInput({ field, value, onChange }: { field: FieldDef; value: unknown; onChange: (v: unknown) => void }) {
+function FieldInput({
+  nodeType,
+  field,
+  value,
+  onChange,
+}: {
+  nodeType: string;
+  field: FieldDef;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
   const id = `field-${field.id}`;
   const str = (value as string) ?? '';
   const label = (
@@ -71,6 +81,19 @@ function FieldInput({ field, value, onChange }: { field: FieldDef; value: unknow
         </div>
       );
     case 'number':
+      if (nodeType === 'loop' && field.id === 'max_iterations') {
+        return shell(
+          <input
+            id={id}
+            type="text"
+            inputMode="numeric"
+            value={str}
+            onChange={(e) => onChange(loopMaxIterationsValue(e.target.value))}
+            className={controlClass}
+          />,
+        );
+      }
+      return shell(<input id={id} type="number" value={str} onChange={(e) => onChange(e.target.value)} className={controlClass} />);
     case 'duration':
       return shell(<input id={id} type="number" value={str} onChange={(e) => onChange(e.target.value)} className={controlClass} />);
     case 'branch_port':
@@ -88,6 +111,11 @@ function FieldInput({ field, value, onChange }: { field: FieldDef; value: unknow
         />,
       );
   }
+}
+
+function loopMaxIterationsValue(raw: string) {
+  const trimmed = raw.trim();
+  return /^[1-9]\d*$/.test(trimmed) ? Number(trimmed) : raw;
 }
 
 function PortListEditor({ value, onChange }: { value: string[]; onChange: (v: string[]) => void }) {

--- a/src/features/workflows/builder/NodeLibrary.tsx
+++ b/src/features/workflows/builder/NodeLibrary.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { X } from 'lucide-react';
 import { nodeTypes } from './registry';
 import { summarizeNodeType } from './nodeSummary';
 import type { NodeTypeDef } from './blueprintTypes';
@@ -27,8 +28,14 @@ export function NodeLibrary({ mode, onAdd, onClose }: NodeLibraryProps) {
             <div className="mt-0.5 text-[10px] text-muted">Registry-backed workflow blocks</div>
           </div>
           {onClose ? (
-            <button type="button" className="rounded border border-wardian-border px-2 py-1 text-xs text-muted" onClick={onClose}>
-              Close
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 items-center justify-center rounded border border-wardian-border text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+              onClick={onClose}
+              aria-label="Close node library"
+              title="Close"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
             </button>
           ) : null}
         </div>
@@ -48,7 +55,7 @@ export function NodeLibrary({ mode, onAdd, onClose }: NodeLibraryProps) {
           <div className="grid gap-3">
             {groups.map(([category, defs]) => (
               <section key={category}>
-                <div className="mb-2 text-[10px] font-bold uppercase tracking-wide text-muted">{category}</div>
+                <div className="mb-2 text-[10px] font-bold text-muted">{category}</div>
                 <div className={mode === 'popover' ? 'grid grid-cols-2 gap-2' : 'grid gap-2'}>
                   {defs.map((def) => (
                     <NodeLibraryCard key={def.id} def={def} onAdd={onAdd} />
@@ -77,7 +84,7 @@ function NodeLibraryCard({ def, onAdd }: { def: NodeTypeDef; onAdd: (def: NodeTy
           <div className="truncate text-sm font-bold text-[var(--color-wardian-text)]">{def.label}</div>
           <div className="mt-1 line-clamp-2 text-[11px] leading-snug text-muted">{def.description}</div>
         </div>
-        <span className="shrink-0 rounded border border-wardian-border px-1.5 py-0.5 text-[9px] font-bold text-muted">{def.kind}</span>
+        <span className="shrink-0 text-[10px] font-bold text-muted">{def.kind}</span>
       </div>
       <div className="mt-3 grid gap-1.5 text-[10px] text-muted">
         {summary.required.length > 0 ? <div>Requires {summary.required.join(', ')}</div> : <div>No required fields</div>}

--- a/src/features/workflows/builder/VariableAssistant.tsx
+++ b/src/features/workflows/builder/VariableAssistant.tsx
@@ -20,7 +20,7 @@ export const VariableAssistant = memo(({ blueprint, selectedNodeId }: VariableAs
   return (
     <div className="grid gap-1.5">
       <div className="flex items-center justify-between gap-2">
-        <div className="text-[10px] font-bold uppercase tracking-wide text-muted">Insert variable</div>
+        <div className="text-[10px] font-bold text-muted">Insert variable</div>
         <div className="text-[9px] font-mono text-muted">{variables.length}</div>
       </div>
       <div className="grid gap-1">

--- a/src/features/workflows/monitor/ActiveRunsList.tsx
+++ b/src/features/workflows/monitor/ActiveRunsList.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from 'lucide-react';
 import type { RunStatusKind, RunSummary } from '../run/runTypes';
+import { formatRunStatus } from '../run/statusLabels';
 
 interface ActiveRunsListProps {
   runs: RunSummary[];
@@ -26,7 +27,7 @@ export function ActiveRunsList({ runs, onOpen, emptyLabel = 'No active runs.' }:
   return (
     <div className="select-text overflow-hidden rounded border border-wardian-border">
       <table className="w-full table-fixed border-collapse text-left">
-        <thead className="bg-[var(--color-wardian-card)] text-[10px] font-bold uppercase tracking-wide text-muted">
+        <thead className="bg-[var(--color-wardian-card)] text-[10px] font-bold text-muted">
           <tr>
             <th scope="col" className="w-[108px] px-3 py-2">Status</th>
             <th scope="col" className="px-3 py-2">Workflow</th>
@@ -41,8 +42,8 @@ export function ActiveRunsList({ runs, onOpen, emptyLabel = 'No active runs.' }:
               className="border-b border-wardian-border/70 bg-[var(--color-wardian-bg)] last:border-b-0 hover:bg-[color-mix(in_srgb,var(--color-wardian-card),transparent_45%)]"
             >
               <td className="px-3 py-2">
-                <span className="text-[10px] font-bold uppercase" style={{ color: STATUS_COLOR[run.status] }}>
-                  {run.status.replace('_', ' ')}
+                <span className="text-[10px] font-bold" style={{ color: STATUS_COLOR[run.status] }}>
+                  {formatRunStatus(run.status)}
                 </span>
               </td>
               <td className="min-w-0 px-3 py-2">

--- a/src/features/workflows/monitor/ScheduleRow.tsx
+++ b/src/features/workflows/monitor/ScheduleRow.tsx
@@ -25,7 +25,7 @@ export function ScheduleRow({ schedule, agentLabels = {}, onPause, onResume, onR
       className="select-text border-b border-wardian-border/70 bg-[var(--color-wardian-bg)] align-middle last:border-b-0 hover:bg-[color-mix(in_srgb,var(--color-wardian-card),transparent_45%)]"
     >
       <td className="w-[92px] px-3 py-2">
-        <div className="flex items-center gap-2 text-[10px] font-bold uppercase text-muted">
+        <div className="flex items-center gap-2 text-[10px] font-bold text-muted">
           <span
             className="h-2 w-2 shrink-0 rounded-full"
             style={{ backgroundColor: scheduleStatusColor(schedule) }}

--- a/src/features/workflows/monitor/SchedulesTable.tsx
+++ b/src/features/workflows/monitor/SchedulesTable.tsx
@@ -24,7 +24,7 @@ export function SchedulesTable(props: SchedulesTableProps) {
   return (
     <div className="select-text rounded border border-wardian-border">
       <table className="w-full table-fixed border-collapse text-left">
-        <thead className="bg-[var(--color-wardian-card)] text-[10px] font-bold uppercase tracking-wide text-muted">
+        <thead className="bg-[var(--color-wardian-card)] text-[10px] font-bold text-muted">
           <tr>
             <th scope="col" className="w-[92px] px-3 py-2">Status</th>
             <th scope="col" className="px-3 py-2">Workflow</th>

--- a/src/features/workflows/monitor/WorkflowMonitor.test.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.test.tsx
@@ -263,6 +263,39 @@ describe('WorkflowMonitor', () => {
     expect(screen.queryByText('run-old-failed')).toBeNull();
   });
 
+  it('expands recent history to show older runs on demand', () => {
+    runState.runs = [
+      {
+        run_id: 'run-new',
+        blueprint_id: 'audit',
+        status: 'completed',
+        node_count: 2,
+        path: '/runs/new',
+        updated_at: '2026-06-01T16:00:00Z',
+      },
+      {
+        run_id: 'run-old',
+        blueprint_id: 'audit',
+        status: 'completed',
+        node_count: 2,
+        path: '/runs/old',
+        updated_at: '2026-06-01T12:00:00Z',
+      },
+    ];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: /recent history/i })).toBeInTheDocument();
+    expect(screen.getByText('run-new')).toBeInTheDocument();
+    expect(screen.queryByText('run-old')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /show older/i }));
+
+    expect(screen.getByText('run-new')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-history-run-run-old')).toHaveTextContent('run-old');
+    expect(screen.getByRole('button', { name: /show less/i })).toBeInTheDocument();
+  });
+
   it('renders scheduled agent assignments as agent names', async () => {
     invokeMock.mockResolvedValue([
       {

--- a/src/features/workflows/monitor/WorkflowMonitor.test.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WorkflowMonitor } from './WorkflowMonitor';
 import type { RunSummary } from '../run/runTypes';
@@ -56,11 +56,11 @@ describe('WorkflowMonitor', () => {
 
     render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
 
-    expect(screen.getByText('heartbeat')).toBeInTheDocument();
-    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-activity-row-heartbeat')).toHaveTextContent('heartbeat');
+    expect(screen.getByTestId('workflow-activity-row-heartbeat')).toHaveTextContent('Completed');
   });
 
-  it('shows an operational stat strip and distinct monitor sections', () => {
+  it('shows one activity surface with triage groups instead of duplicate monitor columns', () => {
     scheduleState.schedules = [
       {
         id: 'schedule-1',
@@ -82,6 +82,16 @@ describe('WorkflowMonitor', () => {
         is_paused: true,
         last_run_status: 'failed',
         last_run_error: 'crashed',
+      },
+      {
+        id: 'schedule-3',
+        blueprint_id: 'report',
+        name: 'Report Sweep',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'daily', time_of_day: '14:00', active: true },
+        is_paused: false,
+        next_run_epoch_ms: Date.UTC(2026, 5, 1, 18, 0, 0),
       },
     ];
     runState.runs = [
@@ -112,10 +122,57 @@ describe('WorkflowMonitor', () => {
 
     expect(screen.getByTestId('workflow-monitor-stats')).toHaveTextContent('1 failed');
     expect(screen.getByTestId('workflow-monitor-stats')).toHaveTextContent('1 running');
-    expect(screen.getByRole('heading', { name: /active runs/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /upcoming/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /^schedules$/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /history/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /activity/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /needs attention/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /running now/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /due soon/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /recent history/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^schedules$/i })).toBeNull();
+    expect(screen.getAllByText('Passive Heartbeat')).toHaveLength(1);
+  });
+
+  it('filters the activity surface by operational state', () => {
+    scheduleState.schedules = [
+      {
+        id: 'schedule-1',
+        blueprint_id: 'heartbeat',
+        name: 'Passive Heartbeat',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'interval', interval_minutes: 60, active: true },
+        is_paused: false,
+        next_run_epoch_ms: Date.UTC(2026, 5, 1, 16, 0, 0),
+      },
+      {
+        id: 'schedule-2',
+        blueprint_id: 'audit',
+        name: 'Audit',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'daily', time_of_day: '09:00', active: true },
+        is_paused: false,
+        last_run_status: 'failed',
+        last_run_error: 'crashed',
+      },
+    ];
+    runState.runs = [{
+      run_id: 'run-active',
+      blueprint_id: 'heartbeat',
+      status: 'running',
+      node_count: 2,
+      path: '/runs/active',
+    }];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /needs attention/i }));
+    expect(screen.getByText('Audit')).toBeInTheDocument();
+    expect(screen.getByText('crashed')).toBeInTheDocument();
+    expect(screen.queryByText('Passive Heartbeat')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /running/i }));
+    expect(screen.getByText('Passive Heartbeat')).toBeInTheDocument();
+    expect(screen.queryByText('Audit')).toBeNull();
   });
 
   it('counts only current workflow failures in the headline stats', () => {
@@ -149,7 +206,8 @@ describe('WorkflowMonitor', () => {
     render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
 
     expect(screen.getByTestId('workflow-monitor-stats')).toHaveTextContent('1 failed');
-    expect(screen.getByText('run-old-failed')).toBeInTheDocument();
+    expect(screen.getByText('run-current-failed')).toBeInTheDocument();
+    expect(screen.queryByText('run-old-failed')).toBeNull();
   });
 
   it('renders scheduled agent assignments as agent names', async () => {
@@ -176,6 +234,6 @@ describe('WorkflowMonitor', () => {
 
     render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
 
-    expect(await screen.findAllByText('reasoning_gate: Assistant - Gemini')).toHaveLength(2);
+    expect(await screen.findAllByText('reasoning_gate: Assistant - Gemini')).toHaveLength(1);
   });
 });

--- a/src/features/workflows/monitor/WorkflowMonitor.test.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.test.tsx
@@ -45,7 +45,7 @@ describe('WorkflowMonitor', () => {
     invokeMock.mockResolvedValue([]);
   });
 
-  it('shows recent completed runs alongside active runs', () => {
+  it('shows completed runs in history', () => {
     runState.runs = [{
       run_id: 'run-1',
       blueprint_id: 'heartbeat',
@@ -55,6 +55,10 @@ describe('WorkflowMonitor', () => {
     }];
 
     render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    expect(screen.queryByTestId('workflow-activity-row-heartbeat')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
 
     expect(screen.getByTestId('workflow-activity-row-heartbeat')).toHaveTextContent('heartbeat');
     expect(screen.getByTestId('workflow-activity-row-heartbeat')).toHaveTextContent('Completed');
@@ -126,7 +130,7 @@ describe('WorkflowMonitor', () => {
     expect(screen.getByRole('heading', { name: /needs attention/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /running now/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /^scheduled$/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /recent history/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^history$/i })).toBeNull();
     expect(screen.queryByRole('heading', { name: /^schedules$/i })).toBeNull();
     expect(screen.getAllByText('Passive Heartbeat')).toHaveLength(1);
   });
@@ -173,6 +177,49 @@ describe('WorkflowMonitor', () => {
     fireEvent.click(screen.getByRole('button', { name: /running/i }));
     expect(screen.getByText('Passive Heartbeat')).toBeInTheDocument();
     expect(screen.queryByText('Audit')).toBeNull();
+  });
+
+  it('shows history only when the history filter is selected', () => {
+    scheduleState.schedules = [{
+      id: 'schedule-1',
+      blueprint_id: 'heartbeat',
+      name: 'Passive Heartbeat',
+      input: {},
+      bindings: {},
+      schedule: { schedule_type: 'interval', interval_minutes: 60, active: true },
+      is_paused: false,
+      next_run_epoch_ms: Date.UTC(2026, 5, 1, 16, 0, 0),
+    }];
+    runState.runs = [
+      {
+        run_id: 'run-current',
+        blueprint_id: 'heartbeat',
+        status: 'running',
+        node_count: 2,
+        path: '/runs/current',
+      },
+      {
+        run_id: 'run-history',
+        blueprint_id: 'manual-review',
+        status: 'completed',
+        node_count: 2,
+        path: '/runs/history',
+        updated_at: '2026-06-01T12:00:00Z',
+      },
+    ];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    expect(screen.queryByRole('heading', { name: /^history$/i })).toBeNull();
+    expect(screen.queryByText('manual-review')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /running/i }));
+    expect(screen.queryByRole('heading', { name: /^history$/i })).toBeNull();
+    expect(screen.queryByText('manual-review')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+    expect(screen.getByRole('heading', { name: /^history$/i })).toBeInTheDocument();
+    expect(screen.getByText('manual-review')).toBeInTheDocument();
   });
 
   it('shows all scheduled workflows with neutral scheduled labeling', () => {
@@ -263,7 +310,7 @@ describe('WorkflowMonitor', () => {
     expect(screen.queryByText('run-old-failed')).toBeNull();
   });
 
-  it('expands recent history to show older runs on demand', () => {
+  it('expands history to show older runs on demand', () => {
     runState.runs = [
       {
         run_id: 'run-new',
@@ -284,10 +331,11 @@ describe('WorkflowMonitor', () => {
     ];
 
     render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
 
-    expect(screen.getByRole('heading', { name: /recent history/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^history$/i })).toBeInTheDocument();
     const latestRunId = screen.getByText('run-new');
-    const showOlderButton = screen.getByRole('button', { name: /show older/i });
+    const showOlderButton = screen.getByRole('button', { name: /show 1 older/i });
     expect(latestRunId.compareDocumentPosition(showOlderButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.queryByText('run-old')).toBeNull();
 
@@ -302,6 +350,46 @@ describe('WorkflowMonitor', () => {
     expect(olderRunRow).toHaveTextContent('Manual only');
     expect(olderRunRow).toHaveTextContent('Default');
     expect(screen.getByRole('button', { name: /show less/i })).toBeInTheDocument();
+  });
+
+  it('reveals older history ten runs at a time', () => {
+    runState.runs = [
+      {
+        run_id: 'run-latest',
+        blueprint_id: 'audit',
+        status: 'completed',
+        node_count: 2,
+        path: '/runs/latest',
+        updated_at: '2026-06-01T23:00:00Z',
+      },
+      ...Array.from({ length: 12 }, (_, index) => ({
+        run_id: `run-old-${String(index + 1).padStart(2, '0')}`,
+        blueprint_id: 'audit',
+        status: 'completed' as const,
+        node_count: 2,
+        path: `/runs/old-${index + 1}`,
+        updated_at: `2026-06-01T${String(22 - index).padStart(2, '0')}:00:00Z`,
+      })),
+    ];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+
+    expect(screen.queryByText('run-old-01')).toBeNull();
+    expect(screen.getByRole('button', { name: /show 10 older/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /show 10 older/i }));
+
+    expect(screen.getByText('run-old-01')).toBeInTheDocument();
+    expect(screen.getByText('run-old-10')).toBeInTheDocument();
+    expect(screen.queryByText('run-old-11')).toBeNull();
+    expect(screen.getByRole('button', { name: /show 2 older/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /show 2 older/i }));
+
+    expect(screen.getByText('run-old-11')).toBeInTheDocument();
+    expect(screen.getByText('run-old-12')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /show .*older/i })).toBeNull();
   });
 
   it('renders scheduled agent assignments as agent names', async () => {

--- a/src/features/workflows/monitor/WorkflowMonitor.test.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.test.tsx
@@ -125,7 +125,7 @@ describe('WorkflowMonitor', () => {
     expect(screen.getByRole('heading', { name: /activity/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /needs attention/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /running now/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /due soon/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^scheduled$/i })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: /recent history/i })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /^schedules$/i })).toBeNull();
     expect(screen.getAllByText('Passive Heartbeat')).toHaveLength(1);
@@ -173,6 +173,59 @@ describe('WorkflowMonitor', () => {
     fireEvent.click(screen.getByRole('button', { name: /running/i }));
     expect(screen.getByText('Passive Heartbeat')).toBeInTheDocument();
     expect(screen.queryByText('Audit')).toBeNull();
+  });
+
+  it('shows all scheduled workflows with neutral scheduled labeling', () => {
+    scheduleState.schedules = [
+      {
+        id: 'schedule-1',
+        blueprint_id: 'heartbeat',
+        name: 'Passive Heartbeat',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'interval', interval_minutes: 60, active: true },
+        is_paused: false,
+        next_run_epoch_ms: Date.UTC(2026, 5, 1, 16, 0, 0),
+      },
+      {
+        id: 'schedule-2',
+        blueprint_id: 'nightly',
+        name: 'Nightly Review',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'daily', time_of_day: '22:00', active: true },
+        is_paused: false,
+        next_run_epoch_ms: Date.UTC(2026, 5, 2, 2, 0, 0),
+      },
+    ];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /scheduled/i }));
+
+    expect(screen.getByRole('heading', { name: /^scheduled$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /due soon/i })).toBeNull();
+    expect(screen.getByText('Passive Heartbeat')).toBeInTheDocument();
+    expect(screen.getByText('Nightly Review')).toBeInTheDocument();
+  });
+
+  it('renders activity actions inside responsive rows instead of a fixed actions table', () => {
+    scheduleState.schedules = [{
+      id: 'schedule-1',
+      blueprint_id: 'heartbeat',
+      name: 'Passive Heartbeat',
+      input: {},
+      bindings: {},
+      schedule: { schedule_type: 'interval', interval_minutes: 60, active: true },
+      is_paused: false,
+      next_run_epoch_ms: Date.UTC(2026, 5, 1, 16, 0, 0),
+    }];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    expect(screen.getByTestId('workflow-activity-row-heartbeat')).toHaveTextContent('Passive Heartbeat');
+    expect(screen.queryByRole('columnheader', { name: /actions/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /pause passive heartbeat/i })).toBeInTheDocument();
   });
 
   it('counts only current workflow failures in the headline stats', () => {

--- a/src/features/workflows/monitor/WorkflowMonitor.test.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.test.tsx
@@ -286,13 +286,21 @@ describe('WorkflowMonitor', () => {
     render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
 
     expect(screen.getByRole('heading', { name: /recent history/i })).toBeInTheDocument();
-    expect(screen.getByText('run-new')).toBeInTheDocument();
+    const latestRunId = screen.getByText('run-new');
+    const showOlderButton = screen.getByRole('button', { name: /show older/i });
+    expect(latestRunId.compareDocumentPosition(showOlderButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.queryByText('run-old')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: /show older/i }));
+    fireEvent.click(showOlderButton);
 
     expect(screen.getByText('run-new')).toBeInTheDocument();
-    expect(screen.getByTestId('workflow-history-run-run-old')).toHaveTextContent('run-old');
+    const olderRunRow = screen.getByTestId('workflow-history-run-run-old');
+    expect(olderRunRow).toHaveTextContent('run-old');
+    expect(olderRunRow).toHaveTextContent('Run');
+    expect(olderRunRow).toHaveTextContent('Schedule');
+    expect(olderRunRow).toHaveTextContent('Assignment');
+    expect(olderRunRow).toHaveTextContent('Manual only');
+    expect(olderRunRow).toHaveTextContent('Default');
     expect(screen.getByRole('button', { name: /show less/i })).toBeInTheDocument();
   });
 

--- a/src/features/workflows/monitor/WorkflowMonitor.test.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.test.tsx
@@ -57,7 +57,7 @@ describe('WorkflowMonitor', () => {
     render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
 
     expect(screen.getByText('heartbeat')).toBeInTheDocument();
-    expect(screen.getByText('completed')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
   });
 
   it('shows an operational stat strip and distinct monitor sections', () => {

--- a/src/features/workflows/monitor/WorkflowMonitor.test.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.test.tsx
@@ -64,6 +64,40 @@ describe('WorkflowMonitor', () => {
     expect(screen.getByTestId('workflow-activity-row-heartbeat')).toHaveTextContent('Completed');
   });
 
+  it('sorts history by latest run timestamp and shows the timestamp', () => {
+    const olderTimestamp = '2026-06-01T12:00:00Z';
+    const newerTimestamp = '2026-06-01T18:30:00Z';
+    runState.runs = [
+      {
+        run_id: 'run-older',
+        blueprint_id: 'older-workflow',
+        status: 'completed',
+        node_count: 2,
+        path: '/runs/older',
+        updated_at: olderTimestamp,
+      },
+      {
+        run_id: 'run-newer',
+        blueprint_id: 'newer-workflow',
+        status: 'completed',
+        node_count: 2,
+        path: '/runs/newer',
+        updated_at: newerTimestamp,
+      },
+    ];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /history/i }));
+
+    const newerRow = screen.getByTestId('workflow-activity-row-newer-workflow');
+    const olderRow = screen.getByTestId('workflow-activity-row-older-workflow');
+    expect(newerRow.compareDocumentPosition(olderRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(newerRow).toHaveTextContent('Time');
+    expect(newerRow).toHaveTextContent(new Date(newerTimestamp).toLocaleString());
+    expect(olderRow).toHaveTextContent(new Date(olderTimestamp).toLocaleString());
+  });
+
   it('shows one activity surface with triage groups instead of duplicate monitor columns', () => {
     scheduleState.schedules = [
       {
@@ -254,6 +288,101 @@ describe('WorkflowMonitor', () => {
     expect(screen.queryByRole('heading', { name: /due soon/i })).toBeNull();
     expect(screen.getByText('Passive Heartbeat')).toBeInTheDocument();
     expect(screen.getByText('Nightly Review')).toBeInTheDocument();
+  });
+
+  it('does not collapse multiple active runs for the same workflow', () => {
+    runState.runs = [
+      {
+        run_id: 'run-active-1',
+        blueprint_id: 'passive-heartbeat',
+        status: 'running',
+        node_count: 2,
+        path: '/runs/active-1',
+        updated_at: '2026-06-01T16:00:00Z',
+      },
+      {
+        run_id: 'run-active-2',
+        blueprint_id: 'passive-heartbeat',
+        status: 'running',
+        node_count: 2,
+        path: '/runs/active-2',
+        updated_at: '2026-06-01T16:01:00Z',
+      },
+    ];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    expect(screen.getByRole('heading', { name: /running now/i })).toBeInTheDocument();
+    expect(screen.getByText('run-active-1')).toBeInTheDocument();
+    expect(screen.getByText('run-active-2')).toBeInTheDocument();
+  });
+
+  it('does not collapse multiple schedules for the same workflow', () => {
+    scheduleState.schedules = [
+      {
+        id: 'schedule-1',
+        blueprint_id: 'passive-heartbeat',
+        name: 'Trader Heartbeat',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'interval', interval_minutes: 60, active: true },
+        is_paused: false,
+        next_run_epoch_ms: Date.UTC(2026, 5, 1, 16, 0, 0),
+      },
+      {
+        id: 'schedule-2',
+        blueprint_id: 'passive-heartbeat',
+        name: 'Assistant Heartbeat',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'interval', interval_minutes: 360, active: true },
+        is_paused: false,
+        next_run_epoch_ms: Date.UTC(2026, 5, 1, 17, 0, 0),
+      },
+    ];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /scheduled/i }));
+
+    expect(screen.getByText('Trader Heartbeat')).toBeInTheDocument();
+    expect(screen.getByText('Assistant Heartbeat')).toBeInTheDocument();
+  });
+
+  it('does not hide scheduled instances when another instance of the same workflow is running', () => {
+    scheduleState.schedules = [
+      {
+        id: 'schedule-trader',
+        blueprint_id: 'passive-heartbeat',
+        name: 'Trader Heartbeat',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'interval', interval_minutes: 60, active: true },
+        is_paused: false,
+        next_run_epoch_ms: Date.UTC(2026, 5, 1, 16, 0, 0),
+      },
+      {
+        id: 'schedule-reviewer',
+        blueprint_id: 'passive-heartbeat',
+        name: 'Reviewer Heartbeat',
+        input: {},
+        bindings: {},
+        schedule: { schedule_type: 'interval', interval_minutes: 360, active: true },
+        is_paused: false,
+        next_run_epoch_ms: Date.UTC(2026, 5, 1, 17, 0, 0),
+      },
+    ];
+    runState.runs = [{
+      run_id: 'run-trader',
+      blueprint_id: 'passive-heartbeat',
+      status: 'running',
+      node_count: 2,
+      path: '/runs/trader',
+    }];
+
+    render(<WorkflowMonitor onOpenRun={vi.fn()} onEditSchedule={vi.fn()} />);
+
+    expect(screen.getByText('Trader Heartbeat')).toBeInTheDocument();
+    expect(screen.getByText('Reviewer Heartbeat')).toBeInTheDocument();
   });
 
   it('renders activity actions inside responsive rows instead of a fixed actions table', () => {

--- a/src/features/workflows/monitor/WorkflowMonitor.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.tsx
@@ -81,6 +81,7 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
   const loadRuns = useRunStore((state) => state.loadRuns);
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [filter, setFilter] = useState<ActivityFilter>('all');
+  const [showOlderHistory, setShowOlderHistory] = useState(false);
 
   useEffect(() => {
     void load();
@@ -114,6 +115,7 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
   );
   const activities = useMemo(() => buildActivities(runs, schedules), [runs, schedules]);
   const groupedActivities = useMemo(() => groupActivities(activities, filter), [activities, filter]);
+  const olderHistoryRuns = useMemo(() => olderHistoryRunsFor(runs, latestRuns), [runs, latestRuns]);
   const agentLabels = useMemo(() => agentLabelMap(agents), [agents]);
 
   const failedRuns = latestRuns.filter((run) => run.status === 'failed');
@@ -169,19 +171,23 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
         <div className="min-h-0 overflow-y-auto p-3">
           {SECTION_ORDER.map((section) => {
             const items = groupedActivities[section];
-            if (items.length === 0 && filter !== 'all') return null;
-            if (items.length === 0) return null;
+            const hasOlderHistory = section === 'history' && olderHistoryRuns.length > 0;
+            if (items.length === 0 && filter !== 'all' && !hasOlderHistory) return null;
+            if (items.length === 0 && !hasOlderHistory) return null;
             return (
               <ActivitySection
                 key={section}
                 title={SECTION_LABELS[section]}
                 activities={items}
+                olderRuns={section === 'history' ? olderHistoryRuns : []}
+                showOlderRuns={section === 'history' && showOlderHistory}
                 agentLabels={agentLabels}
                 onOpenRun={onOpenRun}
                 onPause={pause}
                 onResume={resume}
                 onRunNow={runNow}
                 onEditSchedule={onEditSchedule}
+                onToggleOlderRuns={() => setShowOlderHistory((value) => !value)}
               />
             );
           })}
@@ -199,27 +205,46 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
 function ActivitySection({
   title,
   activities,
+  olderRuns,
+  showOlderRuns,
   agentLabels,
   onOpenRun,
   onPause,
   onResume,
   onRunNow,
   onEditSchedule,
+  onToggleOlderRuns,
 }: {
   title: string;
   activities: WorkflowActivity[];
+  olderRuns: RunSummary[];
+  showOlderRuns: boolean;
   agentLabels: Record<string, string>;
   onOpenRun: (blueprintId: string, runId: string) => void;
   onPause: (id: string) => void;
   onResume: (id: string) => void;
   onRunNow: (id: string) => void;
   onEditSchedule: (schedule: WorkflowSchedule) => void;
+  onToggleOlderRuns: () => void;
 }) {
+  const visibleCount = activities.length + (showOlderRuns ? olderRuns.length : 0);
+
   return (
     <section className="mb-4 last:mb-0">
       <div className="mb-2 flex items-center justify-between gap-3">
         <h4 className="text-xs font-bold text-muted">{title}</h4>
-        <span className="font-mono text-[10px] text-muted">{activities.length}</span>
+        <div className="flex items-center gap-2">
+          {olderRuns.length > 0 ? (
+            <button
+              type="button"
+              onClick={onToggleOlderRuns}
+              className="h-6 cursor-pointer select-none rounded border border-wardian-border px-2 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+            >
+              {showOlderRuns ? 'Show less' : `Show older ${olderRuns.length}`}
+            </button>
+          ) : null}
+          <span className="font-mono text-[10px] text-muted">{visibleCount}</span>
+        </div>
       </div>
       <div className="select-text overflow-hidden rounded border border-wardian-border">
         {activities.map((activity) => (
@@ -234,6 +259,15 @@ function ActivitySection({
             onEditSchedule={onEditSchedule}
           />
         ))}
+        {showOlderRuns
+          ? olderRuns.map((run) => (
+            <HistoryRunRow
+              key={run.run_id}
+              run={run}
+              onOpenRun={onOpenRun}
+            />
+          ))
+          : null}
       </div>
     </section>
   );
@@ -355,6 +389,51 @@ function ActivityRow({
               </button>
             </>
           ) : null}
+      </div>
+    </div>
+  );
+}
+
+function HistoryRunRow({
+  run,
+  onOpenRun,
+}: {
+  run: RunSummary;
+  onOpenRun: (blueprintId: string, runId: string) => void;
+}) {
+  const stamp = run.updated_at ?? run.completed_at ?? run.started_at ?? '';
+  const tone = historyTone(run.status);
+
+  return (
+    <div
+      data-testid={`workflow-history-run-${run.run_id}`}
+      className="flex flex-wrap items-start gap-x-4 gap-y-2 border-b border-wardian-border/70 bg-[color-mix(in_srgb,var(--color-wardian-card),transparent_55%)] p-3 last:border-b-0"
+    >
+      <div className="min-w-[180px] flex-[1.4_1_220px]">
+        <div className="truncate text-xs font-bold text-[var(--color-wardian-text)]" title={run.blueprint_id}>{run.blueprint_id}</div>
+        <div className={`mt-1 flex items-center gap-2 text-[10px] font-bold ${runToneClass(run.status)}`}>
+          <span className={`h-2 w-2 shrink-0 rounded-full ${toneDotClass[tone]}`} aria-hidden />
+          <span>{formatRunStatus(run.status)}</span>
+        </div>
+      </div>
+      <div className="min-w-[140px] flex-[1_1_150px]">
+        <div className="mb-0.5 text-[9px] font-bold text-muted">Run</div>
+        <div className="truncate font-mono text-[10px] text-muted" title={run.run_id}>{run.run_id}</div>
+      </div>
+      <div className="min-w-[150px] flex-[1_1_170px]">
+        <div className="mb-0.5 text-[9px] font-bold text-muted">Updated</div>
+        <div className="truncate text-[10px] text-muted" title={stamp}>{formatRunStamp(stamp)}</div>
+      </div>
+      <div className="ml-auto flex min-w-[34px] shrink-0 items-center justify-end gap-1.5 pr-1 pt-0.5">
+        <button
+          type="button"
+          aria-label={`Open ${run.blueprint_id} run ${run.run_id}`}
+          title="Open run"
+          onClick={() => onOpenRun(run.blueprint_id, run.run_id)}
+          className={actionClass}
+        >
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+        </button>
       </div>
     </div>
   );
@@ -506,12 +585,33 @@ function latestRunPerBlueprint(runs: RunSummary[]) {
   return [...latest.values()];
 }
 
+function olderHistoryRunsFor(runs: RunSummary[], latestRuns: RunSummary[]) {
+  const latestRunIds = new Set(latestRuns.map((run) => run.run_id));
+  return runs
+    .filter((run) => run.status !== 'running' && run.status !== 'awaiting_approval')
+    .filter((run) => !latestRunIds.has(run.run_id))
+    .sort(compareRunRecency);
+}
+
 function compareRunRecency(left: RunSummary, right: RunSummary) {
   const leftStamp = left.updated_at ?? left.completed_at ?? left.started_at ?? '';
   const rightStamp = right.updated_at ?? right.completed_at ?? right.started_at ?? '';
   if (leftStamp !== rightStamp) return leftStamp > rightStamp ? -1 : 1;
   if (left.run_id === right.run_id) return 0;
   return left.run_id > right.run_id ? -1 : 1;
+}
+
+function formatRunStamp(stamp: string) {
+  if (!stamp) return 'Unknown';
+  const date = new Date(stamp);
+  if (Number.isNaN(date.getTime())) return stamp;
+  return date.toLocaleString();
+}
+
+function historyTone(status: RunStatusKind): ActivityTone {
+  if (status === 'failed') return 'error';
+  if (status === 'completed') return 'success';
+  return 'muted';
 }
 
 function assignmentLabels(

--- a/src/features/workflows/monitor/WorkflowMonitor.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.tsx
@@ -233,18 +233,7 @@ function ActivitySection({
     <section className="mb-4 last:mb-0">
       <div className="mb-2 flex items-center justify-between gap-3">
         <h4 className="text-xs font-bold text-muted">{title}</h4>
-        <div className="flex items-center gap-2">
-          {olderRuns.length > 0 ? (
-            <button
-              type="button"
-              onClick={onToggleOlderRuns}
-              className="h-6 cursor-pointer select-none rounded border border-wardian-border px-2 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
-            >
-              {showOlderRuns ? 'Show less' : `Show older ${olderRuns.length}`}
-            </button>
-          ) : null}
-          <span className="font-mono text-[10px] text-muted">{visibleCount}</span>
-        </div>
+        <span className="font-mono text-[10px] text-muted">{visibleCount}</span>
       </div>
       <div className="select-text overflow-hidden rounded border border-wardian-border">
         {activities.map((activity) => (
@@ -261,13 +250,31 @@ function ActivitySection({
         ))}
         {showOlderRuns
           ? olderRuns.map((run) => (
-            <HistoryRunRow
+            <ActivityRow
               key={run.run_id}
-              run={run}
+              activity={historyActivityFromRun(run)}
+              agentLabels={agentLabels}
+              testId={`workflow-history-run-${run.run_id}`}
               onOpenRun={onOpenRun}
+              onPause={onPause}
+              onResume={onResume}
+              onRunNow={onRunNow}
+              onEditSchedule={onEditSchedule}
             />
           ))
           : null}
+        {olderRuns.length > 0 ? (
+          <div className="flex items-center justify-center border-t border-wardian-border/70 bg-[var(--color-wardian-bg)] px-3 py-2">
+            <button
+              type="button"
+              aria-expanded={showOlderRuns}
+              onClick={onToggleOlderRuns}
+              className="h-7 cursor-pointer select-none rounded border border-wardian-border px-3 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+            >
+              {showOlderRuns ? 'Show less' : `Show older ${olderRuns.length}`}
+            </button>
+          </div>
+        ) : null}
       </div>
     </section>
   );
@@ -281,6 +288,7 @@ function ActivityRow({
   onResume,
   onRunNow,
   onEditSchedule,
+  testId,
 }: {
   activity: WorkflowActivity;
   agentLabels: Record<string, string>;
@@ -289,6 +297,7 @@ function ActivityRow({
   onResume: (id: string) => void;
   onRunNow: (id: string) => void;
   onEditSchedule: (schedule: WorkflowSchedule) => void;
+  testId?: string;
 }) {
   const schedule = activity.nextSchedule ?? activity.schedules[0] ?? null;
   const labels = schedule
@@ -297,7 +306,7 @@ function ActivityRow({
 
   return (
     <div
-      data-testid={`workflow-activity-row-${activity.blueprintId}`}
+      data-testid={testId ?? `workflow-activity-row-${activity.blueprintId}`}
       className="flex flex-wrap items-start gap-x-4 gap-y-2 border-b border-wardian-border/70 bg-[var(--color-wardian-bg)] p-3 last:border-b-0 hover:bg-[color-mix(in_srgb,var(--color-wardian-card),transparent_45%)]"
     >
       <div className="min-w-[180px] flex-[1.4_1_220px]">
@@ -394,51 +403,6 @@ function ActivityRow({
   );
 }
 
-function HistoryRunRow({
-  run,
-  onOpenRun,
-}: {
-  run: RunSummary;
-  onOpenRun: (blueprintId: string, runId: string) => void;
-}) {
-  const stamp = run.updated_at ?? run.completed_at ?? run.started_at ?? '';
-  const tone = historyTone(run.status);
-
-  return (
-    <div
-      data-testid={`workflow-history-run-${run.run_id}`}
-      className="flex flex-wrap items-start gap-x-4 gap-y-2 border-b border-wardian-border/70 bg-[color-mix(in_srgb,var(--color-wardian-card),transparent_55%)] p-3 last:border-b-0"
-    >
-      <div className="min-w-[180px] flex-[1.4_1_220px]">
-        <div className="truncate text-xs font-bold text-[var(--color-wardian-text)]" title={run.blueprint_id}>{run.blueprint_id}</div>
-        <div className={`mt-1 flex items-center gap-2 text-[10px] font-bold ${runToneClass(run.status)}`}>
-          <span className={`h-2 w-2 shrink-0 rounded-full ${toneDotClass[tone]}`} aria-hidden />
-          <span>{formatRunStatus(run.status)}</span>
-        </div>
-      </div>
-      <div className="min-w-[140px] flex-[1_1_150px]">
-        <div className="mb-0.5 text-[9px] font-bold text-muted">Run</div>
-        <div className="truncate font-mono text-[10px] text-muted" title={run.run_id}>{run.run_id}</div>
-      </div>
-      <div className="min-w-[150px] flex-[1_1_170px]">
-        <div className="mb-0.5 text-[9px] font-bold text-muted">Updated</div>
-        <div className="truncate text-[10px] text-muted" title={stamp}>{formatRunStamp(stamp)}</div>
-      </div>
-      <div className="ml-auto flex min-w-[34px] shrink-0 items-center justify-end gap-1.5 pr-1 pt-0.5">
-        <button
-          type="button"
-          aria-label={`Open ${run.blueprint_id} run ${run.run_id}`}
-          title="Open run"
-          onClick={() => onOpenRun(run.blueprint_id, run.run_id)}
-          className={actionClass}
-        >
-          <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-        </button>
-      </div>
-    </div>
-  );
-}
-
 function buildActivities(runs: RunSummary[], schedules: WorkflowSchedule[]): WorkflowActivity[] {
   const ids = new Set<string>();
   for (const run of runs) ids.add(run.blueprint_id);
@@ -469,6 +433,21 @@ function buildActivities(runs: RunSummary[], schedules: WorkflowSchedule[]): Wor
       ...state,
     };
   }).sort(compareActivities);
+}
+
+function historyActivityFromRun(run: RunSummary): WorkflowActivity {
+  return {
+    blueprintId: run.blueprint_id,
+    name: run.blueprint_id,
+    schedules: [],
+    latestRun: run,
+    activeRun: null,
+    nextSchedule: null,
+    statusLabel: formatRunStatus(run.status),
+    tone: historyTone(run.status),
+    section: 'history',
+    issue: run.status === 'failed' ? run.failure ?? 'Run failed' : null,
+  };
 }
 
 function activityState(
@@ -599,13 +578,6 @@ function compareRunRecency(left: RunSummary, right: RunSummary) {
   if (leftStamp !== rightStamp) return leftStamp > rightStamp ? -1 : 1;
   if (left.run_id === right.run_id) return 0;
   return left.run_id > right.run_id ? -1 : 1;
-}
-
-function formatRunStamp(stamp: string) {
-  if (!stamp) return 'Unknown';
-  const date = new Date(stamp);
-  if (Number.isNaN(date.getTime())) return stamp;
-  return date.toLocaleString();
 }
 
 function historyTone(status: RunStatusKind): ActivityTone {

--- a/src/features/workflows/monitor/WorkflowMonitor.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.tsx
@@ -175,7 +175,7 @@ function compareRunRecency(left: RunSummary, right: RunSummary) {
 function MonitorSection({ title, scroll, children }: { title: string; scroll?: boolean; children: ReactNode }) {
   return (
     <section className={`min-h-0 ${scroll ? 'overflow-y-auto' : 'overflow-visible'}`}>
-      <h3 className="mb-2 text-xs font-bold uppercase tracking-wide text-muted">{title}</h3>
+      <h3 className="mb-2 text-xs font-bold text-muted">{title}</h3>
       {children}
     </section>
   );

--- a/src/features/workflows/monitor/WorkflowMonitor.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.tsx
@@ -1,17 +1,73 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { ExternalLink, Pause, Pencil, Play, RotateCcw } from 'lucide-react';
 import { useSchedulesStore } from '../../../store/useSchedulesStore';
 import type { AgentConfig } from '../../../types';
-import type { WorkflowSchedule } from '../../../types/workflow';
-import { ActiveRunsList } from './ActiveRunsList';
-import { SchedulesTable } from './SchedulesTable';
+import type { WorkflowAssignments, WorkflowSchedule } from '../../../types/workflow';
 import { useRunStore } from '../run/useRunStore';
-import type { RunSummary } from '../run/runTypes';
+import type { RunStatusKind, RunSummary } from '../run/runTypes';
+import { formatRunStatus } from '../run/statusLabels';
+import { cadenceLabel, nextRunLabel } from './scheduleStatus';
 
 interface WorkflowMonitorProps {
   onOpenRun: (blueprintId: string, runId: string) => void;
   onEditSchedule: (schedule: WorkflowSchedule) => void;
 }
+
+type ActivityFilter = 'all' | 'attention' | 'running' | 'scheduled' | 'history';
+type ActivitySection = Exclude<ActivityFilter, 'all'>;
+type ActivityTone = 'error' | 'active' | 'warning' | 'accent' | 'success' | 'muted';
+
+interface WorkflowActivity {
+  blueprintId: string;
+  name: string;
+  schedules: WorkflowSchedule[];
+  latestRun: RunSummary | null;
+  activeRun: RunSummary | null;
+  nextSchedule: WorkflowSchedule | null;
+  statusLabel: string;
+  tone: ActivityTone;
+  section: ActivitySection;
+  issue: string | null;
+}
+
+const FILTERS: Array<{ id: ActivityFilter; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'attention', label: 'Needs attention' },
+  { id: 'running', label: 'Running' },
+  { id: 'scheduled', label: 'Scheduled' },
+  { id: 'history', label: 'History' },
+];
+
+const SECTION_LABELS: Record<ActivitySection, string> = {
+  attention: 'Needs attention',
+  running: 'Running now',
+  scheduled: 'Due soon',
+  history: 'Recent history',
+};
+
+const SECTION_ORDER: ActivitySection[] = ['attention', 'running', 'scheduled', 'history'];
+
+const toneClass: Record<ActivityTone, string> = {
+  error: 'text-[var(--color-wardian-error)]',
+  active: 'text-[var(--color-wardian-processing)]',
+  warning: 'text-[var(--color-wardian-warning)]',
+  accent: 'text-[var(--color-wardian-accent)]',
+  success: 'text-[var(--color-wardian-success)]',
+  muted: 'text-muted',
+};
+
+const toneDotClass: Record<ActivityTone, string> = {
+  error: 'bg-[var(--color-wardian-error)]',
+  active: 'bg-[var(--color-wardian-processing)]',
+  warning: 'bg-[var(--color-wardian-warning)]',
+  accent: 'bg-[var(--color-wardian-accent)]',
+  success: 'bg-[var(--color-wardian-success)]',
+  muted: 'bg-[var(--color-wardian-text-muted)]',
+};
+
+const actionClass =
+  'inline-flex h-7 w-7 cursor-pointer select-none items-center justify-center rounded border border-wardian-border text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]';
 
 export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorProps) {
   const schedules = useSchedulesStore((state) => state.schedules);
@@ -20,11 +76,11 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
   const pause = useSchedulesStore((state) => state.pause);
   const resume = useSchedulesStore((state) => state.resume);
   const runNow = useSchedulesStore((state) => state.runNow);
-  const remove = useSchedulesStore((state) => state.remove);
 
   const runs = useRunStore((state) => state.runs);
   const loadRuns = useRunStore((state) => state.loadRuns);
   const [agents, setAgents] = useState<AgentConfig[]>([]);
+  const [filter, setFilter] = useState<ActivityFilter>('all');
 
   useEffect(() => {
     void load();
@@ -49,31 +105,17 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
     };
   }, []);
 
-  const monitorRuns = useMemo(
-    () => {
-      const active = runs.filter((run) => run.status === 'running' || run.status === 'awaiting_approval');
-      const recent = runs.filter((run) => run.status !== 'running' && run.status !== 'awaiting_approval');
-      return [...active, ...recent].slice(0, 20);
-    },
-    [runs],
-  );
-  const activeRuns = useMemo(
-    () => runs.filter((run) => run.status === 'running' || run.status === 'awaiting_approval'),
-    [runs],
-  );
-  const historyRuns = useMemo(
-    () => runs.filter((run) => run.status !== 'running' && run.status !== 'awaiting_approval').slice(0, 20),
-    [runs],
-  );
+  const latestRuns = useMemo(() => latestRunPerBlueprint(runs), [runs]);
   const upcomingSchedules = useMemo(
     () => [...schedules]
       .filter((schedule) => !schedule.is_paused && schedule.next_run_epoch_ms)
-      .sort((left, right) => (left.next_run_epoch_ms ?? Number.MAX_SAFE_INTEGER) - (right.next_run_epoch_ms ?? Number.MAX_SAFE_INTEGER))
-      .slice(0, 8),
+      .sort((left, right) => (left.next_run_epoch_ms ?? Number.MAX_SAFE_INTEGER) - (right.next_run_epoch_ms ?? Number.MAX_SAFE_INTEGER)),
     [schedules],
   );
-  const latestRuns = useMemo(() => latestRunPerBlueprint(runs), [runs]);
+  const activities = useMemo(() => buildActivities(runs, schedules), [runs, schedules]);
+  const groupedActivities = useMemo(() => groupActivities(activities, filter), [activities, filter]);
   const agentLabels = useMemo(() => agentLabelMap(agents), [agents]);
+
   const failedRuns = latestRuns.filter((run) => run.status === 'failed');
   const failedRunBlueprintIds = new Set(failedRuns.map((run) => run.blueprint_id));
   const failedCount = failedRuns.length
@@ -94,48 +136,363 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
         <MonitorStat label="failed" value={failedCount} tone={failedCount > 0 ? 'error' : 'muted'} />
         <MonitorStat label="running" value={runningCount} tone={runningCount > 0 ? 'active' : 'muted'} />
         <MonitorStat label="awaiting" value={awaitingCount} tone={awaitingCount > 0 ? 'warning' : 'muted'} />
-        <MonitorStat label="upcoming" value={upcomingSchedules.length} tone={upcomingSchedules.length > 0 ? 'accent' : 'muted'} />
+        <MonitorStat label="due soon" value={upcomingSchedules.length} tone={upcomingSchedules.length > 0 ? 'accent' : 'muted'} />
         <MonitorStat label="paused" value={pausedCount} tone={pausedCount > 0 ? 'warning' : 'muted'} />
       </div>
       {error ? <div className="shrink-0 text-[11px] text-[var(--color-wardian-error)]">{error}</div> : null}
-      <div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-3 overflow-hidden">
-        <div className="grid min-h-0 grid-rows-[auto_auto_minmax(0,1fr)] gap-3 overflow-hidden">
-          <MonitorSection title="Active runs">
-            <ActiveRunsList runs={activeRuns} onOpen={onOpenRun} />
-          </MonitorSection>
-          <MonitorSection title="Upcoming">
-            <SchedulesTable
-              schedules={upcomingSchedules}
-              agentLabels={agentLabels}
-              onPause={pause}
-              onResume={resume}
-              onRunNow={runNow}
-              onRemove={remove}
-              onEdit={onEditSchedule}
-            />
-          </MonitorSection>
-          <MonitorSection title="History" scroll>
-            <ActiveRunsList
-              runs={historyRuns.length > 0 ? historyRuns : monitorRuns.filter((run) => run.status !== 'running' && run.status !== 'awaiting_approval')}
-              onOpen={onOpenRun}
-              emptyLabel="No recent runs."
-            />
-          </MonitorSection>
+
+      <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-wardian-border bg-[var(--color-wardian-bg)]">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-wardian-border bg-[var(--color-wardian-card)] px-3 py-2">
+          <div className="min-w-0">
+            <h3 className="text-xs font-bold text-[var(--color-wardian-text)]">Activity</h3>
+            <div className="mt-0.5 truncate text-[10px] text-muted">{activities.length} workflows tracked</div>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            {FILTERS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                aria-pressed={filter === item.id}
+                onClick={() => setFilter(item.id)}
+                className={`h-7 cursor-pointer select-none rounded border px-2 text-[10px] font-bold transition-colors ${
+                  filter === item.id
+                    ? 'border-[var(--color-wardian-accent)] bg-[color-mix(in_srgb,var(--color-wardian-accent),transparent_88%)] text-[var(--color-wardian-accent)]'
+                    : 'border-wardian-border text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]'
+                }`}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
         </div>
-        <MonitorSection title="Schedules" scroll>
-          <SchedulesTable
-            schedules={schedules}
-            agentLabels={agentLabels}
-            onPause={pause}
-            onResume={resume}
-            onRunNow={runNow}
-            onRemove={remove}
-            onEdit={onEditSchedule}
-          />
-        </MonitorSection>
-      </div>
+
+        <div className="min-h-0 overflow-y-auto p-3">
+          {SECTION_ORDER.map((section) => {
+            const items = groupedActivities[section];
+            if (items.length === 0 && filter !== 'all') return null;
+            if (items.length === 0) return null;
+            return (
+              <ActivitySection
+                key={section}
+                title={SECTION_LABELS[section]}
+                activities={items}
+                agentLabels={agentLabels}
+                onOpenRun={onOpenRun}
+                onPause={pause}
+                onResume={resume}
+                onRunNow={runNow}
+                onEditSchedule={onEditSchedule}
+              />
+            );
+          })}
+          {Object.values(groupedActivities).every((items) => items.length === 0) ? (
+            <div className="select-text rounded border border-dashed border-wardian-border p-4 text-center text-xs text-muted">
+              No workflow activity in this view.
+            </div>
+          ) : null}
+        </div>
+      </section>
     </div>
   );
+}
+
+function ActivitySection({
+  title,
+  activities,
+  agentLabels,
+  onOpenRun,
+  onPause,
+  onResume,
+  onRunNow,
+  onEditSchedule,
+}: {
+  title: string;
+  activities: WorkflowActivity[];
+  agentLabels: Record<string, string>;
+  onOpenRun: (blueprintId: string, runId: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
+  onRunNow: (id: string) => void;
+  onEditSchedule: (schedule: WorkflowSchedule) => void;
+}) {
+  return (
+    <section className="mb-4 last:mb-0">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <h4 className="text-xs font-bold text-muted">{title}</h4>
+        <span className="font-mono text-[10px] text-muted">{activities.length}</span>
+      </div>
+      <div className="select-text overflow-hidden rounded border border-wardian-border">
+        <table className="w-full table-fixed border-collapse text-left">
+          <thead className="bg-[var(--color-wardian-card)] text-[10px] font-bold text-muted">
+            <tr>
+              <th scope="col" className="w-[128px] px-3 py-2">State</th>
+              <th scope="col" className="px-3 py-2">Workflow</th>
+              <th scope="col" className="w-[24%] px-3 py-2">Current run</th>
+              <th scope="col" className="w-[24%] px-3 py-2">Schedule</th>
+              <th scope="col" className="w-[20%] px-3 py-2">Assignment</th>
+              <th scope="col" className="w-[132px] px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {activities.map((activity) => (
+              <ActivityRow
+                key={activity.blueprintId}
+                activity={activity}
+                agentLabels={agentLabels}
+                onOpenRun={onOpenRun}
+                onPause={onPause}
+                onResume={onResume}
+                onRunNow={onRunNow}
+                onEditSchedule={onEditSchedule}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function ActivityRow({
+  activity,
+  agentLabels,
+  onOpenRun,
+  onPause,
+  onResume,
+  onRunNow,
+  onEditSchedule,
+}: {
+  activity: WorkflowActivity;
+  agentLabels: Record<string, string>;
+  onOpenRun: (blueprintId: string, runId: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
+  onRunNow: (id: string) => void;
+  onEditSchedule: (schedule: WorkflowSchedule) => void;
+}) {
+  const schedule = activity.nextSchedule ?? activity.schedules[0] ?? null;
+  const labels = schedule
+    ? assignmentLabels(schedule.assignments, schedule.bindings, schedule.provider, agentLabels)
+    : [];
+
+  return (
+    <tr
+      data-testid={`workflow-activity-row-${activity.blueprintId}`}
+      className="border-b border-wardian-border/70 bg-[var(--color-wardian-bg)] align-middle last:border-b-0 hover:bg-[color-mix(in_srgb,var(--color-wardian-card),transparent_45%)]"
+    >
+      <td className="px-3 py-2">
+        <div className={`flex items-center gap-2 text-[10px] font-bold ${toneClass[activity.tone]}`}>
+          <span className={`h-2 w-2 shrink-0 rounded-full ${toneDotClass[activity.tone]}`} aria-hidden />
+          <span>{activity.statusLabel}</span>
+        </div>
+        {activity.issue ? <div className="mt-0.5 truncate text-[10px] text-[var(--color-wardian-error)]">{activity.issue}</div> : null}
+      </td>
+      <td className="min-w-0 px-3 py-2">
+        <div className="truncate text-xs font-bold text-[var(--color-wardian-text)]" title={activity.name}>{activity.name}</div>
+        {activity.blueprintId !== activity.name ? (
+          <div className="mt-0.5 truncate font-mono text-[10px] text-muted" title={activity.blueprintId}>{activity.blueprintId}</div>
+        ) : null}
+      </td>
+      <td className="min-w-0 px-3 py-2">
+        {activity.latestRun ? (
+          <>
+            <div className={`truncate text-[10px] font-bold ${runToneClass(activity.latestRun.status)}`}>
+              {formatRunStatus(activity.latestRun.status)}
+            </div>
+            <div className="mt-0.5 truncate font-mono text-[10px] text-muted" title={activity.latestRun.run_id}>{activity.latestRun.run_id}</div>
+          </>
+        ) : (
+          <span className="text-[10px] text-muted">No runs yet</span>
+        )}
+      </td>
+      <td className="min-w-0 px-3 py-2">
+        {schedule ? (
+          <>
+            <div className="truncate text-[10px] text-muted" title={cadenceLabel(schedule.schedule)}>{cadenceLabel(schedule.schedule)}</div>
+            <div className="mt-0.5 truncate text-[10px] text-muted" title={nextRunLabel(schedule)}>Next {nextRunLabel(schedule)}</div>
+          </>
+        ) : (
+          <span className="text-[10px] text-muted">Manual only</span>
+        )}
+      </td>
+      <td className="min-w-0 px-3 py-2">
+        {labels.length > 0 ? (
+          <div className="flex max-w-[320px] flex-wrap gap-1">
+            {labels.slice(0, 2).map((label) => (
+              <span
+                key={label}
+                className="max-w-[180px] truncate rounded border border-wardian-border bg-[var(--color-wardian-card)] px-1.5 py-0.5 text-[10px] text-muted"
+                title={label}
+              >
+                {label}
+              </span>
+            ))}
+            {labels.length > 2 ? (
+              <span className="rounded border border-wardian-border bg-[var(--color-wardian-card)] px-1.5 py-0.5 text-[10px] text-muted">
+                +{labels.length - 2} roles
+              </span>
+            ) : null}
+          </div>
+        ) : (
+          <span className="text-[10px] text-muted">Default</span>
+        )}
+      </td>
+      <td className="px-3 py-2 text-right">
+        <div className="inline-flex shrink-0 items-center gap-1">
+          {activity.latestRun ? (
+            <button
+              type="button"
+              aria-label={`Open ${activity.blueprintId} run ${activity.latestRun.run_id}`}
+              title="Open run"
+              onClick={() => onOpenRun(activity.blueprintId, activity.latestRun?.run_id ?? '')}
+              className={actionClass}
+            >
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+            </button>
+          ) : null}
+          {schedule ? (
+            <>
+              {schedule.is_paused ? (
+                <button type="button" className={actionClass} onClick={() => onResume(schedule.id)} aria-label={`Resume ${schedule.name}`} title="Resume">
+                  <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+                </button>
+              ) : (
+                <button type="button" className={actionClass} onClick={() => onPause(schedule.id)} aria-label={`Pause ${schedule.name}`} title="Pause">
+                  <Pause className="h-3.5 w-3.5" aria-hidden />
+                </button>
+              )}
+              <button type="button" className={actionClass} onClick={() => onRunNow(schedule.id)} aria-label={`Run ${schedule.name} now`} title="Run now">
+                <Play className="h-3.5 w-3.5" aria-hidden />
+              </button>
+              <button type="button" className={actionClass} onClick={() => onEditSchedule(schedule)} aria-label={`Edit ${schedule.name}`} title="Edit">
+                <Pencil className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            </>
+          ) : null}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function buildActivities(runs: RunSummary[], schedules: WorkflowSchedule[]): WorkflowActivity[] {
+  const ids = new Set<string>();
+  for (const run of runs) ids.add(run.blueprint_id);
+  for (const schedule of schedules) ids.add(schedule.blueprint_id);
+
+  return [...ids].map((blueprintId) => {
+    const workflowRuns = runs.filter((run) => run.blueprint_id === blueprintId);
+    const workflowSchedules = schedules
+      .filter((schedule) => schedule.blueprint_id === blueprintId)
+      .sort(compareScheduleRecency);
+    const latestRun = workflowRuns.sort(compareRunRecency)[0] ?? null;
+    const activeRun = workflowRuns.find((run) => run.status === 'awaiting_approval')
+      ?? workflowRuns.find((run) => run.status === 'running')
+      ?? null;
+    const nextSchedule = workflowSchedules.find((schedule) => !schedule.is_paused && schedule.next_run_epoch_ms)
+      ?? workflowSchedules[0]
+      ?? null;
+    const name = workflowSchedules[0]?.name ?? blueprintId;
+    const state = activityState(latestRun, activeRun, workflowSchedules, nextSchedule);
+
+    return {
+      blueprintId,
+      name,
+      schedules: workflowSchedules,
+      latestRun,
+      activeRun,
+      nextSchedule,
+      ...state,
+    };
+  }).sort(compareActivities);
+}
+
+function activityState(
+  latestRun: RunSummary | null,
+  activeRun: RunSummary | null,
+  schedules: WorkflowSchedule[],
+  nextSchedule: WorkflowSchedule | null,
+): Pick<WorkflowActivity, 'statusLabel' | 'tone' | 'section' | 'issue'> {
+  const failedSchedule = schedules.find((schedule) => schedule.last_run_status === 'failed' || schedule.last_run_error);
+  if (failedSchedule) {
+    return {
+      statusLabel: 'Needs attention',
+      tone: 'error',
+      section: 'attention',
+      issue: failedSchedule.last_run_error ?? 'Last scheduled run failed',
+    };
+  }
+  if (latestRun?.status === 'failed') {
+    return {
+      statusLabel: 'Needs attention',
+      tone: 'error',
+      section: 'attention',
+      issue: latestRun.failure ?? 'Latest run failed',
+    };
+  }
+  if (activeRun?.status === 'awaiting_approval') {
+    return { statusLabel: 'Awaiting approval', tone: 'warning', section: 'attention', issue: null };
+  }
+  if (activeRun?.status === 'running') {
+    return { statusLabel: 'Running', tone: 'active', section: 'running', issue: null };
+  }
+  if (nextSchedule && !nextSchedule.is_paused && nextSchedule.next_run_epoch_ms) {
+    return { statusLabel: 'Scheduled', tone: 'accent', section: 'scheduled', issue: null };
+  }
+  if (nextSchedule?.is_paused) {
+    return { statusLabel: 'Paused', tone: 'warning', section: 'scheduled', issue: null };
+  }
+  if (latestRun?.status === 'completed') {
+    return { statusLabel: 'Completed', tone: 'success', section: 'history', issue: null };
+  }
+  return { statusLabel: 'Idle', tone: 'muted', section: 'history', issue: null };
+}
+
+function groupActivities(activities: WorkflowActivity[], filter: ActivityFilter) {
+  const grouped: Record<ActivitySection, WorkflowActivity[]> = {
+    attention: [],
+    running: [],
+    scheduled: [],
+    history: [],
+  };
+
+  for (const activity of activities) {
+    if (filter !== 'all' && activity.section !== filter) continue;
+    grouped[activity.section].push(activity);
+  }
+
+  return grouped;
+}
+
+function compareActivities(left: WorkflowActivity, right: WorkflowActivity) {
+  const sectionDelta = SECTION_ORDER.indexOf(left.section) - SECTION_ORDER.indexOf(right.section);
+  if (sectionDelta !== 0) return sectionDelta;
+
+  const leftTime = activitySortTime(left);
+  const rightTime = activitySortTime(right);
+  if (leftTime !== rightTime) return leftTime - rightTime;
+  return left.name.localeCompare(right.name);
+}
+
+function activitySortTime(activity: WorkflowActivity) {
+  if (activity.section === 'scheduled') return activity.nextSchedule?.next_run_epoch_ms ?? Number.MAX_SAFE_INTEGER;
+  const stamp = activity.latestRun?.updated_at ?? activity.latestRun?.completed_at ?? activity.latestRun?.started_at ?? '';
+  return stamp ? -Date.parse(stamp) : 0;
+}
+
+function compareScheduleRecency(left: WorkflowSchedule, right: WorkflowSchedule) {
+  const leftNext = left.next_run_epoch_ms ?? Number.MAX_SAFE_INTEGER;
+  const rightNext = right.next_run_epoch_ms ?? Number.MAX_SAFE_INTEGER;
+  if (leftNext !== rightNext) return leftNext - rightNext;
+  return left.name.localeCompare(right.name);
+}
+
+function runToneClass(status: RunStatusKind) {
+  if (status === 'running') return 'text-[var(--color-wardian-processing)]';
+  if (status === 'awaiting_approval') return 'text-[var(--color-wardian-warning)]';
+  if (status === 'completed') return 'text-[var(--color-wardian-success)]';
+  if (status === 'failed') return 'text-[var(--color-wardian-error)]';
+  return 'text-muted';
 }
 
 function agentLabelMap(agents: AgentConfig[]) {
@@ -157,7 +514,7 @@ function latestRunPerBlueprint(runs: RunSummary[]) {
   const latest = new Map<string, RunSummary>();
   for (const run of runs) {
     const current = latest.get(run.blueprint_id);
-    if (!current || compareRunRecency(run, current) > 0) {
+    if (!current || compareRunRecency(run, current) < 0) {
       latest.set(run.blueprint_id, run);
     }
   }
@@ -167,18 +524,28 @@ function latestRunPerBlueprint(runs: RunSummary[]) {
 function compareRunRecency(left: RunSummary, right: RunSummary) {
   const leftStamp = left.updated_at ?? left.completed_at ?? left.started_at ?? '';
   const rightStamp = right.updated_at ?? right.completed_at ?? right.started_at ?? '';
-  if (leftStamp !== rightStamp) return leftStamp > rightStamp ? 1 : -1;
+  if (leftStamp !== rightStamp) return leftStamp > rightStamp ? -1 : 1;
   if (left.run_id === right.run_id) return 0;
-  return left.run_id > right.run_id ? 1 : -1;
+  return left.run_id > right.run_id ? -1 : 1;
 }
 
-function MonitorSection({ title, scroll, children }: { title: string; scroll?: boolean; children: ReactNode }) {
-  return (
-    <section className={`min-h-0 ${scroll ? 'overflow-y-auto' : 'overflow-visible'}`}>
-      <h3 className="mb-2 text-xs font-bold text-muted">{title}</h3>
-      {children}
-    </section>
-  );
+function assignmentLabels(
+  assignments?: WorkflowAssignments,
+  bindings?: Record<string, string>,
+  provider?: string | null,
+  agentLabels: Record<string, string> = {},
+) {
+  if (assignments && Object.keys(assignments).length > 0) {
+    return Object.entries(assignments).map(([role, assignment]) => {
+      if (assignment.target_type === 'agent') {
+        return `${role}: ${agentLabels[assignment.agent_id] ?? assignment.agent_id}`;
+      }
+      return `${role}: temp ${assignment.provider}`;
+    });
+  }
+  const bindingLabels = Object.entries(bindings ?? {}).map(([role, target]) => `${role}: ${agentLabels[target] ?? target}`);
+  if (bindingLabels.length > 0) return bindingLabels;
+  return provider ? [`temp ${provider}`] : [];
 }
 
 function MonitorStat({
@@ -190,7 +557,7 @@ function MonitorStat({
   value: number;
   tone: 'error' | 'active' | 'warning' | 'accent' | 'muted';
 }) {
-  const toneClass = {
+  const statToneClass = {
     error: 'text-[var(--color-wardian-error)]',
     active: 'text-[var(--color-wardian-processing)]',
     warning: 'text-[var(--color-wardian-warning)]',
@@ -200,7 +567,7 @@ function MonitorStat({
 
   return (
     <div className="min-w-0 rounded border border-wardian-border bg-[var(--color-wardian-bg)] px-3 py-2">
-      <div className={`text-sm font-bold ${toneClass}`}>{value} {label}</div>
+      <div className={`text-sm font-bold ${statToneClass}`}>{value} {label}</div>
     </div>
   );
 }

--- a/src/features/workflows/monitor/WorkflowMonitor.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.tsx
@@ -19,6 +19,7 @@ type ActivitySection = Exclude<ActivityFilter, 'all'>;
 type ActivityTone = 'error' | 'active' | 'warning' | 'accent' | 'success' | 'muted';
 
 interface WorkflowActivity {
+  activityId: string;
   blueprintId: string;
   name: string;
   schedules: WorkflowSchedule[];
@@ -87,7 +88,10 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
   useEffect(() => {
     void load();
     void loadRuns();
-    const timer = window.setInterval(() => void loadRuns(), 1500);
+    const timer = window.setInterval(() => {
+      void load();
+      void loadRuns();
+    }, 1500);
     return () => window.clearInterval(timer);
   }, [load, loadRuns]);
 
@@ -251,7 +255,7 @@ function ActivitySection({
       <div className="select-text overflow-hidden rounded border border-wardian-border">
         {activities.map((activity) => (
           <ActivityRow
-            key={activity.blueprintId}
+            key={activity.activityId}
             activity={activity}
             agentLabels={agentLabels}
             onOpenRun={onOpenRun}
@@ -325,6 +329,8 @@ function ActivityRow({
   const labels = schedule
     ? assignmentLabels(schedule.assignments, schedule.bindings, schedule.provider, agentLabels)
     : [];
+  const runTimestamp = activity.latestRun ? runTimestampValue(activity.latestRun) : null;
+  const runTimestampLabel = runTimestamp ? formatRunTimestamp(runTimestamp) : null;
 
   return (
     <div
@@ -353,6 +359,14 @@ function ActivityRow({
           </>
         ) : (
           <span className="text-[10px] text-muted">No runs yet</span>
+        )}
+      </div>
+      <div className="min-w-[150px] flex-[1_1_170px]">
+        <div className="mb-0.5 text-[9px] font-bold text-muted">Time</div>
+        {runTimestampLabel ? (
+          <div className="truncate text-[10px] text-muted" title={runTimestamp ?? undefined}>{runTimestampLabel}</div>
+        ) : (
+          <span className="text-[10px] text-muted">Unknown</span>
         )}
       </div>
       <div className="min-w-[150px] flex-[1_1_170px]">
@@ -426,39 +440,83 @@ function ActivityRow({
 }
 
 function buildActivities(runs: RunSummary[], schedules: WorkflowSchedule[]): WorkflowActivity[] {
-  const ids = new Set<string>();
-  for (const run of runs) ids.add(run.blueprint_id);
-  for (const schedule of schedules) ids.add(schedule.blueprint_id);
+  const activities: WorkflowActivity[] = [];
+  const activeRuns = runs
+    .filter((run) => run.status === 'running' || run.status === 'awaiting_approval')
+    .sort(compareRunRecency);
+  const activeBlueprintIds = new Set(activeRuns.map((run) => run.blueprint_id));
+  const scheduleBlueprintIds = new Set(schedules.map((schedule) => schedule.blueprint_id));
+  const scheduleCounts = schedules.reduce<Record<string, number>>((counts, schedule) => {
+    counts[schedule.blueprint_id] = (counts[schedule.blueprint_id] ?? 0) + 1;
+    return counts;
+  }, {});
 
-  return [...ids].map((blueprintId) => {
-    const workflowRuns = runs.filter((run) => run.blueprint_id === blueprintId);
+  for (const run of activeRuns) {
     const workflowSchedules = schedules
-      .filter((schedule) => schedule.blueprint_id === blueprintId)
+      .filter((schedule) => schedule.blueprint_id === run.blueprint_id)
       .sort(compareScheduleRecency);
-    const latestRun = workflowRuns.sort(compareRunRecency)[0] ?? null;
-    const activeRun = workflowRuns.find((run) => run.status === 'awaiting_approval')
-      ?? workflowRuns.find((run) => run.status === 'running')
-      ?? null;
-    const nextSchedule = workflowSchedules.find((schedule) => !schedule.is_paused && schedule.next_run_epoch_ms)
-      ?? workflowSchedules[0]
-      ?? null;
-    const name = workflowSchedules[0]?.name ?? blueprintId;
-    const state = activityState(latestRun, activeRun, workflowSchedules, nextSchedule);
+    const unambiguousSchedule = workflowSchedules.length === 1 ? workflowSchedules[0] : null;
+    activities.push(activityFromParts({
+      activityId: `run:${run.run_id}`,
+      blueprintId: run.blueprint_id,
+      name: unambiguousSchedule?.name ?? run.blueprint_id,
+      latestRun: run,
+      activeRun: run,
+      schedules: unambiguousSchedule ? [unambiguousSchedule] : [],
+      nextSchedule: unambiguousSchedule,
+    }));
+  }
 
-    return {
-      blueprintId,
-      name,
-      schedules: workflowSchedules,
+  for (const schedule of schedules) {
+    if (activeBlueprintIds.has(schedule.blueprint_id) && scheduleCounts[schedule.blueprint_id] === 1) continue;
+    const workflowRuns = runs.filter((run) => run.blueprint_id === schedule.blueprint_id);
+    const latestRun = workflowRuns.sort(compareRunRecency)[0] ?? null;
+    activities.push(activityFromParts({
+      activityId: `schedule:${schedule.id}`,
+      blueprintId: schedule.blueprint_id,
+      name: schedule.name,
       latestRun,
-      activeRun,
-      nextSchedule,
-      ...state,
-    };
-  }).sort(compareActivities);
+      activeRun: null,
+      schedules: [schedule],
+      nextSchedule: schedule,
+    }));
+  }
+
+  const manualBlueprintIds = new Set(runs.map((run) => run.blueprint_id));
+  for (const blueprintId of manualBlueprintIds) {
+    if (activeBlueprintIds.has(blueprintId) || scheduleBlueprintIds.has(blueprintId)) continue;
+    const workflowRuns = runs.filter((run) => run.blueprint_id === blueprintId);
+    const latestRun = workflowRuns.sort(compareRunRecency)[0] ?? null;
+    activities.push(activityFromParts({
+      activityId: `workflow:${blueprintId}`,
+      blueprintId,
+      name: blueprintId,
+      latestRun,
+      activeRun: null,
+      schedules: [],
+      nextSchedule: null,
+    }));
+  }
+
+  return activities.sort(compareActivities);
+}
+
+function activityFromParts(parts: {
+  activityId: string;
+  blueprintId: string;
+  name: string;
+  schedules: WorkflowSchedule[];
+  latestRun: RunSummary | null;
+  activeRun: RunSummary | null;
+  nextSchedule: WorkflowSchedule | null;
+}): WorkflowActivity {
+  const state = activityState(parts.latestRun, parts.activeRun, parts.schedules, parts.nextSchedule);
+  return { ...parts, ...state };
 }
 
 function historyActivityFromRun(run: RunSummary): WorkflowActivity {
   return {
+    activityId: `history:${run.run_id}`,
     blueprintId: run.blueprint_id,
     name: run.blueprint_id,
     schedules: [],
@@ -546,8 +604,7 @@ function compareActivities(left: WorkflowActivity, right: WorkflowActivity) {
 
 function activitySortTime(activity: WorkflowActivity) {
   if (activity.section === 'scheduled') return activity.nextSchedule?.next_run_epoch_ms ?? Number.MAX_SAFE_INTEGER;
-  const stamp = activity.latestRun?.updated_at ?? activity.latestRun?.completed_at ?? activity.latestRun?.started_at ?? '';
-  return stamp ? -Date.parse(stamp) : 0;
+  return activity.latestRun ? runSortTime(activity.latestRun) : 0;
 }
 
 function compareScheduleRecency(left: WorkflowSchedule, right: WorkflowSchedule) {
@@ -600,11 +657,28 @@ function olderHistoryRunsFor(runs: RunSummary[], latestRuns: RunSummary[]) {
 }
 
 function compareRunRecency(left: RunSummary, right: RunSummary) {
-  const leftStamp = left.updated_at ?? left.completed_at ?? left.started_at ?? '';
-  const rightStamp = right.updated_at ?? right.completed_at ?? right.started_at ?? '';
-  if (leftStamp !== rightStamp) return leftStamp > rightStamp ? -1 : 1;
+  const leftTime = runSortTime(left);
+  const rightTime = runSortTime(right);
+  if (leftTime !== rightTime) return leftTime - rightTime;
   if (left.run_id === right.run_id) return 0;
   return left.run_id > right.run_id ? -1 : 1;
+}
+
+function runSortTime(run: RunSummary) {
+  const timestamp = runTimestampValue(run);
+  if (!timestamp) return 0;
+  const parsed = Date.parse(timestamp);
+  return Number.isFinite(parsed) ? -parsed : 0;
+}
+
+function runTimestampValue(run: RunSummary) {
+  return run.updated_at ?? run.completed_at ?? run.started_at ?? null;
+}
+
+function formatRunTimestamp(value: string) {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Date(parsed).toLocaleString();
 }
 
 function historyTone(status: RunStatusKind): ActivityTone {

--- a/src/features/workflows/monitor/WorkflowMonitor.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.tsx
@@ -42,7 +42,7 @@ const FILTERS: Array<{ id: ActivityFilter; label: string }> = [
 const SECTION_LABELS: Record<ActivitySection, string> = {
   attention: 'Needs attention',
   running: 'Running now',
-  scheduled: 'Due soon',
+  scheduled: 'Scheduled',
   history: 'Recent history',
 };
 
@@ -222,32 +222,18 @@ function ActivitySection({
         <span className="font-mono text-[10px] text-muted">{activities.length}</span>
       </div>
       <div className="select-text overflow-hidden rounded border border-wardian-border">
-        <table className="w-full table-fixed border-collapse text-left">
-          <thead className="bg-[var(--color-wardian-card)] text-[10px] font-bold text-muted">
-            <tr>
-              <th scope="col" className="w-[128px] px-3 py-2">State</th>
-              <th scope="col" className="px-3 py-2">Workflow</th>
-              <th scope="col" className="w-[24%] px-3 py-2">Current run</th>
-              <th scope="col" className="w-[24%] px-3 py-2">Schedule</th>
-              <th scope="col" className="w-[20%] px-3 py-2">Assignment</th>
-              <th scope="col" className="w-[132px] px-3 py-2 text-right">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {activities.map((activity) => (
-              <ActivityRow
-                key={activity.blueprintId}
-                activity={activity}
-                agentLabels={agentLabels}
-                onOpenRun={onOpenRun}
-                onPause={onPause}
-                onResume={onResume}
-                onRunNow={onRunNow}
-                onEditSchedule={onEditSchedule}
-              />
-            ))}
-          </tbody>
-        </table>
+        {activities.map((activity) => (
+          <ActivityRow
+            key={activity.blueprintId}
+            activity={activity}
+            agentLabels={agentLabels}
+            onOpenRun={onOpenRun}
+            onPause={onPause}
+            onResume={onResume}
+            onRunNow={onRunNow}
+            onEditSchedule={onEditSchedule}
+          />
+        ))}
       </div>
     </section>
   );
@@ -276,24 +262,23 @@ function ActivityRow({
     : [];
 
   return (
-    <tr
+    <div
       data-testid={`workflow-activity-row-${activity.blueprintId}`}
-      className="border-b border-wardian-border/70 bg-[var(--color-wardian-bg)] align-middle last:border-b-0 hover:bg-[color-mix(in_srgb,var(--color-wardian-card),transparent_45%)]"
+      className="flex flex-wrap items-start gap-x-4 gap-y-2 border-b border-wardian-border/70 bg-[var(--color-wardian-bg)] p-3 last:border-b-0 hover:bg-[color-mix(in_srgb,var(--color-wardian-card),transparent_45%)]"
     >
-      <td className="px-3 py-2">
-        <div className={`flex items-center gap-2 text-[10px] font-bold ${toneClass[activity.tone]}`}>
-          <span className={`h-2 w-2 shrink-0 rounded-full ${toneDotClass[activity.tone]}`} aria-hidden />
-          <span>{activity.statusLabel}</span>
-        </div>
-        {activity.issue ? <div className="mt-0.5 truncate text-[10px] text-[var(--color-wardian-error)]">{activity.issue}</div> : null}
-      </td>
-      <td className="min-w-0 px-3 py-2">
+      <div className="min-w-[180px] flex-[1.4_1_220px]">
         <div className="truncate text-xs font-bold text-[var(--color-wardian-text)]" title={activity.name}>{activity.name}</div>
         {activity.blueprintId !== activity.name ? (
           <div className="mt-0.5 truncate font-mono text-[10px] text-muted" title={activity.blueprintId}>{activity.blueprintId}</div>
         ) : null}
-      </td>
-      <td className="min-w-0 px-3 py-2">
+        <div className={`mt-1 flex items-center gap-2 text-[10px] font-bold ${toneClass[activity.tone]}`}>
+          <span className={`h-2 w-2 shrink-0 rounded-full ${toneDotClass[activity.tone]}`} aria-hidden />
+          <span>{activity.statusLabel}</span>
+        </div>
+        {activity.issue ? <div className="mt-0.5 truncate text-[10px] text-[var(--color-wardian-error)]">{activity.issue}</div> : null}
+      </div>
+      <div className="min-w-[140px] flex-[1_1_150px]">
+        <div className="mb-0.5 text-[9px] font-bold text-muted">Run</div>
         {activity.latestRun ? (
           <>
             <div className={`truncate text-[10px] font-bold ${runToneClass(activity.latestRun.status)}`}>
@@ -304,8 +289,9 @@ function ActivityRow({
         ) : (
           <span className="text-[10px] text-muted">No runs yet</span>
         )}
-      </td>
-      <td className="min-w-0 px-3 py-2">
+      </div>
+      <div className="min-w-[150px] flex-[1_1_170px]">
+        <div className="mb-0.5 text-[9px] font-bold text-muted">Schedule</div>
         {schedule ? (
           <>
             <div className="truncate text-[10px] text-muted" title={cadenceLabel(schedule.schedule)}>{cadenceLabel(schedule.schedule)}</div>
@@ -314,8 +300,9 @@ function ActivityRow({
         ) : (
           <span className="text-[10px] text-muted">Manual only</span>
         )}
-      </td>
-      <td className="min-w-0 px-3 py-2">
+      </div>
+      <div className="min-w-[130px] flex-[1_1_150px]">
+        <div className="mb-0.5 text-[9px] font-bold text-muted">Assignment</div>
         {labels.length > 0 ? (
           <div className="flex max-w-[320px] flex-wrap gap-1">
             {labels.slice(0, 2).map((label) => (
@@ -336,9 +323,8 @@ function ActivityRow({
         ) : (
           <span className="text-[10px] text-muted">Default</span>
         )}
-      </td>
-      <td className="px-3 py-2 text-right">
-        <div className="inline-flex shrink-0 items-center gap-1">
+      </div>
+      <div className="ml-auto flex min-w-[112px] shrink-0 items-center justify-end gap-1.5 pr-1 pt-0.5">
           {activity.latestRun ? (
             <button
               type="button"
@@ -369,9 +355,8 @@ function ActivityRow({
               </button>
             </>
           ) : null}
-        </div>
-      </td>
-    </tr>
+      </div>
+    </div>
   );
 }
 

--- a/src/features/workflows/monitor/WorkflowMonitor.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitor.tsx
@@ -43,10 +43,11 @@ const SECTION_LABELS: Record<ActivitySection, string> = {
   attention: 'Needs attention',
   running: 'Running now',
   scheduled: 'Scheduled',
-  history: 'Recent history',
+  history: 'History',
 };
 
 const SECTION_ORDER: ActivitySection[] = ['attention', 'running', 'scheduled', 'history'];
+const HISTORY_PAGE_SIZE = 10;
 
 const toneClass: Record<ActivityTone, string> = {
   error: 'text-[var(--color-wardian-error)]',
@@ -81,7 +82,7 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
   const loadRuns = useRunStore((state) => state.loadRuns);
   const [agents, setAgents] = useState<AgentConfig[]>([]);
   const [filter, setFilter] = useState<ActivityFilter>('all');
-  const [showOlderHistory, setShowOlderHistory] = useState(false);
+  const [visibleOlderHistoryCount, setVisibleOlderHistoryCount] = useState(0);
 
   useEffect(() => {
     void load();
@@ -116,7 +117,16 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
   const activities = useMemo(() => buildActivities(runs, schedules), [runs, schedules]);
   const groupedActivities = useMemo(() => groupActivities(activities, filter), [activities, filter]);
   const olderHistoryRuns = useMemo(() => olderHistoryRunsFor(runs, latestRuns), [runs, latestRuns]);
+  const visibleOlderHistoryLimit = Math.min(visibleOlderHistoryCount, olderHistoryRuns.length);
+  const visibleOlderHistoryRuns = useMemo(
+    () => olderHistoryRuns.slice(0, visibleOlderHistoryLimit),
+    [olderHistoryRuns, visibleOlderHistoryLimit],
+  );
+  const visibleSections = useMemo(() => sectionsForFilter(filter), [filter]);
   const agentLabels = useMemo(() => agentLabelMap(agents), [agents]);
+  const historyFilterActive = filter === 'history';
+  const hasVisibleActivity = visibleSections.some((section) => groupedActivities[section].length > 0)
+    || (historyFilterActive && olderHistoryRuns.length > 0);
 
   const failedRuns = latestRuns.filter((run) => run.status === 'failed');
   const failedRunBlueprintIds = new Set(failedRuns.map((run) => run.blueprint_id));
@@ -169,29 +179,29 @@ export function WorkflowMonitor({ onOpenRun, onEditSchedule }: WorkflowMonitorPr
         </div>
 
         <div className="min-h-0 overflow-y-auto p-3">
-          {SECTION_ORDER.map((section) => {
+          {visibleSections.map((section) => {
             const items = groupedActivities[section];
-            const hasOlderHistory = section === 'history' && olderHistoryRuns.length > 0;
-            if (items.length === 0 && filter !== 'all' && !hasOlderHistory) return null;
+            const hasOlderHistory = historyFilterActive && section === 'history' && olderHistoryRuns.length > 0;
             if (items.length === 0 && !hasOlderHistory) return null;
             return (
               <ActivitySection
                 key={section}
                 title={SECTION_LABELS[section]}
                 activities={items}
-                olderRuns={section === 'history' ? olderHistoryRuns : []}
-                showOlderRuns={section === 'history' && showOlderHistory}
+                olderRuns={hasOlderHistory ? visibleOlderHistoryRuns : []}
+                remainingOlderRuns={hasOlderHistory ? Math.max(0, olderHistoryRuns.length - visibleOlderHistoryRuns.length) : 0}
                 agentLabels={agentLabels}
                 onOpenRun={onOpenRun}
                 onPause={pause}
                 onResume={resume}
                 onRunNow={runNow}
                 onEditSchedule={onEditSchedule}
-                onToggleOlderRuns={() => setShowOlderHistory((value) => !value)}
+                onShowMoreOlderRuns={() => setVisibleOlderHistoryCount((count) => Math.min(olderHistoryRuns.length, count + HISTORY_PAGE_SIZE))}
+                onResetOlderRuns={() => setVisibleOlderHistoryCount(0)}
               />
             );
           })}
-          {Object.values(groupedActivities).every((items) => items.length === 0) ? (
+          {!hasVisibleActivity ? (
             <div className="select-text rounded border border-dashed border-wardian-border p-4 text-center text-xs text-muted">
               No workflow activity in this view.
             </div>
@@ -206,28 +216,31 @@ function ActivitySection({
   title,
   activities,
   olderRuns,
-  showOlderRuns,
+  remainingOlderRuns,
   agentLabels,
   onOpenRun,
   onPause,
   onResume,
   onRunNow,
   onEditSchedule,
-  onToggleOlderRuns,
+  onShowMoreOlderRuns,
+  onResetOlderRuns,
 }: {
   title: string;
   activities: WorkflowActivity[];
   olderRuns: RunSummary[];
-  showOlderRuns: boolean;
+  remainingOlderRuns: number;
   agentLabels: Record<string, string>;
   onOpenRun: (blueprintId: string, runId: string) => void;
   onPause: (id: string) => void;
   onResume: (id: string) => void;
   onRunNow: (id: string) => void;
   onEditSchedule: (schedule: WorkflowSchedule) => void;
-  onToggleOlderRuns: () => void;
+  onShowMoreOlderRuns: () => void;
+  onResetOlderRuns: () => void;
 }) {
-  const visibleCount = activities.length + (showOlderRuns ? olderRuns.length : 0);
+  const visibleCount = activities.length + olderRuns.length;
+  const showMoreCount = Math.min(HISTORY_PAGE_SIZE, remainingOlderRuns);
 
   return (
     <section className="mb-4 last:mb-0">
@@ -248,31 +261,40 @@ function ActivitySection({
             onEditSchedule={onEditSchedule}
           />
         ))}
-        {showOlderRuns
-          ? olderRuns.map((run) => (
-            <ActivityRow
-              key={run.run_id}
-              activity={historyActivityFromRun(run)}
-              agentLabels={agentLabels}
-              testId={`workflow-history-run-${run.run_id}`}
-              onOpenRun={onOpenRun}
-              onPause={onPause}
-              onResume={onResume}
-              onRunNow={onRunNow}
-              onEditSchedule={onEditSchedule}
-            />
-          ))
-          : null}
-        {olderRuns.length > 0 ? (
-          <div className="flex items-center justify-center border-t border-wardian-border/70 bg-[var(--color-wardian-bg)] px-3 py-2">
-            <button
-              type="button"
-              aria-expanded={showOlderRuns}
-              onClick={onToggleOlderRuns}
-              className="h-7 cursor-pointer select-none rounded border border-wardian-border px-3 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
-            >
-              {showOlderRuns ? 'Show less' : `Show older ${olderRuns.length}`}
-            </button>
+        {olderRuns.map((run) => (
+          <ActivityRow
+            key={run.run_id}
+            activity={historyActivityFromRun(run)}
+            agentLabels={agentLabels}
+            testId={`workflow-history-run-${run.run_id}`}
+            onOpenRun={onOpenRun}
+            onPause={onPause}
+            onResume={onResume}
+            onRunNow={onRunNow}
+            onEditSchedule={onEditSchedule}
+          />
+        ))}
+        {remainingOlderRuns > 0 || olderRuns.length > 0 ? (
+          <div className="flex flex-wrap items-center justify-center gap-2 border-t border-wardian-border/70 bg-[var(--color-wardian-bg)] px-3 py-2">
+            {remainingOlderRuns > 0 ? (
+              <button
+                type="button"
+                aria-expanded={olderRuns.length > 0}
+                onClick={onShowMoreOlderRuns}
+                className="h-7 cursor-pointer select-none rounded border border-wardian-border px-3 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+              >
+                Show {showMoreCount} older
+              </button>
+            ) : null}
+            {olderRuns.length > 0 ? (
+              <button
+                type="button"
+                onClick={onResetOlderRuns}
+                className="h-7 cursor-pointer select-none rounded border border-wardian-border px-3 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+              >
+                Show less
+              </button>
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -505,6 +527,11 @@ function groupActivities(activities: WorkflowActivity[], filter: ActivityFilter)
   }
 
   return grouped;
+}
+
+function sectionsForFilter(filter: ActivityFilter): ActivitySection[] {
+  if (filter === 'all') return ['attention', 'running', 'scheduled'];
+  return [filter];
 }
 
 function compareActivities(left: WorkflowActivity, right: WorkflowActivity) {

--- a/src/features/workflows/monitor/WorkflowMonitorGlance.tsx
+++ b/src/features/workflows/monitor/WorkflowMonitorGlance.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { ExternalLink, Pause, Play, RotateCcw } from 'lucide-react';
 import type { WorkflowSchedule } from '../../../types/workflow';
 import type { RunStatusKind, RunSummary } from '../run/runTypes';
+import { formatRunStatus } from '../run/statusLabels';
 import { cadenceLabel, nextRunLabel, scheduleStatusColor, scheduleStatusLabel } from './scheduleStatus';
 
 interface GlanceProps {
@@ -155,7 +156,7 @@ function StatusChip({ label, count, tone }: { label: string; count: number; tone
 
 function SectionHeading({ title, count }: { title: string; count: number }) {
   return (
-    <div className="mb-1 flex items-center justify-between text-[10px] font-bold uppercase tracking-wide text-muted">
+    <div className="mb-1 flex items-center justify-between text-[10px] font-bold text-muted">
       <h3>{title}</h3>
       <span className="font-mono text-[9px]">{count}</span>
     </div>
@@ -179,7 +180,7 @@ function RunCard({ run, onOpenRun }: { run: RunSummary; onOpenRun: (blueprintId:
       <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: RUN_STATUS_COLOR[run.status] }} aria-hidden />
       <div className="min-w-0 flex-1">
         <div className="truncate text-[11px] font-bold text-[var(--color-wardian-text)]">{run.blueprint_id}</div>
-        <div className="truncate text-[9px] font-mono text-muted">{run.status.replace('_', ' ')} · {run.run_id}</div>
+        <div className="truncate text-[9px] font-mono text-muted">{formatRunStatus(run.status)} · {run.run_id}</div>
       </div>
       <button
         type="button"

--- a/src/features/workflows/run/EventTimeline.test.tsx
+++ b/src/features/workflows/run/EventTimeline.test.tsx
@@ -9,6 +9,20 @@ const events: RunEvent[] = [
   { seq: 2, ts: 't2', kind: 'node_failed', node: 'a', error: 'boom' },
 ];
 
+const timedEvents: RunEvent[] = [
+  { seq: 0, ts: '2026-06-04T16:08:09.000Z', kind: 'run_started', blueprint_id: 'wf', schema: 2, trigger: {} },
+  { seq: 1, ts: '2026-06-04T16:08:10.250Z', kind: 'node_started', node: 'a' },
+  { seq: 2, ts: '2026-06-04T16:09:20.000Z', kind: 'branch_taken', node: 'a', port: 'success' },
+];
+
+function localTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
 describe('EventTimeline', () => {
   it('shows event sequence, kind, and node labels', () => {
     render(<EventTimeline events={events} scrubIndex={1} onScrub={vi.fn()} />);
@@ -48,5 +62,24 @@ describe('EventTimeline', () => {
     expect(screen.getByText('Latest event')).toBeInTheDocument();
     expect(screen.getByText('node_failed')).toBeInTheDocument();
     expect(screen.queryByLabelText('Event scrubber')).toBeNull();
+  });
+
+  it('shows local time, elapsed time, previous-event delta, and compact details', () => {
+    render(<EventTimeline events={timedEvents} scrubIndex={2} onScrub={vi.fn()} />);
+
+    expect(screen.getByText(localTime('2026-06-04T16:08:10.250Z'))).toBeInTheDocument();
+    expect(screen.getByText('T+1.3s')).toBeInTheDocument();
+    expect(screen.getByText('+1.3s')).toBeInTheDocument();
+    expect(screen.getByText('T+1m 11s')).toBeInTheDocument();
+    expect(screen.getByText('+1m 10s')).toBeInTheDocument();
+    expect(screen.getByText('port success')).toBeInTheDocument();
+  });
+
+  it('keeps timing visible when collapsed', () => {
+    render(<EventTimeline events={timedEvents} scrubIndex={2} onScrub={vi.fn()} collapsed />);
+
+    expect(screen.getByText(localTime('2026-06-04T16:09:20.000Z'))).toBeInTheDocument();
+    expect(screen.getByText('T+1m 11s')).toBeInTheDocument();
+    expect(screen.getByText('+1m 10s')).toBeInTheDocument();
   });
 });

--- a/src/features/workflows/run/EventTimeline.tsx
+++ b/src/features/workflows/run/EventTimeline.tsx
@@ -110,7 +110,7 @@ export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, colla
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-3 rounded-lg border border-wardian-border bg-[var(--color-wardian-card)] p-3">
+    <div className="flex h-full min-h-0 flex-col gap-3 overflow-hidden rounded border border-wardian-border bg-[var(--color-wardian-card)] p-3">
       <div className="flex items-center gap-3">
         <button
           type="button"
@@ -141,7 +141,7 @@ export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, colla
         </button>
       </div>
 
-      <div className="min-h-0 overflow-y-auto rounded border border-wardian-border bg-[var(--color-wardian-bg)]">
+      <div className="min-h-0 overflow-y-auto overflow-x-hidden rounded border border-wardian-border bg-[var(--color-wardian-bg)]">
         {events.map((event, index) => {
           const selected = index === currentIndex;
           const node = eventNode(event);
@@ -155,7 +155,7 @@ export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, colla
                 onScrub(index);
                 if (node) onSelectNode?.(node);
               }}
-              className={`grid w-full grid-cols-[44px_minmax(0,1fr)_minmax(72px,auto)_minmax(128px,auto)] items-center gap-3 border-b border-wardian-border/50 px-3 py-2 text-left text-[11px] last:border-b-0 ${
+              className={`grid w-full grid-cols-[44px_minmax(0,1fr)_minmax(96px,0.55fr)_minmax(148px,0.7fr)] items-center gap-3 border-b border-wardian-border/50 px-3 py-2.5 text-left text-[11px] last:border-b-0 ${
                 selected
                   ? 'bg-[color-mix(in_srgb,var(--color-wardian-accent),transparent_88%)] text-[var(--color-wardian-text)]'
                   : 'text-[var(--color-wardian-text-muted)] hover:bg-[var(--color-wardian-card-bg-muted)]'
@@ -166,8 +166,8 @@ export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, colla
                 <span className="block truncate font-bold">{event.kind}</span>
                 {detail ? <span className="mt-0.5 block truncate text-[10px] text-muted">{detail}</span> : null}
               </span>
-              {node ? <span className="max-w-[120px] truncate font-mono text-[var(--color-wardian-processing)]">{node}</span> : <span />}
-              <span className="grid min-w-[128px] grid-cols-[1fr_auto] gap-x-2 gap-y-0.5 text-right font-mono text-[10px] text-muted" title={timing.title}>
+              {node ? <span className="min-w-0 truncate font-mono text-[var(--color-wardian-processing)]">{node}</span> : <span />}
+              <span className="grid min-w-0 grid-cols-[1fr_auto] gap-x-2 gap-y-0.5 text-right font-mono text-[10px] text-muted" title={timing.title}>
                 <span className="col-span-2 truncate text-[var(--color-wardian-text)]">{timing.clock}</span>
                 <span>{timing.elapsed}</span>
                 <span>{timing.delta}</span>

--- a/src/features/workflows/run/EventTimeline.tsx
+++ b/src/features/workflows/run/EventTimeline.tsx
@@ -12,6 +12,65 @@ function eventNode(event: RunEvent): string | null {
   return 'node' in event ? event.node : null;
 }
 
+function eventDetail(event: RunEvent): string | null {
+  if (event.kind === 'branch_taken' || event.kind === 'decision_made') return `port ${event.port}`;
+  if (event.kind === 'loop_iteration') return `iteration ${event.iteration}`;
+  if (event.kind === 'approval_granted' || event.kind === 'approval_rejected') return `by ${event.actor}`;
+  if (event.kind === 'awaiting_approval') return 'approval needed';
+  if (event.kind === 'node_failed' || event.kind === 'run_failed') return event.error;
+  if (event.kind === 'node_skipped') return 'skipped';
+  if (event.kind === 'node_completed') return 'output ready';
+  return null;
+}
+
+function parseEventTime(timestamp: string): number | null {
+  const value = Date.parse(timestamp);
+  return Number.isFinite(value) ? value : null;
+}
+
+function formatClock(timestamp: string): string {
+  const value = parseEventTime(timestamp);
+  if (value === null) return timestamp;
+  return new Date(value).toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function formatDuration(milliseconds: number): string {
+  const totalMilliseconds = Math.max(0, Math.round(milliseconds));
+  if (totalMilliseconds < 1000) return `${totalMilliseconds}ms`;
+
+  const totalSeconds = Math.round(totalMilliseconds / 1000);
+  if (totalSeconds < 60) {
+    const seconds = totalMilliseconds / 1000;
+    return `${seconds < 10 ? seconds.toFixed(1).replace(/\.0$/, '') : String(totalSeconds)}s`;
+  }
+
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) return `${totalMinutes}m ${seconds}s`;
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m`;
+}
+
+function eventTiming(events: RunEvent[], index: number) {
+  const event = events[index];
+  const currentTime = parseEventTime(event.ts);
+  const firstTime = parseEventTime(events[0]?.ts ?? '');
+  const previousTime = index > 0 ? parseEventTime(events[index - 1]?.ts ?? '') : null;
+
+  return {
+    clock: formatClock(event.ts),
+    elapsed: currentTime !== null && firstTime !== null ? `T+${formatDuration(currentTime - firstTime)}` : 'T+--',
+    delta: currentTime !== null && previousTime !== null ? `+${formatDuration(currentTime - previousTime)}` : index === 0 ? 'start' : '+--',
+    title: currentTime !== null ? new Date(currentTime).toLocaleString() : event.ts,
+  };
+}
+
 export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, collapsed = false }: EventTimelineProps) {
   const max = Math.max(0, events.length - 1);
   const currentIndex = Math.min(Math.max(0, scrubIndex), max);
@@ -27,6 +86,8 @@ export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, colla
 
   if (collapsed) {
     const node = eventNode(currentEvent);
+    const timing = eventTiming(events, currentIndex);
+    const detail = eventDetail(currentEvent);
     return (
       <button
         type="button"
@@ -39,6 +100,10 @@ export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, colla
         <span className="shrink-0 font-bold text-muted">Latest event</span>
         <span className="min-w-0 flex-1 truncate font-bold">{currentEvent.kind}</span>
         {node ? <span className="max-w-[160px] truncate font-mono text-[var(--color-wardian-processing)]">{node}</span> : null}
+        {detail ? <span className="hidden max-w-[180px] truncate text-muted sm:inline">{detail}</span> : null}
+        <span className="hidden shrink-0 font-mono text-muted sm:inline" title={timing.title}>{timing.clock}</span>
+        <span className="shrink-0 font-mono text-muted">{timing.elapsed}</span>
+        <span className="hidden shrink-0 font-mono text-muted md:inline">{timing.delta}</span>
         <span className="shrink-0 font-mono text-muted">#{currentEvent.seq}</span>
       </button>
     );
@@ -80,6 +145,8 @@ export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, colla
         {events.map((event, index) => {
           const selected = index === currentIndex;
           const node = eventNode(event);
+          const detail = eventDetail(event);
+          const timing = eventTiming(events, index);
           return (
             <button
               key={`${event.seq}:${event.kind}`}
@@ -88,15 +155,23 @@ export function EventTimeline({ events, scrubIndex, onScrub, onSelectNode, colla
                 onScrub(index);
                 if (node) onSelectNode?.(node);
               }}
-              className={`grid w-full grid-cols-[48px_1fr_auto] items-center gap-3 border-b border-wardian-border/50 px-3 py-2 text-left text-[11px] last:border-b-0 ${
+              className={`grid w-full grid-cols-[44px_minmax(0,1fr)_minmax(72px,auto)_minmax(128px,auto)] items-center gap-3 border-b border-wardian-border/50 px-3 py-2 text-left text-[11px] last:border-b-0 ${
                 selected
                   ? 'bg-[color-mix(in_srgb,var(--color-wardian-accent),transparent_88%)] text-[var(--color-wardian-text)]'
                   : 'text-[var(--color-wardian-text-muted)] hover:bg-[var(--color-wardian-card-bg-muted)]'
               }`}
             >
               <span className="font-mono">#{event.seq}</span>
-              <span className="truncate font-bold">{event.kind}</span>
-              {node ? <span className="max-w-[120px] truncate font-mono text-[var(--color-wardian-processing)]">{node}</span> : null}
+              <span className="min-w-0">
+                <span className="block truncate font-bold">{event.kind}</span>
+                {detail ? <span className="mt-0.5 block truncate text-[10px] text-muted">{detail}</span> : null}
+              </span>
+              {node ? <span className="max-w-[120px] truncate font-mono text-[var(--color-wardian-processing)]">{node}</span> : <span />}
+              <span className="grid min-w-[128px] grid-cols-[1fr_auto] gap-x-2 gap-y-0.5 text-right font-mono text-[10px] text-muted" title={timing.title}>
+                <span className="col-span-2 truncate text-[var(--color-wardian-text)]">{timing.clock}</span>
+                <span>{timing.elapsed}</span>
+                <span>{timing.delta}</span>
+              </span>
             </button>
           );
         })}

--- a/src/features/workflows/run/NodeInspector.test.tsx
+++ b/src/features/workflows/run/NodeInspector.test.tsx
@@ -28,7 +28,7 @@ describe('NodeInspector', () => {
     render(<NodeInspector selectedNodeId="a" state={state} currentStatuses={{ a: 'failed' }} events={events} />);
 
     expect(screen.getByText('a')).toBeInTheDocument();
-    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
     expect(screen.getByText(/"ok": true/)).toBeInTheDocument();
     expect(screen.getByText('boom')).toBeInTheDocument();
   });
@@ -55,5 +55,13 @@ describe('NodeInspector', () => {
     render(<NodeInspector selectedNodeId="a" state={state} currentStatuses={{ a: 'failed' }} events={events} />);
 
     expect(screen.getByText('boom').closest('.select-text')).not.toBeNull();
+  });
+
+  it('uses regular capitalization for inspector headings', () => {
+    render(<NodeInspector selectedNodeId="a" state={state} currentStatuses={{ a: 'failed' }} events={events} />);
+
+    expect(screen.getByText('Node')).not.toHaveClass('uppercase');
+    expect(screen.getByText('Output')).not.toHaveClass('uppercase');
+    expect(screen.getByText('Failure')).not.toHaveClass('uppercase');
   });
 });

--- a/src/features/workflows/run/NodeInspector.test.tsx
+++ b/src/features/workflows/run/NodeInspector.test.tsx
@@ -32,4 +32,28 @@ describe('NodeInspector', () => {
     expect(screen.getByText(/"ok": true/)).toBeInTheDocument();
     expect(screen.getByText('boom')).toBeInTheDocument();
   });
+
+  it('formats timestamp fields as local display values', () => {
+    const timestamp = '2026-06-05T03:03:35.136Z';
+    const expected = new Date(timestamp).toLocaleString();
+    render(
+      <NodeInspector
+        selectedNodeId="a"
+        state={state}
+        currentStatuses={{ a: 'completed' }}
+        events={[
+          { seq: 0, ts: 't0', kind: 'node_completed', node: 'a', output: { timestamp } },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeInTheDocument();
+    expect(screen.queryByText(/2026-06-05T03:03:35/)).toBeNull();
+  });
+
+  it('allows selecting text in the inspector', () => {
+    render(<NodeInspector selectedNodeId="a" state={state} currentStatuses={{ a: 'failed' }} events={events} />);
+
+    expect(screen.getByText('boom').closest('.select-text')).not.toBeNull();
+  });
 });

--- a/src/features/workflows/run/NodeInspector.tsx
+++ b/src/features/workflows/run/NodeInspector.tsx
@@ -1,4 +1,5 @@
 import type { NodeStatusKind, RunEvent, RunState } from './runTypes';
+import { formatNodeStatus } from './statusLabels';
 
 interface NodeInspectorProps {
   selectedNodeId: string | null;
@@ -63,19 +64,19 @@ export function NodeInspector({ selectedNodeId, state, currentStatuses, events }
   return (
     <aside className="flex h-full min-h-0 select-text flex-col gap-4 rounded-lg border border-wardian-border bg-[var(--color-wardian-card)] p-4">
       <div>
-        <div className="text-[10px] font-bold uppercase tracking-wide text-[var(--color-wardian-text-muted)]">Node</div>
+        <div className="text-[10px] font-bold text-[var(--color-wardian-text-muted)]">Node</div>
         <div className="mt-1 truncate text-lg font-bold text-[var(--color-wardian-text)]">{selectedNodeId}</div>
       </div>
 
       <div className="grid grid-cols-[88px_1fr] gap-2 text-xs">
         <span className="font-bold text-[var(--color-wardian-text-muted)]">Status</span>
-        <span className="font-mono text-[var(--color-wardian-text)]">{status}</span>
+        <span className="font-mono text-[var(--color-wardian-text)]">{formatNodeStatus(status)}</span>
         <span className="font-bold text-[var(--color-wardian-text-muted)]">Run</span>
         <span className="truncate font-mono text-[var(--color-wardian-text)]">{state?.run_id ?? '-'}</span>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mb-2 text-[10px] font-bold uppercase tracking-wide text-[var(--color-wardian-text-muted)]">Output</div>
+        <div className="mb-2 text-[10px] font-bold text-[var(--color-wardian-text-muted)]">Output</div>
         {output ? (
           <pre className="overflow-x-auto rounded border border-wardian-border bg-[var(--color-wardian-bg)] p-3 text-[11px] text-[var(--color-wardian-text)]">
             {output}
@@ -89,7 +90,7 @@ export function NodeInspector({ selectedNodeId, state, currentStatuses, events }
 
       {payload.error ? (
         <div>
-          <div className="mb-2 text-[10px] font-bold uppercase tracking-wide text-[var(--color-wardian-error)]">Failure</div>
+          <div className="mb-2 text-[10px] font-bold text-[var(--color-wardian-error)]">Failure</div>
           <div className="rounded border border-[color-mix(in_srgb,var(--color-wardian-error),transparent_55%)] bg-[color-mix(in_srgb,var(--color-wardian-error),transparent_90%)] p-3 text-xs text-[var(--color-wardian-error)]">
             {payload.error}
           </div>

--- a/src/features/workflows/run/NodeInspector.tsx
+++ b/src/features/workflows/run/NodeInspector.tsx
@@ -24,6 +24,29 @@ function nodePayload(events: RunEvent[], nodeId: string): { output?: unknown; er
   return payload;
 }
 
+const TIMESTAMP_FIELD_PATTERN = /(^ts$|timestamp|_at$|At$)/;
+
+function inspectorDisplayValue(value: unknown, key?: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => inspectorDisplayValue(item));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([entryKey, entryValue]) => [
+        entryKey,
+        inspectorDisplayValue(entryValue, entryKey),
+      ]),
+    );
+  }
+  if (typeof value === 'string' && key && TIMESTAMP_FIELD_PATTERN.test(key)) {
+    const date = new Date(value);
+    if (Number.isFinite(date.getTime())) {
+      return date.toLocaleString();
+    }
+  }
+  return value;
+}
+
 export function NodeInspector({ selectedNodeId, state, currentStatuses, events }: NodeInspectorProps) {
   if (!selectedNodeId) {
     return (
@@ -35,10 +58,10 @@ export function NodeInspector({ selectedNodeId, state, currentStatuses, events }
 
   const status = currentStatuses[selectedNodeId] ?? state?.nodes[selectedNodeId] ?? 'pending';
   const payload = nodePayload(events, selectedNodeId);
-  const output = payload.output === undefined ? null : JSON.stringify(payload.output, null, 2);
+  const output = payload.output === undefined ? null : JSON.stringify(inspectorDisplayValue(payload.output), null, 2);
 
   return (
-    <aside className="flex h-full min-h-0 flex-col gap-4 rounded-lg border border-wardian-border bg-[var(--color-wardian-card)] p-4">
+    <aside className="flex h-full min-h-0 select-text flex-col gap-4 rounded-lg border border-wardian-border bg-[var(--color-wardian-card)] p-4">
       <div>
         <div className="text-[10px] font-bold uppercase tracking-wide text-[var(--color-wardian-text-muted)]">Node</div>
         <div className="mt-1 truncate text-lg font-bold text-[var(--color-wardian-text)]">{selectedNodeId}</div>

--- a/src/features/workflows/run/RunDag.test.tsx
+++ b/src/features/workflows/run/RunDag.test.tsx
@@ -44,7 +44,7 @@ describe('RunDag', () => {
     fitViewMock.mockClear();
   });
 
-  it('renders failed node status directly on the graph', () => {
+  it('renders human-readable node status directly on the graph', () => {
     render(
       <RunDag
         blueprint={blueprint}
@@ -57,7 +57,7 @@ describe('RunDag', () => {
 
     const task = screen.getByTestId('run-dag-node-task-1');
     expect(task).toHaveAttribute('data-status', 'failed');
-    expect(within(task).getByText('failed')).toBeVisible();
+    expect(within(task).getByText('Failed')).toBeVisible();
   });
 
   it('refits the viewport when a run blueprint loads after an empty observe surface', async () => {

--- a/src/features/workflows/run/RunDag.tsx
+++ b/src/features/workflows/run/RunDag.tsx
@@ -17,6 +17,7 @@ import '@xyflow/react/dist/style.css';
 import { findNodeType } from '../builder/registry';
 import { toReactFlow } from '../builder/blueprintGraph';
 import { nodeStatusColor } from './statusColors';
+import { formatNodeStatus } from './statusLabels';
 import type { Blueprint, BlueprintNode, PortDef } from '../builder/blueprintTypes';
 import type { NodeStatusKind } from './runTypes';
 
@@ -135,9 +136,9 @@ const RunNode = memo(({ data, selected }: NodeProps<Node<RunNodeData>>) => {
       {renderHandles('target', portsFor(def?.inputs ?? []), Position.Left)}
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between gap-2">
-          <span className="text-[9px] font-bold tracking-wide text-muted">{def?.label ?? node.type}</span>
+          <span className="text-[9px] font-bold text-muted">{def?.label ?? node.type}</span>
           <span className="rounded border px-1.5 py-0.5 text-[9px] font-bold" style={{ borderColor: data.statusColor, color: data.statusColor }}>
-            {data.status}
+            {formatNodeStatus(data.status)}
           </span>
         </div>
         <div className="truncate text-sm font-bold text-[var(--color-wardian-text)]">{node.name ?? node.id}</div>
@@ -161,11 +162,11 @@ const RunGroupNode = memo(({ data, selected }: NodeProps<Node<RunNodeData>>) => 
       {renderHandles('target', portsFor(def?.inputs ?? []), Position.Left)}
       <div className="flex items-center justify-between gap-3">
         <div>
-          <div className="text-[10px] font-bold tracking-wide text-muted">{def?.label ?? 'Loop'}</div>
+          <div className="text-[10px] font-bold text-muted">{def?.label ?? 'Loop'}</div>
           <div className="mt-1 text-sm font-bold text-[var(--color-wardian-text)]">{node.name ?? node.id}</div>
         </div>
         <span className="rounded border px-1.5 py-0.5 text-[9px] font-bold" style={{ borderColor: data.statusColor, color: data.statusColor }}>
-          {data.status}
+          {formatNodeStatus(data.status)}
         </span>
       </div>
       {renderHandles('source', outputPorts(node, def?.outputs ?? [], def?.outputs_from_field), Position.Right)}

--- a/src/features/workflows/run/RunList.test.tsx
+++ b/src/features/workflows/run/RunList.test.tsx
@@ -28,7 +28,7 @@ describe('RunList', () => {
     fireEvent.click(screen.getByRole('button', { name: /open wf run run-1/i }));
 
     expect(onOpen).toHaveBeenCalledWith('wf', 'run-1');
-    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
   });
 
   it('keeps run text selectable instead of making the whole card a button', () => {

--- a/src/features/workflows/run/RunList.tsx
+++ b/src/features/workflows/run/RunList.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from 'lucide-react';
 import type { RunStatusKind, RunSummary } from './runTypes';
+import { formatRunStatus } from './statusLabels';
 
 interface RunListProps {
   runs: RunSummary[];
@@ -51,7 +52,7 @@ export function RunList({ runs, selectedRunId, onOpen }: RunListProps) {
                     backgroundColor: `color-mix(in srgb, ${color}, transparent 86%)`,
                   }}
                 >
-                  {run.status}
+                  {formatRunStatus(run.status)}
                 </span>
                 <button
                   type="button"

--- a/src/features/workflows/run/WorkflowObserveMode.test.tsx
+++ b/src/features/workflows/run/WorkflowObserveMode.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WorkflowObserveMode } from './WorkflowObserveMode';
+import { useRunStore } from './useRunStore';
+import type { RunEvent, RunState } from './runTypes';
+
+vi.mock('../RunControls', () => ({
+  RunControls: () => <div data-testid="run-controls" />,
+}));
+
+vi.mock('./EventTimeline', () => ({
+  EventTimeline: () => <div data-testid="event-timeline">Timeline content</div>,
+}));
+
+vi.mock('./RunDag', () => ({
+  RunDag: () => <div data-testid="run-dag" />,
+}));
+
+vi.mock('./NodeInspector', () => ({
+  NodeInspector: () => <div data-testid="node-inspector" />,
+}));
+
+const state: RunState = {
+  run_id: 'run-1',
+  blueprint_id: 'workflow-1',
+  status: 'completed',
+  nodes: {},
+};
+
+const events: RunEvent[] = [
+  { seq: 0, ts: '2026-06-04T16:08:09.000Z', kind: 'run_started', blueprint_id: 'workflow-1', schema: 2, trigger: {} },
+  { seq: 1, ts: '2026-06-04T16:08:10.000Z', kind: 'run_completed' },
+];
+
+describe('WorkflowObserveMode', () => {
+  beforeEach(() => {
+    useRunStore.getState().reset();
+    useRunStore.setState({ state, events, scrubIndex: 1 });
+  });
+
+  it('unmounts timeline content when the events panel is minimized', () => {
+    render(<WorkflowObserveMode theme="light" />);
+
+    expect(screen.getByTestId('event-timeline')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse events' }));
+
+    expect(screen.getByRole('button', { name: 'Expand events' })).toBeInTheDocument();
+    expect(screen.queryByTestId('event-timeline')).toBeNull();
+  });
+});

--- a/src/features/workflows/run/WorkflowObserveMode.tsx
+++ b/src/features/workflows/run/WorkflowObserveMode.tsx
@@ -53,7 +53,7 @@ export function WorkflowObserveMode({ theme }: WorkflowObserveModeProps) {
         }}
       />
       <div className={`grid min-h-0 ${selectedNodeId ? 'grid-cols-[minmax(0,1fr)_320px]' : 'grid-cols-[minmax(0,1fr)]'}`}>
-        <section className={`grid min-h-0 ${timelineCollapsed ? 'grid-rows-[minmax(0,1fr)_44px]' : 'grid-rows-[minmax(0,1fr)_clamp(280px,34vh,420px)]'}`}>
+        <section className={`grid min-h-0 ${timelineCollapsed ? 'grid-rows-[minmax(0,1fr)_auto]' : 'grid-rows-[minmax(0,1fr)_clamp(280px,34vh,420px)]'}`}>
           <div className="min-h-0 p-3">
             <RunDag
               blueprint={blueprint}
@@ -63,7 +63,7 @@ export function WorkflowObserveMode({ theme }: WorkflowObserveModeProps) {
               theme={theme}
             />
           </div>
-          <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] border-t border-wardian-border bg-[var(--color-wardian-card)]">
+          <div className={`grid min-h-0 overflow-hidden border-t border-wardian-border bg-[var(--color-wardian-card)] ${timelineCollapsed ? 'grid-rows-[auto]' : 'grid-rows-[auto_minmax(0,1fr)]'}`}>
             <div className="flex min-h-[34px] items-center justify-between gap-3 border-b border-wardian-border px-3">
               <div className="text-[10px] font-bold text-muted">Events</div>
               <button
@@ -76,15 +76,16 @@ export function WorkflowObserveMode({ theme }: WorkflowObserveModeProps) {
                 {timelineCollapsed ? <ChevronUp className="h-3.5 w-3.5" aria-hidden /> : <ChevronDown className="h-3.5 w-3.5" aria-hidden />}
               </button>
             </div>
-            <div className="min-h-0 p-2">
-              <EventTimeline
-                events={events}
-                scrubIndex={scrubIndex}
-                onScrub={setScrubIndex}
-                onSelectNode={setSelectedNodeId}
-                collapsed={timelineCollapsed}
-              />
-            </div>
+            {timelineCollapsed ? null : (
+              <div className="min-h-0 p-2">
+                <EventTimeline
+                  events={events}
+                  scrubIndex={scrubIndex}
+                  onScrub={setScrubIndex}
+                  onSelectNode={setSelectedNodeId}
+                />
+              </div>
+            )}
           </div>
         </section>
         {selectedNodeId ? (

--- a/src/features/workflows/run/WorkflowObserveMode.tsx
+++ b/src/features/workflows/run/WorkflowObserveMode.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { RunControls, type RunControlStatus } from '../RunControls';
 import { EventTimeline } from './EventTimeline';
 import { NodeInspector } from './NodeInspector';
 import { RunDag } from './RunDag';
 import type { RunEvent, RunStatusKind } from './runTypes';
+import { formatRunStatus } from './statusLabels';
 import { useRunStore } from './useRunStore';
 
 interface WorkflowObserveModeProps {
@@ -63,13 +65,15 @@ export function WorkflowObserveMode({ theme }: WorkflowObserveModeProps) {
           </div>
           <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)] border-t border-wardian-border bg-[var(--color-wardian-card)]">
             <div className="flex min-h-[34px] items-center justify-between gap-3 border-b border-wardian-border px-3">
-              <div className="text-[10px] font-bold uppercase text-muted">Events</div>
+              <div className="text-[10px] font-bold text-muted">Events</div>
               <button
                 type="button"
-                className="cursor-pointer select-none rounded border border-wardian-border px-2 py-1 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+                className="inline-flex h-7 w-7 cursor-pointer select-none items-center justify-center rounded border border-wardian-border text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
                 onClick={() => setTimelineCollapsed((collapsed) => !collapsed)}
+                aria-label={timelineCollapsed ? 'Expand events' : 'Collapse events'}
+                title={timelineCollapsed ? 'Expand events' : 'Collapse events'}
               >
-                {timelineCollapsed ? 'Expand' : 'Collapse'}
+                {timelineCollapsed ? <ChevronUp className="h-3.5 w-3.5" aria-hidden /> : <ChevronDown className="h-3.5 w-3.5" aria-hidden />}
               </button>
             </div>
             <div className="min-h-0 p-2">
@@ -119,7 +123,7 @@ function ObserveRunHeader({ state, events, activeBlueprintPath, controlsStatus, 
         <div className="min-w-0">
           <div className="flex min-w-0 items-center gap-2">
             <div className="truncate text-sm font-bold text-[var(--color-wardian-text)]">{state?.run_id ?? 'No run selected'}</div>
-            {state?.status ? <span className="shrink-0 rounded border border-wardian-border px-1.5 py-0.5 text-[9px] font-bold uppercase text-muted">{state.status}</span> : null}
+            {state?.status ? <span className="shrink-0 rounded border border-wardian-border px-1.5 py-0.5 text-[9px] font-bold text-muted">{formatRunStatus(state.status)}</span> : null}
           </div>
           <div className="mt-0.5 truncate text-[10px] font-mono text-muted">{state?.blueprint_id ?? 'Open a run from Runs or Monitor'}</div>
         </div>
@@ -147,7 +151,7 @@ function ObserveRunHeader({ state, events, activeBlueprintPath, controlsStatus, 
 function PulseLabel({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <span className="font-bold uppercase text-[var(--color-wardian-text-muted)]">{label}</span>
+      <span className="font-bold text-[var(--color-wardian-text-muted)]">{label}</span>
       <span className="ml-1 font-mono text-[var(--color-wardian-text)]">{value}</span>
     </div>
   );

--- a/src/features/workflows/run/WorkflowObserveMode.tsx
+++ b/src/features/workflows/run/WorkflowObserveMode.tsx
@@ -53,7 +53,7 @@ export function WorkflowObserveMode({ theme }: WorkflowObserveModeProps) {
         }}
       />
       <div className={`grid min-h-0 ${selectedNodeId ? 'grid-cols-[minmax(0,1fr)_320px]' : 'grid-cols-[minmax(0,1fr)]'}`}>
-        <section className={`grid min-h-0 ${timelineCollapsed ? 'grid-rows-[minmax(0,1fr)_44px]' : 'grid-rows-[minmax(0,1fr)_190px]'}`}>
+        <section className={`grid min-h-0 ${timelineCollapsed ? 'grid-rows-[minmax(0,1fr)_44px]' : 'grid-rows-[minmax(0,1fr)_clamp(280px,34vh,420px)]'}`}>
           <div className="min-h-0 p-3">
             <RunDag
               blueprint={blueprint}

--- a/src/features/workflows/run/statusLabels.ts
+++ b/src/features/workflows/run/statusLabels.ts
@@ -1,0 +1,25 @@
+import type { NodeStatusKind, RunStatusKind } from './runTypes';
+
+const NODE_STATUS_LABELS: Record<NodeStatusKind, string> = {
+  pending: 'Pending',
+  running: 'Running',
+  completed: 'Completed',
+  failed: 'Failed',
+  skipped: 'Skipped',
+};
+
+const RUN_STATUS_LABELS: Record<RunStatusKind | 'interrupted', string> = {
+  running: 'Running',
+  awaiting_approval: 'Awaiting approval',
+  completed: 'Completed',
+  failed: 'Failed',
+  interrupted: 'Interrupted',
+};
+
+export function formatNodeStatus(status: NodeStatusKind): string {
+  return NODE_STATUS_LABELS[status] ?? status;
+}
+
+export function formatRunStatus(status: RunStatusKind | 'interrupted'): string {
+  return RUN_STATUS_LABELS[status] ?? status;
+}

--- a/src/views/WorkflowsView.test.tsx
+++ b/src/views/WorkflowsView.test.tsx
@@ -598,7 +598,7 @@ describe('WorkflowsView', () => {
     });
     render(<WorkflowsView theme="dark" />);
 
-    await waitFor(() => expect(screen.getByText('failed')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Failed')).toBeInTheDocument());
     expect(screen.getByText('Task crashed')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /save/i })).toBeNull();
   });

--- a/src/views/WorkflowsView.tsx
+++ b/src/views/WorkflowsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { RefreshCw, X } from 'lucide-react';
 import { BlueprintSelector } from '../features/workflows/BlueprintSelector';
 import { RunLaunchDialog, type RunInputParam } from '../features/workflows/RunLaunchDialog';
 import { BuilderCanvas } from '../features/workflows/builder/BuilderCanvas';
@@ -286,10 +287,12 @@ export function WorkflowsView({ theme }: WorkflowsViewProps) {
           {mode !== 'edit' ? (
             <button
               type="button"
-              className="cursor-pointer select-none rounded border border-wardian-border px-3 py-1.5 text-xs font-bold text-muted transition-colors hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+              className="inline-flex h-8 w-8 cursor-pointer select-none items-center justify-center rounded border border-wardian-border text-muted transition-colors hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
               onClick={() => void refreshCurrentMode()}
+              aria-label="Refresh workflow view"
+              title="Refresh"
             >
-              Refresh
+              <RefreshCw className="h-3.5 w-3.5" aria-hidden />
             </button>
           ) : null}
           <button
@@ -336,9 +339,11 @@ export function WorkflowsView({ theme }: WorkflowsViewProps) {
               <button
                 type="button"
                 onClick={() => void loadRuns()}
-                className="cursor-pointer select-none rounded border border-wardian-border px-2 py-1 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+                className="inline-flex h-7 w-7 cursor-pointer select-none items-center justify-center rounded border border-wardian-border text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+                aria-label="Refresh runs"
+                title="Refresh"
               >
-                Refresh
+                <RefreshCw className="h-3.5 w-3.5" aria-hidden />
               </button>
             </div>
             <RunList
@@ -504,13 +509,13 @@ function WorkflowEditMode({ theme, addNodeRequest }: WorkflowEditModeProps) {
 
   const contextMenuItems: ContextMenuItem[] = contextMenu?.type === 'node'
     ? [
-        { label: 'Duplicate Node', onClick: () => duplicateNode(contextMenu.targetId) },
-        { label: 'Copy Node ID', onClick: () => copyNodeId(contextMenu.targetId) },
+        { label: 'Duplicate node', onClick: () => duplicateNode(contextMenu.targetId) },
+        { label: 'Copy node ID', onClick: () => copyNodeId(contextMenu.targetId) },
         { divider: true },
-        { label: 'Delete Node', danger: true, onClick: () => deleteNode(contextMenu.targetId) },
+        { label: 'Delete node', danger: true, onClick: () => deleteNode(contextMenu.targetId) },
       ]
     : [
-        { label: 'Delete Connection', danger: true, onClick: () => deleteEdge(contextMenu?.targetId ?? '') },
+        { label: 'Delete connection', danger: true, onClick: () => deleteEdge(contextMenu?.targetId ?? '') },
       ];
 
   return (
@@ -569,7 +574,7 @@ function WorkflowEditMode({ theme, addNodeRequest }: WorkflowEditModeProps) {
                   {selectedNode.name ?? selectedNodeDef?.label ?? selectedNode.id}
                 </div>
                 <div className="mt-1 flex min-w-0 items-center gap-2 text-[10px] text-muted">
-                  <span className="shrink-0 rounded border border-wardian-border px-1.5 py-0.5 font-bold uppercase tracking-wide">
+                  <span className="shrink-0 font-bold text-[var(--color-wardian-text-muted)]">
                     {selectedNodeDef?.label ?? selectedNode.type}
                   </span>
                   <button
@@ -584,10 +589,12 @@ function WorkflowEditMode({ theme, addNodeRequest }: WorkflowEditModeProps) {
               </div>
               <button
                 type="button"
-                className="rounded border border-wardian-border px-2 py-1 text-[10px] font-bold text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
+                className="inline-flex h-7 w-7 items-center justify-center rounded border border-wardian-border text-muted hover:border-[var(--color-wardian-accent)] hover:text-[var(--color-wardian-accent)]"
                 onClick={() => setSelectedNodeId(null)}
+                aria-label="Close node inspector"
+                title="Close"
               >
-                Close
+                <X className="h-3.5 w-3.5" aria-hidden />
               </button>
             </div>
             <div className="grid min-h-0 gap-4 overflow-y-auto p-3">


### PR DESCRIPTION
## Description

This hardens workflow execution around live/background agents and tightens the workflow monitor/observe UI after the Sync LaDuc and autoreview failures.

- Waits for real provider readiness/reply evidence before considering live-agent workflow nodes complete.
- Fixes background/fresh agent execution gaps across Codex, Claude, OpenCode, Gemini, and provider command/config inheritance paths.
- Adds loop `max_iterations` template support with validation coverage for autoreview-style runtime caps.
- Improves workflow monitor and observe UX: history-only history, timestamp-sorted rows with visible time, gradual older-history expansion, better scheduled/running instance handling, larger event details, normalized headings, and layout fixes.
- Documents provider/live-agent workflow contracts and related behavior.

## Related Issues

Fixes #500

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## How Has This Been Tested?

- [x] Autoreview workflow completed and converged: `1780699071916-ec9466e1`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build` (passes; Vite still reports the existing large chunk warning)
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo clippy`
- [x] `cd src-tauri && cargo test -- --test-threads=1`
- [x] `npm run docs:check-llms`
- [x] `npm run docs:build`
- [x] `git diff --check`

Note: a parallel `cargo test` run exposed existing env/PATH interference in workflow shell tests; the project guidance calls out serial Rust tests for env-var-sensitive cases, and the serial run passed.

## Screenshots

![workflow monitor history](https://gist.githubusercontent.com/tangemicioglu/d7ba912c1b5b7cbda87c102868174a91/raw/monitor-history.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

