### PR TITLE
docs(specs): normalize spec metadata

### DIFF
--- a/docs/specs/2026-03-15-kts-milestone-1.md
+++ b/docs/specs/2026-03-15-kts-milestone-1.md
@@ -1,6 +1,6 @@
 # Knowledge Task System (KTS) Milestone 1
 
-* **Status:** Proposed
+* **Status:** Deprecated
 * **Date:** 2026-03-15
 
 > Note: This proposal is partially superseded by [Evidence-First Memory](./2026-04-17-evidence-first-memory.md). KTS remains valid as a promoted knowledge layer, but it is no longer the recommended base memory substrate.

--- a/docs/specs/2026-03-15-kts-milestone-1.md
+++ b/docs/specs/2026-03-15-kts-milestone-1.md
@@ -2,7 +2,6 @@
 
 * **Status:** Proposed
 * **Date:** 2026-03-15
-* **Decider:** Architect
 
 > Note: This proposal is partially superseded by [Evidence-First Memory](./2026-04-17-evidence-first-memory.md). KTS remains valid as a promoted knowledge layer, but it is no longer the recommended base memory substrate.
 

--- a/docs/specs/2026-03-15-multi-provider.md
+++ b/docs/specs/2026-03-15-multi-provider.md
@@ -2,7 +2,6 @@
 
 * **Status:** Implemented
 * **Date:** 2026-03-15
-* **Decider:** Architect
 
 ## Context and Problem Statement
 Currently, Wardian's backend logic in `manager.rs` is tightly coupled to the `gemini-cli`. To achieve our goal of being a universal agent habitat, we need to support multiple providers (Claude Code, Codex, OpenClaw, etc.) without rewriting the core spawning and telemetry logic.

--- a/docs/specs/2026-03-15-scheduler.md
+++ b/docs/specs/2026-03-15-scheduler.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-03-25
-- **Decider:** Architect
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-03-22-explorer-view.md
+++ b/docs/specs/2026-03-22-explorer-view.md
@@ -2,7 +2,6 @@
 
 * **Status:** Implemented
 * **Date:** 2026-03-22
-* **Decider:** Architect
 
 ## Context and Problem Statement
 Agents often work within specific local directories, but there is currently no way for the user to visually browse the agent's workspace files within Wardian. A file explorer is a standard expectation for developer productivity tools.

--- a/docs/specs/2026-03-22-modernized-navigation.md
+++ b/docs/specs/2026-03-22-modernized-navigation.md
@@ -2,7 +2,6 @@
 
 * **Status:** Implemented
 * **Date:** 2026-03-17
-* **Decider:** Architect
 
 ## Context and Problem Statement
 Wardian's current navigation is "nested" within the main content area, and sidebar controls use inconsistent floating arrows. To elevate the application to a "Pro-Tool" status (similar to Obsidian or VS Code), we need a global navigation layer that remains consistent across all views.

--- a/docs/specs/2026-03-26-workflow-engine.md
+++ b/docs/specs/2026-03-26-workflow-engine.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-03-25
-- **Decider:** Architect
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-03-27-codex-provider.md
+++ b/docs/specs/2026-03-27-codex-provider.md
@@ -2,7 +2,6 @@
 
 * **Status:** Implemented
 * **Date:** 2026-03-27
-* **Decider:** Architect
 
 ## Context and Problem Statement
 Wardian already has a multi-provider backend, but the current implementation only supports Gemini and Claude. Codex support is required for local agent sessions, headless execution, and telemetry without expanding the workflow-engine merge surface.

--- a/docs/specs/2026-03-27-continuous-integration.md
+++ b/docs/specs/2026-03-27-continuous-integration.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-03-25
-- **Decider:** Architect
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-01-automated-testing-harness.md
+++ b/docs/specs/2026-04-01-automated-testing-harness.md
@@ -2,7 +2,6 @@
 
 * **Status:** Accepted
 * **Date:** 2026-03-31
-* **Decider:** Architect
 
 ## Context and Problem Statement
 Wardian still depends heavily on manual verification for agent orchestration, workflow execution, PTY behavior, and provider-specific runtime behavior. That is slow, expensive, and risky because the current runtime shares the user's real `~/.wardian` state, real providers, and real agent sessions.

--- a/docs/specs/2026-04-01-automated-testing-harness.md
+++ b/docs/specs/2026-04-01-automated-testing-harness.md
@@ -1,6 +1,6 @@
 # Automated Testing Harness
 
-* **Status:** Accepted
+* **Status:** Proposed
 * **Date:** 2026-03-31
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-01-automated-testing-harness.md
+++ b/docs/specs/2026-04-01-automated-testing-harness.md
@@ -1,6 +1,6 @@
 # Automated Testing Harness
 
-* **Status:** Proposed
+* **Status:** Implemented
 * **Date:** 2026-03-31
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-07-opencode-provider-stabilization.md
+++ b/docs/specs/2026-04-07-opencode-provider-stabilization.md
@@ -1,6 +1,6 @@
 # OpenCode Provider Stabilization
 
-* **Status:** Proposed
+* **Status:** Implemented
 * **Date:** 2026-04-06
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-07-opencode-provider-stabilization.md
+++ b/docs/specs/2026-04-07-opencode-provider-stabilization.md
@@ -2,7 +2,6 @@
 
 * **Status:** Proposed
 * **Date:** 2026-04-06
-* **Decider:** Architect
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-07-opencode-provider.md
+++ b/docs/specs/2026-04-07-opencode-provider.md
@@ -2,7 +2,6 @@
 
 * **Status:** Implemented
 * **Date:** 2026-04-03
-* **Decider:** Architect
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-11-terminal-runtime-hardening.md
+++ b/docs/specs/2026-04-11-terminal-runtime-hardening.md
@@ -1,6 +1,6 @@
 # Terminal Runtime Hardening
 
-* **Status:** Proposed
+* **Status:** Implemented
 * **Date:** 2026-04-09
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-11-terminal-runtime-hardening.md
+++ b/docs/specs/2026-04-11-terminal-runtime-hardening.md
@@ -2,7 +2,6 @@
 
 * **Status:** Proposed
 * **Date:** 2026-04-09
-* **Decider:** Architect
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-12-synchronized-grid-layout.md
+++ b/docs/specs/2026-04-12-synchronized-grid-layout.md
@@ -1,6 +1,6 @@
 # Synchronized Grid Layout & Tactile Resizing
 
-* **Status:** Proposed
+* **Status:** Implemented
 * **Date:** 2026-04-12
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-12-synchronized-grid-layout.md
+++ b/docs/specs/2026-04-12-synchronized-grid-layout.md
@@ -2,7 +2,6 @@
 
 * **Status:** Draft (Flush Layout)
 * **Date:** 2026-04-12
-* **Decider:** Designer / User
 
 ## Context and Problem Statement
 Current grid management in Wardian is limited to a simple `flex-wrap` layout with heavy whitespace gaps. To create a high-fidelity "Command Center" experience, we need a system that allows for **Direct Visual Manipulation** of a flush, zero-gap grid where terminals share edges.

--- a/docs/specs/2026-04-12-synchronized-grid-layout.md
+++ b/docs/specs/2026-04-12-synchronized-grid-layout.md
@@ -1,6 +1,6 @@
 # Synchronized Grid Layout & Tactile Resizing
 
-* **Status:** Draft (Flush Layout)
+* **Status:** Proposed
 * **Date:** 2026-04-12
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-17-evidence-first-memory.md
+++ b/docs/specs/2026-04-17-evidence-first-memory.md
@@ -1,6 +1,6 @@
 # Evidence-First Memory
 
-- **Status:** Placeholder
+- **Status:** Proposed
 - **Date:** 2026-04-17
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-17-evidence-first-memory.md
+++ b/docs/specs/2026-04-17-evidence-first-memory.md
@@ -2,7 +2,6 @@
 
 - **Status:** Placeholder
 - **Date:** 2026-04-17
-- **Decider:** User
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-17-session-persistence-policy.md
+++ b/docs/specs/2026-04-17-session-persistence-policy.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-04-17
-- **Decider:** User
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-17-session-persistence-policy.md
+++ b/docs/specs/2026-04-17-session-persistence-policy.md
@@ -1,6 +1,6 @@
 # Session Persistence Policy
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-04-17
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-17-source-control-panel.md
+++ b/docs/specs/2026-04-17-source-control-panel.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-04-17
-- **Decider:** User
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-19-agent-teams-and-bulk-actions.md
+++ b/docs/specs/2026-04-19-agent-teams-and-bulk-actions.md
@@ -1,6 +1,6 @@
 # Agent Teams and Bulk Actions
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-04-19
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-19-agent-teams-and-bulk-actions.md
+++ b/docs/specs/2026-04-19-agent-teams-and-bulk-actions.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-04-19
-- **Decider:** User
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-19-release-system.md
+++ b/docs/specs/2026-04-19-release-system.md
@@ -1,6 +1,6 @@
 # Release System
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-04-19
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-19-release-system.md
+++ b/docs/specs/2026-04-19-release-system.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-04-19
-- **Decider:** Wardian Claude
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-19-responsive-terminal-width.md
+++ b/docs/specs/2026-04-19-responsive-terminal-width.md
@@ -1,6 +1,6 @@
 # Responsive Terminal Width
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-04-19
 
 ## Context and Problem Statement

--- a/docs/specs/2026-04-19-responsive-terminal-width.md
+++ b/docs/specs/2026-04-19-responsive-terminal-width.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-04-19
-- **Decider:** Tan Gemicioglu
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-21-wardian-cli-and-agent-command.md
+++ b/docs/specs/2026-04-21-wardian-cli-and-agent-command.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-04-21
-- **Decider:** Wardian Claude
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-04-26-testing-coverage-and-screenshot-docs.md
+++ b/docs/specs/2026-04-26-testing-coverage-and-screenshot-docs.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-04-26
-- **Decider:** Tan Gemicioglu
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-04-agent-list-ordering.md
+++ b/docs/specs/2026-05-04-agent-list-ordering.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-04
-- **Decider:** Wardian maintainers
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-04-team-order-synchronization.md
+++ b/docs/specs/2026-05-04-team-order-synchronization.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-04
-- **Decider:** Wardian maintainers
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-04-user-terminal-panel-design.md
+++ b/docs/specs/2026-05-04-user-terminal-panel-design.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-04
-- **Decider:** Wardian maintainers
 
 ## Goal
 

--- a/docs/specs/2026-05-07-agent-watch-and-communication.md
+++ b/docs/specs/2026-05-07-agent-watch-and-communication.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-07
-- **Decider:** Wardian Codex
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-07-cli-agent-control.md
+++ b/docs/specs/2026-05-07-cli-agent-control.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-06
-- **Decider:** Wardian Codex
 
 ## Context
 

--- a/docs/specs/2026-05-10-custom-agent-clone.md
+++ b/docs/specs/2026-05-10-custom-agent-clone.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-10
-- **Decider:** User
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-12-agent-status-transition-gate.md
+++ b/docs/specs/2026-05-12-agent-status-transition-gate.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-12
-- **Decider:** User
 
 ## Context
 

--- a/docs/specs/2026-05-12-cli-surface-parity.md
+++ b/docs/specs/2026-05-12-cli-surface-parity.md
@@ -1,6 +1,6 @@
 # CLI Surface Parity Matrix
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-12
 
 ## Context

--- a/docs/specs/2026-05-12-cli-surface-parity.md
+++ b/docs/specs/2026-05-12-cli-surface-parity.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-05-12
-- **Decider:** User
 
 ## Context
 

--- a/docs/specs/2026-05-12-codex-runtime-policy.md
+++ b/docs/specs/2026-05-12-codex-runtime-policy.md
@@ -2,7 +2,6 @@
 
 * **Status:** Implemented
 * **Date:** 2026-05-12
-* **Decider:** Architect
 
 ## Context
 

--- a/docs/specs/2026-05-12-codex-windows-sandbox-projection.md
+++ b/docs/specs/2026-05-12-codex-windows-sandbox-projection.md
@@ -2,7 +2,6 @@
 
 * **Status:** Implemented
 * **Date:** 2026-05-12
-* **Decider:** Architect
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-12-core-feature-screenshot-documentation.md
+++ b/docs/specs/2026-05-12-core-feature-screenshot-documentation.md
@@ -1,6 +1,6 @@
 # Core Feature Screenshot Documentation
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-12
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-12-core-feature-screenshot-documentation.md
+++ b/docs/specs/2026-05-12-core-feature-screenshot-documentation.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-05-12
-- **Decider:** Tan Gemicioglu
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-13-provider-config.md
+++ b/docs/specs/2026-05-13-provider-config.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-13
-- **Decider:** Architect
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-13-structured-ask-reply.md
+++ b/docs/specs/2026-05-13-structured-ask-reply.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-13
-- **Decider:** Tan Gemicioglu
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-18-agent-id-display.md
+++ b/docs/specs/2026-05-18-agent-id-display.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-18
-- **Decider:** User
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-18-agent-watch-readable-output.md
+++ b/docs/specs/2026-05-18-agent-watch-readable-output.md
@@ -3,7 +3,6 @@
 - **Status:** Implemented
 - **Date:** 2026-05-16
 - **Issue:** [#273](https://github.com/wardian-app/Wardian/issues/273)
-- **Decider:** Wardian Codex
 
 ## Decision
 

--- a/docs/specs/2026-05-19-in-app-updates.md
+++ b/docs/specs/2026-05-19-in-app-updates.md
@@ -1,6 +1,6 @@
 # In-App Updates
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-19
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-19-in-app-updates.md
+++ b/docs/specs/2026-05-19-in-app-updates.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-05-19
-- **Decider:** Wardian Codex and user
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-19-provider-readiness-gating.md
+++ b/docs/specs/2026-05-19-provider-readiness-gating.md
@@ -1,6 +1,6 @@
 # Provider Readiness Gating
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-19
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-19-provider-readiness-gating.md
+++ b/docs/specs/2026-05-19-provider-readiness-gating.md
@@ -1,6 +1,6 @@
 # Provider Readiness Gating
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-05-19
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-19-provider-readiness-gating.md
+++ b/docs/specs/2026-05-19-provider-readiness-gating.md
@@ -2,7 +2,6 @@
 
 - **Status:** Accepted
 - **Date:** 2026-05-19
-- **Decider:** Product/Engineering
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-20-antigravity-provider.md
+++ b/docs/specs/2026-05-20-antigravity-provider.md
@@ -3,7 +3,6 @@
 - **Status:** Implemented
 - **Date:** 2026-05-20
 - **Issue:** #314
-- **Decider:** Wardian maintainers
 
 ## Context
 

--- a/docs/specs/2026-05-20-os-package-managers-phase-1.md
+++ b/docs/specs/2026-05-20-os-package-managers-phase-1.md
@@ -1,6 +1,6 @@
 # OS Package Managers Phase 1
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-05-20
 - **Issue:** [#325](https://github.com/wardian-app/Wardian/issues/325)
 - **Follow-up:** Linux package-manager publishing is tracked in [#324](https://github.com/wardian-app/Wardian/issues/324).

--- a/docs/specs/2026-05-20-os-package-managers-phase-1.md
+++ b/docs/specs/2026-05-20-os-package-managers-phase-1.md
@@ -1,6 +1,6 @@
 # OS Package Managers Phase 1
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-20
 - **Issue:** [#325](https://github.com/wardian-app/Wardian/issues/325)
 - **Follow-up:** Linux package-manager publishing is tracked in [#324](https://github.com/wardian-app/Wardian/issues/324).

--- a/docs/specs/2026-05-20-os-package-managers-phase-1.md
+++ b/docs/specs/2026-05-20-os-package-managers-phase-1.md
@@ -2,7 +2,6 @@
 
 - **Status:** Accepted
 - **Date:** 2026-05-20
-- **Decider:** Wardian Codex and user
 - **Issue:** [#325](https://github.com/wardian-app/Wardian/issues/325)
 - **Follow-up:** Linux package-manager publishing is tracked in [#324](https://github.com/wardian-app/Wardian/issues/324).
 

--- a/docs/specs/2026-05-20-release-asset-cleanup.md
+++ b/docs/specs/2026-05-20-release-asset-cleanup.md
@@ -1,6 +1,6 @@
 # Release Asset Cleanup
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-20
 
 ## Context

--- a/docs/specs/2026-05-20-release-asset-cleanup.md
+++ b/docs/specs/2026-05-20-release-asset-cleanup.md
@@ -2,7 +2,6 @@
 
 - **Status:** Accepted
 - **Date:** 2026-05-20
-- **Decider:** Wardian Codex and user
 
 ## Context
 

--- a/docs/specs/2026-05-20-release-asset-cleanup.md
+++ b/docs/specs/2026-05-20-release-asset-cleanup.md
@@ -1,6 +1,6 @@
 # Release Asset Cleanup
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-05-20
 
 ## Context

--- a/docs/specs/2026-05-21-agent-lifecycle-locking.md
+++ b/docs/specs/2026-05-21-agent-lifecycle-locking.md
@@ -1,6 +1,6 @@
 # Agent Lifecycle Locking
 
-* **Status:** Accepted
+* **Status:** Proposed
 * **Date:** 2026-05-21
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-21-agent-lifecycle-locking.md
+++ b/docs/specs/2026-05-21-agent-lifecycle-locking.md
@@ -2,7 +2,6 @@
 
 * **Status:** Accepted
 * **Date:** 2026-05-21
-* **Decider:** Core Runtime
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-21-agent-lifecycle-locking.md
+++ b/docs/specs/2026-05-21-agent-lifecycle-locking.md
@@ -1,6 +1,6 @@
 # Agent Lifecycle Locking
 
-* **Status:** Proposed
+* **Status:** Implemented
 * **Date:** 2026-05-21
 
 ## Context and Problem Statement
@@ -28,4 +28,3 @@ Lifecycle handlers follow this lock policy:
 * **Positive:** State-file writes no longer require the global agent lock to remain held during synchronous filesystem work in the touched lifecycle paths.
 * **Tradeoff:** The lifecycle lock registry retains one small mutex entry per session ID touched during an app run. The registry is reset when the app restarts.
 * **Tradeoff:** Persistence remains best-effort; failures to write `state.json` or SQLite metadata are logged or ignored consistently with existing behavior.
-

--- a/docs/specs/2026-05-21-global-settings-redesign.md
+++ b/docs/specs/2026-05-21-global-settings-redesign.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-05-21
-- **Decider:** Product/Engineering
 - **Issue:** [#184](https://github.com/wardian-app/Wardian/issues/184)
 - **Related:** [#336](https://github.com/wardian-app/Wardian/issues/336)
 

--- a/docs/specs/2026-05-21-global-settings-redesign.md
+++ b/docs/specs/2026-05-21-global-settings-redesign.md
@@ -1,6 +1,6 @@
 # Global Settings Redesign
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-21
 - **Issue:** [#184](https://github.com/wardian-app/Wardian/issues/184)
 - **Related:** [#336](https://github.com/wardian-app/Wardian/issues/336)

--- a/docs/specs/2026-05-21-grid-chat-mode.md
+++ b/docs/specs/2026-05-21-grid-chat-mode.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-05-21
-- **Decider:** Wardian maintainers
 
 ## Context
 

--- a/docs/specs/2026-05-21-grid-chat-mode.md
+++ b/docs/specs/2026-05-21-grid-chat-mode.md
@@ -1,6 +1,6 @@
 # Grid Chat Mode
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-21
 
 ## Context

--- a/docs/specs/2026-05-21-pwa-remote-control-v1.md
+++ b/docs/specs/2026-05-21-pwa-remote-control-v1.md
@@ -2,7 +2,7 @@
 
 Filename: `2026-05-21-pwa-remote-control-v1.md`
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-21
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-21-pwa-remote-control-v1.md
+++ b/docs/specs/2026-05-21-pwa-remote-control-v1.md
@@ -4,7 +4,6 @@ Filename: `2026-05-21-pwa-remote-control-v1.md`
 
 - **Status:** Proposed
 - **Date:** 2026-05-21
-- **Decider:** Product/Engineering
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-22-agent-delivery-transport.md
+++ b/docs/specs/2026-05-22-agent-delivery-transport.md
@@ -1,6 +1,6 @@
 # Agent Delivery Transport
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-22
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-22-agent-delivery-transport.md
+++ b/docs/specs/2026-05-22-agent-delivery-transport.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-05-22
-- **Decider:** Product/Engineering
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-23-antigravity-clear-design.md
+++ b/docs/specs/2026-05-23-antigravity-clear-design.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-23
-- **Decider:** Antigravity and Wardian maintainers
 
 ## Context
 

--- a/docs/specs/2026-05-23-mobile-terminal-default-view.md
+++ b/docs/specs/2026-05-23-mobile-terminal-default-view.md
@@ -4,7 +4,6 @@ Filename: `2026-05-23-mobile-terminal-default-view.md`
 
 - **Status:** Implemented
 - **Date:** 2026-05-23
-- **Decider:** User
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-23-watchlist-team-collapse.md
+++ b/docs/specs/2026-05-23-watchlist-team-collapse.md
@@ -2,7 +2,6 @@
 
 - **Status:** Planned
 - **Date:** 2026-05-23
-- **Decider:** Wardian maintainers
 
 ## Context and Problem Statement
 

--- a/docs/specs/2026-05-23-watchlist-team-collapse.md
+++ b/docs/specs/2026-05-23-watchlist-team-collapse.md
@@ -1,6 +1,6 @@
 # Watchlist Team Collapse
 
-- **Status:** Planned
+- **Status:** Proposed
 - **Date:** 2026-05-23
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-23-watchlist-team-collapse.md
+++ b/docs/specs/2026-05-23-watchlist-team-collapse.md
@@ -1,6 +1,6 @@
 # Watchlist Team Collapse
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-23
 
 ## Context and Problem Statement

--- a/docs/specs/2026-05-26-chat-first-long-prompt-composition.md
+++ b/docs/specs/2026-05-26-chat-first-long-prompt-composition.md
@@ -1,6 +1,6 @@
 # Chat-First Long Prompt Composition
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-26
 
 ## Context

--- a/docs/specs/2026-05-26-chat-first-long-prompt-composition.md
+++ b/docs/specs/2026-05-26-chat-first-long-prompt-composition.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-05-26
-- **Decider:** Product/Engineering
 
 ## Context
 

--- a/docs/specs/2026-05-29-workflow-cli.md
+++ b/docs/specs/2026-05-29-workflow-cli.md
@@ -2,7 +2,6 @@
 
 - **Status:** Accepted
 - **Date:** 2026-05-29
-- **Decider:** User
 
 ## Context
 

--- a/docs/specs/2026-05-29-workflow-cli.md
+++ b/docs/specs/2026-05-29-workflow-cli.md
@@ -1,6 +1,6 @@
 # Workflow CLI Verbs
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-05-29
 
 ## Context

--- a/docs/specs/2026-05-29-workflow-cli.md
+++ b/docs/specs/2026-05-29-workflow-cli.md
@@ -1,6 +1,6 @@
 # Workflow CLI Verbs
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-29
 
 ## Context

--- a/docs/specs/2026-05-29-workflow-executor.md
+++ b/docs/specs/2026-05-29-workflow-executor.md
@@ -1,6 +1,6 @@
 # Workflow Engine — Live Executor (sub-project 5a) Design
 
-- **Status:** Implemented (5a)
+- **Status:** Implemented
 - **Date:** 2026-05-29
 - **Part of:** [Workflow rework epic (#425)]; follows sub-projects 1 (library/registry), 2 (durable engine), 3a (builder), 3b (run view), 4 (CLI).
 

--- a/docs/specs/2026-05-29-workflow-unified-view.md
+++ b/docs/specs/2026-05-29-workflow-unified-view.md
@@ -1,6 +1,6 @@
 # Workflow Engine — Unified Workflows View (sub-project 5b) Design
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-29
 - **Part of:** [Workflow rework epic (#425)]; follows 1 (library/registry), 2 (engine), 3a (builder), 3b (run view), 4 (CLI), 5a (live executor, #448). Precedes 5c (old workflow system retirement + migration).
 

--- a/docs/specs/2026-05-30-old-workflow-system-deletion.md
+++ b/docs/specs/2026-05-30-old-workflow-system-deletion.md
@@ -1,6 +1,6 @@
 # Old Workflow System Deletion (sub-project 6d) Design
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-30
 - **Part of:** [Workflow rework epic (#425)] — the FINAL parity-track step. Workflow reached parity across 6a (invoker foundation #456), 6b (schedule invoker #457), 6c (monitoring/schedule UI #458), and the 6b test cleanup (#459). 6d removes old workflow system; after it, the epic is complete.
 

--- a/docs/specs/2026-05-30-workflow-invoker-foundation.md
+++ b/docs/specs/2026-05-30-workflow-invoker-foundation.md
@@ -1,6 +1,6 @@
 # Workflow Engine — Trigger / Invoker Foundation (sub-project 6a) Design
 
-- **Status:** Implemented (6a)
+- **Status:** Implemented
 - **Date:** 2026-05-30
 - **Part of:** [Workflow rework epic (#425)]; old-system parity track. Foundation for 6b (schedule invoker), 6c (monitoring sidebar), 6d (old workflow system deletion). Builds on 5a (`workflow_run`) + 5b (Run dialog).
 

--- a/docs/specs/2026-05-30-workflow-monitoring-ui.md
+++ b/docs/specs/2026-05-30-workflow-monitoring-ui.md
@@ -1,6 +1,6 @@
 # Workflow Engine — Monitoring Sidebar + Schedule-Management UI (sub-project 6c) Design
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-30
 - **Part of:** [Workflow rework epic (#425)]; old-system parity track. The UI layer on 6a (invoker foundation, #456) + 6b (schedule invoker, #457). Last parity piece before 6d (old workflow system deletion).
 

--- a/docs/specs/2026-05-30-workflow-schedule-invoker.md
+++ b/docs/specs/2026-05-30-workflow-schedule-invoker.md
@@ -1,6 +1,6 @@
 # Workflow Engine — Schedule Invoker (sub-project 6b) Design
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-30
 - **Part of:** [Workflow rework epic (#425)]; old-system parity track. Builds on 6a (invoker foundation, #456). Followed by 6c (monitoring sidebar — schedule-management UI) and 6d (old workflow system deletion).
 

--- a/docs/specs/2026-05-31-claude-status-transition-consistency.md
+++ b/docs/specs/2026-05-31-claude-status-transition-consistency.md
@@ -2,7 +2,6 @@
 
 - **Status:** Implemented
 - **Date:** 2026-05-31
-- **Decider:** User
 
 ## Context
 

--- a/docs/specs/2026-05-31-workflow-authoring-ux.md
+++ b/docs/specs/2026-05-31-workflow-authoring-ux.md
@@ -1,6 +1,6 @@
 # Workflow Authoring UX Refresh
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-05-31
 - **Branch:** `debug/workflow-crash`
 - **Scope:** Frontend authoring experience for workflow blueprints.

--- a/docs/specs/2026-06-01-fullscreen-e2e-visual-defaults.md
+++ b/docs/specs/2026-06-01-fullscreen-e2e-visual-defaults.md
@@ -1,6 +1,6 @@
 # Fullscreen E2E Visual Defaults
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-06-01
 
 ## Context

--- a/docs/specs/2026-06-01-fullscreen-e2e-visual-defaults.md
+++ b/docs/specs/2026-06-01-fullscreen-e2e-visual-defaults.md
@@ -2,7 +2,6 @@
 
 - **Status:** Accepted
 - **Date:** 2026-06-01
-- **Decider:** Tan Gemicioglu
 
 ## Context
 

--- a/docs/specs/2026-06-01-fullscreen-e2e-visual-defaults.md
+++ b/docs/specs/2026-06-01-fullscreen-e2e-visual-defaults.md
@@ -1,6 +1,6 @@
 # Fullscreen E2E Visual Defaults
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Date:** 2026-06-01
 
 ## Context

--- a/docs/specs/2026-06-01-workflow-agent-session-semantics.md
+++ b/docs/specs/2026-06-01-workflow-agent-session-semantics.md
@@ -1,6 +1,6 @@
 # Workflow Agent Session Semantics
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-06-01
 - **Branch:** `debug/v2-workflow-crash`
 - **Scope:** Workflow agent assignment, background execution, conversation leases, and `Headless` status semantics.

--- a/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
+++ b/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
@@ -1,6 +1,6 @@
 # Explorer Filesystem Watch Refresh
 
-* **Status:** Accepted
+* **Status:** Proposed
 * **Date:** 2026-06-02
 
 ## Context

--- a/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
+++ b/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
@@ -2,7 +2,6 @@
 
 * **Status:** Accepted
 * **Date:** 2026-06-02
-* **Decider:** User, Codex
 
 ## Context
 

--- a/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
+++ b/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
@@ -1,6 +1,6 @@
 # Explorer Filesystem Watch Refresh
 
-* **Status:** Proposed
+* **Status:** Implemented
 * **Date:** 2026-06-02
 
 ## Context

--- a/docs/specs/2026-06-02-malleable-garden.md
+++ b/docs/specs/2026-06-02-malleable-garden.md
@@ -2,7 +2,6 @@
 
 - **Status:** Proposed
 - **Date:** 2026-06-02
-- **Decider:** User
 
 ## Context and Problem Statement
 

--- a/docs/specs/template.md
+++ b/docs/specs/template.md
@@ -4,7 +4,6 @@ Filename: `YYYY-MM-DD-short-slug.md`
 
 - **Status:** Proposed | Implemented | Deprecated
 - **Date:** [YYYY-MM-DD]
-- **Decider:** [Role/User]
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
## Description
Removes the ambiguous `Decider` metadata field from repository-internal specs and the spec template. Also normalizes explicit `Status` labels to the template vocabulary, so historical specs no longer mix in values like `Accepted`, `Planned`, `Placeholder`, or phase-qualified `Implemented` labels.

I also audited the specs that were still marked `Proposed` against the current codebase and docs. The implemented ones are now marked `Implemented`; the explicitly superseded KTS milestone is marked `Deprecated`. The only specs still marked `Proposed` are future-facing design work: Evidence-First Memory and Malleable Garden.

Specs that need provenance can describe it directly in Context instead of relying on a mandatory field that mixed people, roles, teams, and agent identities.

## Related Issues
Fixes #509

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `rg -n "decider|Decider|DECIDER" docs/specs -g "*.md"` returned no matches
- explicit spec `Status` metadata now uses only `Proposed`, `Implemented`, or `Deprecated` outside the template
- remaining `Proposed` specs are only Evidence-First Memory and Malleable Garden, plus the template vocabulary line
- `git diff --check`
- `npm run lint`
- `npm run test` - 112 files / 1040 tests passed
- `npm run build` - passed with existing large-chunk warning
- `cargo clippy` in `src-tauri`
- `cargo check` in `src-tauri`
- `cargo test` in `src-tauri` - one full-suite run failed on `workflow::runs::tests::input_interpolates_and_role_binding_selects_provider`; the test passed in isolation, and the subsequent full-suite rerun passed: 887 unit tests, 7 mock provider tests, 1 workflow executor test

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable