### PR TITLE
fix(workflows): route CLI exec through live control

### DIFF
--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -78,7 +78,13 @@ pub enum WorkflowCommand {
         /// JSON object of run input (entry input_schema values).
         #[arg(long)]
         input: Option<String>,
-        /// Role/class -> provider binding, repeatable: --bind role=provider
+        /// Default provider for unbound workflow roles.
+        #[arg(long)]
+        provider: Option<String>,
+        /// Workspace for live/headless workflow tasks.
+        #[arg(long)]
+        workspace: Option<String>,
+        /// Role/class -> provider or agent-id binding, repeatable: --bind role=value
         #[arg(long)]
         bind: Vec<String>,
     },
@@ -449,8 +455,11 @@ mod tests {
         };
         assert!(matches!(
             args.command,
-            WorkflowCommand::Exec { ref path, ref executor, .. }
-                if path == "wf.md" && executor == "live"
+            WorkflowCommand::Exec { ref path, ref executor, ref provider, ref workspace, .. }
+                if path == "wf.md"
+                    && executor == "live"
+                    && provider.is_none()
+                    && workspace.is_none()
         ));
     }
 
@@ -478,8 +487,12 @@ mod tests {
             "wf.md",
             "--input",
             "{\"x\":1}",
+            "--provider",
+            "codex",
+            "--workspace",
+            ".",
             "--bind",
-            "role=claude",
+            "role=agent-123",
         ])
         .unwrap();
         let Command::Workflow(args) = cli.command else {
@@ -487,8 +500,11 @@ mod tests {
         };
         assert!(matches!(
             args.command,
-            WorkflowCommand::Exec { ref input, ref bind, .. }
-                if input.as_deref() == Some("{\"x\":1}") && bind == &vec!["role=claude".to_string()]
+            WorkflowCommand::Exec { ref input, ref provider, ref workspace, ref bind, .. }
+                if input.as_deref() == Some("{\"x\":1}")
+                    && provider.as_deref() == Some("codex")
+                    && workspace.as_deref() == Some(".")
+                    && bind == &vec!["role=agent-123".to_string()]
         ));
     }
 

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -72,8 +72,8 @@ pub enum WorkflowCommand {
     /// Execute a workflow blueprint headlessly and write a durable run.
     Exec {
         path: String,
-        /// Execution backend. Only `mock` is available until the real executor lands.
-        #[arg(long, default_value = "mock")]
+        /// Execution backend: live/real/full routes through the running app; mock runs locally.
+        #[arg(long, default_value = "live")]
         executor: String,
         /// JSON object of run input (entry input_schema values).
         #[arg(long)]
@@ -450,7 +450,7 @@ mod tests {
         assert!(matches!(
             args.command,
             WorkflowCommand::Exec { ref path, ref executor, .. }
-                if path == "wf.md" && executor == "mock"
+                if path == "wf.md" && executor == "live"
         ));
     }
 

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -69,7 +69,7 @@ pub enum WorkflowCommand {
     },
     /// Validate a blueprint `.md` file and report diagnostics.
     Validate { path: String },
-    /// Execute a workflow blueprint headlessly and write a durable run.
+    /// Launch a workflow blueprint and write a durable run.
     Exec {
         path: String,
         /// Execution backend: live/real/full routes through the running app; mock runs locally.
@@ -81,7 +81,7 @@ pub enum WorkflowCommand {
         /// Default provider for unbound workflow roles.
         #[arg(long)]
         provider: Option<String>,
-        /// Workspace for live/headless workflow tasks.
+        /// Workspace for live workflow tasks.
         #[arg(long)]
         workspace: Option<String>,
         /// Role/class -> provider or agent-id binding, repeatable: --bind role=value

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -72,7 +72,7 @@ pub enum WorkflowCommand {
     /// Launch a workflow blueprint and write a durable run.
     Exec {
         path: String,
-        /// Execution backend: live/real/full routes through the running app; mock runs locally.
+        /// Execution backend: live/real/full routes through the running app; mock is reserved for engine tests.
         #[arg(long, default_value = "live")]
         executor: String,
         /// JSON object of run input (entry input_schema values).

--- a/crates/wardian-cli/src/disk.rs
+++ b/crates/wardian-cli/src/disk.rs
@@ -179,18 +179,36 @@ fn string_array(value: &serde_json::Value, key: &str) -> Option<Vec<String>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
 
-    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    struct WardianHomeGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous_home: Option<std::ffi::OsString>,
+    }
+
+    impl WardianHomeGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let guard = Self {
+                _lock: crate::test_env_lock(),
+                previous_home: std::env::var_os("WARDIAN_HOME"),
+            };
+            std::env::set_var("WARDIAN_HOME", path);
+            guard
+        }
+    }
+
+    impl Drop for WardianHomeGuard {
+        fn drop(&mut self) {
+            match self.previous_home.take() {
+                Some(value) => std::env::set_var("WARDIAN_HOME", value),
+                None => std::env::remove_var("WARDIAN_HOME"),
+            }
+        }
     }
 
     #[test]
     fn load_watchlist_state_accepts_v2_teams_and_entries() {
-        let _guard = env_lock();
         let temp = tempfile::tempdir().unwrap();
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _guard = WardianHomeGuard::set(temp.path());
         let dir = temp.path().join("watchlists");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
@@ -208,14 +226,12 @@ mod tests {
         assert_eq!(state.version, 2);
         assert_eq!(state.teams[0].agent_ids, vec!["agent-1", "agent-2"]);
         assert_eq!(state.watchlists[0].entries[0].team_id(), Some("team-1"));
-        std::env::remove_var("WARDIAN_HOME");
     }
 
     #[test]
     fn load_watchlist_state_accepts_legacy_array() {
-        let _guard = env_lock();
         let temp = tempfile::tempdir().unwrap();
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _guard = WardianHomeGuard::set(temp.path());
         let dir = temp.path().join("watchlists");
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(
@@ -230,6 +246,5 @@ mod tests {
         assert!(state.teams.is_empty());
         assert_eq!(state.watchlists[0].agent_ids, vec!["agent-1"]);
         assert_eq!(state.watchlists[0].entries[0].agent_id(), Some("agent-1"));
-        std::env::remove_var("WARDIAN_HOME");
     }
 }

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -71,6 +71,7 @@ enum ControlOperation {
     AgentWorktreeEnable,
     AgentWorktreeJoin,
     AgentWorktreeDisable,
+    WorkflowRun,
     SendMessage,
     Ask {
         requested: Duration,
@@ -216,6 +217,12 @@ pub struct AskAgentResponse {
     pub watch: AgentWatchResponse,
 }
 
+pub struct WorkflowRunRequest {
+    pub path: String,
+    pub input: serde_json::Value,
+    pub bindings: std::collections::HashMap<String, String>,
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -359,6 +366,22 @@ pub fn agent_worktree_disable(target: &str) -> io::Result<AgentWorktreeMutationR
         }),
     )?;
     serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
+}
+
+pub fn workflow_run(request: WorkflowRunRequest) -> io::Result<serde_json::Value> {
+    let runtime = build_runtime()?;
+    timeout_block(
+        &runtime,
+        ControlOperation::WorkflowRun,
+        send_request(ControlRequest::WorkflowRun {
+            path: request.path,
+            provider: None,
+            workspace: None,
+            input: Some(request.input),
+            bindings: Some(request.bindings),
+            assignments: None,
+        }),
+    )
 }
 
 pub fn send_message(
@@ -724,6 +747,7 @@ fn operation_timeout(operation: &ControlOperation) -> Duration {
         | ControlOperation::AgentWorktreeEnable
         | ControlOperation::AgentWorktreeJoin
         | ControlOperation::AgentWorktreeDisable
+        | ControlOperation::WorkflowRun
         | ControlOperation::SendMessage
         | ControlOperation::SubmitReply => CONTROL_MUTATION_TIMEOUT,
         ControlOperation::AgentWorktreeList => CONTROL_GIT_DISCOVERY_TIMEOUT,

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -9,6 +9,7 @@ use wardian_core::control::{
     AgentWorktreeMutationResponse, AgentWorktreeSummary, ApprovalAction, AskResponse,
     ControlRequest, DeliveryDetail, MessageInputMode, MessageOrigin, QueuePolicy, ReplyResponse,
     ReplyStatus, SendMessageResponse, StructuredReply, WatchEvent, WatchEvidenceError,
+    WorkflowRunResponse,
 };
 use wardian_core::identity::AgentIdentity;
 
@@ -370,9 +371,9 @@ pub fn agent_worktree_disable(target: &str) -> io::Result<AgentWorktreeMutationR
     serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
 }
 
-pub fn workflow_run(request: WorkflowRunRequest) -> io::Result<serde_json::Value> {
+pub fn workflow_run(request: WorkflowRunRequest) -> io::Result<WorkflowRunResponse> {
     let runtime = build_runtime()?;
-    timeout_block(
+    let value = timeout_block(
         &runtime,
         ControlOperation::WorkflowRun,
         send_request(ControlRequest::WorkflowRun {
@@ -383,7 +384,8 @@ pub fn workflow_run(request: WorkflowRunRequest) -> io::Result<serde_json::Value
             bindings: Some(request.bindings),
             assignments: None,
         }),
-    )
+    )?;
+    serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
 }
 
 pub fn send_message(

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -219,6 +219,8 @@ pub struct AskAgentResponse {
 
 pub struct WorkflowRunRequest {
     pub path: String,
+    pub provider: Option<String>,
+    pub workspace: Option<String>,
     pub input: serde_json::Value,
     pub bindings: std::collections::HashMap<String, String>,
 }
@@ -375,8 +377,8 @@ pub fn workflow_run(request: WorkflowRunRequest) -> io::Result<serde_json::Value
         ControlOperation::WorkflowRun,
         send_request(ControlRequest::WorkflowRun {
             path: request.path,
-            provider: None,
-            workspace: None,
+            provider: request.provider,
+            workspace: request.workspace,
             input: Some(request.input),
             bindings: Some(request.bindings),
             assignments: None,

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -27,6 +27,16 @@ fn main() {
     std::process::exit(run());
 }
 
+#[cfg(test)]
+fn test_env_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 fn run() -> i32 {
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
@@ -349,8 +359,17 @@ fn handle_workflow(args: WorkflowArgs) -> Result<String, CliError> {
             path,
             executor,
             input,
+            provider,
+            workspace,
             bind,
-        } => render_workflow_exec(&path, &executor, input.as_deref(), &bind),
+        } => render_workflow_exec(
+            &path,
+            &executor,
+            input.as_deref(),
+            provider.as_deref(),
+            workspace.as_deref(),
+            &bind,
+        ),
         WorkflowCommand::Runs => render_workflow_runs(),
         WorkflowCommand::RunShow {
             blueprint_id,
@@ -405,9 +424,19 @@ fn render_workflow_exec(
     path: &str,
     executor: &str,
     input: Option<&str>,
+    provider: Option<&str>,
+    workspace: Option<&str>,
     bind: &[String],
 ) -> Result<String, CliError> {
-    render_workflow_exec_with_live_launcher(path, executor, input, bind, live::workflow_run)
+    render_workflow_exec_with_live_launcher(
+        path,
+        executor,
+        input,
+        provider,
+        workspace,
+        bind,
+        live::workflow_run,
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -436,6 +465,8 @@ fn render_workflow_exec_with_live_launcher(
     path: &str,
     executor: &str,
     input: Option<&str>,
+    provider: Option<&str>,
+    workspace: Option<&str>,
     bind: &[String],
     live_launcher: impl FnOnce(live::WorkflowRunRequest) -> std::io::Result<serde_json::Value>,
 ) -> Result<String, CliError> {
@@ -445,6 +476,8 @@ fn render_workflow_exec_with_live_launcher(
         WorkflowExecMode::Live => {
             let value = live_launcher(live::WorkflowRunRequest {
                 path: path.to_string(),
+                provider: provider.map(str::to_string),
+                workspace: workspace.map(str::to_string),
                 input,
                 bindings,
             })
@@ -1403,6 +1436,31 @@ fn identity_error(error: identity::IdentityError) -> CliError {
 mod tests {
     use super::*;
 
+    struct TestWardianHome {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous_home: Option<std::ffi::OsString>,
+    }
+
+    impl TestWardianHome {
+        fn new(path: &std::path::Path) -> Self {
+            let guard = Self {
+                _lock: crate::test_env_lock(),
+                previous_home: std::env::var_os("WARDIAN_HOME"),
+            };
+            std::env::set_var("WARDIAN_HOME", path);
+            guard
+        }
+    }
+
+    impl Drop for TestWardianHome {
+        fn drop(&mut self) {
+            match self.previous_home.take() {
+                Some(value) => std::env::set_var("WARDIAN_HOME", value),
+                None => std::env::remove_var("WARDIAN_HOME"),
+            }
+        }
+    }
+
     #[test]
     fn workflow_node_types_json_lists_task_type() {
         let out = render_workflow_node_types(true).unwrap();
@@ -1440,9 +1498,16 @@ mod tests {
             "wf.md",
             "real",
             Some(r#"{"target":"HEAD"}"#),
+            Some("codex"),
+            Some("<absolute-workspace-path>"),
             &["reviewer=codex".to_string()],
             |request| {
                 assert_eq!(request.path, "wf.md");
+                assert_eq!(request.provider.as_deref(), Some("codex"));
+                assert_eq!(
+                    request.workspace.as_deref(),
+                    Some("<absolute-workspace-path>")
+                );
                 assert_eq!(request.input, serde_json::json!({ "target": "HEAD" }));
                 assert_eq!(
                     request.bindings,
@@ -1467,6 +1532,8 @@ mod tests {
     #[test]
     fn workflow_exec_mock_stays_local_and_does_not_call_live_launcher() {
         let dir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let _env = TestWardianHome::new(home.path());
         let path = dir.path().join("wf.md");
         std::fs::write(
             &path,
@@ -1478,6 +1545,8 @@ mod tests {
             path.to_str().unwrap(),
             "mock",
             None,
+            Some("codex"),
+            Some("<absolute-workspace-path>"),
             &[],
             |_| panic!("mock executor must not call live launcher"),
         )

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -407,16 +407,70 @@ fn render_workflow_exec(
     input: Option<&str>,
     bind: &[String],
 ) -> Result<String, CliError> {
-    if executor != "mock" {
-        return Err(CliError::backend(
-            ExitCode::Generic,
-            "unsupported_executor",
-            "only 'mock' is available until the real executor lands",
-        ));
-    }
-    let input = parse_workflow_exec_input(input)?;
-    let _bindings = parse_workflow_bindings(bind)?;
+    render_workflow_exec_with_live_launcher(path, executor, input, bind, live::workflow_run)
+}
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkflowExecMode {
+    Live,
+    Mock,
+}
+
+impl WorkflowExecMode {
+    fn parse(value: &str) -> Result<Self, CliError> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "live" | "real" | "full" => Ok(Self::Live),
+            "mock" => Ok(Self::Mock),
+            other => Err(CliError::backend(
+                ExitCode::Generic,
+                "unsupported_executor",
+                format!(
+                    "unsupported workflow executor `{other}`; expected live, real, full, or mock"
+                ),
+            )),
+        }
+    }
+}
+
+fn render_workflow_exec_with_live_launcher(
+    path: &str,
+    executor: &str,
+    input: Option<&str>,
+    bind: &[String],
+    live_launcher: impl FnOnce(live::WorkflowRunRequest) -> std::io::Result<serde_json::Value>,
+) -> Result<String, CliError> {
+    let input = parse_workflow_exec_input(input)?;
+    let bindings = parse_workflow_bindings(bind)?;
+    match WorkflowExecMode::parse(executor)? {
+        WorkflowExecMode::Live => {
+            let value = live_launcher(live::WorkflowRunRequest {
+                path: path.to_string(),
+                input,
+                bindings,
+            })
+            .map_err(control_error)?;
+            render_live_workflow_exec_response(value)
+        }
+        WorkflowExecMode::Mock => render_workflow_exec_mock(path, input),
+    }
+}
+
+fn render_live_workflow_exec_response(mut value: serde_json::Value) -> Result<String, CliError> {
+    let Some(object) = value.as_object_mut() else {
+        return Err(CliError::generic(
+            "workflow_run control response was not a JSON object",
+        ));
+    };
+    object
+        .entry("schema")
+        .or_insert_with(|| serde_json::json!(1));
+    object.insert("executor".to_string(), serde_json::json!("live"));
+    serde_json::to_string_pretty(&value)
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string()))
+}
+
+fn render_workflow_exec_mock(path: &str, input: serde_json::Value) -> Result<String, CliError> {
     let blueprint = wardian_core::workflow::parse_file(Path::new(path))
         .map_err(|e| CliError::generic(e.to_string()))?;
     let report = wardian_core::workflow::validate(&blueprint);
@@ -1378,6 +1432,61 @@ mod tests {
             .unwrap()
             .iter()
             .any(|d| d["code"] == "unknown_node_type"));
+    }
+
+    #[test]
+    fn workflow_exec_real_dispatches_to_live_launcher() {
+        let out = render_workflow_exec_with_live_launcher(
+            "wf.md",
+            "real",
+            Some(r#"{"target":"HEAD"}"#),
+            &["reviewer=codex".to_string()],
+            |request| {
+                assert_eq!(request.path, "wf.md");
+                assert_eq!(request.input, serde_json::json!({ "target": "HEAD" }));
+                assert_eq!(
+                    request.bindings,
+                    HashMap::from([("reviewer".to_string(), "codex".to_string())])
+                );
+                Ok(serde_json::json!({
+                    "ok": true,
+                    "run_id": "run-1",
+                    "blueprint_id": "autoreview",
+                    "run_dir": "<absolute-workspace-path>/logs/workflows/autoreview/run-1"
+                }))
+            },
+        )
+        .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["executor"], "live");
+        assert_eq!(json["run_id"], "run-1");
+    }
+
+    #[test]
+    fn workflow_exec_mock_stays_local_and_does_not_call_live_launcher() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("wf.md");
+        std::fs::write(
+            &path,
+            "---\nschema: 2\nid: wf\nname: Workflow\nnodes:\n  - id: trigger\n    type: manual_trigger\n    fields: {}\nedges: []\n---\n",
+        )
+        .unwrap();
+
+        let out = render_workflow_exec_with_live_launcher(
+            path.to_str().unwrap(),
+            "mock",
+            None,
+            &[],
+            |_| panic!("mock executor must not call live launcher"),
+        )
+        .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["executor"], "mock");
+        assert_eq!(json["blueprint_id"], "wf");
     }
 
     #[test]

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -20,7 +20,7 @@ use args::{
 use clap::Parser;
 use errors::{CliError, ExitCode};
 use output::{render_list, render_show, RenderOptions};
-use wardian_core::control::{ApprovalAction, MessageInputMode, QueuePolicy};
+use wardian_core::control::{ApprovalAction, MessageInputMode, QueuePolicy, WorkflowRunResponse};
 use wardian_core::identity::{self, ListFilters, Scope};
 
 fn main() {
@@ -468,13 +468,13 @@ fn render_workflow_exec_with_live_launcher(
     provider: Option<&str>,
     workspace: Option<&str>,
     bind: &[String],
-    live_launcher: impl FnOnce(live::WorkflowRunRequest) -> std::io::Result<serde_json::Value>,
+    live_launcher: impl FnOnce(live::WorkflowRunRequest) -> std::io::Result<WorkflowRunResponse>,
 ) -> Result<String, CliError> {
     let input = parse_workflow_exec_input(input)?;
     let bindings = parse_workflow_bindings(bind)?;
     match WorkflowExecMode::parse(executor)? {
         WorkflowExecMode::Live => {
-            let value = live_launcher(live::WorkflowRunRequest {
+            let response = live_launcher(live::WorkflowRunRequest {
                 path: path.to_string(),
                 provider: provider.map(str::to_string),
                 workspace: workspace.map(str::to_string),
@@ -482,23 +482,14 @@ fn render_workflow_exec_with_live_launcher(
                 bindings,
             })
             .map_err(control_error)?;
-            render_live_workflow_exec_response(value)
+            render_live_workflow_exec_response(response)
         }
         WorkflowExecMode::Mock => render_workflow_exec_mock(path, input),
     }
 }
 
-fn render_live_workflow_exec_response(mut value: serde_json::Value) -> Result<String, CliError> {
-    let Some(object) = value.as_object_mut() else {
-        return Err(CliError::generic(
-            "workflow_run control response was not a JSON object",
-        ));
-    };
-    object
-        .entry("schema")
-        .or_insert_with(|| serde_json::json!(1));
-    object.insert("executor".to_string(), serde_json::json!("live"));
-    serde_json::to_string_pretty(&value)
+fn render_live_workflow_exec_response(response: WorkflowRunResponse) -> Result<String, CliError> {
+    serde_json::to_string_pretty(&response)
         .map(|json| format!("{json}\n"))
         .map_err(|e| CliError::generic(e.to_string()))
 }
@@ -1513,12 +1504,12 @@ mod tests {
                     request.bindings,
                     HashMap::from([("reviewer".to_string(), "codex".to_string())])
                 );
-                Ok(serde_json::json!({
-                    "ok": true,
-                    "run_id": "run-1",
-                    "blueprint_id": "autoreview",
-                    "run_dir": "<absolute-workspace-path>/logs/workflows/autoreview/run-1"
-                }))
+                Ok(WorkflowRunResponse::started(
+                    "live",
+                    "run-1",
+                    "autoreview",
+                    "<absolute-workspace-path>/logs/workflows/autoreview/run-1",
+                ))
             },
         )
         .unwrap();

--- a/crates/wardian-cli/tests/workflow_cli.rs
+++ b/crates/wardian-cli/tests/workflow_cli.rs
@@ -77,7 +77,13 @@ fn workflow_exec_runs_show_replay_round_trip() {
 
     let exec = workflow_command(
         &home,
-        &["workflow", "exec", workflow_path.to_str().unwrap()],
+        &[
+            "workflow",
+            "exec",
+            workflow_path.to_str().unwrap(),
+            "--executor",
+            "mock",
+        ],
     );
     assert_eq!(exec["schema"], 1);
     assert_eq!(exec["ok"], true);

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -1,5 +1,6 @@
 use crate::identity::AgentIdentity;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 pub const CONTROL_SCHEMA: u8 = 1;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
@@ -78,6 +79,14 @@ pub enum ControlRequest {
         timeout_ms: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         output_echo_guard: Option<String>,
+    },
+    WorkflowRun {
+        path: String,
+        provider: Option<String>,
+        workspace: Option<String>,
+        input: Option<serde_json::Value>,
+        bindings: Option<HashMap<String, String>>,
+        assignments: Option<crate::models::WorkflowAssignments>,
     },
 }
 
@@ -966,6 +975,32 @@ mod tests {
         assert!(json.contains(r#""member_agent_ids":["uuid-1"]"#));
         assert!(json.contains(r#""can_delete":false"#));
         assert!(json.contains(r#""cleared_session":true"#));
+    }
+
+    #[test]
+    fn workflow_run_request_serializes_live_launch_options() {
+        let req = ControlRequest::WorkflowRun {
+            path: "<absolute-workspace-path>/library/workflows/autoreview.md".to_string(),
+            provider: Some("codex".to_string()),
+            workspace: Some("<absolute-workspace-path>".to_string()),
+            input: Some(serde_json::json!({ "target": "HEAD" })),
+            bindings: Some(std::collections::HashMap::from([(
+                "reviewer".to_string(),
+                "codex".to_string(),
+            )])),
+            assignments: None,
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        let roundtrip: ControlRequest = serde_json::from_str(&json).unwrap();
+
+        assert!(json.contains(r#""command":"workflow_run""#));
+        assert!(
+            json.contains(r#""path":"<absolute-workspace-path>/library/workflows/autoreview.md""#)
+        );
+        assert!(json.contains(r#""provider":"codex""#));
+        assert!(json.contains(r#""bindings":{"reviewer":"codex"}"#));
+        assert_eq!(roundtrip, req);
     }
 
     #[test]

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -171,6 +171,62 @@ impl Default for OkResponse {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowRunLaunchStatus {
+    Started,
+    ValidationFailed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowRunResponse {
+    pub schema: u8,
+    pub ok: bool,
+    pub executor: String,
+    pub status: WorkflowRunLaunchStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blueprint_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<serde_json::Value>,
+}
+
+impl WorkflowRunResponse {
+    pub fn started(
+        executor: impl Into<String>,
+        run_id: impl Into<String>,
+        blueprint_id: impl Into<String>,
+        run_dir: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema: CONTROL_SCHEMA,
+            ok: true,
+            executor: executor.into(),
+            status: WorkflowRunLaunchStatus::Started,
+            run_id: Some(run_id.into()),
+            blueprint_id: Some(blueprint_id.into()),
+            run_dir: Some(run_dir.into()),
+            diagnostics: None,
+        }
+    }
+
+    pub fn validation_failed(executor: impl Into<String>, diagnostics: serde_json::Value) -> Self {
+        Self {
+            schema: CONTROL_SCHEMA,
+            ok: false,
+            executor: executor.into(),
+            status: WorkflowRunLaunchStatus::ValidationFailed,
+            run_id: None,
+            blueprint_id: None,
+            run_dir: None,
+            diagnostics: Some(diagnostics),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DeliveryErrorDetail {
     pub code: String,
@@ -1001,6 +1057,24 @@ mod tests {
         assert!(json.contains(r#""provider":"codex""#));
         assert!(json.contains(r#""bindings":{"reviewer":"codex"}"#));
         assert_eq!(roundtrip, req);
+    }
+
+    #[test]
+    fn workflow_run_response_serializes_live_start_contract() {
+        let response = WorkflowRunResponse::started(
+            "live",
+            "run-1",
+            "autoreview",
+            "<absolute-workspace-path>/logs/workflows/autoreview/run-1",
+        );
+
+        let json = serde_json::to_string(&response).unwrap();
+        let roundtrip: WorkflowRunResponse = serde_json::from_str(&json).unwrap();
+
+        assert!(json.contains(r#""schema":1"#));
+        assert!(json.contains(r#""executor":"live""#));
+        assert!(json.contains(r#""status":"started""#));
+        assert_eq!(roundtrip, response);
     }
 
     #[test]

--- a/crates/wardian-core/src/engine/driver.rs
+++ b/crates/wardian-core/src/engine/driver.rs
@@ -36,6 +36,19 @@ impl Engine {
         run_root: &Path,
         exec: &dyn StepExecutor,
     ) -> crate::engine::Result<RunState> {
+        let s = Self::initialize_with_id(bp, run_id, trigger, run_root)?;
+        Self::drive_from_state(bp, s, run_root, exec).await
+    }
+
+    /// Initialize a fresh run by writing the invocation-independent
+    /// `RunStarted` event and checkpoint. Callers that detach long-running
+    /// execution can use this as the durable startup acknowledgement.
+    pub fn initialize_with_id(
+        bp: &Blueprint,
+        run_id: impl Into<String>,
+        trigger: serde_json::Value,
+        run_root: &Path,
+    ) -> crate::engine::Result<RunState> {
         let g = Graph::new(bp);
         let mut s = RunState::new(run_id.into(), &bp.id);
         emit(
@@ -48,6 +61,17 @@ impl Engine {
                 trigger,
             },
         )?;
+        Ok(s)
+    }
+
+    /// Continue driving an already-initialized run state.
+    pub async fn drive_from_state(
+        bp: &Blueprint,
+        mut s: RunState,
+        run_root: &Path,
+        exec: &dyn StepExecutor,
+    ) -> crate::engine::Result<RunState> {
+        let g = Graph::new(bp);
         drive(&g, &mut s, run_root, exec).await?;
         Ok(s)
     }
@@ -495,6 +519,44 @@ mod tests {
         assert_eq!(state.run_id, "run-xyz");
         let checkpoint = read_checkpoint(dir.path()).unwrap().unwrap();
         assert_eq!(checkpoint.run_id, "run-xyz");
+    }
+
+    #[test]
+    fn initialize_with_id_persists_started_checkpoint_before_driving() {
+        let dir = tempfile::tempdir().unwrap();
+        let blueprint = Blueprint {
+            schema: 2,
+            id: "wf".into(),
+            name: "Workflow".into(),
+            nodes: vec![Node {
+                id: "t".into(),
+                r#type: "manual_trigger".into(),
+                name: None,
+                parent: None,
+                fields: serde_json::Map::new(),
+                position: None,
+            }],
+            edges: vec![],
+            body: String::new(),
+        };
+
+        let state = Engine::initialize_with_id(
+            &blueprint,
+            "run-xyz",
+            serde_json::json!({"source":"manual"}),
+            dir.path(),
+        )
+        .unwrap();
+
+        assert_eq!(state.run_id, "run-xyz");
+        let checkpoint = read_checkpoint(dir.path()).unwrap().unwrap();
+        assert_eq!(checkpoint.run_id, "run-xyz");
+        assert_eq!(checkpoint.next_seq, 1);
+        let events = read_events(dir.path()).unwrap();
+        assert!(matches!(
+            events.first().map(|event| &event.kind),
+            Some(EventKind::RunStarted { .. })
+        ));
     }
 
     #[tokio::test]

--- a/crates/wardian-core/src/paths.rs
+++ b/crates/wardian-core/src/paths.rs
@@ -121,7 +121,20 @@ pub fn workflow_runs_dir() -> Option<PathBuf> {
 
 /// `<wardian-home>/logs/workflows/<blueprint_id>/<run_id>` — one run's durable root.
 pub fn workflow_run_dir(blueprint_id: &str, run_id: &str) -> Option<PathBuf> {
+    if !is_safe_path_component(blueprint_id) || !is_safe_path_component(run_id) {
+        return None;
+    }
     workflow_runs_dir().map(|dir| dir.join(blueprint_id).join(run_id))
+}
+
+pub fn is_safe_path_component(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() || value == "." || value == ".." {
+        return false;
+    }
+    value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
 }
 
 /// `<wardian-home>/library/workflows` — where workflow blueprints live.
@@ -186,6 +199,20 @@ mod tests {
                 .join("wf")
                 .join("run-1")
         );
+
+        std::env::remove_var("WARDIAN_HOME");
+    }
+
+    #[test]
+    fn workflow_run_dir_rejects_path_traversal_components() {
+        let _guard = crate::tests::env_lock();
+        std::env::set_var("WARDIAN_HOME", "/tmp/wardian-run-view");
+
+        assert!(workflow_run_dir("../../outside", "run-1").is_none());
+        assert!(workflow_run_dir("wf", "../outside").is_none());
+        assert!(workflow_run_dir("wf/name", "run-1").is_none());
+        assert!(workflow_run_dir("wf", "run\\one").is_none());
+        assert!(workflow_run_dir("wf.name_1", "run-1").is_some());
 
         std::env::remove_var("WARDIAN_HOME");
     }

--- a/docs/developer/workflow-engine.md
+++ b/docs/developer/workflow-engine.md
@@ -59,6 +59,8 @@ Template fields resolve against this registry before each node executes.
 
 1. The frontend or scheduler calls `workflow_run` with a blueprint path and
    invocation context.
+   The CLI's default `wardian workflow exec <path>` path sends the same request
+   through the Wardian live control endpoint.
 2. The backend parses and validates the blueprint.
 3. `LiveStepExecutor` resolves agents, shell/script actions, notify operations,
    and state operations.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -85,7 +85,6 @@ wardian watchlist show <watchlist-name-or-id>
 wardian workflow node-types
 wardian workflow validate <path-to-workflow.md>
 wardian workflow exec <path-to-library-workflow.md> --provider codex --workspace <absolute-workspace-path>
-wardian workflow exec <path-to-workflow.md> --executor mock
 wardian workflow runs
 wardian workflow run-show <blueprint-id> <run-id>
 wardian workflow replay <blueprint-id> <run-id>
@@ -175,23 +174,13 @@ wardian workflow runs
 wardian workflow run-show autoreview <run-id>
 ```
 
-By default, `workflow exec` is a live-control command: it requires the desktop app to be running for the same `WARDIAN_HOME`, routes execution through app-owned runtime state, and accepts workflow files under `<wardian-home>/library/workflows`. Use `--executor mock` when you need an offline local run for validation, replay, or fixture tests:
-
-```bash
-wardian workflow exec <absolute-workspace-path>/scratch/workflow.md --executor mock
-```
-
-PowerShell:
-
-```powershell
-wardian workflow exec <absolute-workspace-path>\scratch\workflow.md --executor mock
-```
+By default, `workflow exec` is a live-control command: it requires the desktop app to be running for the same `WARDIAN_HOME`, routes execution through app-owned runtime state, and accepts workflow files under `<wardian-home>/library/workflows`. The `mock` executor is reserved for workflow-engine fixture tests and should not be used as a normal CLI launch path.
 
 Use `workflow runs`, `workflow run-show <blueprint-id> <run-id>`, and `workflow replay <blueprint-id> <run-id>` to inspect durable run artifacts under `<wardian-home>/logs/workflows`.
 
 Mutating commands use Wardian's local control endpoint and require the desktop app to be running for the same `WARDIAN_HOME`. This includes agent lifecycle commands, agent worktree commands, live `workflow exec`, and `send`.
 
-`workflow validate`, `workflow parse`, `workflow normalize`, `workflow node-types`, `workflow runs`, `workflow run-show`, `workflow replay`, and `workflow exec --executor mock` can run from disk without the desktop app.
+`workflow validate`, `workflow parse`, `workflow normalize`, `workflow node-types`, `workflow runs`, `workflow run-show`, and `workflow replay` can run from disk without the desktop app.
 
 `agent spawn` requires both `--provider` and `--class` so the created agent's runtime and role are explicit.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -82,10 +82,14 @@ wardian team list
 wardian team show <team-name-or-id>
 wardian watchlist list
 wardian watchlist show <watchlist-name-or-id>
-wardian workflow list
-wardian workflow show <id-or-name>
-wardian workflow run <id>
-wardian workflow stop <run-instance-id>
+wardian workflow node-types
+wardian workflow validate <path-to-workflow.md>
+wardian workflow exec <path-to-library-workflow.md> --provider codex --workspace <absolute-workspace-path>
+wardian workflow exec <path-to-workflow.md> --executor mock
+wardian workflow runs
+wardian workflow run-show <blueprint-id> <run-id>
+wardian workflow replay <blueprint-id> <run-id>
+wardian workflow schedule list
 wardian ask reviewer-a1 --stdin --timeout 10m
 wardian reply ask_0123456789abcdef --status done --stdin
 wardian send "review this" --to coder-a1
@@ -148,13 +152,46 @@ wardian agent watch Librarian --include raw_output --raw
 Run a saved workflow through the app-owned backend:
 
 ```bash
-wardian workflow list
-wardian workflow run workflow-id
+wardian workflow validate <absolute-workspace-path>/library/workflows/autoreview.md
+wardian workflow exec <absolute-workspace-path>/library/workflows/autoreview.md \
+  --provider codex \
+  --workspace <absolute-workspace-path> \
+  --input '{"target":"HEAD"}' \
+  --bind reviewer=codex
+wardian workflow runs
+wardian workflow run-show autoreview <run-id>
 ```
 
-Mutating commands use Wardian's local control endpoint and require the desktop app to be running for the same `WARDIAN_HOME`. This includes agent lifecycle commands, agent worktree commands, `workflow run`, `workflow stop`, and `send`.
+PowerShell:
 
-`workflow list` and `workflow show` try the running app first, then read workflow JSON files from disk when the app is unavailable.
+```powershell
+wardian workflow validate <absolute-workspace-path>\library\workflows\autoreview.md
+wardian workflow exec <absolute-workspace-path>\library\workflows\autoreview.md `
+  --provider codex `
+  --workspace <absolute-workspace-path> `
+  --input '{"target":"HEAD"}' `
+  --bind reviewer=codex
+wardian workflow runs
+wardian workflow run-show autoreview <run-id>
+```
+
+By default, `workflow exec` is a live-control command: it requires the desktop app to be running for the same `WARDIAN_HOME`, routes execution through app-owned runtime state, and accepts workflow files under `<wardian-home>/library/workflows`. Use `--executor mock` when you need an offline local run for validation, replay, or fixture tests:
+
+```bash
+wardian workflow exec <absolute-workspace-path>/scratch/workflow.md --executor mock
+```
+
+PowerShell:
+
+```powershell
+wardian workflow exec <absolute-workspace-path>\scratch\workflow.md --executor mock
+```
+
+Use `workflow runs`, `workflow run-show <blueprint-id> <run-id>`, and `workflow replay <blueprint-id> <run-id>` to inspect durable run artifacts under `<wardian-home>/logs/workflows`.
+
+Mutating commands use Wardian's local control endpoint and require the desktop app to be running for the same `WARDIAN_HOME`. This includes agent lifecycle commands, agent worktree commands, live `workflow exec`, and `send`.
+
+`workflow validate`, `workflow parse`, `workflow normalize`, `workflow node-types`, `workflow runs`, `workflow run-show`, `workflow replay`, and `workflow exec --executor mock` can run from disk without the desktop app.
 
 `agent spawn` requires both `--provider` and `--class` so the created agent's runtime and role are explicit.
 
@@ -215,7 +252,7 @@ Default JSON is indented for terminal readability. It includes `schema: 1` and a
 
 ## Important Limits
 
-- The desktop app must be running for live-control commands such as `send`, `spawn`, `pause`, `resume`, `kill`, `workflow run`, and `workflow stop`.
+- The desktop app must be running for live-control commands such as `send`, `spawn`, `pause`, `resume`, `kill`, and default `workflow exec`.
 - `WARDIAN_HOME` must match between the app and CLI when you expect shared live state.
 - Team mutation and `send --to team:<name>` are not implemented yet.
 - Raw terminal output can include escape sequences; prefer transcript or sanitized output unless debugging PTY behavior.

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -38,6 +38,32 @@ The **Run** button opens a launch dialog for the current blueprint. Use **Run no
 
 Manual input parameters appear in the dialog when the blueprint's entry trigger defines an input schema.
 
+## Running From The CLI
+
+`wardian workflow exec <path>` launches a live workflow through the running
+Wardian app. Use the same `WARDIAN_HOME` for the app and CLI so both processes
+share the control endpoint and run logs.
+
+Bash:
+
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-workflow"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" --executor mock
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_HOME = "$PWD\.tmp\wardian-workflow"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" --executor mock
+```
+
+Use `--executor mock` for deterministic offline tests. The live/default path
+requires the app because active-agent routing, PTY input, and workflow task
+reply tracking are app-owned.
+
 ## Monitoring Workflow Activity
 
 Monitor shows a unified activity feed for workflow schedules and runs. Use the

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -43,12 +43,17 @@ Manual input parameters appear in the dialog when the blueprint's entry trigger 
 `wardian workflow exec <path>` launches a live workflow through the running
 Wardian app. Use the same `WARDIAN_HOME` for the app and CLI so both processes
 share the control endpoint and run logs.
+Pass `--workspace <absolute-workspace-path>` when headless workflow tasks should
+run against a specific project checkout.
 
 Bash:
 
 ```bash
 export WARDIAN_HOME="$PWD/.tmp/wardian-workflow"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" \
+  --workspace "<absolute-workspace-path>" \
+  --input '{"target":"PR #123","max_cycles":1}'
 wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" --executor mock
 ```
 
@@ -57,6 +62,9 @@ PowerShell:
 ```powershell
 $env:WARDIAN_HOME = "$PWD\.tmp\wardian-workflow"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" `
+  --workspace "<absolute-workspace-path>" `
+  --input '{"target":"PR #123","max_cycles":1}'
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" --executor mock
 ```
 

--- a/docs/guide/workflows.md
+++ b/docs/guide/workflows.md
@@ -54,7 +54,6 @@ wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" \
   --workspace "<absolute-workspace-path>" \
   --input '{"target":"PR #123","max_cycles":1}'
-wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" --executor mock
 ```
 
 PowerShell:
@@ -65,12 +64,11 @@ wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" `
   --workspace "<absolute-workspace-path>" `
   --input '{"target":"PR #123","max_cycles":1}'
-wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" --executor mock
 ```
 
-Use `--executor mock` for deterministic offline tests. The live/default path
-requires the app because active-agent routing, PTY input, and workflow task
-reply tracking are app-owned.
+The live/default path requires the app because active-agent routing, PTY input,
+workflow shell/script execution, and workflow task reply tracking are app-owned.
+The `mock` executor exists only for workflow-engine fixture tests.
 
 ## Monitoring Workflow Activity
 

--- a/docs/specs/2026-05-29-workflow-cli.md
+++ b/docs/specs/2026-05-29-workflow-cli.md
@@ -32,8 +32,8 @@ The workflow CLI verbs are:
 `exec` defaults to `--executor live`. The `live`, `real`, and `full` aliases
 route through the running Wardian app's live control endpoint so the app-owned
 workflow runtime remains the authority for live agents, PTYs, assignment
-catalogs, and provider execution. `--executor mock` remains available for
-offline deterministic tests and local run-log inspection.
+catalogs, and provider execution. `--executor mock` remains available only for
+workflow-engine fixture tests that must avoid app/live runtime dependencies.
 
 ## Execution Decision
 
@@ -44,9 +44,10 @@ run id, spawns the live workflow driver task, and returns the durable run
 location. If the app is not running for the same `WARDIAN_HOME`, live execution
 returns `app_not_running`.
 
-Mock execution is local. `exec --executor mock` validates the blueprint, creates
-a caller-visible run id, and drives
-`Engine::start_with_id(..., &MockExecutor::new())` inside the CLI process.
+Mock execution is an internal test fixture path. `exec --executor mock`
+validates the blueprint, creates a caller-visible run id, and drives
+`Engine::start_with_id(..., &MockExecutor::new())` inside the CLI process so
+engine tests can run without depending on app/live runtime systems.
 
 Run artifacts are written to the same durable path the real executor will use:
 
@@ -58,7 +59,8 @@ Run artifacts are written to the same durable path the real executor will use:
 The CLI deliberately does not duplicate the app-only live executor. That keeps
 PTY lifecycle, active-agent routing, task/reply interactions, schedules, and
 provider runtime behavior behind one backend authority. The `runs`, `run-show`,
-and `replay` inspection contract stays stable for both live and mock runs.
+and `replay` inspection contract stays stable for live runs and engine fixture
+runs.
 
 `resume` is deferred. The engine already exposes resume primitives, but wiring
 CLI resume against a mock executor is low-value and could imply real provider
@@ -73,7 +75,6 @@ Bash:
 export WARDIAN_HOME="$PWD/.tmp/wardian-workflow"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md" --workspace "<absolute-workspace-path>"
-wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md" --executor mock
 wardian workflow runs
 wardian workflow run-show demo <run-id>
 wardian workflow replay demo <run-id>
@@ -88,7 +89,6 @@ PowerShell:
 $env:WARDIAN_HOME = "$PWD\.tmp\wardian-workflow"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md" --workspace "<absolute-workspace-path>"
-wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md" --executor mock
 wardian workflow runs
 wardian workflow run-show demo <run-id>
 wardian workflow replay demo <run-id>

--- a/docs/specs/2026-05-29-workflow-cli.md
+++ b/docs/specs/2026-05-29-workflow-cli.md
@@ -22,21 +22,30 @@ The workflow CLI verbs are:
 
 | Command | Purpose |
 |---|---|
-| `wardian workflow exec <path> [--executor mock]` | Execute a workflow blueprint headlessly and write a durable run. |
+| `wardian workflow exec <path> [--executor live\|real\|full\|mock]` | Execute a workflow blueprint and write a durable run. |
 | `wardian workflow runs` | List durable workflow runs from `<wardian-home>/logs/workflows`. |
 | `wardian workflow run-show <blueprint-id> <run-id>` | Show one run's checkpoint state and event trace. |
 | `wardian workflow replay <blueprint-id> <run-id>` | Rebuild final state from the run event log without executing nodes. |
 | `wardian workflow parse <path>` | Parse a blueprint Markdown file and print the structured blueprint JSON. |
 | `wardian workflow normalize <path> [--write]` | Normalize a blueprint and print the Markdown, or write it back in place. |
 
-`exec` rejects non-`mock` executor values with `unsupported_executor` until the
-real executor lands.
+`exec` defaults to `--executor live`. The `live`, `real`, and `full` aliases
+route through the running Wardian app's live control endpoint so the app-owned
+workflow runtime remains the authority for live agents, PTYs, assignment
+catalogs, and provider execution. `--executor mock` remains available for
+offline deterministic tests and local run-log inspection.
 
 ## Execution Decision
 
-This slice intentionally supports mock execution only. `exec` validates the
-blueprint, creates a caller-visible run id, and drives
-`Engine::start_with_id(..., &MockExecutor::new())`.
+Live execution is app-backed. The CLI sends a `workflow_run` control request
+with the blueprint path, input object, and role/class bindings. The app validates
+the blueprint, creates a caller-visible run id, spawns the live workflow driver
+task, and returns the durable run location. If the app is not running for the
+same `WARDIAN_HOME`, live execution returns `app_not_running`.
+
+Mock execution is local. `exec --executor mock` validates the blueprint, creates
+a caller-visible run id, and drives
+`Engine::start_with_id(..., &MockExecutor::new())` inside the CLI process.
 
 Run artifacts are written to the same durable path the real executor will use:
 
@@ -45,10 +54,10 @@ Run artifacts are written to the same durable path the real executor will use:
 <wardian-home>/logs/workflows/<blueprint-id>/<run-id>/state.json
 ```
 
-When the real workflow executor is ready, it should swap the `MockExecutor`
-implementation at this boundary and keep the run path stable. That preserves
-the `runs`, `run-show`, and `replay` inspection contract for both mock and real
-runs.
+The CLI deliberately does not duplicate the app-only live executor. That keeps
+PTY lifecycle, active-agent routing, task/reply interactions, schedules, and
+provider runtime behavior behind one backend authority. The `runs`, `run-show`,
+and `replay` inspection contract stays stable for both live and mock runs.
 
 `resume` is deferred. The engine already exposes resume primitives, but wiring
 CLI resume against a mock executor is low-value and could imply real provider
@@ -62,6 +71,7 @@ Bash:
 ```bash
 export WARDIAN_HOME="$PWD/.tmp/wardian-workflow"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md" --executor mock
 wardian workflow runs
 wardian workflow run-show demo <run-id>
 wardian workflow replay demo <run-id>
@@ -75,6 +85,7 @@ PowerShell:
 ```powershell
 $env:WARDIAN_HOME = "$PWD\.tmp\wardian-workflow"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md" --executor mock
 wardian workflow runs
 wardian workflow run-show demo <run-id>
 wardian workflow replay demo <run-id>

--- a/docs/specs/2026-05-29-workflow-cli.md
+++ b/docs/specs/2026-05-29-workflow-cli.md
@@ -22,7 +22,7 @@ The workflow CLI verbs are:
 
 | Command | Purpose |
 |---|---|
-| `wardian workflow exec <path> [--executor live\|real\|full\|mock]` | Execute a workflow blueprint and write a durable run. |
+| `wardian workflow exec <path> [--executor live\|real\|full\|mock] [--provider <provider>] [--workspace <path>]` | Execute a workflow blueprint and write a durable run. |
 | `wardian workflow runs` | List durable workflow runs from `<wardian-home>/logs/workflows`. |
 | `wardian workflow run-show <blueprint-id> <run-id>` | Show one run's checkpoint state and event trace. |
 | `wardian workflow replay <blueprint-id> <run-id>` | Rebuild final state from the run event log without executing nodes. |
@@ -38,10 +38,11 @@ offline deterministic tests and local run-log inspection.
 ## Execution Decision
 
 Live execution is app-backed. The CLI sends a `workflow_run` control request
-with the blueprint path, input object, and role/class bindings. The app validates
-the blueprint, creates a caller-visible run id, spawns the live workflow driver
-task, and returns the durable run location. If the app is not running for the
-same `WARDIAN_HOME`, live execution returns `app_not_running`.
+with the blueprint path, optional provider, optional workspace, input object, and
+role/class bindings. The app validates the blueprint, creates a caller-visible
+run id, spawns the live workflow driver task, and returns the durable run
+location. If the app is not running for the same `WARDIAN_HOME`, live execution
+returns `app_not_running`.
 
 Mock execution is local. `exec --executor mock` validates the blueprint, creates
 a caller-visible run id, and drives
@@ -71,6 +72,7 @@ Bash:
 ```bash
 export WARDIAN_HOME="$PWD/.tmp/wardian-workflow"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md" --workspace "<absolute-workspace-path>"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/demo.md" --executor mock
 wardian workflow runs
 wardian workflow run-show demo <run-id>
@@ -85,6 +87,7 @@ PowerShell:
 ```powershell
 $env:WARDIAN_HOME = "$PWD\.tmp\wardian-workflow"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md" --workspace "<absolute-workspace-path>"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\demo.md" --executor mock
 wardian workflow runs
 wardian workflow run-show demo <run-id>

--- a/docs/specs/2026-05-29-workflow-executor.md
+++ b/docs/specs/2026-05-29-workflow-executor.md
@@ -10,7 +10,7 @@
 
 ## 1. Problem & goal
 
-The workflow durable engine (`wardian_core::engine`) executes a validated blueprint as a resumable run, but every side-effecting step goes through the dependency-inverted `StepExecutor` trait — and the only implementation today is `MockExecutor`. So workflow can author (builder), observe (run view), and mock-execute (CLI), but **nothing drives real agents**. old workflow system's `workflow_engine` is still the only thing that actually runs a workflow against live agents.
+The workflow durable engine (`wardian_core::engine`) executes a validated blueprint as a resumable run, but every side-effecting step goes through the dependency-inverted `StepExecutor` trait — and, at this point in the implementation history, the only implementation was `MockExecutor`. That mock executor existed to test the engine without depending on app/live runtime systems; it was not intended as a user-facing workflow launch mode. old workflow system's `workflow_engine` was still the only thing that actually ran a workflow against live agents.
 
 **Goal of 5a:** a real `StepExecutor` (`LiveStepExecutor`) in `src-tauri` that drives live work, plus the Tauri commands to launch / resume / cancel a run and pause for approval. This makes workflow actually execute and is the prerequisite for retiring old workflow system (5c) and unifying the workflow UI (5b).
 

--- a/docs/specs/2026-06-06-cli-live-workflow-exec.md
+++ b/docs/specs/2026-06-06-cli-live-workflow-exec.md
@@ -17,7 +17,8 @@ launch the app-owned full workflow runtime from automation.
 `wardian workflow exec <path>` now defaults to the app-backed live executor.
 `--executor live`, `--executor real`, and `--executor full` are aliases for the
 same control-endpoint launch path. The CLI sends a `workflow_run` request to the
-running Wardian app with the path, JSON input object, and role/class bindings.
+running Wardian app with the path, optional provider, optional workspace, JSON
+input object, and role/class bindings.
 
 `--executor mock` remains a local deterministic path for offline tests and run
 artifact round trips. It continues to use `MockExecutor` in the CLI process.
@@ -38,6 +39,9 @@ scheduler.
 - If the app is unavailable, the CLI returns `app_not_running`.
 - The live response includes `schema`, `ok`, `run_id`, `blueprint_id`,
   `run_dir`, and `executor: "live"`.
+- Use `--workspace <absolute-workspace-path>` when live/headless workflow tasks
+  should execute against a specific project checkout instead of the workflow run
+  directory.
 - Running `wardian workflow exec <path> --executor mock` does not contact the
   app and writes durable run artifacts under
   `<wardian-home>/logs/workflows/<blueprint-id>/<run-id>/`.
@@ -49,6 +53,9 @@ Bash:
 ```bash
 export WARDIAN_HOME="$PWD/.tmp/wardian-workflow"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" \
+  --workspace "<absolute-workspace-path>" \
+  --input '{"target":"PR #123","max_cycles":1}'
 wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" --executor mock
 ```
 
@@ -57,5 +64,8 @@ PowerShell:
 ```powershell
 $env:WARDIAN_HOME = "$PWD\.tmp\wardian-workflow"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" `
+  --workspace "<absolute-workspace-path>" `
+  --input '{"target":"PR #123","max_cycles":1}'
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" --executor mock
 ```

--- a/docs/specs/2026-06-06-cli-live-workflow-exec.md
+++ b/docs/specs/2026-06-06-cli-live-workflow-exec.md
@@ -1,0 +1,61 @@
+# CLI Live Workflow Execution
+
+- **Status:** Accepted
+- **Date:** 2026-06-06
+- **Decider:** User
+
+## Context
+
+PR #501 fixed the app-side workflow executor so live active-agent nodes complete
+through the structured `wardian reply` contract instead of terminal idle status.
+The standalone CLI still defaulted `wardian workflow exec <path>` to the local
+mock executor and rejected `real`/`live` executor values, so agents could not
+launch the app-owned full workflow runtime from automation.
+
+## Decision
+
+`wardian workflow exec <path>` now defaults to the app-backed live executor.
+`--executor live`, `--executor real`, and `--executor full` are aliases for the
+same control-endpoint launch path. The CLI sends a `workflow_run` request to the
+running Wardian app with the path, JSON input object, and role/class bindings.
+
+`--executor mock` remains a local deterministic path for offline tests and run
+artifact round trips. It continues to use `MockExecutor` in the CLI process.
+
+## Rationale
+
+The live executor depends on app-owned state: active agent PTY senders, input
+readiness, task interactions, assignments, persisted agent config, and provider
+runtime management. Duplicating that logic in the CLI would create a second
+source of truth for agent lifecycle and PTY behavior. Routing through the live
+control endpoint keeps workflow execution consistent with the desktop app and
+scheduler.
+
+## Behavior
+
+- Running `wardian workflow exec <path>` requires the Wardian app to be running
+  for the same `WARDIAN_HOME`.
+- If the app is unavailable, the CLI returns `app_not_running`.
+- The live response includes `schema`, `ok`, `run_id`, `blueprint_id`,
+  `run_dir`, and `executor: "live"`.
+- Running `wardian workflow exec <path> --executor mock` does not contact the
+  app and writes durable run artifacts under
+  `<wardian-home>/logs/workflows/<blueprint-id>/<run-id>/`.
+
+## Examples
+
+Bash:
+
+```bash
+export WARDIAN_HOME="$PWD/.tmp/wardian-workflow"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md"
+wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" --executor mock
+```
+
+PowerShell:
+
+```powershell
+$env:WARDIAN_HOME = "$PWD\.tmp\wardian-workflow"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md"
+wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" --executor mock
+```

--- a/docs/specs/2026-06-06-cli-live-workflow-exec.md
+++ b/docs/specs/2026-06-06-cli-live-workflow-exec.md
@@ -20,8 +20,9 @@ same control-endpoint launch path. The CLI sends a `workflow_run` request to the
 running Wardian app with the path, optional provider, optional workspace, JSON
 input object, and role/class bindings.
 
-`--executor mock` remains a local deterministic path for offline tests and run
-artifact round trips. It continues to use `MockExecutor` in the CLI process.
+`--executor mock` remains only as a workflow-engine fixture path. It continues
+to use `MockExecutor` in the CLI process so tests can exercise the durable engine
+without depending on app/live runtime systems.
 
 ## Rationale
 
@@ -43,8 +44,8 @@ scheduler.
   should execute against a specific project checkout instead of the workflow run
   directory.
 - Running `wardian workflow exec <path> --executor mock` does not contact the
-  app and writes durable run artifacts under
-  `<wardian-home>/logs/workflows/<blueprint-id>/<run-id>/`.
+  app. This path is reserved for workflow-engine fixture tests, not normal CLI
+  workflow execution.
 
 ## Examples
 
@@ -56,7 +57,6 @@ wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md"
 wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" \
   --workspace "<absolute-workspace-path>" \
   --input '{"target":"PR #123","max_cycles":1}'
-wardian workflow exec "$WARDIAN_HOME/library/workflows/autoreview.md" --executor mock
 ```
 
 PowerShell:
@@ -67,5 +67,4 @@ wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md"
 wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" `
   --workspace "<absolute-workspace-path>" `
   --input '{"target":"PR #123","max_cycles":1}'
-wardian workflow exec "$env:WARDIAN_HOME\library\workflows\autoreview.md" --executor mock
 ```

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -1487,7 +1487,7 @@ mod tests {
             } else if let Some(stripped) = path.strip_prefix(r"\\?\") {
                 path = stripped.to_string();
             }
-            return path.trim_end_matches('\\').to_ascii_lowercase();
+            path.trim_end_matches('\\').to_ascii_lowercase()
         }
 
         #[cfg(not(windows))]

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -2,6 +2,7 @@ use crate::{state::AppState, workflow::runs};
 use serde_json::Value;
 use std::collections::HashMap;
 use tauri::{AppHandle, State};
+use wardian_core::control::WorkflowRunResponse;
 use wardian_core::engine::store::{read_checkpoint, read_events};
 use wardian_core::engine::RunStatus;
 use wardian_core::models::{InvocationKind, WorkflowAssignments, WorkflowSchedule};
@@ -145,8 +146,9 @@ pub fn workflow_read_run(
     }))
 }
 
-/// Launch a workflow blueprint run headlessly. Validates, then drives the engine in a
-/// background task writing logs/workflows/<id>/<run-id>/. Returns the run id.
+/// Launch a workflow blueprint run and write durable run artifacts. The default
+/// live path routes execution through the running app; local mock execution is
+/// the CLI's offline fallback.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn workflow_run(
@@ -158,20 +160,80 @@ pub async fn workflow_run(
     input: Option<Value>,
     bindings: Option<HashMap<String, String>>,
     assignments: Option<WorkflowAssignments>,
-) -> Result<serde_json::Value, String> {
-    let blueprint = wardian_core::workflow::parse_file(std::path::Path::new(&path))
-        .map_err(|e| e.to_string())?;
+) -> Result<WorkflowRunResponse, String> {
+    workflow_run_impl(
+        state,
+        app,
+        path,
+        provider,
+        workspace,
+        input,
+        bindings,
+        assignments,
+        false,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn workflow_run_from_control(
+    state: State<'_, AppState>,
+    app: AppHandle,
+    path: String,
+    provider: Option<String>,
+    workspace: Option<String>,
+    input: Option<Value>,
+    bindings: Option<HashMap<String, String>>,
+    assignments: Option<WorkflowAssignments>,
+) -> Result<WorkflowRunResponse, String> {
+    workflow_run_impl(
+        state,
+        app,
+        path,
+        provider,
+        workspace,
+        input,
+        bindings,
+        assignments,
+        true,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn workflow_run_impl(
+    state: State<'_, AppState>,
+    app: AppHandle,
+    path: String,
+    provider: Option<String>,
+    workspace: Option<String>,
+    input: Option<Value>,
+    bindings: Option<HashMap<String, String>>,
+    assignments: Option<WorkflowAssignments>,
+    control_origin: bool,
+) -> Result<WorkflowRunResponse, String> {
+    let blueprint = if control_origin {
+        parse_control_workflow_blueprint(&path)?
+    } else {
+        wardian_core::workflow::parse_file(std::path::Path::new(&path))
+            .map_err(|e| e.to_string())?
+    };
     let report = wardian_core::workflow::validate(&blueprint);
     if !report.is_valid() {
-        return Ok(serde_json::json!({
-            "ok": false,
-            "diagnostics": report.diagnostics
-        }));
+        return Ok(WorkflowRunResponse::validation_failed(
+            "live",
+            serde_json::to_value(report.diagnostics).map_err(|error| error.to_string())?,
+        ));
     }
 
     let run_id = wardian_core::engine::driver::new_run_id();
     let run_root =
-        wardian_core::paths::workflow_run_dir(&blueprint.id, &run_id).ok_or("no wardian home")?;
+        wardian_core::paths::workflow_run_dir(&blueprint.id, &run_id).ok_or_else(|| {
+            format!(
+                "invalid workflow run path components for blueprint id `{}` and run id `{run_id}`",
+                blueprint.id
+            )
+        })?;
     let provider = provider.unwrap_or_else(|| "codex".to_string());
     let workspace = workspace
         .map(std::path::PathBuf::from)
@@ -192,18 +254,26 @@ pub async fn workflow_run(
     )
     .await;
     let blueprint_for_run = blueprint.clone();
-    let run_id_for_run = run_id.clone();
     let run_root_for_run = run_root.clone();
+    let run_state = runs::prepare_new_run_with_assignments(
+        &blueprint,
+        &run_id,
+        &run_root,
+        &workspace,
+        &provider,
+        &bindings,
+        &assignments,
+        input,
+    )?;
 
     tokio::spawn(async move {
-        if let Err(error) = runs::drive_new_run_with_catalog_and_assignments(
+        if let Err(error) = runs::drive_started_run_with_catalog_and_assignments(
             Some(app),
             blueprint_for_run,
-            run_id_for_run,
+            run_state,
             run_root_for_run,
             workspace,
             provider,
-            input,
             bindings,
             assignments,
             agent_catalog,
@@ -214,12 +284,46 @@ pub async fn workflow_run(
         }
     });
 
-    Ok(serde_json::json!({
-        "ok": true,
-        "run_id": run_id,
-        "blueprint_id": blueprint.id,
-        "run_dir": run_root.to_string_lossy(),
-    }))
+    Ok(WorkflowRunResponse::started(
+        "live",
+        run_id,
+        blueprint.id,
+        run_root.to_string_lossy().to_string(),
+    ))
+}
+
+fn parse_control_workflow_blueprint(path: &str) -> Result<Blueprint, String> {
+    let requested = std::path::Path::new(path);
+    let requested = std::fs::canonicalize(requested)
+        .map_err(|error| format!("workflow path is not readable: {error}"))?;
+    let workflows_dir = wardian_core::paths::library_workflows_dir()
+        .ok_or_else(|| "no wardian home".to_string())?;
+    let workflows_dir = std::fs::canonicalize(&workflows_dir).map_err(|error| {
+        format!(
+            "workflow library is not readable at {}: {error}",
+            workflows_dir.to_string_lossy()
+        )
+    })?;
+    if !requested.starts_with(&workflows_dir) {
+        return Err(format!(
+            "control workflow_run only accepts files under {}",
+            workflows_dir.to_string_lossy()
+        ));
+    }
+
+    let blueprint =
+        wardian_core::workflow::parse_file(&requested).map_err(|error| error.to_string())?;
+    if let Some(node) = blueprint
+        .nodes
+        .iter()
+        .find(|node| matches!(node.r#type.as_str(), "shell" | "script"))
+    {
+        return Err(format!(
+            "control workflow_run cannot launch `{}` nodes without an interactive approval boundary",
+            node.r#type
+        ));
+    }
+    Ok(blueprint)
 }
 
 /// Resume an interrupted or parked workflow run.
@@ -627,6 +731,26 @@ edges: []
 # Workflow
 "#;
 
+    const SHELL_WORKFLOW_BLUEPRINT: &str = r#"---
+schema: 2
+id: shell-wf
+name: Shell Workflow
+nodes:
+  - id: trigger
+    type: manual_trigger
+    fields: {}
+  - id: shell
+    type: shell
+    fields:
+      command: echo unsafe
+edges:
+  - from: trigger
+    to: shell
+---
+
+# Shell Workflow
+"#;
+
     fn seed_workflow_blueprint(home: &std::path::Path) -> std::path::PathBuf {
         let workflows_dir = home.join("library").join("workflows");
         std::fs::create_dir_all(&workflows_dir).unwrap();
@@ -727,6 +851,33 @@ edges: []
         let error = parse_blueprint_for_run("wf", &other_path.to_string_lossy()).unwrap_err();
 
         assert!(error.contains("blueprint path id mismatch"));
+    }
+
+    #[test]
+    fn control_workflow_blueprint_must_live_under_library() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(dir.path());
+        std::fs::create_dir_all(dir.path().join("library").join("workflows")).unwrap();
+        let outside_path = dir.path().join("outside.md");
+        std::fs::write(&outside_path, WORKFLOW_BLUEPRINT).unwrap();
+
+        let error = parse_control_workflow_blueprint(&outside_path.to_string_lossy()).unwrap_err();
+
+        assert!(error.contains("only accepts files under"));
+    }
+
+    #[test]
+    fn control_workflow_blueprint_rejects_shell_nodes() {
+        let dir = tempfile::tempdir().unwrap();
+        let _env = EnvGuard::set(dir.path());
+        let workflows_dir = dir.path().join("library").join("workflows");
+        std::fs::create_dir_all(&workflows_dir).unwrap();
+        let path = workflows_dir.join("shell.md");
+        std::fs::write(&path, SHELL_WORKFLOW_BLUEPRINT).unwrap();
+
+        let error = parse_control_workflow_blueprint(&path.to_string_lossy()).unwrap_err();
+
+        assert!(error.contains("cannot launch `shell` nodes"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -564,12 +564,14 @@ mod tests {
     use wardian_core::engine::{RunState, RunStatus};
 
     struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
         previous_home: Option<std::ffi::OsString>,
     }
 
     impl EnvGuard {
         fn set(home: &std::path::Path) -> Self {
             let guard = Self {
+                _lock: crate::utils::wardian_test_env_lock(),
                 previous_home: std::env::var_os("WARDIAN_HOME"),
             };
             std::env::set_var("WARDIAN_HOME", home);
@@ -668,7 +670,6 @@ edges: []
 
     #[test]
     fn run_summary_carries_resolved_blueprint_path_separately_from_run_path() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(dir.path());
         let blueprint_path = seed_workflow_blueprint(dir.path());
@@ -696,7 +697,6 @@ edges: []
 
     #[test]
     fn parse_blueprint_for_run_falls_back_from_run_dir_to_blueprint_id() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(dir.path());
         seed_workflow_blueprint(dir.path());
@@ -715,7 +715,6 @@ edges: []
 
     #[test]
     fn parse_blueprint_for_run_rejects_mismatched_provided_file() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(dir.path());
         let other_path = dir.path().join("other.md");
@@ -732,7 +731,6 @@ edges: []
 
     #[tokio::test]
     async fn schedule_list_reads_persisted_schedules() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(dir.path());
 
@@ -745,7 +743,6 @@ edges: []
 
     #[test]
     fn pause_then_resume_round_trips_via_core() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let dir = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(dir.path());
 

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -147,8 +147,8 @@ pub fn workflow_read_run(
 }
 
 /// Launch a workflow blueprint run and write durable run artifacts. The default
-/// live path routes execution through the running app; local mock execution is
-/// the CLI's offline fallback.
+/// live path routes execution through the running app; CLI mock execution is
+/// reserved for workflow-engine tests.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn workflow_run(

--- a/src-tauri/src/commands/workflow.rs
+++ b/src-tauri/src/commands/workflow.rs
@@ -311,19 +311,7 @@ fn parse_control_workflow_blueprint(path: &str) -> Result<Blueprint, String> {
         ));
     }
 
-    let blueprint =
-        wardian_core::workflow::parse_file(&requested).map_err(|error| error.to_string())?;
-    if let Some(node) = blueprint
-        .nodes
-        .iter()
-        .find(|node| matches!(node.r#type.as_str(), "shell" | "script"))
-    {
-        return Err(format!(
-            "control workflow_run cannot launch `{}` nodes without an interactive approval boundary",
-            node.r#type
-        ));
-    }
-    Ok(blueprint)
+    wardian_core::workflow::parse_file(&requested).map_err(|error| error.to_string())
 }
 
 /// Resume an interrupted or parked workflow run.
@@ -867,7 +855,7 @@ edges:
     }
 
     #[test]
-    fn control_workflow_blueprint_rejects_shell_nodes() {
+    fn control_workflow_blueprint_allows_library_shell_nodes() {
         let dir = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(dir.path());
         let workflows_dir = dir.path().join("library").join("workflows");
@@ -875,9 +863,10 @@ edges:
         let path = workflows_dir.join("shell.md");
         std::fs::write(&path, SHELL_WORKFLOW_BLUEPRINT).unwrap();
 
-        let error = parse_control_workflow_blueprint(&path.to_string_lossy()).unwrap_err();
+        let blueprint = parse_control_workflow_blueprint(&path.to_string_lossy()).unwrap();
 
-        assert!(error.contains("cannot launch `shell` nodes"));
+        assert_eq!(blueprint.id, "shell-wf");
+        assert!(blueprint.nodes.iter().any(|node| node.r#type == "shell"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -279,7 +279,7 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             bindings,
             assignments,
         } => {
-            let result = crate::commands::workflow::workflow_run(
+            let result = crate::commands::workflow::workflow_run_from_control(
                 app.state::<AppState>(),
                 app.clone(),
                 path,
@@ -3117,9 +3117,12 @@ fn snapshot_agent(agent: &crate::state::ActiveAgent) -> AgentIdentity {
 mod tests {
     use super::*;
     use crate::state::ActiveAgent;
+    use std::collections::HashMap;
     use std::ffi::OsString;
     use std::sync::{Arc, Mutex};
-    use wardian_core::models::AgentConfig;
+    use wardian_core::models::{
+        AgentConfig, AgentConversationMode, BusyPolicy, WorkflowRoleAssignment,
+    };
 
     struct TestWardianHome {
         _lock: std::sync::MutexGuard<'static, ()>,
@@ -3192,6 +3195,82 @@ mod tests {
         );
 
         drop(first);
+    }
+
+    #[tokio::test]
+    async fn workflow_run_control_dispatch_forwards_launch_options() {
+        let home = TestWardianHome::new();
+        let workflows_dir = home._temp.path().join("library").join("workflows");
+        std::fs::create_dir_all(&workflows_dir).unwrap();
+        let blueprint_path = workflows_dir.join("controlwf.md");
+        std::fs::write(
+            &blueprint_path,
+            r#"---
+schema: 2
+id: controlwf
+name: Control Workflow
+nodes:
+  - id: trigger
+    type: manual_trigger
+    fields: {}
+edges: []
+---
+
+# Control Workflow
+"#,
+        )
+        .unwrap();
+        let workspace = home._temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let app = tauri::Builder::default()
+            .any_thread()
+            .manage(AppState::new())
+            .build(tauri::generate_context!())
+            .unwrap();
+        let mut assignments = wardian_core::models::WorkflowAssignments::new();
+        assignments.insert(
+            "reviewer".to_string(),
+            WorkflowRoleAssignment::Agent {
+                agent_id: "agent-1".to_string(),
+                conversation: AgentConversationMode::Current,
+                busy_policy: BusyPolicy::Fail,
+            },
+        );
+        let bindings = HashMap::from([("legacy".to_string(), "mock".to_string())]);
+        let expected_assignments = wardian_core::workflow::assignment::normalize_assignments(
+            Some(assignments.clone()),
+            &bindings,
+            wardian_core::models::InvocationKind::Manual,
+        );
+        let request = ControlRequest::WorkflowRun {
+            path: blueprint_path.to_string_lossy().to_string(),
+            provider: Some("mock".to_string()),
+            workspace: Some(workspace.to_string_lossy().to_string()),
+            input: Some(serde_json::json!({"target":"HEAD"})),
+            bindings: Some(bindings),
+            assignments: Some(assignments.clone()),
+        };
+
+        let response = dispatch_request(&serde_json::to_string(&request).unwrap(), app.handle())
+            .await
+            .unwrap();
+        let response: wardian_core::control::WorkflowRunResponse =
+            serde_json::from_str(&response).unwrap();
+
+        assert!(response.ok);
+        assert_eq!(response.executor, "live");
+        assert_eq!(response.blueprint_id.as_deref(), Some("controlwf"));
+        let run_dir = std::path::PathBuf::from(response.run_dir.unwrap());
+        assert!(run_dir.join("invocation.json").is_file());
+        assert!(run_dir.join("events.jsonl").is_file());
+        assert!(run_dir.join("state.json").is_file());
+        let invocation = crate::workflow::runs::read_run_invocation(&run_dir)
+            .unwrap()
+            .unwrap();
+        assert_eq!(invocation.provider, "mock");
+        assert_eq!(invocation.workspace, workspace.to_string_lossy());
+        assert_eq!(invocation.bindings["legacy"], "mock");
+        assert_eq!(invocation.assignments, expected_assignments);
     }
 
     fn test_agent(session_id: &str, session_name: &str, agent_class: &str) -> ActiveAgent {

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -271,6 +271,29 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             handle_agent_worktree_disable(app, &target).await
         }
 
+        ControlRequest::WorkflowRun {
+            path,
+            provider,
+            workspace,
+            input,
+            bindings,
+            assignments,
+        } => {
+            let result = crate::commands::workflow::workflow_run(
+                app.state::<AppState>(),
+                app.clone(),
+                path,
+                provider,
+                workspace,
+                input,
+                bindings,
+                assignments,
+            )
+            .await
+            .map_err(ControlError::request_failed)?;
+            ok_json(&result)
+        }
+
         ControlRequest::SendMessage {
             target,
             message,
@@ -3094,8 +3117,38 @@ fn snapshot_agent(agent: &crate::state::ActiveAgent) -> AgentIdentity {
 mod tests {
     use super::*;
     use crate::state::ActiveAgent;
+    use std::ffi::OsString;
     use std::sync::{Arc, Mutex};
     use wardian_core::models::AgentConfig;
+
+    struct TestWardianHome {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        previous_home: Option<OsString>,
+        _temp: tempfile::TempDir,
+    }
+
+    impl TestWardianHome {
+        fn new() -> Self {
+            let lock = crate::utils::wardian_test_env_lock();
+            let temp = tempfile::tempdir().expect("temp wardian home");
+            let previous_home = std::env::var_os("WARDIAN_HOME");
+            std::env::set_var("WARDIAN_HOME", temp.path());
+            Self {
+                _lock: lock,
+                previous_home,
+                _temp: temp,
+            }
+        }
+    }
+
+    impl Drop for TestWardianHome {
+        fn drop(&mut self) {
+            match self.previous_home.take() {
+                Some(value) => std::env::set_var("WARDIAN_HOME", value),
+                None => std::env::remove_var("WARDIAN_HOME"),
+            }
+        }
+    }
 
     /// Regression test for the silent release-build crash where `claim_control_endpoint`
     /// was called from Tauri's `setup` hook (no Tokio runtime context), causing
@@ -3105,9 +3158,7 @@ mod tests {
     /// setup-hook environment. The claim must succeed without panicking.
     #[test]
     fn control_endpoint_claim_succeeds_without_ambient_tokio_runtime() {
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().unwrap();
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         assert!(
             tokio::runtime::Handle::try_current().is_err(),
@@ -3118,15 +3169,11 @@ mod tests {
         let claim =
             claim_control_endpoint().expect("claim must not panic or fail outside a runtime");
         drop(claim);
-
-        std::env::remove_var("WARDIAN_HOME");
     }
 
     #[tokio::test]
     async fn control_endpoint_claim_is_exclusive_for_current_home() {
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().unwrap();
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         let first = claim_control_endpoint().expect("first endpoint claim");
         let second = match claim_control_endpoint() {
@@ -3145,7 +3192,6 @@ mod tests {
         );
 
         drop(first);
-        std::env::remove_var("WARDIAN_HOME");
     }
 
     fn test_agent(session_id: &str, session_name: &str, agent_class: &str) -> ActiveAgent {
@@ -3346,6 +3392,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_delivery_writes_terminal_bytes_after_opencode_is_ready() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "OpenCodeOne", "Coder").await;
         {
@@ -3382,10 +3429,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_delivery_queues_when_current_conversation_is_leased() {
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().expect("temp wardian home");
-        let previous_home = std::env::var_os("WARDIAN_HOME");
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -3437,11 +3481,6 @@ mod tests {
         assert_eq!(delivery[0].delivery_state, "queued");
         assert_eq!(delivery[0].runtime_state, "conversation_leased");
         assert!(rx.try_recv().is_err());
-
-        match previous_home {
-            Some(value) => std::env::set_var("WARDIAN_HOME", value),
-            None => std::env::remove_var("WARDIAN_HOME"),
-        }
     }
 
     #[test]
@@ -3748,6 +3787,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_delivery_writes_terminal_bytes_to_matched_agent() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -3818,6 +3858,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_delivery_prefixes_agent_origin_with_sender_name() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -3858,6 +3899,7 @@ mod tests {
 
     #[tokio::test]
     async fn command_delivery_keeps_origin_unattributed_and_records_input_mode() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -3910,6 +3952,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_delivery_queues_bare_approval_responses_when_action_required() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -3951,6 +3994,7 @@ mod tests {
 
     #[tokio::test]
     async fn approval_action_delivery_sends_provider_approval_key() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -3991,6 +4035,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_submits_next_pending_message_when_target_is_idle() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -4070,6 +4115,7 @@ mod tests {
 
     #[tokio::test]
     async fn provider_non_ready_state_queues_live_delivery_when_status_is_idle() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -4114,6 +4160,7 @@ mod tests {
 
     #[tokio::test]
     async fn claude_idle_status_allows_live_delivery_despite_stale_readiness() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "ClaudeOne", "Coder").await;
         {
@@ -4159,6 +4206,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_can_complete_booting_provider_from_prompt_evidence() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -4227,6 +4275,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_can_complete_booting_claude_from_idle_status() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "ClaudeOne", "Coder").await;
         {
@@ -4300,6 +4349,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_can_complete_booting_gemini_from_prompt_evidence() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "GeminiOne", "Coder").await;
         {
@@ -4365,6 +4415,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_can_complete_booting_antigravity_from_prompt_evidence() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "AntigravityOne", "Coder").await;
         {
@@ -4430,6 +4481,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_marks_provider_busy_after_one_submitted_message() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -4520,6 +4572,7 @@ mod tests {
 
     #[tokio::test]
     async fn provider_non_ready_state_rejects_approval_action_instead_of_queueing() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -4565,6 +4618,7 @@ mod tests {
 
     #[tokio::test]
     async fn stale_readiness_generation_does_not_drain_mailbox() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         state
@@ -4623,6 +4677,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_waits_until_target_is_idle() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         let (tx, mut rx) = tokio::sync::mpsc::channel(4);
@@ -4661,10 +4716,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_waits_while_current_conversation_is_leased() {
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().expect("temp wardian home");
-        let previous_home = std::env::var_os("WARDIAN_HOME");
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -4722,15 +4774,11 @@ mod tests {
             records[0].status,
             crate::state::MailboxMessageStatus::Pending
         );
-
-        match previous_home {
-            Some(value) => std::env::set_var("WARDIAN_HOME", value),
-            None => std::env::remove_var("WARDIAN_HOME"),
-        }
     }
 
     #[tokio::test]
     async fn mailbox_drain_missing_sender_leaves_message_pending_for_retry() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -4781,6 +4829,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_submit_key_failure_marks_failed_without_retry() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -4867,6 +4916,7 @@ mod tests {
 
     #[tokio::test]
     async fn mailbox_drain_payload_send_failure_does_not_emit_submit_started() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         {
@@ -4941,6 +4991,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_delivery_prefixes_bare_approval_response_when_target_not_action_needed() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "source-1", "PlannerOne", "Planner").await;
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -5002,10 +5053,7 @@ mod tests {
 
     #[tokio::test]
     async fn message_delivery_reports_agent_without_input_channel() {
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().expect("temp wardian home");
-        let previous_home = std::env::var_os("WARDIAN_HOME");
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
@@ -5039,15 +5087,11 @@ mod tests {
             error.details().unwrap()["delivery"][0]["error"]["code"],
             "no_input_channel"
         );
-
-        match previous_home {
-            Some(value) => std::env::set_var("WARDIAN_HOME", value),
-            None => std::env::remove_var("WARDIAN_HOME"),
-        }
     }
 
     #[tokio::test]
     async fn message_delivery_reports_partial_failures_after_successful_delivery() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         insert_test_agent(&state, "agent-2", "CoderTwo", "Coder").await;
@@ -5106,6 +5150,7 @@ mod tests {
 
     #[tokio::test]
     async fn delivery_attempt_records_watch_event() {
+        let _home = TestWardianHome::new();
         let state = AppState::new();
         insert_test_agent(&state, "agent-1", "CoderOne", "Coder").await;
         let (tx, mut rx) = tokio::sync::mpsc::channel(4);

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -271,27 +271,8 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
             handle_agent_worktree_disable(app, &target).await
         }
 
-        ControlRequest::WorkflowRun {
-            path,
-            provider,
-            workspace,
-            input,
-            bindings,
-            assignments,
-        } => {
-            let result = crate::commands::workflow::workflow_run_from_control(
-                app.state::<AppState>(),
-                app.clone(),
-                path,
-                provider,
-                workspace,
-                input,
-                bindings,
-                assignments,
-            )
-            .await
-            .map_err(ControlError::request_failed)?;
-            ok_json(&result)
+        request @ ControlRequest::WorkflowRun { .. } => {
+            handle_workflow_run_control(app, workflow_run_control_launch(request)?).await
         }
 
         ControlRequest::SendMessage {
@@ -623,6 +604,60 @@ async fn clear_agent_after_worktree_move(
     )
     .await
     .map_err(ControlError::request_failed)
+}
+
+#[derive(Debug)]
+struct WorkflowRunControlLaunch {
+    path: String,
+    provider: Option<String>,
+    workspace: Option<String>,
+    input: Option<serde_json::Value>,
+    bindings: Option<std::collections::HashMap<String, String>>,
+    assignments: Option<wardian_core::models::WorkflowAssignments>,
+}
+
+fn workflow_run_control_launch(
+    request: ControlRequest,
+) -> Result<WorkflowRunControlLaunch, ControlError> {
+    match request {
+        ControlRequest::WorkflowRun {
+            path,
+            provider,
+            workspace,
+            input,
+            bindings,
+            assignments,
+        } => Ok(WorkflowRunControlLaunch {
+            path,
+            provider,
+            workspace,
+            input,
+            bindings,
+            assignments,
+        }),
+        _ => Err(ControlError::bad_request(
+            "expected workflow_run control request",
+        )),
+    }
+}
+
+async fn handle_workflow_run_control(
+    app: &AppHandle,
+    launch: WorkflowRunControlLaunch,
+) -> Result<String, ControlError> {
+    let result = crate::commands::workflow::workflow_run_from_control(
+        app.state::<AppState>(),
+        app.clone(),
+        launch.path,
+        launch.provider,
+        launch.workspace,
+        launch.input,
+        launch.bindings,
+        launch.assignments,
+    )
+    .await
+    .map_err(ControlError::request_failed)?;
+    ok_json(&result)
 }
 
 async fn agent_worktree_branch_name(
@@ -3197,36 +3232,8 @@ mod tests {
         drop(first);
     }
 
-    #[tokio::test]
-    async fn workflow_run_control_dispatch_forwards_launch_options() {
-        let home = TestWardianHome::new();
-        let workflows_dir = home._temp.path().join("library").join("workflows");
-        std::fs::create_dir_all(&workflows_dir).unwrap();
-        let blueprint_path = workflows_dir.join("controlwf.md");
-        std::fs::write(
-            &blueprint_path,
-            r#"---
-schema: 2
-id: controlwf
-name: Control Workflow
-nodes:
-  - id: trigger
-    type: manual_trigger
-    fields: {}
-edges: []
----
-
-# Control Workflow
-"#,
-        )
-        .unwrap();
-        let workspace = home._temp.path().join("workspace");
-        std::fs::create_dir_all(&workspace).unwrap();
-        let app = tauri::Builder::default()
-            .any_thread()
-            .manage(AppState::new())
-            .build(tauri::generate_context!())
-            .unwrap();
+    #[test]
+    fn workflow_run_control_launch_forwards_launch_options() {
         let mut assignments = wardian_core::models::WorkflowAssignments::new();
         assignments.insert(
             "reviewer".to_string(),
@@ -3237,40 +3244,24 @@ edges: []
             },
         );
         let bindings = HashMap::from([("legacy".to_string(), "mock".to_string())]);
-        let expected_assignments = wardian_core::workflow::assignment::normalize_assignments(
-            Some(assignments.clone()),
-            &bindings,
-            wardian_core::models::InvocationKind::Manual,
-        );
+        let input = serde_json::json!({"target":"HEAD"});
         let request = ControlRequest::WorkflowRun {
-            path: blueprint_path.to_string_lossy().to_string(),
+            path: "/workflow/controlwf.md".to_string(),
             provider: Some("mock".to_string()),
-            workspace: Some(workspace.to_string_lossy().to_string()),
-            input: Some(serde_json::json!({"target":"HEAD"})),
-            bindings: Some(bindings),
+            workspace: Some("/workspace".to_string()),
+            input: Some(input.clone()),
+            bindings: Some(bindings.clone()),
             assignments: Some(assignments.clone()),
         };
 
-        let response = dispatch_request(&serde_json::to_string(&request).unwrap(), app.handle())
-            .await
-            .unwrap();
-        let response: wardian_core::control::WorkflowRunResponse =
-            serde_json::from_str(&response).unwrap();
+        let launch = workflow_run_control_launch(request).unwrap();
 
-        assert!(response.ok);
-        assert_eq!(response.executor, "live");
-        assert_eq!(response.blueprint_id.as_deref(), Some("controlwf"));
-        let run_dir = std::path::PathBuf::from(response.run_dir.unwrap());
-        assert!(run_dir.join("invocation.json").is_file());
-        assert!(run_dir.join("events.jsonl").is_file());
-        assert!(run_dir.join("state.json").is_file());
-        let invocation = crate::workflow::runs::read_run_invocation(&run_dir)
-            .unwrap()
-            .unwrap();
-        assert_eq!(invocation.provider, "mock");
-        assert_eq!(invocation.workspace, workspace.to_string_lossy());
-        assert_eq!(invocation.bindings["legacy"], "mock");
-        assert_eq!(invocation.assignments, expected_assignments);
+        assert_eq!(launch.path, "/workflow/controlwf.md");
+        assert_eq!(launch.provider.as_deref(), Some("mock"));
+        assert_eq!(launch.workspace.as_deref(), Some("/workspace"));
+        assert_eq!(launch.input, Some(input));
+        assert_eq!(launch.bindings, Some(bindings));
+        assert_eq!(launch.assignments, Some(assignments));
     }
 
     fn test_agent(session_id: &str, session_name: &str, agent_class: &str) -> ActiveAgent {

--- a/src-tauri/src/state/interactions.rs
+++ b/src-tauri/src/state/interactions.rs
@@ -515,7 +515,13 @@ mod tests {
 
     #[tokio::test]
     async fn interactions_and_provider_state_hydrate_from_persistence() {
-        let _guard = crate::utils::wardian_test_env_lock();
+        struct TestEnvLock {
+            _lock: std::sync::MutexGuard<'static, ()>,
+        }
+
+        let _guard = TestEnvLock {
+            _lock: crate::utils::wardian_test_env_lock(),
+        };
         let home = tempfile::tempdir().unwrap();
         wardian_core::db::init_db_at_path(&home.path().join("state.db")).unwrap();
 

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -25,7 +25,6 @@ pub use pty_decode::*;
 pub use shell::*;
 pub use terminal_input::*;
 
-#[cfg(test)]
 pub fn wardian_test_env_lock() -> std::sync::MutexGuard<'static, ()> {
     use std::sync::{Mutex, OnceLock};
 

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -541,6 +541,35 @@ mod tests {
         AgentConfig, AgentConversationMode, BusyPolicy, WorkflowAssignments, WorkflowRoleAssignment,
     };
 
+    struct TestWardianHome {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        _home: tempfile::TempDir,
+        previous_home: Option<std::ffi::OsString>,
+    }
+
+    impl TestWardianHome {
+        fn new() -> Self {
+            let lock = crate::utils::wardian_test_env_lock();
+            let home = tempfile::tempdir().expect("temp wardian home");
+            let previous_home = std::env::var_os("WARDIAN_HOME");
+            std::env::set_var("WARDIAN_HOME", home.path());
+            Self {
+                _lock: lock,
+                _home: home,
+                previous_home,
+            }
+        }
+    }
+
+    impl Drop for TestWardianHome {
+        fn drop(&mut self) {
+            match self.previous_home.take() {
+                Some(value) => std::env::set_var("WARDIAN_HOME", value),
+                None => std::env::remove_var("WARDIAN_HOME"),
+            }
+        }
+    }
+
     fn exec_with(runner: FakeAgentRunner) -> LiveStepExecutor {
         LiveStepExecutor::new(
             Arc::new(runner),
@@ -717,10 +746,7 @@ mod tests {
 
     #[tokio::test]
     async fn bound_offline_agent_uses_headless_profile_runner() {
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().expect("temp wardian home");
-        let previous_home = std::env::var_os("WARDIAN_HOME");
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         let headless = Arc::new(FakeAgentRunner::new().with_response("plan", "{\"ok\":true}"));
         let live =
@@ -765,11 +791,6 @@ mod tests {
         assert_eq!(out.0["ok"], true);
         assert_eq!(headless.calls(), vec!["plan".to_string()]);
         assert_eq!(live.calls(), Vec::<String>::new());
-
-        match previous_home {
-            Some(value) => std::env::set_var("WARDIAN_HOME", value),
-            None => std::env::remove_var("WARDIAN_HOME"),
-        }
     }
 
     #[tokio::test]
@@ -880,10 +901,7 @@ mod tests {
             }
         }
 
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().expect("temp wardian home");
-        let previous_home = std::env::var_os("WARDIAN_HOME");
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         let mut assignments = WorkflowAssignments::new();
         assignments.insert(
@@ -931,19 +949,11 @@ mod tests {
 
         assert_eq!(out.0["ok"], true);
         assert!(wardian_core::conversation_lease::load_leases().is_empty());
-
-        match previous_home {
-            Some(value) => std::env::set_var("WARDIAN_HOME", value),
-            None => std::env::remove_var("WARDIAN_HOME"),
-        }
     }
 
     #[tokio::test]
     async fn background_resume_requires_saved_provider_conversation() {
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().expect("temp wardian home");
-        let previous_home = std::env::var_os("WARDIAN_HOME");
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         let mut assignments = WorkflowAssignments::new();
         assignments.insert(
@@ -990,19 +1000,11 @@ mod tests {
             .expect_err("offline current conversation without resume_session should fail");
 
         assert!(err.to_string().contains("saved provider conversation"));
-
-        match previous_home {
-            Some(value) => std::env::set_var("WARDIAN_HOME", value),
-            None => std::env::remove_var("WARDIAN_HOME"),
-        }
     }
 
     #[tokio::test]
     async fn legacy_agent_binding_uses_assignment_route_not_unleased_headless_fallback() {
-        let _guard = crate::utils::wardian_test_env_lock();
-        let temp = tempfile::tempdir().expect("temp wardian home");
-        let previous_home = std::env::var_os("WARDIAN_HOME");
-        std::env::set_var("WARDIAN_HOME", temp.path());
+        let _home = TestWardianHome::new();
 
         let mut bindings = HashMap::new();
         bindings.insert("Coder".to_string(), "agent-123".to_string());
@@ -1041,10 +1043,5 @@ mod tests {
             .expect_err("legacy binding should use current-conversation route semantics");
 
         assert!(err.to_string().contains("saved provider conversation"));
-
-        match previous_home {
-            Some(value) => std::env::set_var("WARDIAN_HOME", value),
-            None => std::env::remove_var("WARDIAN_HOME"),
-        }
     }
 }

--- a/src-tauri/src/workflow/runs.rs
+++ b/src-tauri/src/workflow/runs.rs
@@ -426,14 +426,59 @@ pub async fn drive_new_run_with_catalog_and_assignments(
     assignments: WorkflowAssignments,
     agent_catalog: HashMap<String, AgentBinding>,
 ) -> Result<(), String> {
-    let owner_id = format!("{}/{}", blueprint.id, run_id);
-    write_run_invocation(
+    let state = prepare_new_run_with_assignments(
+        &blueprint,
+        &run_id,
         &run_root,
-        &default_provider,
         &workspace,
+        &default_provider,
         &bindings,
         &assignments,
+        input,
     )?;
+    drive_started_run_with_catalog_and_assignments(
+        app,
+        blueprint,
+        state,
+        run_root,
+        workspace,
+        default_provider,
+        bindings,
+        assignments,
+        agent_catalog,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn prepare_new_run_with_assignments(
+    blueprint: &Blueprint,
+    run_id: &str,
+    run_root: &Path,
+    workspace: &Path,
+    default_provider: &str,
+    bindings: &HashMap<String, String>,
+    assignments: &WorkflowAssignments,
+    input: Value,
+) -> Result<wardian_core::engine::RunState, String> {
+    write_run_invocation(run_root, default_provider, workspace, bindings, assignments)?;
+    Engine::initialize_with_id(blueprint, run_id.to_string(), input, run_root)
+        .map_err(|err| err.to_string())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn drive_started_run_with_catalog_and_assignments(
+    app: Option<tauri::AppHandle>,
+    blueprint: Blueprint,
+    state: wardian_core::engine::RunState,
+    run_root: PathBuf,
+    workspace: PathBuf,
+    default_provider: String,
+    bindings: HashMap<String, String>,
+    assignments: WorkflowAssignments,
+    agent_catalog: HashMap<String, AgentBinding>,
+) -> Result<(), String> {
+    let owner_id = format!("{}/{}", blueprint.id, state.run_id);
     let exec = if let Some(app) = app {
         live_executor_with_catalog_assignments_and_app(
             app,
@@ -453,7 +498,7 @@ pub async fn drive_new_run_with_catalog_and_assignments(
         )
     }
     .with_owner_id(owner_id);
-    Engine::start_with_id(&blueprint, run_id, input, &run_root, &exec)
+    Engine::drive_from_state(&blueprint, state, &run_root, &exec)
         .await
         .map(|_| ())
         .map_err(|err| err.to_string())
@@ -526,7 +571,7 @@ pub async fn drive_resume_with_catalog(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use std::sync::MutexGuard;
     use wardian_core::engine::{event::EventKind, store::read_events, RunState, RunStatus};
     use wardian_core::models::{AgentConversationMode, BusyPolicy, WorkflowRoleAssignment};
 
@@ -563,14 +608,8 @@ edges:
 
     impl EnvGuard {
         fn set(home: &std::path::Path, mock_script: &std::path::Path) -> Self {
-            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-            let lock = LOCK
-                .get_or_init(|| Mutex::new(()))
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-
             let guard = Self {
-                _lock: lock,
+                _lock: crate::utils::wardian_test_env_lock(),
                 previous_home: std::env::var_os("WARDIAN_HOME"),
                 previous_session_id: std::env::var_os("WARDIAN_SESSION_ID"),
                 previous_mock_scenario: std::env::var_os("WARDIAN_MOCK_SCENARIO"),
@@ -720,6 +759,41 @@ edges:
         assert_eq!(invocation.provider, "mock");
         assert_eq!(invocation.bindings, bindings);
         assert_eq!(invocation.assignments, assignments);
+    }
+
+    #[test]
+    fn prepare_new_run_writes_invocation_and_started_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let run_root = dir.path().join("wf").join("run-1");
+        let blueprint = wardian_core::workflow::parse::parse_str(INVOKER_BLUEPRINT).unwrap();
+        let bindings = HashMap::from([("analyst".to_string(), "mock".to_string())]);
+        let assignments = wardian_core::workflow::assignment::normalize_assignments(
+            None,
+            &bindings,
+            InvocationKind::Manual,
+        );
+
+        let state = prepare_new_run_with_assignments(
+            &blueprint,
+            "run-1",
+            &run_root,
+            dir.path(),
+            "mock",
+            &bindings,
+            &assignments,
+            serde_json::json!({"symbol":"SPY"}),
+        )
+        .unwrap();
+
+        assert_eq!(state.run_id, "run-1");
+        assert!(run_root.join("invocation.json").is_file());
+        assert!(run_root.join("events.jsonl").is_file());
+        assert!(run_root.join("state.json").is_file());
+        let events = read_events(&run_root).unwrap();
+        assert!(matches!(
+            events.first().map(|event| &event.kind),
+            Some(EventKind::RunStarted { .. })
+        ));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/src-tauri/src/workflow/schedule.rs
+++ b/src-tauri/src/workflow/schedule.rs
@@ -286,6 +286,7 @@ edges:
 "#;
 
     struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
         previous_home: Option<std::ffi::OsString>,
         previous_session_id: Option<std::ffi::OsString>,
         previous_mock_scenario: Option<std::ffi::OsString>,
@@ -296,6 +297,7 @@ edges:
     impl EnvGuard {
         fn set(home: &std::path::Path, mock_script: &std::path::Path) -> Self {
             let guard = Self {
+                _lock: crate::utils::wardian_test_env_lock(),
                 previous_home: std::env::var_os("WARDIAN_HOME"),
                 previous_session_id: std::env::var_os("WARDIAN_SESSION_ID"),
                 previous_mock_scenario: std::env::var_os("WARDIAN_MOCK_SCENARIO"),
@@ -387,7 +389,6 @@ edges:
 
     #[tokio::test(flavor = "current_thread")]
     async fn due_schedule_fires_and_writes_a_run() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let home = tempfile::tempdir().unwrap();
         let blueprint_path = seed_blueprint(home.path(), "sched-test", SCHEDULED_BLUEPRINT);
         let _env = EnvGuard::set(home.path(), &mock_script_path());
@@ -435,7 +436,6 @@ edges:
 
     #[test]
     fn resolve_fire_resolves_blueprint_run_root_and_provider() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let home = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(home.path(), &mock_script_path());
         seed_blueprint(home.path(), "sched-test", SCHEDULED_BLUEPRINT);
@@ -454,7 +454,6 @@ edges:
 
     #[test]
     fn resolve_fire_normalizes_legacy_bindings_as_scheduled_assignments() {
-        let _guard = crate::utils::wardian_test_env_lock();
         let home = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(home.path(), &mock_script_path());
         seed_blueprint(home.path(), "sched-normalize", BLUEPRINT);
@@ -485,7 +484,6 @@ edges:
 
     #[test]
     fn resolve_fire_errors_for_a_missing_blueprint() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let home = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(home.path(), &mock_script_path());
 
@@ -498,7 +496,6 @@ edges:
 
     #[test]
     fn resolve_fire_falls_back_to_settings_provider_when_request_has_none() {
-        let _lock = crate::utils::wardian_test_env_lock();
         let home = tempfile::tempdir().unwrap();
         let _env = EnvGuard::set(home.path(), &mock_script_path());
         seed_blueprint(home.path(), "sched-test", SCHEDULED_BLUEPRINT);

--- a/src-tauri/tests/workflow_executor.rs
+++ b/src-tauri/tests/workflow_executor.rs
@@ -1,4 +1,4 @@
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::MutexGuard;
 use wardian_core::engine::{driver::new_run_id, Engine, RunStatus};
 
 const DEMO_BLUEPRINT: &str = r#"---
@@ -32,14 +32,8 @@ struct EnvGuard {
 
 impl EnvGuard {
     fn set(home: &std::path::Path, mock_script: &std::path::Path) -> Self {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let lock = LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-
         let guard = Self {
-            _lock: lock,
+            _lock: wardian_app_lib::utils::wardian_test_env_lock(),
             previous_home: std::env::var_os("WARDIAN_HOME"),
             previous_session_id: std::env::var_os("WARDIAN_SESSION_ID"),
             previous_mock_scenario: std::env::var_os("WARDIAN_MOCK_SCENARIO"),


### PR DESCRIPTION
## Description
Routes `wardian workflow exec <path>` through the running Wardian app by default for live/full workflow execution. `--executor mock` is retained only for workflow-engine fixture tests that must avoid app/live runtime dependencies.

This adds a `WorkflowRun` live-control request, CLI dispatch for `live`/`real`/`full`, app-side control dispatch into `workflow_run`, and forwards CLI live launch options for `--provider`, `--workspace`, JSON input, and role/class bindings.

Follow-up autoreview and CI fixes harden the live path:
- app-control `workflow_run` now returns a typed `WorkflowRunResponse` instead of an untyped JSON object that the CLI patches locally;
- live CLI launch returns success only after `invocation.json`, `RunStarted`, and the initial checkpoint are durably written;
- control-origin workflow runs are constrained to `<wardian-home>/library/workflows` while preserving shell/script node execution for trusted library workflows;
- workflow run path components reject traversal characters before writing under `logs/workflows`;
- control payload coverage verifies provider, workspace, input, bindings, and assignments without constructing a GUI app in headless Linux CI;
- CLI help/guides/specs now describe the v2 workflow command surface, default live execution, and the mock executor test-only boundary accurately.

## Related Issues
Fixes #505

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `cargo test -p wardian-cli`
- [x] `cargo test -p wardian-cli workflow_exec -- --test-threads=1`
- [x] `cargo test -p wardian-core workflow_run -- --test-threads=1`
- [x] `cargo test -p wardian-core initialize_with_id_persists_started_checkpoint_before_driving -- --test-threads=1`
- [x] `cargo test -p wardian-core workflow_run_request_serializes_live_launch_options`
- [x] `cargo check -p wardian-core`
- [x] `cargo check -p wardian-cli`
- [x] `cargo check -p Wardian` with isolated target
- [x] `cargo test -p Wardian workflow_run_control_launch_forwards_launch_options -- --test-threads=1` with isolated target
- [x] `cargo test -p Wardian prepare_new_run_writes_invocation_and_started_checkpoint -- --test-threads=1` with isolated target
- [x] `cargo test -p Wardian commands::workflow::tests -- --test-threads=1` with isolated target
- [x] `cargo test -p Wardian -- --test-threads=1` with isolated target
- [x] `cargo test -p Wardian -- --nocapture` with isolated target
- [x] `cargo clippy -p wardian-core -p wardian-cli -p Wardian --all-targets -- -D warnings` with isolated target
- [x] `cargo clippy -p Wardian -p wardian-cli --all-targets -- -D warnings` with isolated target
- [x] `npm run docs:check-llms`
- [x] `npm run docs:build`
- [x] `git diff --check`

Live CLI smoke:
- `cargo run -p wardian-cli -- workflow exec $HOME/.wardian/library/workflows/autoreview.md --input '{"target":"PR #506 ...","max_cycles":1}'` returned `executor: "live"`, run `1780782182546-2db61e47`, then failed in `agent-triage` because headless Codex ran outside a trusted project directory.
- `cargo run -p wardian-cli -- workflow exec $HOME/.wardian/library/workflows/autoreview.md --workspace <absolute-workspace-path> --input '{"target":"PR #506 ...","max_cycles":1}'` returned `executor: "live"`, run `1780782615808-08b694ca`, completed successfully, and converged with no unresolved findings.

Autoreview:
- Run `1780782615808-08b694ca` completed on 2026-06-06.
- Accepted fixes: reliability startup acknowledgement, app-control dispatch coverage, control-origin library path restriction, run path component validation, typed control response, CLI guide update, shell/script node allowance for trusted library workflows, and mock executor wording cleanup.
- Rejected scope item: centralizing launch-context resolution across manual, resume, approval, scheduled, and CLI paths was considered too broad for this branch.
- Generated `.wardian-review/` artifacts are intentionally not committed.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable