### PR TITLE
test(e2e): align run view status assertions

### DIFF
--- a/e2e/tests/run-view.spec.ts
+++ b/e2e/tests/run-view.spec.ts
@@ -152,14 +152,14 @@ test("run view observes, scrubs, and inspects a failed run", async ({ page }) =>
   const nodeA = nodeById(page, "a");
   const nodeB = nodeById(page, "b");
 
-  await expect(nodeA).toContainText("completed");
-  await expect(nodeB).toContainText("failed");
+  await expect(nodeA.getByText("Completed")).toBeVisible();
+  await expect(nodeB.getByText("Failed")).toBeVisible();
   await expect(nodeA).toHaveAttribute("data-status", "completed");
   await expect(nodeB).toHaveAttribute("data-status", "failed");
 
   await scrubTo(page, 1);
-  await expect(nodeA).toContainText("running");
-  await expect(nodeB).toContainText("pending");
+  await expect(nodeA.getByText("Running")).toBeVisible();
+  await expect(nodeB.getByText("Pending")).toBeVisible();
   await expect(nodeA).toHaveAttribute("data-status", "running");
   await expect(nodeB).toHaveAttribute("data-status", "pending");
 


### PR DESCRIPTION
## Description
Fixes the browser E2E failure in the run observe view by aligning the test with the UI's human-readable status badges. The test now asserts `Completed`, `Failed`, `Running`, and `Pending` as visible labels while preserving lowercase `data-status` checks for machine state.

## Related Issues
Fixes #511

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] `npm run test:e2e` - 50 passed, 15 skipped
- [x] `npm run test:e2e -- e2e/tests/run-view.spec.ts` - 1 passed
- [x] `npm run lint`
- [x] `npm run test` - 112 files passed, 1040 tests passed
- [x] `npm run build`
- [x] `cd src-tauri && cargo clippy`
- [x] `cd src-tauri && cargo test`
- [x] `cd src-tauri && cargo check`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Hard-to-understand code comments are not applicable; this only updates E2E assertions
- [x] Documentation changes are not applicable; this is an internal test-only fix with no user-facing behavior change
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have updated tests to prove the fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Frontend screenshot evidence is not applicable; no frontend behavior or visual behavior changed