### PR TITLE
feat(chat): improve markdown rendering and activity feedback

### DIFF
--- a/docs/guide/grid.md
+++ b/docs/guide/grid.md
@@ -34,6 +34,8 @@ Change the default globally in **Settings > Grid > Grid card display**. Each car
 
 Chat mode sends ordinary text through the same provider submit path used by Wardian's command tools. Use **Enter** to send and **Shift+Enter** for a newline in the composer. When Wardian recognizes an action-required prompt with approval choices, Chat mode renders those choices as buttons that submit the matching response. Switch back to Terminal mode when you need raw TUI controls, provider-specific keybindings, or detailed terminal behavior.
 
+Chat mode renders common GitHub-flavored Markdown in agent messages, including tables, task lists, nested lists, blockquotes, strikethrough, autolinks, and fenced code blocks. Tool activity is summarized for scanning: empty successful tool results are folded into their command rows, while failures, changed files, command output, approvals, and errors remain visible.
+
 In Terminal mode, Wardian follows conservative terminal shortcut handling. On macOS, **Cmd+A** selects the visible terminal buffer. Windows and Linux control-key combinations, including **Ctrl+A** and **Ctrl+Shift+A**, continue through to the shell or provider TUI by default.
 
 Terminal output can also expose clickable HTTP/HTTPS URLs and workspace file paths. URL links open in the system browser, while file path links use the external editor behavior configured in Settings.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -53,7 +53,7 @@ Wardian-managed roots usually live under hidden `.wardian` directories. Antigrav
 
 Wardian launches visible Antigravity agents with `agy --prompt-interactive ""` so the CLI starts in interactive mode without an initial task. Headless workflow runs use `agy --print` and, when resuming, `--conversation <conversation-id>`. Provider options include `--sandbox`, `--dangerously-skip-permissions`, and `--print-timeout <duration>`.
 
-Antigravity stores runtime state under `~/.gemini/antigravity-cli`. Wardian discovers the conversation ID from the provider cache and reads `brain/<conversation-id>/.system_generated/logs/transcript.jsonl` for status and assistant transcript text. `wardian agent watch` uses completed `MODEL` `PLANNER_RESPONSE` transcript records as provider-adapted assistant output.
+Antigravity stores runtime state under `~/.gemini/antigravity-cli`. Wardian discovers the conversation ID from the provider cache and reads `brain/<conversation-id>/.system_generated/logs/transcript.jsonl` for status, assistant transcript text, and tool activity. `wardian agent watch` uses completed `MODEL` `PLANNER_RESPONSE` transcript records as provider-adapted assistant output, planner `tool_calls` as tool-call rows, and model action records such as `RUN_COMMAND`, `VIEW_FILE`, `CODE_ACTION`, `SEARCH_WEB`, `LIST_DIRECTORY`, `GREP_SEARCH`, `READ_URL_CONTENT`, `ASK_QUESTION`, and `GENERIC` as tool-result rows.
 
 ### Debug First
 

--- a/docs/specs/2026-05-21-grid-chat-mode.md
+++ b/docs/specs/2026-05-21-grid-chat-mode.md
@@ -228,6 +228,10 @@ Map:
 - `USER_INPUT` records from explicit user sources to user message events.
 - `MODEL` `PLANNER_RESPONSE` records with `DONE` status to assistant message
   events.
+- Planner `tool_calls` entries to tool-call activity rows.
+- Model action records such as `RUN_COMMAND`, `VIEW_FILE`, `CODE_ACTION`,
+  `SEARCH_WEB`, `LIST_DIRECTORY`, `GREP_SEARCH`, `READ_URL_CONTENT`,
+  `ASK_QUESTION`, and `GENERIC` to tool-result activity rows.
 - Planner responses without `DONE` status to processing status.
 - System/history records to status or ignored metadata unless they are useful to
   users.
@@ -314,6 +318,9 @@ Rules:
   transcript confirms the message.
 - The composer is disabled while the agent is off, paused, headless, in an
   error state, or actively processing.
+- While the agent is actively processing or chat mode is awaiting the first
+  response after a submitted prompt, chat mode appends a subtle latest
+  `Working...` row in the transcript.
 - The terminal remains the authoritative fallback for provider states that
   require raw keyboard interaction.
 - Action-required states may be answered through the composer, but dedicated

--- a/docs/specs/2026-06-07-chat-markdown-renderer.md
+++ b/docs/specs/2026-06-07-chat-markdown-renderer.md
@@ -1,0 +1,310 @@
+# Chat Markdown Renderer
+
+- **Status:** Proposed
+- **Date:** 2026-06-07
+
+## Context
+
+Wardian chat mode renders provider-normalized `AgentChatEvent` records into a
+dense supervision surface. Message rendering currently uses a custom lightweight
+parser in `src/features/grid/AgentChatView.tsx`. It handles fenced code blocks,
+ATX headings, flat ordered and unordered lists, paragraphs, markdown links,
+inline code, and bold text.
+
+That first slice made chat mode readable without adding dependencies, but it now
+misses markdown that agents routinely emit. GitHub-flavored tables are the most
+visible failure: a table such as an email inbox summary is shown as wrapped pipe
+text instead of a scannable grid. The same limitation affects task lists,
+nested lists, blockquotes, autolinks, strikethrough, and mixed inline formatting.
+
+Chat mode should render common agent-authored markdown with high fidelity while
+preserving Wardian's safety and density requirements. Raw terminal mode remains
+the authoritative fallback for provider TUIs and PTY-specific behavior; this
+spec only changes how already-normalized chat message text is rendered.
+
+## Goals
+
+- Render common GitHub-flavored markdown in agent messages, especially tables.
+- Replace the current regex-oriented message parser with a maintained markdown
+  pipeline that can parse block and inline markdown consistently.
+- Keep message rendering safe: no raw HTML execution, no unsafe URL schemes, no
+  unbounded remote media, and no layout-breaking content.
+- Preserve Wardian's compact chat-mode visual language and theme-variable
+  styling.
+- Keep code block copy and syntax-highlighting affordances.
+- Add focused tests for markdown features that agents produce in real sessions.
+
+## Non-Goals
+
+- Changing the backend `AgentChatEvent` DTO.
+- Changing provider transcript normalization.
+- Replacing terminal mode or making chat mode a full provider TUI.
+- Supporting arbitrary raw HTML from markdown.
+- Rendering remote images inline by default.
+- Implementing every CommonMark extension in the first slice.
+
+## Current Gaps
+
+### P0
+
+- **Tables:** Pipe tables, alignment markers, empty cells, and long cell content
+  do not render as tables. Escaped pipes inside cells are not handled.
+- **Task lists:** `- [ ]` and `- [x]` are rendered as ordinary list text.
+- **Nested lists and continuations:** Indentation and wrapped list lines are
+  flattened, which can change the meaning of plans and decision trees.
+- **Inline composition:** Current inline parsing only handles links, inline
+  code, and bold. Italic, strikethrough, nested emphasis, and mixed inline
+  formatting are incomplete.
+
+### P1
+
+- **Blockquotes:** Quoted errors, quoted user text, and excerpts render as
+  ordinary paragraphs.
+- **Horizontal rules:** Standalone `---`, `***`, and `___` render as text.
+- **Autolinks and bare URLs:** Only `[label](url)` links become anchors.
+- **Markdown escaping:** Escaped punctuation such as `\*`, `\|`, and escaped
+  brackets can render incorrectly.
+- **Code fence variants:** Tilde fences and some malformed or unterminated
+  fences are not handled with predictable fallback behavior.
+
+### P2
+
+- **Images:** Image markdown should be represented safely, but inline remote
+  image loading should not be enabled by default because it can leak tracking
+  requests, destabilize layout, and consume bandwidth.
+- **Footnotes and definition lists:** Useful in long-form analysis, but lower
+  frequency in chat supervision.
+- **Raw HTML:** Should remain disabled unless there is a separate audited need.
+
+## Decision
+
+Adopt a sanitized GitHub-flavored markdown renderer for chat message bodies.
+The preferred frontend stack is:
+
+- `react-markdown` for React rendering;
+- `remark-gfm` for GFM tables, task lists, strikethrough, and autolinks;
+- a sanitization layer that rejects raw HTML and unsafe attributes;
+- Wardian-owned component overrides for table, list, blockquote, link, image,
+  code, paragraph, and heading nodes.
+
+The custom parser in `AgentChatView.tsx` should be retired for message prose
+once the new renderer covers existing behavior. Code block rendering can keep
+using Wardian's current copy button and lightweight syntax highlighting by
+adapting the markdown renderer's `code` node override.
+
+If dependency risk blocks the first implementation, the fallback is not to grow
+the current parser broadly. The fallback is a narrow P0-only patch for tables,
+task lists, and nested list continuations, with the full GFM renderer still
+tracked as the target architecture.
+
+## Rendering Requirements
+
+### Tables
+
+Tables render as compact, theme-styled grids inside a horizontal overflow
+container. Requirements:
+
+- Header rows use stronger text and subtle themed background.
+- Alignment markers map to cell text alignment.
+- Empty cells stay visible.
+- Long subjects, paths, or email addresses wrap within cells without expanding
+  the chat card.
+- Wide tables scroll horizontally within the message block instead of forcing
+  the whole transcript to overflow.
+- Table text remains selectable and included when copying the whole message.
+
+### Lists
+
+Lists render with stable indentation and no layout jumps:
+
+- Ordered, unordered, and nested lists preserve hierarchy.
+- Wrapped list item lines remain part of the item.
+- Task list checkboxes are visible, disabled, and accessible.
+- Adjacent lists of different types remain separate lists.
+
+### Inline Markdown
+
+Inline rendering supports:
+
+- inline code;
+- strong emphasis;
+- italic emphasis;
+- strikethrough;
+- safe markdown links;
+- bare HTTP, HTTPS, and file URLs where allowed by Wardian policy;
+- escaped punctuation and nested inline content.
+
+Links keep Wardian's current safety posture. Allowed URL protocols are `http:`,
+`https:`, and `file:`. Unsafe links render as plain text rather than clickable
+anchors. Safe links open through Wardian's native URL opener instead of relying
+on webview `_blank` navigation.
+
+### Blocks
+
+Block rendering supports:
+
+- ATX headings with compact chat-scale typography;
+- blockquotes with a muted left border and themed text;
+- horizontal rules as subtle dividers;
+- fenced code blocks with copy action and existing syntax highlighting;
+- inline code with compact monospace styling;
+- paragraphs with preserved intentional line breaks where the markdown parser
+  represents them.
+
+### Images
+
+Image markdown renders as a safe attachment-style placeholder by default:
+
+- show the alt text when present;
+- show the sanitized URL as a clickable link only when the protocol is allowed;
+- do not fetch or display the remote image inline;
+- do not reserve large image dimensions in the chat transcript.
+
+A future spec may allow trusted local or explicitly approved image previews.
+
+## Architecture
+
+Add a focused markdown rendering boundary, for example:
+
+```text
+src/features/grid/markdown/
+- ChatMarkdown.tsx
+- markdownComponents.tsx
+- markdownSafety.ts
+- ChatMarkdown.test.tsx
+```
+
+`AgentChatView` should delegate message prose rendering to this boundary:
+
+```tsx
+<ChatMarkdown source={messageText} />
+```
+
+The boundary owns:
+
+- markdown parser configuration;
+- component overrides;
+- URL sanitization;
+- image placeholder behavior;
+- table overflow behavior;
+- tests for markdown rendering.
+
+`AgentChatView` continues to own transcript rows, activity blocks, approval
+controls, lazy rendering, message copy actions, and provider event grouping.
+
+## Styling
+
+Markdown components must use theme variables or themed utility classes, not
+hardcoded Tailwind color tokens. The renderer should match chat mode's dense
+supervision style:
+
+- compact margins between blocks;
+- no decorative nested cards inside message bubbles;
+- stable table and code block dimensions;
+- predictable wrapping for long tokens;
+- no viewport-width font scaling;
+- no text overflow outside message containers.
+
+## Security
+
+The renderer must be safe for untrusted provider output:
+
+- Raw HTML is not rendered.
+- Unsafe URL schemes such as `javascript:`, `data:`, and `vbscript:` are not
+  clickable.
+- Link text is rendered as React text, not HTML.
+- Images do not fetch remote resources by default.
+- Markdown parsing failures fall back to readable text rather than blank output.
+
+## Accessibility
+
+- Tables use semantic table elements.
+- Task-list checkboxes are disabled and have accessible labels where possible.
+- Links have visible focus states inherited from the design system.
+- Code copy buttons keep descriptive labels.
+- Blockquotes and horizontal rules do not hide meaningful text from screen
+  readers.
+
+## Testing
+
+Add focused frontend tests for:
+
+- the provided email-summary table rendering as a semantic table;
+- table alignment, empty cells, escaped pipes, and long-cell overflow;
+- nested ordered and unordered lists;
+- task lists with checked and unchecked items;
+- blockquotes and horizontal rules;
+- italic, bold, strikethrough, inline code, and nested inline formatting;
+- safe links, bare autolinks, `file:` links, and unsafe link fallback;
+- image markdown rendering as a safe placeholder;
+- code fences preserving copy and syntax-highlighting behavior;
+- markdown parser failure fallback.
+
+Existing `AgentChatView` tests should be updated only where they assert current
+parser internals. Transcript loading, activity rows, approvals, and lazy
+rendering tests should continue to prove their existing behavior.
+
+Browser E2E is appropriate for a representative chat-rendering smoke test with
+the mock provider. Native E2E is not required unless an implementation claims
+PTY or provider-runtime behavior changed.
+
+Frontend PRs must capture a feature-specific screenshot under
+`e2e/screenshots/chat-markdown-renderer/<timestamp>/` and embed a hosted image
+in the PR description.
+
+## Acceptance Examples
+
+The synthetic email summary table must render as a table with four columns:
+`#`, `Subject`, `From`, and `Received`. Rows with empty subjects remain visually
+aligned, and long subjects wrap inside the `Subject` cell.
+
+```markdown
+| # | Subject | From | Received |
+|---|---------|------|----------|
+| 1 | RE: Synthetic compliance question for TEST-123 | Alex Reviewer | 2026-06-06 |
+| 8 | | Morgan Coordinator | 2026-06-05 |
+```
+
+Nested plan markdown must preserve hierarchy:
+
+```markdown
+1. Inspect renderer
+   - Confirm table support
+   - Confirm link safety
+2. Add tests
+   - [x] Existing markdown behavior
+   - [ ] GFM table coverage
+```
+
+Unsafe links must remain plain text:
+
+```markdown
+Safe: [docs](https://example.test)
+Unsafe: [run](javascript:alert)
+```
+
+Image markdown must not fetch remote content:
+
+```markdown
+![diagram](https://example.test/diagram.png)
+```
+
+It should render as an attachment/link placeholder rather than an inline image.
+
+## Rollout
+
+1. Add the markdown rendering boundary and dependencies.
+2. Port existing message markdown behavior to `ChatMarkdown`.
+3. Add P0/P1 markdown tests before removing the old parser path.
+4. Replace message block rendering in `AgentChatView`.
+5. Verify chat activity rendering, message copy, code copy, and approval rows.
+6. Capture screenshot evidence for the PR.
+7. Update `docs/guide/grid.md` if user-visible markdown support changes.
+
+## Open Questions
+
+- Should `file:` links continue to be allowed everywhere in chat markdown, or
+  should they be limited to known workspace paths in a later hardening slice?
+- Should markdown rendering be shared with the remote mobile chat view in the
+  same implementation, or should the desktop grid chat renderer migrate first
+  and the PWA follow after parity is proven?

--- a/docs/specs/2026-06-07-chat-work-log-signal.md
+++ b/docs/specs/2026-06-07-chat-work-log-signal.md
@@ -1,0 +1,298 @@
+# Chat Work Log Signal
+
+- **Status:** Proposed
+- **Date:** 2026-06-07
+
+## Context
+
+Wardian chat mode renders non-message `AgentChatEvent` records as activity
+blocks and grouped work logs. This is useful for supervising agent work, but
+the current renderer shows too much low-signal provider plumbing. In particular,
+successful `tool_result` events with no meaningful payload can appear as visible
+rows that say only `Tool result` and `Exit code: 0`.
+
+The screenshot that triggered this spec shows a grouped work log with two shell
+commands followed by two separate result bullets. Those result bullets contain
+no user-relevant information beyond successful completion. They make the work
+log harder to scan and imply that something happened when the real information
+is already carried by the command rows.
+
+This is separate from markdown rendering. Markdown fidelity affects how message
+text is displayed. Work-log signal affects which tool events are visible, how
+tool call/result pairs are summarized, and what details remain available for
+copying or debugging.
+
+## Goals
+
+- Reduce low-signal activity rows in chat mode.
+- Merge empty successful tool results into their corresponding tool call when
+  possible.
+- Preserve failures, nonzero exits, meaningful output, changed files, diffs,
+  search results, approvals, and errors.
+- Keep raw event details available through copy actions or expanded diagnostic
+  output where useful.
+- Keep the grouped work-log surface compact and trustworthy.
+
+## Non-Goals
+
+- Changing provider transcript parsing in this slice.
+- Removing tool visibility from chat mode.
+- Hiding failures or nonzero exit codes.
+- Changing the backend `AgentChatEvent` DTO.
+- Building a full command timeline or trace viewer.
+
+## Current Behavior
+
+`src/features/grid/AgentChatView.tsx` currently hides some empty running
+`tool_call` placeholders, but most `tool_result` events pass through:
+
+- `shouldShowChatEvent()` hides empty running calls, not empty successful
+  results.
+- `activityContent()` falls back to status text when a result has no text.
+- `workEntrySummary()` falls back to `Exit code: 0`.
+- `deriveChatRows()` groups adjacent tool calls and results, but the grouped
+  work log still renders each event as a separate `WorkEntry`.
+
+The result is visible duplication: a shell command row says what ran, while the
+following result row only confirms success.
+
+## Decision
+
+Introduce a work-event presentation layer between normalized transcript events
+and rendered chat rows. The layer classifies each tool event as one of:
+
+- **visible:** render as its own activity row or grouped work entry;
+- **mergeable result:** attach completion metadata to the nearest compatible
+  preceding tool call;
+- **suppressed result:** hide visually because it carries no user-relevant
+  signal;
+- **diagnostic only:** omit from the main visual flow but include in copied raw
+  group details.
+
+The first implementation can live in `AgentChatView` or a small helper module,
+but the behavior should be tested as its own unit so future provider adapters do
+not reintroduce noise.
+
+## Signal Rules
+
+### Always Visible
+
+Render these events visibly:
+
+- `error` events;
+- `approval` events and any `action_required` status;
+- tool results with `status: failed` or `status: cancelled`;
+- tool results with nonzero `exit_code`;
+- tool results with meaningful `text`;
+- tool results with changed files, paths, diffs, JSON payloads, search matches,
+  todo updates, or other structured output;
+- terminal fallback output.
+
+### Mergeable
+
+A `tool_result` is mergeable when all of the following are true:
+
+- it is adjacent to, or provider-linked to, a preceding compatible `tool_call`;
+- it has no meaningful text;
+- it has no changed paths or structured payload;
+- it has `status: succeeded` or `exit_code: 0`;
+- it is not an approval, error, cancellation, or action-required event.
+
+Merged result metadata appears on the command row as subtle completion text,
+for example `succeeded`, `exit 0`, or `0.8s` if duration metadata exists.
+The metadata should not create a second bullet in grouped work logs.
+
+### Suppressed
+
+A successful result with no meaningful output may be suppressed when no matching
+tool call can be found. This avoids rendering generic `Tool result` rows that
+only say `Exit code: 0`.
+
+Suppression must be conservative. If the renderer is unsure whether a result
+contains useful signal, it should render the result.
+
+### Meaningful Text
+
+Text is meaningful when it contains user-relevant content beyond routine status
+or empty-result boilerplate. Examples of non-meaningful text:
+
+- `succeeded`
+- `success`
+- `ok`
+- `done`
+- `exit code: 0`
+- `Wall time: ...` lines when paired only with other empty-result boilerplate
+- empty `Output:` labels
+- whitespace-only text
+
+Examples of meaningful text:
+
+- stdout or stderr from a command;
+- a test summary;
+- file content;
+- search matches;
+- JSON or structured data;
+- diff output;
+- changed-file summaries;
+- provider error messages.
+
+## Grouped Work Log Behavior
+
+Grouped work logs should summarize work, not replay provider event plumbing.
+
+Requirements:
+
+- A command/result pair with an empty successful result renders as one work
+  entry.
+- The work entry title and summary prioritize the command, file path, tool name,
+  or specific operation.
+- Successful empty results do not appear as separate bullets.
+- Non-empty results appear under the relevant command when pairing is available.
+- Failed results appear visibly even if the matching command is also visible.
+- The group event count should reflect visible work entries, not suppressed
+  low-signal result events.
+- Changed files remain surfaced at the group level.
+
+## Pairing Rules
+
+The first slice should use deterministic local pairing:
+
+- Prefer explicit provider metadata if available, such as a call id, tool id,
+  turn id, or parent id.
+- Otherwise pair a result with the nearest previous unpaired tool call in the
+  same turn.
+- If turn identity is missing, pair only adjacent call/result sequences.
+- Do not pair across user or assistant message boundaries.
+- Do not pair across approvals or errors unless provider metadata explicitly
+  links the events.
+
+When pairing fails, apply the suppression rules conservatively.
+
+## Copy And Debuggability
+
+Visual suppression must not destroy evidence.
+
+- Copying a work group should include suppressed diagnostic-only result details
+  when they exist.
+- Copying an individual visible command row should include merged result
+  metadata and any non-empty result output.
+- The renderer may expose a future debug toggle for raw event details, but that
+  toggle is not required in this slice.
+
+## Architecture
+
+Add a small presentation model before rendering rows, for example:
+
+```text
+src/features/grid/workLogPresentation.ts
+```
+
+Potential model:
+
+```text
+PresentedWorkEntry
+- id
+- primary_event
+- merged_result_events[]
+- diagnostic_events[]
+- title
+- summary
+- status
+- command
+- output
+- changed_paths[]
+- visible
+```
+
+`deriveChatRows()` should group presented work entries rather than raw tool
+events. `ActivityRow` and `WorkEntry` should receive already-classified
+presentation data instead of recomputing signal from raw event fields in
+multiple places.
+
+This keeps the renderer honest: event normalization remains the backend's job,
+while frontend presentation decides what is useful to show in a dense
+supervision surface.
+
+## Testing
+
+Add focused frontend tests for:
+
+- empty successful `tool_result` with `exit_code: 0` is not rendered as a
+  standalone row;
+- adjacent shell command plus empty successful result renders as one visible
+  command entry;
+- grouped work-log event count excludes suppressed empty results;
+- nonzero `exit_code` remains visible;
+- failed and cancelled tool results remain visible;
+- meaningful stdout remains visible and copyable;
+- changed-file metadata on a result remains visible at row or group level;
+- JSON, diff, todo, search, and file-content outputs are not suppressed;
+- result pairing does not cross assistant/user message boundaries;
+- copy group includes suppressed diagnostic result metadata.
+
+Browser E2E should cover one representative mock-provider transcript with
+multiple commands and empty successes. Native E2E is only needed if the
+implementation claims provider-runtime or PTY behavior changed.
+
+Frontend PRs must capture a feature-specific screenshot under
+`e2e/screenshots/chat-work-log-signal/<timestamp>/` and embed a hosted image in
+the PR description.
+
+## Acceptance Examples
+
+### Empty Successful Result
+
+Input events:
+
+```text
+tool_call: command = git status --short --branch
+tool_result: status = succeeded, exit_code = 0, text = null
+```
+
+Expected visible output:
+
+```text
+git status --short --branch
+succeeded - exit 0
+```
+
+There is no separate `Tool result` row.
+
+### Nonzero Exit
+
+Input events:
+
+```text
+tool_call: command = npm run test
+tool_result: status = failed, exit_code = 1, text = "1 failed"
+```
+
+Expected visible output keeps the failure visible with the command and output.
+
+### Meaningful Success
+
+Input events:
+
+```text
+tool_call: command = npm run docs:build
+tool_result: status = succeeded, exit_code = 0, text = "build complete in 7.03s"
+```
+
+Expected visible output includes the successful output because it carries useful
+evidence.
+
+## Rollout
+
+1. Add presentation tests that reproduce the screenshot behavior.
+2. Add work-log presentation helpers and conservative signal classifiers.
+3. Update `deriveChatRows()` to group presented entries.
+4. Update visible activity rows and copy behavior.
+5. Verify existing activity-block, approval, copy, and lazy-rendering tests.
+6. Capture screenshot evidence for the PR.
+
+## Open Questions
+
+- Should routine `ok` and `done` result text be suppressed for all providers, or
+  should that list be provider-specific?
+- Should command duration be parsed from existing result text such as `Wall
+  time: 0.8 seconds`, or only shown when structured metadata exists?

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "qrcode": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
         "sigma": "^3.0.3",
         "zustand": "^5.0.11"
       },
@@ -875,9 +877,9 @@
       }
     },
     "node_modules/@docsearch/js/node_modules/@types/react": {
-      "version": "18.3.29",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
-      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2702,6 +2704,15 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2712,14 +2723,21 @@
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -2747,7 +2765,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -2758,6 +2775,12 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2793,7 +2816,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2811,7 +2833,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
@@ -2825,7 +2846,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3532,6 +3552,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -3637,7 +3667,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3654,11 +3683,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3669,7 +3707,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3776,7 +3823,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3869,8 +3915,7 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -3995,7 +4040,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4024,11 +4068,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4047,7 +4103,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -4167,6 +4222,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4195,6 +4272,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -4350,11 +4433,37 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
@@ -4390,6 +4499,16 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
@@ -4454,6 +4573,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4461,6 +4620,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4893,6 +5074,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4994,11 +5185,235 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -5016,6 +5431,40 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
@@ -5023,11 +5472,307 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5044,11 +5789,111 @@
         "micromark-util-types": "^2.0.0"
       }
     },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5061,11 +5906,64 @@
       ],
       "license": "MIT"
     },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5083,11 +5981,32 @@
         "micromark-util-symbol": "^2.0.0"
       }
     },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5104,7 +6023,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -5144,8 +6062,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -5236,6 +6153,31 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -5420,7 +6362,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5479,6 +6420,33 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5545,6 +6513,72 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5771,7 +6805,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5816,7 +6849,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
@@ -5838,6 +6870,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/superjson": {
@@ -6022,7 +7072,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6059,11 +7118,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -6077,7 +7154,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -6091,7 +7167,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -6105,7 +7180,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6121,7 +7195,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6182,7 +7255,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6197,7 +7269,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6659,7 +7730,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "qrcode": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "sigma": "^3.0.3",
     "zustand": "^5.0.11"
   },

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -507,9 +507,27 @@ fn merge_chat_events(
     provider_events: Vec<AgentChatEvent>,
 ) -> Vec<AgentChatEvent> {
     let mut seen = HashSet::new();
+    let mut provider_message_text_seen = HashSet::new();
     let mut merged = Vec::with_capacity(watch_events.len() + provider_events.len());
 
-    for event in provider_events.into_iter().chain(watch_events) {
+    for event in provider_events {
+        let key = chat_event_dedupe_key(&event);
+        if seen.insert(key) {
+            if let Some(message_key) = chat_message_text_key(&event) {
+                provider_message_text_seen.insert(message_key);
+            }
+            merged.push(event);
+        }
+    }
+
+    for event in watch_events {
+        if chat_message_text_key(&event)
+            .as_ref()
+            .is_some_and(|key| provider_message_text_seen.contains(key))
+        {
+            continue;
+        }
+
         let key = chat_event_dedupe_key(&event);
         if seen.insert(key) {
             merged.push(event);
@@ -557,6 +575,24 @@ fn chat_event_dedupe_key(event: &AgentChatEvent) -> String {
         event.text.as_deref().unwrap_or(""),
         event.source.as_deref().unwrap_or("")
     )
+}
+
+fn chat_message_text_key(event: &AgentChatEvent) -> Option<String> {
+    if event.kind != AgentChatEventKind::Message {
+        return None;
+    }
+    let text = normalized_dedupe_text(event.text.as_deref().unwrap_or(""));
+    if text.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "{:?}|{:?}|{}|{}",
+        event.kind, event.role, event.provider, text
+    ))
+}
+
+fn normalized_dedupe_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 fn status_event_from_watch_event(
@@ -1134,10 +1170,78 @@ Do you want to proceed?
         duplicate.id = "agent-1:provider:2".to_string();
         duplicate.source = Some("item.completed".to_string());
 
-        let chat_events = merge_chat_events(Vec::new(), vec![first, duplicate]);
+        let chat_events = merge_chat_events(vec![duplicate], vec![first]);
 
         assert_eq!(chat_events.len(), 1);
         assert_eq!(chat_events[0].text.as_deref(), Some("Same answer"));
+    }
+
+    #[test]
+    fn merge_deduplicates_same_message_text_across_distinct_turn_ids() {
+        let first = AgentChatEvent {
+            id: "agent-1:provider:1".to_string(),
+            session_id: "agent-1".to_string(),
+            provider: "codex".to_string(),
+            kind: AgentChatEventKind::Message,
+            role: Some(AgentChatRole::User),
+            text: Some(
+                "OK. It seems like you have lots of tiny positions. Are you exiting ever"
+                    .to_string(),
+            ),
+            title: None,
+            status: None,
+            turn_id: Some("live-input".to_string()),
+            source: Some("watch_transcript".to_string()),
+            command: None,
+            exit_code: None,
+            path: None,
+            language: None,
+            created_at: None,
+            sequence: Some(1),
+            metadata: serde_json::json!({}),
+        };
+        let mut duplicate = first.clone();
+        duplicate.id = "agent-1:provider:2".to_string();
+        duplicate.turn_id = Some("provider-history".to_string());
+        duplicate.source = Some("transcript".to_string());
+
+        let chat_events = merge_chat_events(vec![first], vec![duplicate]);
+
+        assert_eq!(chat_events.len(), 1);
+        assert_eq!(
+            chat_events[0].text.as_deref(),
+            Some("OK. It seems like you have lots of tiny positions. Are you exiting ever")
+        );
+    }
+
+    #[test]
+    fn merge_preserves_repeated_same_text_messages_from_the_same_source() {
+        let first = AgentChatEvent {
+            id: "agent-1:provider:1".to_string(),
+            session_id: "agent-1".to_string(),
+            provider: "codex".to_string(),
+            kind: AgentChatEventKind::Message,
+            role: Some(AgentChatRole::User),
+            text: Some("run tests".to_string()),
+            title: None,
+            status: None,
+            turn_id: Some("turn-1".to_string()),
+            source: Some("response_item".to_string()),
+            command: None,
+            exit_code: None,
+            path: None,
+            language: None,
+            created_at: None,
+            sequence: Some(1),
+            metadata: serde_json::json!({}),
+        };
+        let mut repeated = first.clone();
+        repeated.id = "agent-1:provider:2".to_string();
+        repeated.turn_id = Some("turn-2".to_string());
+
+        let chat_events = merge_chat_events(Vec::new(), vec![first, repeated]);
+
+        assert_eq!(chat_events.len(), 2);
     }
 
     #[test]

--- a/src-tauri/src/providers/chat_transcript.rs
+++ b/src-tauri/src/providers/chat_transcript.rs
@@ -648,6 +648,11 @@ fn normalize_antigravity(
             if str_field(parsed, "source") != Some("MODEL") {
                 return None;
             }
+            if let Some(tool_call) =
+                antigravity_tool_call_event(session_id, provider, parsed, sequence)
+            {
+                return Some(tool_call);
+            }
             if str_field(parsed, "status") != Some("DONE") {
                 return Some(status_event(
                     session_id,
@@ -669,7 +674,84 @@ fn normalize_antigravity(
                 msg_type,
             )
         }
+        "ASK_QUESTION" | "CODE_ACTION" | "GENERIC" | "GREP_SEARCH" | "LIST_DIRECTORY"
+        | "READ_URL_CONTENT" | "RUN_COMMAND" | "SEARCH_WEB" | "VIEW_FILE" => {
+            antigravity_tool_result_event(session_id, provider, parsed, sequence, msg_type)
+        }
         _ => None,
+    }
+}
+
+fn antigravity_tool_call_event(
+    session_id: &str,
+    provider: &str,
+    parsed: &Value,
+    sequence: u64,
+) -> Option<AgentChatEvent> {
+    let tool_call = parsed
+        .get("tool_calls")
+        .and_then(|value| value.as_array())
+        .and_then(|items| items.iter().find(|item| item.is_object()))?;
+    let tool_name = str_field(tool_call, "name").unwrap_or("tool_call");
+    let args = tool_call.get("args");
+    let command = args
+        .and_then(|value| value.get("command"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string);
+    let text = command.clone().or_else(|| args.and_then(compact_json_text));
+
+    Some(tool_call_event(
+        session_id,
+        provider,
+        sequence,
+        tool_name.to_string(),
+        step_index(parsed),
+        command,
+        text,
+        antigravity_tool_title(tool_name),
+        AgentChatStatus::Running,
+    ))
+}
+
+fn antigravity_tool_result_event(
+    session_id: &str,
+    provider: &str,
+    parsed: &Value,
+    sequence: u64,
+    msg_type: &str,
+) -> Option<AgentChatEvent> {
+    Some(event(
+        session_id,
+        provider,
+        sequence,
+        AgentChatEventKind::ToolResult,
+        EventFields {
+            text: text_from_value(parsed),
+            title: Some(antigravity_tool_title(msg_type).to_string()),
+            status: status_from_str(str_field(parsed, "status")).or(Some(AgentChatStatus::Unknown)),
+            turn_id: step_index(parsed),
+            source: Some(msg_type.to_string()),
+            created_at: created_at(parsed),
+            metadata: json!({"raw_type": msg_type}),
+            ..Default::default()
+        },
+    ))
+}
+
+fn antigravity_tool_title(tool_name: &str) -> &'static str {
+    match tool_name {
+        "ASK_QUESTION" => "Ask question",
+        "CODE_ACTION" => "Code action",
+        "GENERIC" => "Generic action",
+        "GREP_SEARCH" => "Search files",
+        "LIST_DIRECTORY" => "List directory",
+        "READ_URL_CONTENT" => "Read URL",
+        "RUN_COMMAND" => "Run command",
+        "SEARCH_WEB" => "Search web",
+        "VIEW_FILE" => "View file",
+        _ => "Tool call",
     }
 }
 
@@ -1069,6 +1151,11 @@ fn text_from_value(value: &Value) -> Option<String> {
     None
 }
 
+fn compact_json_text(value: &Value) -> Option<String> {
+    let text = serde_json::to_string(value).ok()?;
+    (!text.trim().is_empty() && text != "null").then_some(text)
+}
+
 fn text_from_array(items: &[Value]) -> Option<String> {
     let parts = items
         .iter()
@@ -1429,6 +1516,33 @@ mod tests {
         assert_eq!(assistant.role, Some(AgentChatRole::Assistant));
         assert_eq!(assistant.text.as_deref(), Some("Antigravity answer"));
         assert_eq!(assistant.source.as_deref(), Some("transcript"));
+    }
+
+    #[test]
+    fn antigravity_planner_tool_calls_are_normalized() {
+        let tool = one(
+            "antigravity",
+            r#"{"step_index":3,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","tool_calls":[{"name":"RUN_COMMAND","args":{"command":"npm run test -- --run"}}]}"#,
+        );
+
+        assert_eq!(tool.kind, AgentChatEventKind::ToolCall);
+        assert_eq!(tool.title.as_deref(), Some("Run command"));
+        assert_eq!(tool.command.as_deref(), Some("npm run test -- --run"));
+        assert_eq!(tool.turn_id.as_deref(), Some("3"));
+    }
+
+    #[test]
+    fn antigravity_model_action_records_are_normalized_as_tool_results() {
+        let result = one(
+            "antigravity",
+            r#"{"step_index":4,"source":"MODEL","type":"RUN_COMMAND","status":"DONE","content":"3 tests passed"}"#,
+        );
+
+        assert_eq!(result.kind, AgentChatEventKind::ToolResult);
+        assert_eq!(result.title.as_deref(), Some("Run command"));
+        assert_eq!(result.text.as_deref(), Some("3 tests passed"));
+        assert_eq!(result.status, Some(AgentChatStatus::Succeeded));
+        assert_eq!(result.turn_id.as_deref(), Some("4"));
     }
 
     #[test]

--- a/src/features/grid/AgentChatView.test.tsx
+++ b/src/features/grid/AgentChatView.test.tsx
@@ -176,6 +176,66 @@ describe("AgentChatView", () => {
     expect(await screen.findByText("failed")).toBeInTheDocument();
   });
 
+  it("shows a subtle working indicator while processing before visible work starts", async () => {
+    invokeMock.mockResolvedValue([
+      event({
+        id: "user-before-thinking",
+        kind: "message",
+        role: "user",
+        text: "Draft a concise reply.",
+        sequence: 1,
+      }),
+    ]);
+
+    render(<AgentChatView sessionId="agent-1" status="Processing" />);
+
+    expect(await screen.findByText("Draft a concise reply.")).toBeInTheDocument();
+    expect(screen.getByText("Working...")).toBeInTheDocument();
+  });
+
+  it("renders the working ellipsis as inline animated period glyphs", async () => {
+    invokeMock.mockResolvedValue([]);
+
+    render(<AgentChatView sessionId="agent-1" status="Processing" />);
+
+    const workingRow = await screen.findByLabelText("agent working");
+    expect(within(workingRow).getByText("Working...")).toHaveClass("sr-only");
+
+    const animatedDots = within(workingRow).getByTestId("thinking-dots");
+    expect(animatedDots).toHaveTextContent("...");
+    expect(animatedDots).toHaveClass("wardian-thinking-dots");
+    expect(animatedDots).not.toHaveClass("wardian-thinking-dots-frame");
+
+    const dotGlyphs = animatedDots.querySelectorAll(".wardian-thinking-dot");
+    expect(dotGlyphs).toHaveLength(3);
+    dotGlyphs.forEach((dot) => expect(dot).toHaveTextContent("."));
+  });
+
+  it("keeps the subtle working indicator as the latest row when a running tool row is visible", async () => {
+    invokeMock.mockResolvedValue([
+      event({
+        id: "user-before-tool",
+        kind: "message",
+        role: "user",
+        text: "Run the tests.",
+        sequence: 1,
+      }),
+      event({
+        id: "running-tool",
+        kind: "tool_call",
+        title: "Run command",
+        command: "npm run test",
+        status: "running",
+        sequence: 2,
+      }),
+    ]);
+
+    render(<AgentChatView sessionId="agent-1" status="Processing" />);
+
+    expect(await screen.findByText("Run command")).toBeInTheDocument();
+    expect(screen.getByText("Working...")).toBeInTheDocument();
+  });
+
   it("hides empty running tool placeholders", async () => {
     invokeMock.mockResolvedValue([
       event({
@@ -1163,6 +1223,47 @@ describe("AgentChatView", () => {
     fireEvent.click(screen.getByRole("button", { name: "Send message" }));
 
     await waitFor(() => expect(screen.getAllByText("run tests")).toHaveLength(3));
+  });
+
+  it("clears an optimistic prompt when the matching transcript prompt is renumbered below the send snapshot", async () => {
+    let loadCount = 0;
+    invokeMock.mockImplementation((command) => {
+      if (command === "load_agent_chat_transcript") {
+        loadCount += 1;
+        const baseEvents = [
+          event({
+            id: "assistant-before-send",
+            kind: "message",
+            role: "assistant",
+            text: "Ready.",
+            sequence: 50,
+          }),
+        ];
+        if (loadCount === 1) return Promise.resolve(baseEvents);
+        return Promise.resolve([
+          ...baseEvents,
+          event({
+            id: "renumbered-user-message",
+            kind: "message",
+            role: "user",
+            text: "Summarize my status.",
+            sequence: 2,
+          }),
+        ]);
+      }
+      if (command === "submit_prompt_to_agent") return Promise.resolve(undefined);
+      return Promise.reject(new Error(`unexpected command: ${command}`));
+    });
+
+    render(<AgentChatView sessionId="agent-1" status="Idle" />);
+
+    const input = await screen.findByLabelText("Message agent");
+    fireEvent.change(input, { target: { value: "Summarize my status." } });
+    fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+
+    await waitFor(() => expect(loadCount).toBeGreaterThanOrEqual(2));
+    await waitFor(() => expect(screen.getAllByText("Summarize my status.")).toHaveLength(1));
+    expect(screen.getByText("Working...")).toBeInTheDocument();
   });
 
   it("disables chat input while the agent is busy but allows action required responses", async () => {

--- a/src/features/grid/AgentChatView.test.tsx
+++ b/src/features/grid/AgentChatView.test.tsx
@@ -398,6 +398,69 @@ describe("AgentChatView", () => {
     expect(within(article).queryAllByText("running")).toHaveLength(0);
   });
 
+  it("hides empty successful tool result rows in grouped work logs", async () => {
+    invokeMock.mockResolvedValue([
+      event({ id: "call-1", kind: "tool_call", title: "shell_command", command: "git status --short --branch", sequence: 1 }),
+      event({ id: "result-1", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, sequence: 2 }),
+      event({ id: "call-2", kind: "tool_call", title: "shell_command", command: "git log -1 --oneline --decorate", sequence: 3 }),
+      event({ id: "result-2", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, sequence: 4 }),
+      event({ id: "call-3", kind: "tool_call", title: "shell_command", command: "npm run docs:build", sequence: 5 }),
+      event({ id: "result-3", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, text: "build complete", sequence: 6 }),
+    ]);
+
+    render(<AgentChatView sessionId="agent-1" />);
+
+    const group = await screen.findByText("Work log");
+    const article = group.closest("article") as HTMLElement;
+
+    expect(within(article).getByText("4 events")).toBeInTheDocument();
+    expect(within(article).getByText("git status --short --branch")).toBeInTheDocument();
+    expect(within(article).getByText("git log -1 --oneline --decorate")).toBeInTheDocument();
+    expect(within(article).getByText("npm run docs:build")).toBeInTheDocument();
+    expect(within(article).queryAllByText("Tool result")).toHaveLength(0);
+    expect(within(article).queryAllByText("Exit code: 0")).toHaveLength(0);
+  });
+
+  it("copies merged result metadata from individual command rows", async () => {
+    writeTextMock.mockResolvedValue(undefined);
+    invokeMock.mockResolvedValue([
+      event({
+        id: "call-1",
+        kind: "tool_call",
+        title: "shell_command",
+        command: "git status --short --branch",
+        text: "## docs/chat-markdown-renderer-spec...origin/main [ahead 9]",
+        sequence: 1,
+      }),
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        sequence: 2,
+      }),
+    ]);
+
+    render(<AgentChatView sessionId="agent-1" />);
+
+    const activityArticle = (await screen.findByText("git status --short --branch")).closest("article") as HTMLElement;
+    fireEvent.click(within(activityArticle).getByRole("button", { name: "Copy activity output" }));
+
+    await waitFor(() =>
+      expect(writeTextMock).toHaveBeenLastCalledWith(
+        [
+          "shell_command - succeeded - exit 0 - 3 lines",
+          "$ git status --short --branch",
+          "",
+          "## docs/chat-markdown-renderer-spec...origin/main [ahead 9]",
+          "Diagnostics",
+          "Tool result - succeeded - exit 0",
+        ].join("\n"),
+      ),
+    );
+  });
+
   it("renders diff stats and todo tools as specialized activity", async () => {
     invokeMock.mockResolvedValue([
       event({
@@ -689,9 +752,18 @@ describe("AgentChatView", () => {
         text: [
           "### Focus Area: `01-generalist`",
           "",
-          "- [AGENTS.md](file:///tmp/AGENTS.md): Defines the core mission",
-          "- [GEMINI.md](file:///tmp/GEMINI.md): Points at `CLAUDE.md`",
-          "- **00-common**: Contains the wardian-cli skill",
+          "| # | Subject | From | Received |",
+          "|---|---------|------|----------|",
+          "| 1 | RE: Synthetic compliance question for TEST-123 | Alex Reviewer | 2026-06-06 |",
+          "| 8 | | Morgan Coordinator | 2026-06-05 |",
+          "",
+          "1. Inspect renderer",
+          "   - [x] Existing markdown behavior",
+          "   - [ ] GFM table coverage",
+          "",
+          "> quoted detail",
+          "",
+          "Safe [AGENTS.md](file:///tmp/AGENTS.md) and ~~old~~ text.",
           "",
           "```ts",
           "const ready = true;",
@@ -706,9 +778,12 @@ describe("AgentChatView", () => {
     expect(await screen.findByText("Focus Area:")).toBeInTheDocument();
     expect(screen.getByLabelText("assistant message")).toBeInTheDocument();
     expect(screen.getByText("01-generalist")).toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "RE: Synthetic compliance question for TEST-123" })).toBeInTheDocument();
+    expect(screen.getByText("Existing markdown behavior")).toBeInTheDocument();
+    expect(screen.getByText("quoted detail")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "AGENTS.md" })).toHaveAttribute("href", "file:///tmp/AGENTS.md");
-    expect(screen.getAllByRole("list")).toHaveLength(2);
-    expect(screen.getByText("00-common").tagName).toBe("STRONG");
+    expect(screen.getByText("old").tagName).toBe("DEL");
     expect(screen.getByText("const ready = true;")).toBeInTheDocument();
   });
 
@@ -727,7 +802,28 @@ describe("AgentChatView", () => {
 
     expect(await screen.findByRole("link", { name: "docs" })).toHaveAttribute("href", "https://example.test/docs");
     expect(screen.queryByRole("link", { name: "run" })).not.toBeInTheDocument();
-    expect(screen.getByLabelText("assistant message")).toHaveTextContent("[run](javascript:alert)");
+    expect(screen.getByLabelText("assistant message")).toHaveTextContent("run");
+  });
+
+  it("keeps changed-file metadata visible on otherwise empty successful tool results", async () => {
+    invokeMock.mockResolvedValue([
+      event({
+        id: "changed-files-result",
+        kind: "tool_result",
+        role: null,
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        metadata: { changed_files: ["src/features/grid/AgentChatView.tsx"] },
+        sequence: 1,
+      }),
+    ]);
+
+    render(<AgentChatView sessionId="agent-1" />);
+
+    expect(await screen.findByText("Tool result")).toBeInTheDocument();
+    expect(screen.getByText("Changed files")).toBeInTheDocument();
+    expect(screen.getByText(".../grid/AgentChatView.tsx")).toBeInTheDocument();
   });
 
   it("copies messages, code blocks, activity output, and grouped file paths", async () => {

--- a/src/features/grid/AgentChatView.tsx
+++ b/src/features/grid/AgentChatView.tsx
@@ -61,6 +61,7 @@ const TONE_CLASSES: Record<ActivityTone, string> = {
 type ChatRow = PresentedChatRow;
 
 type ApprovalChoice = { value: string; label: string };
+type AwaitingResponseMarker = { id: string; response_count_after: number };
 type ToolDisplayKind = "diff" | "file" | "permission" | "search" | "shell" | "todo" | "generic";
 type ToolPresentation = {
   kind: ToolDisplayKind;
@@ -91,6 +92,7 @@ export function AgentChatView({
 }: AgentChatViewProps) {
   const [events, setEvents] = useState<AgentChatEvent[]>([]);
   const [pendingMessages, setPendingMessages] = useState<AgentChatEvent[]>([]);
+  const [awaitingResponse, setAwaitingResponse] = useState<AwaitingResponseMarker | null>(null);
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
@@ -115,6 +117,7 @@ export function AgentChatView({
       prependScrollSnapshotRef.current = null;
       setEvents([]);
       setPendingMessages([]);
+      setAwaitingResponse(null);
       setLoadState("ready");
       setError(null);
       setSubmitError(null);
@@ -158,6 +161,7 @@ export function AgentChatView({
           }
           setEvents(nextEvents);
           setPendingMessages((pending) => unconfirmedPendingMessages(nextEvents, pending));
+          setAwaitingResponse((marker) => clearAwaitingResponseWhenAnswered(nextEvents, marker));
           setLoadState("ready");
           setError(null);
         })
@@ -179,17 +183,30 @@ export function AgentChatView({
   }, [sessionId, reloadKey, refreshIntervalMs]);
 
   const mergedEvents = useMemo(() => mergePendingMessages(events, pendingMessages), [events, pendingMessages]);
-  const chatRows = useMemo(() => derivePresentedChatRows(sortTranscriptEvents(mergedEvents).filter(shouldShowChatEvent)), [mergedEvents]);
+  const activeStatus = status ?? telemetry?.current_status ?? null;
+  const showThinking = isProcessingAgentStatus(activeStatus) || awaitingResponse !== null || pendingMessages.length > 0;
+  const displayEvents = useMemo(
+    () =>
+      appendThinkingIndicator(
+        mergedEvents,
+        sessionId,
+        agent?.provider ?? provider ?? providerFromEvents(mergedEvents),
+        showThinking,
+      ),
+    [agent?.provider, mergedEvents, provider, sessionId, showThinking],
+  );
+  const chatRows = useMemo(() => derivePresentedChatRows(sortTranscriptEvents(displayEvents).filter(shouldShowChatEvent)), [displayEvents]);
   const hiddenOlderRowCount = Math.max(0, chatRows.length - visibleRowLimit);
   const visibleChatRows = useMemo(() => chatRows.slice(hiddenOlderRowCount), [chatRows, hiddenOlderRowCount]);
   const latestVisibleRowKey = visibleChatRows.length > 0 ? chatRowKey(visibleChatRows[visibleChatRows.length - 1]) : "";
   const hasActionRequired = mergedEvents.some((event) => event.status === "action_required");
-  const disabledReason = inputDisabledReason(status ?? telemetry?.current_status ?? null, isSubmitting);
+  const disabledReason = inputDisabledReason(activeStatus, isSubmitting);
 
   useEffect(() => {
     stickToLatestRef.current = true;
     prependScrollSnapshotRef.current = null;
     setVisibleRowLimit(CHAT_INITIAL_ROW_LIMIT);
+    setAwaitingResponse(null);
   }, [sessionId]);
 
   useLayoutEffect(() => {
@@ -222,8 +239,18 @@ export function AgentChatView({
       if (clearDraft) setActiveDraft("");
       setPendingMessages((pending) => [
         ...pending,
-        createPendingUserMessage(sessionId, agent?.provider ?? provider ?? providerFromEvents(events), prompt, maxSequence(events)),
+        createPendingUserMessage(
+          sessionId,
+          agent?.provider ?? provider ?? providerFromEvents(events),
+          prompt,
+          maxSequence(events),
+          matchingUserMessageCount(events, prompt),
+        ),
       ]);
+      setAwaitingResponse({
+        id: `awaiting-response-${sessionId}-${Date.now()}`,
+        response_count_after: responseEventCount(events),
+      });
       setReloadKey((key) => key + 1);
     } catch (reason) {
       setSubmitError(errorMessage(reason));
@@ -382,9 +409,29 @@ function ActivityEvent({
   onApprovalSubmit: (response: string) => void;
 }) {
   const block = entry?.block ?? toActivityBlock(event);
+  if (isThinkingIndicator(event)) return <ThinkingRow />;
   if (event.kind === "status") return <StatusRow event={event} block={block} />;
   if (event.kind === "terminal_output") return <TerminalFallback block={block} />;
   return <ActivityRow event={event} entry={entry} block={block} isSubmitting={isSubmitting} onApprovalSubmit={onApprovalSubmit} />;
+}
+
+function ThinkingRow() {
+  return (
+    <article aria-label="agent working" className="flex justify-start">
+      <div className="inline-flex items-center gap-1.5 px-1 py-0.5 text-[12px] leading-5 text-muted-neutral">
+        <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-wardian-processing)]" aria-hidden="true" />
+        <span className="sr-only">Working...</span>
+        <span aria-hidden="true">
+          Working
+          <span data-testid="thinking-dots" className="wardian-thinking-dots">
+            <span className="wardian-thinking-dot wardian-thinking-dot-1">.</span>
+            <span className="wardian-thinking-dot wardian-thinking-dot-2">.</span>
+            <span className="wardian-thinking-dot wardian-thinking-dot-3">.</span>
+          </span>
+        </span>
+      </div>
+    </article>
+  );
 }
 
 function WorkGroupRow({ row }: { row: Extract<ChatRow, { kind: "work_group" }> }) {
@@ -987,12 +1034,69 @@ function mergePendingMessages(events: AgentChatEvent[], pendingMessages: AgentCh
   return [...events, ...unconfirmed.map((message, index) => ({ ...message, sequence: pendingSequence(events, index) }))];
 }
 
+function appendThinkingIndicator(
+  events: AgentChatEvent[],
+  sessionId: string,
+  provider: string,
+  showThinking: boolean,
+): AgentChatEvent[] {
+  if (!showThinking) return events;
+
+  const sequence = pendingSequence(events, 0);
+  return [
+    ...events,
+    {
+      id: `thinking-${sessionId}`,
+      session_id: sessionId,
+      provider,
+      kind: "status",
+      role: null,
+      text: "Working...",
+      title: "Working...",
+      status: "processing",
+      turn_id: null,
+      source: "chat_ui",
+      command: null,
+      exit_code: null,
+      path: null,
+      language: null,
+      created_at: null,
+      sequence,
+      metadata: { chat_thinking_indicator: true },
+    },
+  ];
+}
+
+function isThinkingIndicator(event: AgentChatEvent): boolean {
+  return event.kind === "status" && event.metadata?.chat_thinking_indicator === true;
+}
+
+function clearAwaitingResponseWhenAnswered(
+  events: AgentChatEvent[],
+  marker: AwaitingResponseMarker | null,
+): AwaitingResponseMarker | null {
+  if (!marker) return null;
+  return responseEventCount(events) > marker.response_count_after ? null : marker;
+}
+
 function unconfirmedPendingMessages(events: AgentChatEvent[], pendingMessages: AgentChatEvent[]): AgentChatEvent[] {
   const consumedEventIndexes = new Set<number>();
+  const consumedTranscriptMatchesByText = new Map<string, number>();
 
   return pendingMessages.filter((message) => {
     const pendingText = normalizePromptText(message.text ?? "");
     if (!pendingText) return false;
+    const confirmAfterMatchingCount = pendingConfirmAfterMatchingUserCount(message);
+    if (confirmAfterMatchingCount !== null) {
+      const consumed = consumedTranscriptMatchesByText.get(pendingText) ?? 0;
+      const matchingCount = matchingUserMessageCount(events, pendingText);
+      if (matchingCount > confirmAfterMatchingCount + consumed) {
+        consumedTranscriptMatchesByText.set(pendingText, consumed + 1);
+        return false;
+      }
+      return true;
+    }
+
     const confirmAfterSequence = pendingConfirmAfterSequence(message);
     const matchingIndex = events.findIndex((event, index) => {
       if (consumedEventIndexes.has(index)) return false;
@@ -1015,7 +1119,18 @@ function pendingConfirmAfterSequence(pendingMessage: AgentChatEvent): number {
   return typeof value === "number" ? value : 0;
 }
 
-function createPendingUserMessage(sessionId: string, provider: string, text: string, confirmAfterSequence: number): AgentChatEvent {
+function pendingConfirmAfterMatchingUserCount(pendingMessage: AgentChatEvent): number | null {
+  const value = pendingMessage.metadata?.confirm_after_matching_user_count;
+  return typeof value === "number" ? value : null;
+}
+
+function createPendingUserMessage(
+  sessionId: string,
+  provider: string,
+  text: string,
+  confirmAfterSequence: number,
+  confirmAfterMatchingUserCount: number,
+): AgentChatEvent {
   const createdAt = new Date().toISOString();
   return {
     id: `pending-user-${sessionId}-${createdAt}`,
@@ -1034,7 +1149,11 @@ function createPendingUserMessage(sessionId: string, provider: string, text: str
     language: null,
     created_at: createdAt,
     sequence: null,
-    metadata: { optimistic: true, confirm_after_sequence: confirmAfterSequence },
+    metadata: {
+      optimistic: true,
+      confirm_after_sequence: confirmAfterSequence,
+      confirm_after_matching_user_count: confirmAfterMatchingUserCount,
+    },
   };
 }
 
@@ -1050,6 +1169,20 @@ function normalizePromptText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+function matchingUserMessageCount(events: AgentChatEvent[], text: string): number {
+  const normalized = normalizePromptText(text);
+  if (!normalized) return 0;
+  return events.filter((event) => event.kind === "message" && event.role === "user" && normalizePromptText(event.text ?? "") === normalized)
+    .length;
+}
+
+function responseEventCount(events: AgentChatEvent[]): number {
+  return events.filter((event) => {
+    if (event.kind === "message") return event.role === "assistant" || event.role === "system" || event.role === "tool";
+    return event.kind === "tool_call" || event.kind === "tool_result" || event.kind === "approval" || event.kind === "terminal_output" || event.kind === "error";
+  }).length;
+}
+
 function inputDisabledReason(status: string | null, isSubmitting: boolean): string | null {
   if (isSubmitting) return "Sending...";
   const normalized = (status ?? "").toLowerCase();
@@ -1061,6 +1194,11 @@ function inputDisabledReason(status: string | null, isSubmitting: boolean): stri
   if (normalized.includes("error")) return "Agent is in an error state";
   if (normalized.includes("processing") || normalized.includes("running")) return "Agent is processing";
   return null;
+}
+
+function isProcessingAgentStatus(status: string | null): boolean {
+  const normalized = (status ?? "").toLowerCase();
+  return normalized.includes("processing") || normalized.includes("running");
 }
 
 function sortTranscriptEvents(events: AgentChatEvent[]): AgentChatEvent[] {
@@ -1090,6 +1228,7 @@ function shouldShowChatEvent(event: AgentChatEvent): boolean {
     return false;
   }
   if (event.kind !== "status") return true;
+  if (isThinkingIndicator(event)) return true;
   return shouldShowStatusEvent(event);
 }
 

--- a/src/features/grid/AgentChatView.tsx
+++ b/src/features/grid/AgentChatView.tsx
@@ -1,13 +1,24 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import { Check, Copy, FileText, GitCompare, ListChecks, Loader2, Search, SendHorizontal, ShieldAlert, Terminal, Wrench } from "lucide-react";
+import { Check, FileText, GitCompare, ListChecks, Loader2, Search, SendHorizontal, ShieldAlert, Terminal, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent, ReactNode } from "react";
+import type { KeyboardEvent } from "react";
 import type { AgentChatEvent, AgentChatRole, AgentConfig, AgentTelemetry } from "../../types";
 import { submitInputToAgent } from "../../utils/terminalInput";
-import { toActivityBlock, type ActivityBlockModel, type ActivityTone } from "./activityBlocks";
+import { isGenericActivityTitle, toActivityBlock, type ActivityBlockModel, type ActivityTone } from "./activityBlocks";
+import { CodePanel, renderHighlightedCode } from "./chatCode";
+import { CopyIconButton } from "./chatCopy";
+import { ChatMarkdown } from "./markdown/ChatMarkdown";
+import {
+  changedPathsFromEvents,
+  derivePresentedChatRows,
+  formatPresentedEntryForCopy,
+  formatPresentedWorkGroupForCopy,
+  shouldShowStatusEvent,
+  type PresentedChatRow,
+  type PresentedWorkEntry,
+} from "./workLogPresentation";
 
 interface AgentChatViewBaseProps {
   sessionId: string;
@@ -47,17 +58,8 @@ const TONE_CLASSES: Record<ActivityTone, string> = {
   warning: "border-[var(--color-wardian-warning)]",
 };
 
-type MessageBlock =
-  | { kind: "paragraph"; content: string }
-  | { kind: "heading"; level: number; content: string }
-  | { kind: "list"; ordered: boolean; items: string[] }
-  | { kind: "code"; language: string | null; content: string };
+type ChatRow = PresentedChatRow;
 
-type ChatRow =
-  | { kind: "event"; event: AgentChatEvent }
-  | { kind: "work_group"; id: string; events: AgentChatEvent[]; changedPaths: string[] };
-
-type CopyState = "idle" | "copied" | "error";
 type ApprovalChoice = { value: string; label: string };
 type ToolDisplayKind = "diff" | "file" | "permission" | "search" | "shell" | "todo" | "generic";
 type ToolPresentation = {
@@ -71,7 +73,6 @@ type ToolPresentation = {
 const CHAT_INITIAL_ROW_LIMIT = 80;
 const CHAT_ROW_PAGE_SIZE = 60;
 const CHAT_SCROLL_BOTTOM_THRESHOLD_PX = 48;
-const WORK_GROUP_MIN_EVENTS = 4;
 
 export function AgentChatView({
   sessionId,
@@ -178,7 +179,7 @@ export function AgentChatView({
   }, [sessionId, reloadKey, refreshIntervalMs]);
 
   const mergedEvents = useMemo(() => mergePendingMessages(events, pendingMessages), [events, pendingMessages]);
-  const chatRows = useMemo(() => deriveChatRows(sortTranscriptEvents(mergedEvents).filter(shouldShowChatEvent)), [mergedEvents]);
+  const chatRows = useMemo(() => derivePresentedChatRows(sortTranscriptEvents(mergedEvents).filter(shouldShowChatEvent)), [mergedEvents]);
   const hiddenOlderRowCount = Math.max(0, chatRows.length - visibleRowLimit);
   const visibleChatRows = useMemo(() => chatRows.slice(hiddenOlderRowCount), [chatRows, hiddenOlderRowCount]);
   const latestVisibleRowKey = visibleChatRows.length > 0 ? chatRowKey(visibleChatRows[visibleChatRows.length - 1]) : "";
@@ -292,6 +293,7 @@ export function AgentChatView({
                   <WorkGroupRow row={row} />
                 ) : (
                   <TranscriptEvent
+                    entry={row.entry}
                     event={row.event}
                     isSubmitting={isSubmitting}
                     onApprovalSubmit={handleApprovalSubmit}
@@ -327,24 +329,25 @@ function isNearTranscriptBottom(scrollRegion: HTMLElement): boolean {
 
 function TranscriptEvent({
   event,
+  entry,
   isSubmitting,
   onApprovalSubmit,
 }: {
   event: AgentChatEvent;
+  entry?: PresentedWorkEntry;
   isSubmitting: boolean;
   onApprovalSubmit: (response: string) => void;
 }) {
   return event.kind === "message" ? (
     <MessageEvent event={event} />
   ) : (
-    <ActivityEvent event={event} isSubmitting={isSubmitting} onApprovalSubmit={onApprovalSubmit} />
+    <ActivityEvent event={event} entry={entry} isSubmitting={isSubmitting} onApprovalSubmit={onApprovalSubmit} />
   );
 }
 
 function MessageEvent({ event }: { event: AgentChatEvent }) {
   const role = event.role ?? "assistant";
   const text = event.text?.trimEnd() || event.title || "";
-  const blocks = parseMessageBlocks(text);
   const isUser = role === "user";
 
   return (
@@ -357,12 +360,8 @@ function MessageEvent({ event }: { event: AgentChatEvent }) {
             <CopyIconButton label="Copy message" value={text} />
           </div>
         ) : null}
-        {blocks.length > 0 ? (
-          <div className="space-y-2 text-[13px] leading-5 text-primary">
-            {blocks.map((block, index) => (
-              <MessageBlockView block={block} key={`${block.kind}-${index}`} />
-            ))}
-          </div>
+        {text ? (
+          <ChatMarkdown source={text} />
         ) : (
           <div className="text-[13px] leading-5 text-muted-neutral">No message content</div>
         )}
@@ -371,66 +370,29 @@ function MessageEvent({ event }: { event: AgentChatEvent }) {
   );
 }
 
-function MessageBlockView({ block }: { block: MessageBlock }) {
-  if (block.kind === "code") {
-    return (
-      <div className="relative">
-        <div className="absolute right-1.5 top-1.5 z-10">
-          <CopyIconButton label="Copy code block" value={block.content} />
-        </div>
-        <pre className="max-h-[320px] overflow-auto whitespace-pre-wrap break-words rounded border border-wardian-light bg-[var(--color-wardian-sidebar-primary)] p-2 pr-9 text-[12px] leading-5 text-primary">
-          <code data-language={block.language ?? "text"}>{renderHighlightedCode(block.content, block.language ?? "text")}</code>
-        </pre>
-      </div>
-    );
-  }
-
-  if (block.kind === "heading") {
-    const className =
-      block.level <= 2
-        ? "mt-1 text-[14px] font-bold leading-5 text-primary"
-        : "mt-1 text-[13px] font-bold leading-5 text-primary";
-    return <div className={className}>{renderInlineMarkdown(block.content)}</div>;
-  }
-
-  if (block.kind === "list") {
-    const ListTag = block.ordered ? "ol" : "ul";
-    return (
-      <ListTag className={`${block.ordered ? "list-decimal" : "list-disc"} space-y-1 pl-5 marker:text-muted-neutral`}>
-        {block.items.map((item, index) => (
-          <li className="break-words" key={`${index}-${item.slice(0, 24)}`}>
-            {renderInlineMarkdown(item)}
-          </li>
-        ))}
-      </ListTag>
-    );
-  }
-
-  return <div className="break-words">{renderInlineMarkdown(block.content)}</div>;
-}
-
 function ActivityEvent({
   event,
+  entry,
   isSubmitting,
   onApprovalSubmit,
 }: {
   event: AgentChatEvent;
+  entry?: PresentedWorkEntry;
   isSubmitting: boolean;
   onApprovalSubmit: (response: string) => void;
 }) {
-  const block = toActivityBlock(event);
+  const block = entry?.block ?? toActivityBlock(event);
   if (event.kind === "status") return <StatusRow event={event} block={block} />;
   if (event.kind === "terminal_output") return <TerminalFallback block={block} />;
-  return <ActivityRow event={event} block={block} isSubmitting={isSubmitting} onApprovalSubmit={onApprovalSubmit} />;
+  return <ActivityRow event={event} entry={entry} block={block} isSubmitting={isSubmitting} onApprovalSubmit={onApprovalSubmit} />;
 }
 
 function WorkGroupRow({ row }: { row: Extract<ChatRow, { kind: "work_group" }> }) {
   const [expanded, setExpanded] = useState(false);
-  const entries = row.events.map((event) => ({ event, block: toActivityBlock(event) }));
-  const visibleEntries = expanded ? entries : entries.slice(-6);
-  const hiddenCount = entries.length - visibleEntries.length;
-  const title = workGroupTitle(row.events);
-  const copyValue = formatWorkGroupForCopy(entries, row.changedPaths);
+  const visibleEntries = expanded ? row.entries : row.entries.slice(-6);
+  const hiddenCount = row.entries.length - visibleEntries.length;
+  const title = workGroupTitleFromEntries(row.entries);
+  const copyValue = formatPresentedWorkGroupForCopy(row);
 
   return (
     <article className="border-l-2 border-wardian-light bg-[color-mix(in_srgb,var(--color-wardian-card-bg-muted),transparent_18%)] px-3 py-2">
@@ -438,13 +400,13 @@ function WorkGroupRow({ row }: { row: Extract<ChatRow, { kind: "work_group" }> }
         <div className="min-w-0 flex-1">
           <div className="truncate text-[12px] font-semibold leading-5 text-primary">{title}</div>
           <div className="text-[11px] leading-4 text-muted-neutral">
-            {entries.length} {entries.length === 1 ? "event" : "events"}
+            {row.entries.length} {row.entries.length === 1 ? "event" : "events"}
             {hiddenCount > 0 ? ` - showing latest ${visibleEntries.length}` : ""}
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
           <CopyIconButton label="Copy work log" value={copyValue} />
-          {entries.length > visibleEntries.length || expanded ? (
+          {row.entries.length > visibleEntries.length || expanded ? (
             <button
               type="button"
               className="rounded border border-wardian-light px-2 py-1 text-[11px] font-semibold leading-4 text-muted-neutral hover:text-primary"
@@ -459,12 +421,18 @@ function WorkGroupRow({ row }: { row: Extract<ChatRow, { kind: "work_group" }> }
       {row.changedPaths.length > 0 ? <ChangedFiles paths={row.changedPaths} /> : null}
 
       <div className="mt-2 space-y-1">
-        {visibleEntries.map(({ event, block }) => (
-          <WorkEntry block={block} event={event} key={block.id} />
+        {visibleEntries.map((entry) => (
+          <WorkEntry entry={entry} key={entry.id} />
         ))}
       </div>
     </article>
   );
+}
+
+function workGroupTitleFromEntries(entries: PresentedWorkEntry[]): string {
+  if (entries.some((entry) => entry.primary_event.kind === "error" || entry.primary_event.status === "failed")) return "Work log with error";
+  if (entries.some((entry) => entry.primary_event.status === "action_required")) return "Work log needs attention";
+  return "Work log";
 }
 
 function ChangedFiles({ paths }: { paths: string[] }) {
@@ -488,18 +456,18 @@ function ChangedFiles({ paths }: { paths: string[] }) {
   );
 }
 
-function WorkEntry({ event, block }: { event: AgentChatEvent; block: ActivityBlockModel }) {
-  const summary = workEntrySummary(event, block);
+function WorkEntry({ entry }: { entry: PresentedWorkEntry }) {
   return (
     <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-2 rounded border border-transparent py-1 text-[12px] leading-4">
-      <span className={`mt-1 h-1.5 w-1.5 rounded-full ${toneDotClass(block.tone)}`} aria-hidden="true" />
+      <span className={`mt-1 h-1.5 w-1.5 rounded-full ${toneDotClass(entry.block.tone)}`} aria-hidden="true" />
       <div className="min-w-0">
-        <div className="truncate font-medium text-primary">{block.title}</div>
-        {summary ? (
-          <div className="truncate font-mono text-[11px] text-muted-neutral" title={summary}>
-            {summary}
+        <div className="truncate font-medium text-primary">{entry.title}</div>
+        {entry.summary ? (
+          <div className="truncate font-mono text-[11px] text-muted-neutral" title={entry.summary}>
+            {entry.summary}
           </div>
         ) : null}
+        {entry.details.length > 0 ? <div className="truncate text-[11px] text-muted-neutral">{entry.details.join(" - ")}</div> : null}
       </div>
     </div>
   );
@@ -520,11 +488,13 @@ function StatusRow({ event, block }: { event: AgentChatEvent; block: ActivityBlo
 
 function ActivityRow({
   event,
+  entry,
   block,
   isSubmitting,
   onApprovalSubmit,
 }: {
   event: AgentChatEvent;
+  entry?: PresentedWorkEntry;
   block: ActivityBlockModel;
   isSubmitting: boolean;
   onApprovalSubmit: (response: string) => void;
@@ -534,9 +504,11 @@ function ActivityRow({
   const isApproval = block.kind === "approval" || block.tone === "warning";
   const approvalChoices = isApproval ? parseApprovalChoices(event.text ?? block.content) : [];
   const presentation = toolPresentation(event, block);
+  const details = entry?.details ?? presentation.details;
   const Icon = presentation.icon;
   const output = outputWithoutCommandPrefix(block.content, event.command);
   const changedPaths = changedPathsFromEvents([event]);
+  const copyValue = entry && entry.merged_result_events.length > 0 ? formatPresentedEntryForCopy(entry) : block.content;
 
   return (
     <article className={`border-l-2 bg-[var(--color-wardian-card-bg-muted)] px-3 py-2 ${TONE_CLASSES[block.tone]}`}>
@@ -549,7 +521,7 @@ function ActivityRow({
             <div className="min-w-0">
               <div className="truncate text-[12px] font-semibold leading-5 text-primary">{presentation.title}</div>
               <div className="truncate text-[11px] leading-4 text-muted-neutral">
-                {presentation.details.join(" - ")}
+                {details.join(" - ")}
               </div>
             </div>
           </div>
@@ -563,7 +535,7 @@ function ActivityRow({
           ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-1.5">
-          <CopyIconButton label="Copy activity output" value={block.content} />
+          <CopyIconButton label="Copy activity output" value={copyValue} />
           {block.defaultCollapsed ? (
             <button
               type="button"
@@ -668,14 +640,6 @@ function ToolBody({
   return <CodePanel content={safeContent} language={block.language} />;
 }
 
-function CodePanel({ content, language }: { content: string; language: string }) {
-  return (
-    <pre className="mt-2 max-h-[300px] overflow-auto whitespace-pre-wrap break-words rounded border border-wardian-light bg-[var(--color-wardian-sidebar-primary)] p-2 text-[12px] leading-5 text-primary">
-      <code data-language={language}>{renderHighlightedCode(content, language)}</code>
-    </pre>
-  );
-}
-
 function toolPresentation(event: AgentChatEvent, block: ActivityBlockModel): ToolPresentation {
   const rawType = stringMetadata(event.metadata, "raw_type");
   const toolName = toolNameFromEvent(event);
@@ -729,7 +693,7 @@ function readableToolTitle(event: AgentChatEvent, fallback: string): string {
   const title = event.title?.trim();
   const toolName = toolNameFromEvent(event);
   const command = event.command?.trim();
-  if (title && !/^(custom_tool_call|function_call|tool_call|tool_use)$/i.test(title)) return title.replace(/_/g, " ");
+  if (title && !isGenericActivityTitle(title)) return title.replace(/_/g, " ");
   if (toolName) return toolName.replace(/_/g, " ");
   if (command) return commandName(command);
   return fallback;
@@ -743,7 +707,7 @@ function commandName(command: string): string {
 
 function toolLabelFromEvent(event: AgentChatEvent, rawType: string | null, toolName: string | null): string | null {
   const title = event.title?.trim();
-  if (title && !/^(custom_tool_call|function_call|tool_call|tool_use)$/i.test(title)) return title.replace(/_/g, " ");
+  if (title && !isGenericActivityTitle(title)) return title.replace(/_/g, " ");
   if (toolName) return toolName.replace(/_/g, " ");
   if (rawType) return rawType.replace(/_/g, " ");
   if (event.kind === "tool_call") return "tool call";
@@ -886,39 +850,6 @@ function TerminalFallback({ block }: { block: ActivityBlockModel }) {
         </pre>
       ) : null}
     </article>
-  );
-}
-
-function CopyIconButton({ label, value }: { label: string; value: string }) {
-  const [state, setState] = useState<CopyState>("idle");
-  const copy = async () => {
-    if (!value) return;
-    try {
-      await writeText(value);
-      setState("copied");
-      window.setTimeout(() => setState("idle"), 1400);
-    } catch {
-      setState("error");
-      window.setTimeout(() => setState("idle"), 2200);
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      aria-label={state === "copied" ? `${label} copied` : state === "error" ? `${label} failed` : label}
-      title={state === "copied" ? "Copied" : state === "error" ? "Copy failed" : label}
-      className={`inline-flex h-6 w-6 items-center justify-center rounded border text-muted-neutral transition-colors ${
-        state === "copied"
-          ? "border-[color-mix(in_srgb,var(--color-wardian-success),transparent_40%)] bg-[color-mix(in_srgb,var(--color-wardian-success),transparent_86%)] text-[var(--color-wardian-success)]"
-          : state === "error"
-            ? "border-[color-mix(in_srgb,var(--color-wardian-error),transparent_40%)] bg-[color-mix(in_srgb,var(--color-wardian-error),transparent_88%)] text-[var(--color-wardian-error)]"
-            : "border-wardian-light bg-[var(--color-wardian-card-bg-muted)] hover:text-primary"
-      }`}
-      onClick={copy}
-    >
-      {state === "copied" ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : <Copy className="h-3.5 w-3.5" aria-hidden="true" />}
-    </button>
   );
 }
 
@@ -1159,153 +1090,19 @@ function shouldShowChatEvent(event: AgentChatEvent): boolean {
     return false;
   }
   if (event.kind !== "status") return true;
-  return event.status === "failed" || event.status === "cancelled" || event.status === "action_required";
+  return shouldShowStatusEvent(event);
 }
 
 function hasMeaningfulToolIdentity(event: AgentChatEvent): boolean {
   const title = event.title?.trim();
-  if (title && !/^(custom_tool_call|function_call|tool_call|tool_use)$/i.test(title)) return true;
+  if (title && !isGenericActivityTitle(title)) return true;
   return Boolean(toolNameFromEvent(event));
-}
-
-function deriveChatRows(events: AgentChatEvent[]): ChatRow[] {
-  const rows: ChatRow[] = [];
-  let pendingWorkEvents: AgentChatEvent[] = [];
-
-  const flushPendingWork = () => {
-    if (pendingWorkEvents.length === 0) return;
-
-    if (pendingWorkEvents.length < WORK_GROUP_MIN_EVENTS) {
-      pendingWorkEvents.forEach((event) => rows.push({ kind: "event", event }));
-    } else {
-      const first = pendingWorkEvents[0];
-      const last = pendingWorkEvents[pendingWorkEvents.length - 1];
-      rows.push({
-        kind: "work_group",
-        id: `work-group-${first.id}-${last.id}`,
-        events: pendingWorkEvents,
-        changedPaths: changedPathsFromEvents(pendingWorkEvents),
-      });
-    }
-
-    pendingWorkEvents = [];
-  };
-
-  events.forEach((event) => {
-    if (isGroupableWorkEvent(event)) {
-      pendingWorkEvents.push(event);
-      return;
-    }
-
-    flushPendingWork();
-    rows.push({ kind: "event", event });
-  });
-
-  flushPendingWork();
-  return rows;
-}
-
-function isGroupableWorkEvent(event: AgentChatEvent): boolean {
-  if (event.status === "action_required") return false;
-  return event.kind === "tool_call" || event.kind === "tool_result" || event.kind === "error";
-}
-
-function changedPathsFromEvents(events: AgentChatEvent[]): string[] {
-  const paths = new Set<string>();
-
-  events.forEach((event) => {
-    addPath(paths, event.path);
-    extractMetadataPaths(event.metadata).forEach((path) => addPath(paths, path));
-  });
-
-  return [...paths];
-}
-
-function extractMetadataPaths(metadata: Record<string, unknown>): string[] {
-  const paths: string[] = [];
-  const pathKeys = new Set(["changed_files", "changedFiles", "file", "file_path", "filePath", "files", "path", "paths"]);
-
-  Object.entries(metadata).forEach(([key, value]) => {
-    if (pathKeys.has(key)) collectPathValues(value, paths);
-  });
-
-  return paths;
-}
-
-function collectPathValues(value: unknown, paths: string[]) {
-  if (typeof value === "string") {
-    if (looksLikePath(value)) paths.push(value);
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    value.forEach((item) => collectPathValues(item, paths));
-    return;
-  }
-
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    ["path", "file", "file_path", "filePath"].forEach((key) => collectPathValues(record[key], paths));
-  }
-}
-
-function addPath(paths: Set<string>, value: string | null) {
-  const path = value?.trim();
-  if (path && looksLikePath(path)) paths.add(path);
-}
-
-function looksLikePath(value: string): boolean {
-  const trimmed = value.trim();
-  if (!trimmed || trimmed.length > 300) return false;
-  if (/^https?:\/\//i.test(trimmed)) return false;
-  return /[\\/]/.test(trimmed) || /(^|[A-Za-z0-9_-])\.[A-Za-z0-9]{1,8}$/.test(trimmed);
-}
-
-function workGroupTitle(events: AgentChatEvent[]): string {
-  if (events.some((event) => event.kind === "error" || event.status === "failed")) return "Work log with error";
-  if (events.some((event) => event.status === "action_required")) return "Work log needs attention";
-  return "Work log";
 }
 
 function compactPath(path: string): string {
   const parts = path.split(/[\\/]/).filter(Boolean);
   if (parts.length <= 2) return path;
   return `.../${parts.slice(-2).join("/")}`;
-}
-
-function firstContentLine(content: string): string {
-  const line = content
-    .split(/\r\n|\r|\n/)
-    .map((part) => part.trim())
-    .find(Boolean);
-  if (!line) return "";
-  return line.length > 140 ? `${line.slice(0, 137)}...` : line;
-}
-
-function workEntrySummary(event: AgentChatEvent, block: ActivityBlockModel): string {
-  const command = event.command?.trim();
-  if (command) return command.length > 140 ? `${command.slice(0, 137)}...` : command;
-
-  const content = firstContentLine(block.content);
-  const status = formatStatus(event.status);
-  if (content && content !== status) return content;
-
-  if (typeof event.exit_code === "number") return `Exit code: ${event.exit_code}`;
-  return "";
-}
-
-function formatWorkGroupForCopy(entries: Array<{ event: AgentChatEvent; block: ActivityBlockModel }>, changedPaths: string[]): string {
-  const sections = entries.map(({ event, block }) => {
-    const header = [block.title, block.subtitle].filter(Boolean).join(" - ");
-    const content = event.command?.trim() && !block.content.includes(event.command.trim()) ? `$ ${event.command.trim()}\n\n${block.content}` : block.content;
-    return `${header}\n${content}`.trim();
-  });
-
-  if (changedPaths.length > 0) {
-    sections.push(`Changed files\n${changedPaths.join("\n")}`);
-  }
-
-  return sections.join("\n\n---\n\n");
 }
 
 function previewContent(content: string): string {
@@ -1322,237 +1119,6 @@ function compactTerminalPreview(content: string): string {
     .filter(Boolean)
     .slice(0, 2)
     .join("  ");
-}
-
-function parseMessageBlocks(text: string): MessageBlock[] {
-  if (!text.trim()) return [];
-
-  const blocks: MessageBlock[] = [];
-  const fencePattern = /```([A-Za-z0-9_-]+)?\n([\s\S]*?)```/g;
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = fencePattern.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      blocks.push(...parseMarkdownTextBlocks(text.slice(lastIndex, match.index)));
-    }
-    blocks.push({
-      kind: "code",
-      language: match[1]?.trim() || null,
-      content: match[2].replace(/\n$/, ""),
-    });
-    lastIndex = match.index + match[0].length;
-  }
-
-  if (lastIndex < text.length) {
-    blocks.push(...parseMarkdownTextBlocks(text.slice(lastIndex)));
-  }
-
-  return blocks;
-}
-
-function parseMarkdownTextBlocks(content: string): MessageBlock[] {
-  const lines = content.replace(/\r\n|\r/g, "\n").split("\n");
-  const blocks: MessageBlock[] = [];
-  let index = 0;
-
-  while (index < lines.length) {
-    const line = lines[index];
-    if (!line.trim()) {
-      index += 1;
-      continue;
-    }
-
-    const heading = /^(#{1,6})\s+(.+)$/.exec(line.trim());
-    if (heading) {
-      blocks.push({ kind: "heading", level: heading[1].length, content: heading[2].trim() });
-      index += 1;
-      continue;
-    }
-
-    const unordered = /^\s*[-*+]\s+(.+)$/.exec(line);
-    const ordered = /^\s*\d+[.)]\s+(.+)$/.exec(line);
-    if (unordered || ordered) {
-      const orderedList = Boolean(ordered);
-      const items: string[] = [];
-      while (index < lines.length) {
-        const item = orderedList ? /^\s*\d+[.)]\s+(.+)$/.exec(lines[index]) : /^\s*[-*+]\s+(.+)$/.exec(lines[index]);
-        if (!item) break;
-        items.push(item[1].trim());
-        index += 1;
-      }
-      blocks.push({ kind: "list", ordered: orderedList, items });
-      continue;
-    }
-
-    const paragraph: string[] = [];
-    while (index < lines.length) {
-      const next = lines[index];
-      if (!next.trim()) break;
-      if (/^(#{1,6})\s+/.test(next.trim()) || /^\s*([-*+]|\d+[.)])\s+/.test(next)) break;
-      paragraph.push(next.trimEnd());
-      index += 1;
-    }
-    blocks.push({ kind: "paragraph", content: paragraph.join("\n").trim() });
-  }
-
-  return blocks.filter((block) => block.kind !== "paragraph" || block.content.length > 0);
-}
-
-function renderInlineMarkdown(content: string): ReactNode {
-  const parts: ReactNode[] = [];
-  const pattern = /\[([^\]]+)\]\(([^)\s]+)\)|`([^`]+)`|\*\*\s*([^*]+?)\s*\*\*|__\s*([^_]+?)\s*__/g;
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = pattern.exec(content)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push(renderTextWithBreaks(content.slice(lastIndex, match.index), `text-${lastIndex}`));
-    }
-    if (match[3]) {
-      parts.push(
-        <code className="rounded bg-[var(--color-wardian-sidebar-primary)] px-1 py-0.5 text-[12px]" key={`code-${match.index}`}>
-          {match[3]}
-        </code>,
-      );
-    } else if (match[4] || match[5]) {
-      parts.push(
-        <strong className="font-semibold text-primary" key={`strong-${match.index}`}>
-          {match[4] ?? match[5]}
-        </strong>,
-      );
-    } else {
-      const safeUrl = safeMarkdownLinkUrl(match[2]);
-      if (!safeUrl) {
-        parts.push(renderTextWithBreaks(match[0], `unsafe-link-${match.index}`));
-        lastIndex = match.index + match[0].length;
-        continue;
-      }
-      parts.push(
-        <a
-          className="break-all font-medium text-[var(--color-wardian-accent)] underline decoration-[color-mix(in_srgb,var(--color-wardian-accent),transparent_55%)] underline-offset-2"
-          href={safeUrl}
-          key={`link-${match.index}`}
-          rel="noreferrer"
-          target="_blank"
-        >
-          {match[1]}
-        </a>,
-      );
-    }
-    lastIndex = match.index + match[0].length;
-  }
-
-  if (lastIndex < content.length) {
-    parts.push(renderTextWithBreaks(content.slice(lastIndex), `text-${lastIndex}`));
-  }
-
-  return parts.length > 0 ? parts : content;
-}
-
-function safeMarkdownLinkUrl(rawUrl: string | undefined): string | null {
-  if (!rawUrl) return null;
-  try {
-    const url = new URL(rawUrl, window.location.href);
-    return url.protocol === "http:" || url.protocol === "https:" || url.protocol === "file:" ? url.href : null;
-  } catch {
-    return null;
-  }
-}
-
-function renderTextWithBreaks(content: string, keyPrefix: string): ReactNode {
-  const lines = content.split("\n");
-  if (lines.length === 1) return content;
-  return lines.flatMap((line, index) => (index === 0 ? [line] : [<br key={`${keyPrefix}-br-${index}`} />, line]));
-}
-
-function renderHighlightedCode(content: string, language: string): ReactNode {
-  const normalized = language.toLowerCase();
-  const lines = content.split("\n");
-  return lines.flatMap((line, index) => {
-    const tokens = highlightLine(line, normalized, index);
-    return index === lines.length - 1 ? tokens : [...tokens, "\n"];
-  });
-}
-
-function highlightLine(line: string, language: string, lineIndex: number): ReactNode[] {
-  if (language === "diff") return highlightDiffLine(line, lineIndex);
-  if (language === "json") return highlightJsonLine(line, lineIndex);
-  if (language === "shell" || language === "powershell" || language === "batch" || language === "terminal") {
-    return highlightShellLine(line, lineIndex);
-  }
-  if (language === "rust" || language === "typescript" || language === "javascript" || language === "python") {
-    return highlightCodeLine(line, lineIndex);
-  }
-  return [line];
-}
-
-function highlightDiffLine(line: string, lineIndex: number): ReactNode[] {
-  if (/^\+[^+]/.test(line)) return [<span className="text-[var(--color-wardian-success)]" data-token="diff-add" key={`diff-${lineIndex}`}>{line}</span>];
-  if (/^-[^-]/.test(line)) return [<span className="text-[var(--color-wardian-error)]" data-token="diff-remove" key={`diff-${lineIndex}`}>{line}</span>];
-  if (/^@@/.test(line)) return [<span className="text-[var(--color-wardian-accent)]" data-token="diff-hunk" key={`diff-${lineIndex}`}>{line}</span>];
-  return [line];
-}
-
-function highlightShellLine(line: string, lineIndex: number): ReactNode[] {
-  const prompt = /^(\s*(?:\$|>|PS [^>]+>)\s+)(.*)$/.exec(line);
-  if (!prompt) return [line];
-  return [
-    <span className="text-[var(--color-wardian-accent)]" data-token="shell-prompt" key={`shell-prompt-${lineIndex}`}>
-      {prompt[1]}
-    </span>,
-    <span data-token="shell-command" key={`shell-command-${lineIndex}`}>
-      {prompt[2]}
-    </span>,
-  ];
-}
-
-function highlightCodeLine(line: string, lineIndex: number): ReactNode[] {
-  const pattern = /\b(const|let|var|fn|pub|struct|enum|impl|use|import|from|return|if|else|for|while|async|await|class|def)\b/g;
-  const tokens: ReactNode[] = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = pattern.exec(line)) !== null) {
-    if (match.index > lastIndex) tokens.push(line.slice(lastIndex, match.index));
-    tokens.push(
-      <span className="text-[var(--color-wardian-accent)]" data-token="keyword" key={`kw-${lineIndex}-${match.index}`}>
-        {match[0]}
-      </span>,
-    );
-    lastIndex = match.index + match[0].length;
-  }
-
-  if (lastIndex < line.length) tokens.push(line.slice(lastIndex));
-  return tokens.length > 0 ? tokens : [line];
-}
-
-function highlightJsonLine(line: string, lineIndex: number): ReactNode[] {
-  const pattern = /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false|null)\b|-?\b\d+(?:\.\d+)?\b/g;
-  const tokens: ReactNode[] = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = pattern.exec(line)) !== null) {
-    if (match.index > lastIndex) tokens.push(line.slice(lastIndex, match.index));
-    const value = match[0];
-    const token = match[2] ? "json-key" : match[3] ? "json-literal" : /^-?\d/.test(value) ? "json-number" : "json-string";
-    const className =
-      token === "json-key"
-        ? "text-[var(--color-wardian-accent)]"
-        : token === "json-string"
-          ? "text-[var(--color-wardian-success)]"
-          : "text-[var(--color-wardian-warning)]";
-    tokens.push(
-      <span className={className} data-token={token} key={`json-${lineIndex}-${match.index}`}>
-        {value}
-      </span>,
-    );
-    lastIndex = match.index + value.length;
-  }
-
-  if (lastIndex < line.length) tokens.push(line.slice(lastIndex));
-  return tokens.length > 0 ? tokens : [line];
 }
 
 function toneDotClass(tone: ActivityTone): string {

--- a/src/features/grid/activityBlocks.ts
+++ b/src/features/grid/activityBlocks.ts
@@ -65,6 +65,11 @@ export function shouldCollapseActivity(content: string): boolean {
   return countLines(content) > ACTIVITY_COLLAPSE_LINE_LIMIT || content.length > ACTIVITY_COLLAPSE_CHAR_LIMIT;
 }
 
+export function isGenericActivityTitle(title: string | null | undefined): boolean {
+  const normalized = title?.trim().toLowerCase();
+  return Boolean(normalized && GENERIC_TITLES.has(normalized));
+}
+
 export function classifyActivityLanguage(event: AgentChatEvent): string {
   if (event.language?.trim()) return normalizeLanguage(event.language);
 
@@ -101,7 +106,7 @@ export function toActivityBlock(event: AgentChatEvent): ActivityBlockModel {
 
 function activityTitle(event: AgentChatEvent): string {
   const title = event.title?.trim();
-  if (title && !GENERIC_TITLES.has(title.toLowerCase())) return title;
+  if (title && !isGenericActivityTitle(title)) return title;
   if (event.command?.trim()) return event.command.trim();
   if (event.kind === "message") return event.role ?? "message";
   if (title) return title.replace(/_/g, " ");

--- a/src/features/grid/chatCode.tsx
+++ b/src/features/grid/chatCode.tsx
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react";
+
+export function CodePanel({ content, language, className = "" }: { content: string; language: string; className?: string }) {
+  return (
+    <pre
+      className={`mt-2 max-h-[300px] overflow-auto whitespace-pre-wrap break-words rounded border border-wardian-light bg-[var(--color-wardian-sidebar-primary)] p-2 text-[12px] leading-5 text-primary ${className}`}
+    >
+      <code data-language={language}>{renderHighlightedCode(content, language)}</code>
+    </pre>
+  );
+}
+
+export function renderHighlightedCode(content: string, language: string): ReactNode {
+  const normalized = language.toLowerCase();
+  const lines = content.split("\n");
+  return lines.flatMap((line, index) => {
+    const tokens = highlightLine(line, normalized, index);
+    return index === lines.length - 1 ? tokens : [...tokens, "\n"];
+  });
+}
+
+function highlightLine(line: string, language: string, lineIndex: number): ReactNode[] {
+  if (language === "diff") return highlightDiffLine(line, lineIndex);
+  if (language === "json") return highlightJsonLine(line, lineIndex);
+  if (language === "shell" || language === "powershell" || language === "batch" || language === "terminal") {
+    return highlightShellLine(line, lineIndex);
+  }
+  if (language === "rust" || language === "typescript" || language === "javascript" || language === "python") {
+    return highlightCodeLine(line, lineIndex);
+  }
+  return [line];
+}
+
+function highlightDiffLine(line: string, lineIndex: number): ReactNode[] {
+  if (/^\+[^+]/.test(line)) return [<span className="text-[var(--color-wardian-success)]" data-token="diff-add" key={`diff-${lineIndex}`}>{line}</span>];
+  if (/^-[^-]/.test(line)) return [<span className="text-[var(--color-wardian-error)]" data-token="diff-remove" key={`diff-${lineIndex}`}>{line}</span>];
+  if (/^@@/.test(line)) return [<span className="text-[var(--color-wardian-accent)]" data-token="diff-hunk" key={`diff-${lineIndex}`}>{line}</span>];
+  return [line];
+}
+
+function highlightShellLine(line: string, lineIndex: number): ReactNode[] {
+  const prompt = /^(\s*(?:\$|>|PS [^>]+>)\s+)(.*)$/.exec(line);
+  if (!prompt) return [line];
+  return [
+    <span className="text-[var(--color-wardian-accent)]" data-token="shell-prompt" key={`shell-prompt-${lineIndex}`}>
+      {prompt[1]}
+    </span>,
+    <span data-token="shell-command" key={`shell-command-${lineIndex}`}>
+      {prompt[2]}
+    </span>,
+  ];
+}
+
+function highlightCodeLine(line: string, lineIndex: number): ReactNode[] {
+  const pattern = /\b(const|let|var|fn|pub|struct|enum|impl|use|import|from|return|if|else|for|while|async|await|class|def)\b/g;
+  const tokens: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(line)) !== null) {
+    if (match.index > lastIndex) tokens.push(line.slice(lastIndex, match.index));
+    tokens.push(
+      <span className="text-[var(--color-wardian-accent)]" data-token="keyword" key={`kw-${lineIndex}-${match.index}`}>
+        {match[0]}
+      </span>,
+    );
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < line.length) tokens.push(line.slice(lastIndex));
+  return tokens.length > 0 ? tokens : [line];
+}
+
+function highlightJsonLine(line: string, lineIndex: number): ReactNode[] {
+  const pattern = /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false|null)\b|-?\b\d+(?:\.\d+)?\b/g;
+  const tokens: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(line)) !== null) {
+    if (match.index > lastIndex) tokens.push(line.slice(lastIndex, match.index));
+    const value = match[0];
+    const token = match[2] ? "json-key" : match[3] ? "json-literal" : /^-?\d/.test(value) ? "json-number" : "json-string";
+    const className =
+      token === "json-key"
+        ? "text-[var(--color-wardian-accent)]"
+        : token === "json-string"
+          ? "text-[var(--color-wardian-success)]"
+          : "text-[var(--color-wardian-warning)]";
+    tokens.push(
+      <span className={className} data-token={token} key={`json-${lineIndex}-${match.index}`}>
+        {value}
+      </span>,
+    );
+    lastIndex = match.index + value.length;
+  }
+
+  if (lastIndex < line.length) tokens.push(line.slice(lastIndex));
+  return tokens.length > 0 ? tokens : [line];
+}

--- a/src/features/grid/chatCopy.tsx
+++ b/src/features/grid/chatCopy.tsx
@@ -1,0 +1,38 @@
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+
+type CopyState = "idle" | "copied" | "error";
+
+export function CopyIconButton({ label, value }: { label: string; value: string }) {
+  const [state, setState] = useState<CopyState>("idle");
+  const copy = async () => {
+    if (!value) return;
+    try {
+      await writeText(value);
+      setState("copied");
+      window.setTimeout(() => setState("idle"), 1400);
+    } catch {
+      setState("error");
+      window.setTimeout(() => setState("idle"), 2200);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={state === "copied" ? `${label} copied` : state === "error" ? `${label} failed` : label}
+      title={state === "copied" ? "Copied" : state === "error" ? "Copy failed" : label}
+      className={`inline-flex h-6 w-6 items-center justify-center rounded border text-muted-neutral transition-colors ${
+        state === "copied"
+          ? "border-[color-mix(in_srgb,var(--color-wardian-success),transparent_40%)] bg-[color-mix(in_srgb,var(--color-wardian-success),transparent_86%)] text-[var(--color-wardian-success)]"
+          : state === "error"
+            ? "border-[color-mix(in_srgb,var(--color-wardian-error),transparent_40%)] bg-[color-mix(in_srgb,var(--color-wardian-error),transparent_88%)] text-[var(--color-wardian-error)]"
+            : "border-wardian-light bg-[var(--color-wardian-card-bg-muted)] hover:text-primary"
+      }`}
+      onClick={copy}
+    >
+      {state === "copied" ? <Check className="h-3.5 w-3.5" aria-hidden="true" /> : <Copy className="h-3.5 w-3.5" aria-hidden="true" />}
+    </button>
+  );
+}

--- a/src/features/grid/markdown/ChatMarkdown.test.tsx
+++ b/src/features/grid/markdown/ChatMarkdown.test.tsx
@@ -1,0 +1,157 @@
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ChatMarkdown } from "./ChatMarkdown";
+import { safeMarkdownUrl } from "./markdownSafety";
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  writeText: vi.fn(),
+}));
+
+describe("safeMarkdownUrl", () => {
+  it("allows http, https, and file urls while rejecting unsafe schemes", () => {
+    expect(safeMarkdownUrl("https://example.test/docs")).toBe("https://example.test/docs");
+    expect(safeMarkdownUrl("http://example.test/docs")).toBe("http://example.test/docs");
+    expect(safeMarkdownUrl("file:///tmp/AGENTS.md")).toBe("file:///tmp/AGENTS.md");
+    expect(safeMarkdownUrl("javascript:alert(1)")).toBeNull();
+    expect(safeMarkdownUrl("data:text/html,hello")).toBeNull();
+  });
+});
+
+describe("ChatMarkdown", () => {
+  it("renders email summaries as semantic GFM tables", () => {
+    render(
+      <ChatMarkdown
+        source={[
+          "| # | Subject | From | Received |",
+          "|---|---------|------|----------|",
+          "| 1 | RE: Synthetic compliance question for TEST-123 | Alex Reviewer | 2026-06-06 |",
+          "| 8 | | Morgan Coordinator | 2026-06-05 |",
+        ].join("\n")}
+      />,
+    );
+
+    const table = screen.getByRole("table");
+    expect(within(table).getByRole("columnheader", { name: "#" })).toBeInTheDocument();
+    expect(within(table).getByRole("columnheader", { name: "Subject" })).toBeInTheDocument();
+    expect(within(table).getByRole("cell", { name: "RE: Synthetic compliance question for TEST-123" })).toBeInTheDocument();
+    expect(within(table).getByRole("cell", { name: "Morgan Coordinator" })).toBeInTheDocument();
+  });
+
+  it("preserves table alignment, escaped pipes, empty cells, and overflow wrapping", () => {
+    const { container } = render(
+      <ChatMarkdown
+        source={[
+          "| Left | Center | Right | Empty |",
+          "|:-----|:------:|------:|-------|",
+          "| alpha | escaped \\| pipe | VeryLongSyntheticSubjectWithoutSpacesForWrapping | |",
+        ].join("\n")}
+      />,
+    );
+
+    const wrapper = container.querySelector(".overflow-x-auto");
+    expect(wrapper).not.toBeNull();
+
+    const table = screen.getByRole("table");
+    expect(within(table).getByRole("columnheader", { name: "Center" })).toHaveStyle({ textAlign: "center" });
+    expect(within(table).getByRole("columnheader", { name: "Right" })).toHaveStyle({ textAlign: "right" });
+    expect(within(table).getByRole("cell", { name: "escaped | pipe" })).toBeInTheDocument();
+    expect(within(table).getByRole("cell", { name: "VeryLongSyntheticSubjectWithoutSpacesForWrapping" })).toHaveClass("break-words");
+    expect(table.querySelectorAll("tbody td")[3]).toHaveTextContent("");
+  });
+
+  it("renders nested lists and task lists", () => {
+    render(
+      <ChatMarkdown
+        source={[
+          "1. Inspect renderer",
+          "   - Confirm table support",
+          "   - Confirm link safety",
+          "2. Add tests",
+          "   - [x] Existing markdown behavior",
+          "   - [ ] GFM table coverage",
+        ].join("\n")}
+      />,
+    );
+
+    expect(screen.getByText("Inspect renderer")).toBeInTheDocument();
+    const topList = screen.getByText("Inspect renderer").closest("ol");
+    expect(topList).not.toBeNull();
+    const topItems = topList ? within(topList).getAllByRole("listitem", { hidden: true }) : [];
+    const inspectItem = screen.getByText("Inspect renderer").closest("li") as HTMLElement;
+    const testsItem = screen.getByText("Add tests").closest("li") as HTMLElement;
+    expect(inspectItem.parentElement).toBe(topList);
+    expect(testsItem.parentElement).toBe(topList);
+    expect(topItems).toContain(inspectItem);
+    expect(topItems).toContain(testsItem);
+    expect(within(inspectItem).getByText("Confirm table support")).toBeInTheDocument();
+    expect(within(inspectItem).getByText("Confirm link safety")).toBeInTheDocument();
+    expect(within(inspectItem).getByRole("list")).toHaveTextContent("Confirm table support");
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[0]).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Completed task item" })).toBe(checkboxes[0]);
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes[1]).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Incomplete task item" })).toBe(checkboxes[1]);
+    expect(within(testsItem).getByText("Existing markdown behavior")).toBeInTheDocument();
+    expect(within(testsItem).getByText("GFM table coverage")).toBeInTheDocument();
+    expect(checkboxes[0].closest("li")?.parentElement).toBe(within(testsItem).getByRole("list"));
+    expect(checkboxes[1].closest("li")?.parentElement).toBe(within(testsItem).getByRole("list"));
+  });
+
+  it("renders blockquotes, horizontal rules, and inline GFM", () => {
+    const { container } = render(<ChatMarkdown source={["> quoted error", "", "---", "", "Use **bold**, *italic*, ~~old~~, and `code`."].join("\n")} />);
+
+    expect(screen.getByText("quoted error")).toBeInTheDocument();
+    expect(container.querySelector("hr")).not.toBeNull();
+    expect(screen.getByText("bold").tagName).toBe("STRONG");
+    expect(screen.getByText("italic").tagName).toBe("EM");
+    expect(screen.getByText("old").tagName).toBe("DEL");
+    expect(screen.getByText("code").tagName).toBe("CODE");
+  });
+
+  it("renders safe links and unsafe links without clickable anchors", () => {
+    render(<ChatMarkdown source="Safe [docs](https://example.test/docs), local [file](file:///tmp/a.md), unsafe [run](javascript:alert), and bare https://example.test/bare." />);
+
+    expect(screen.getByRole("link", { name: "docs" })).toHaveAttribute("href", "https://example.test/docs");
+    expect(screen.getByRole("link", { name: "file" })).toHaveAttribute("href", "file:///tmp/a.md");
+    expect(screen.getByRole("link", { name: "https://example.test/bare" })).toHaveAttribute("href", "https://example.test/bare");
+    expect(screen.queryByRole("link", { name: "run" })).not.toBeInTheDocument();
+    expect(screen.getByText("run")).toBeInTheDocument();
+  });
+
+  it("opens safe links through the native opener instead of webview navigation", async () => {
+    const openUrlMock = vi.mocked(openUrl);
+    openUrlMock.mockResolvedValue(undefined);
+    render(<ChatMarkdown source="Read the [docs](https://example.test/docs)." />);
+
+    const link = screen.getByRole("link", { name: "docs" });
+    const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+    link.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+    await waitFor(() => expect(openUrlMock).toHaveBeenCalledWith("https://example.test/docs"));
+  });
+
+  it("renders image markdown as a safe placeholder instead of an img element", () => {
+    const { container } = render(<ChatMarkdown source="![diagram](https://example.test/diagram.png)" />);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("diagram")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "https://example.test/diagram.png" })).toHaveAttribute("href", "https://example.test/diagram.png");
+  });
+
+  it("keeps code block copy and highlighting behavior", async () => {
+    const writeTextMock = vi.mocked(writeText);
+    writeTextMock.mockResolvedValue(undefined);
+
+    const { container } = render(<ChatMarkdown source={"```ts\nconst ready = true;\n```"} />);
+
+    expect(screen.getByText("const ready = true;")).toBeInTheDocument();
+    expect(container.querySelector('code[data-language="ts"]')).not.toBeNull();
+    screen.getByRole("button", { name: "Copy code block" }).click();
+    expect(writeTextMock).toHaveBeenCalledWith("const ready = true;");
+  });
+});

--- a/src/features/grid/markdown/ChatMarkdown.tsx
+++ b/src/features/grid/markdown/ChatMarkdown.tsx
@@ -1,0 +1,168 @@
+import Markdown from "react-markdown";
+import type { Components } from "react-markdown";
+import type { CSSProperties, MouseEvent } from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import remarkGfm from "remark-gfm";
+import { CodePanel } from "../chatCode";
+import { CopyIconButton } from "../chatCopy";
+import { markdownUrlTransform, safeMarkdownUrl } from "./markdownSafety";
+
+interface ChatMarkdownProps {
+  source: string;
+}
+
+function tableTextAlign(align: string | null | undefined): CSSProperties | undefined {
+  return align === "left" || align === "center" || align === "right" || align === "justify" ? { textAlign: align as CSSProperties["textAlign"] } : undefined;
+}
+
+function tableAlignFromNode(node: unknown): string | null {
+  if (!node || typeof node !== "object" || !("properties" in node)) return null;
+  const properties = (node as { properties?: Record<string, unknown> }).properties;
+  const align = properties?.align;
+  return typeof align === "string" ? align : null;
+}
+
+function openMarkdownUrl(event: MouseEvent<HTMLAnchorElement>) {
+  event.preventDefault();
+  event.stopPropagation();
+  const href = event.currentTarget.href;
+  void openUrl(href).catch(() => {
+    window.open(href, "_blank", "noopener,noreferrer");
+  });
+}
+
+const components: Components = {
+  a({ href, children }) {
+    const safeUrl = safeMarkdownUrl(href);
+    if (!safeUrl) return <span>{children}</span>;
+    return (
+      <a
+        className="break-all font-medium text-[var(--color-wardian-accent)] underline decoration-[color-mix(in_srgb,var(--color-wardian-accent),transparent_55%)] underline-offset-2"
+        href={safeUrl}
+        onClick={openMarkdownUrl}
+        rel="noreferrer"
+        target="_blank"
+      >
+        {children}
+      </a>
+    );
+  },
+  blockquote({ children }) {
+    return <blockquote className="border-l-2 border-wardian-light pl-3 text-muted-neutral">{children}</blockquote>;
+  },
+  code({ className, children }) {
+    const raw = String(children).replace(/\n$/, "");
+    const language = /language-([A-Za-z0-9_-]+)/.exec(className ?? "")?.[1] ?? "text";
+    if (!className) {
+      return <code className="rounded bg-[var(--color-wardian-sidebar-primary)] px-1 py-0.5 text-[12px]">{children}</code>;
+    }
+    return (
+      <div className="relative">
+        <div className="absolute right-1.5 top-1.5 z-10">
+          <CopyIconButton label="Copy code block" value={raw} />
+        </div>
+        <CodePanel content={raw} language={language} className="pr-9" />
+      </div>
+    );
+  },
+  del({ children }) {
+    return <del className="text-muted-neutral">{children}</del>;
+  },
+  h1({ children }) {
+    return <div className="mt-1 text-[14px] font-bold leading-5 text-primary">{children}</div>;
+  },
+  h2({ children }) {
+    return <div className="mt-1 text-[14px] font-bold leading-5 text-primary">{children}</div>;
+  },
+  h3({ children }) {
+    return <div className="mt-1 text-[13px] font-bold leading-5 text-primary">{children}</div>;
+  },
+  h4({ children }) {
+    return <div className="mt-1 text-[13px] font-bold leading-5 text-primary">{children}</div>;
+  },
+  h5({ children }) {
+    return <div className="mt-1 text-[13px] font-bold leading-5 text-primary">{children}</div>;
+  },
+  h6({ children }) {
+    return <div className="mt-1 text-[13px] font-bold leading-5 text-primary">{children}</div>;
+  },
+  hr() {
+    return <hr className="border-0 border-t border-wardian-light" />;
+  },
+  img({ alt, src }) {
+    const safeUrl = safeMarkdownUrl(src);
+    return (
+      <span className="inline-flex max-w-full flex-wrap items-center gap-1 rounded border border-wardian-light bg-[var(--color-wardian-card-bg-muted)] px-1.5 py-0.5 text-[12px] leading-5 text-muted-neutral">
+        <span>{alt?.trim() || "Image"}</span>
+        {safeUrl ? (
+          <a className="break-all text-[var(--color-wardian-accent)] underline underline-offset-2" href={safeUrl} onClick={openMarkdownUrl} rel="noreferrer" target="_blank">
+            {safeUrl}
+          </a>
+        ) : null}
+      </span>
+    );
+  },
+  input(props) {
+    const label = props.checked ? "Completed task item" : "Incomplete task item";
+    return <input {...props} aria-label={label} className="mr-1 align-middle accent-[var(--color-wardian-accent)]" disabled type="checkbox" />;
+  },
+  li({ children }) {
+    return <li className="break-words">{children}</li>;
+  },
+  ol({ children }) {
+    return <ol className="list-decimal space-y-1 pl-5 marker:text-muted-neutral">{children}</ol>;
+  },
+  p({ children }) {
+    return <p className="break-words">{children}</p>;
+  },
+  pre({ children }) {
+    return <>{children}</>;
+  },
+  strong({ children }) {
+    return <strong className="font-semibold text-primary">{children}</strong>;
+  },
+  table({ children }) {
+    return (
+      <div className="overflow-x-auto rounded border border-wardian-light">
+        <table className="min-w-full border-collapse text-left text-[12px] leading-5">{children}</table>
+      </div>
+    );
+  },
+  tbody({ children }) {
+    return <tbody className="divide-y divide-wardian-light">{children}</tbody>;
+  },
+  td({ align, children, node }) {
+    return (
+      <td className="max-w-[320px] whitespace-normal break-words px-2 py-1 align-top text-primary" style={tableTextAlign(align ?? tableAlignFromNode(node))}>
+        {children}
+      </td>
+    );
+  },
+  th({ align, children, node }) {
+    return (
+      <th
+        className="max-w-[320px] whitespace-normal break-words bg-[var(--color-wardian-card-bg-muted)] px-2 py-1 align-top font-semibold text-primary"
+        style={tableTextAlign(align ?? tableAlignFromNode(node))}
+        scope="col"
+      >
+        {children}
+      </th>
+    );
+  },
+  thead({ children }) {
+    return <thead className="border-b border-wardian-light">{children}</thead>;
+  },
+  ul({ children }) {
+    return <ul className="list-disc space-y-1 pl-5 marker:text-muted-neutral">{children}</ul>;
+  },
+};
+
+export function ChatMarkdown({ source }: ChatMarkdownProps) {
+  return (
+    <div className="space-y-2 text-[13px] leading-5 text-primary">
+      <Markdown components={components} remarkPlugins={[[remarkGfm, { singleTilde: false }]]} skipHtml urlTransform={markdownUrlTransform}>
+        {source}
+      </Markdown>
+    </div>
+  );
+}

--- a/src/features/grid/markdown/markdownSafety.ts
+++ b/src/features/grid/markdown/markdownSafety.ts
@@ -1,0 +1,15 @@
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "file:"]);
+
+export function safeMarkdownUrl(rawUrl: string | undefined): string | null {
+  if (!rawUrl) return null;
+  try {
+    const url = new URL(rawUrl, window.location.href);
+    return ALLOWED_PROTOCOLS.has(url.protocol) ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+export function markdownUrlTransform(rawUrl: string): string {
+  return safeMarkdownUrl(rawUrl) ?? "";
+}

--- a/src/features/grid/workLogPresentation.test.ts
+++ b/src/features/grid/workLogPresentation.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "vitest";
+import type { AgentChatEvent } from "../../types";
+import { derivePresentedChatRows, formatPresentedWorkGroupForCopy } from "./workLogPresentation";
+
+const event = (overrides: Partial<AgentChatEvent>): AgentChatEvent => ({
+  id: "event-1",
+  session_id: "agent-1",
+  provider: "codex",
+  kind: "tool_result",
+  role: null,
+  text: null,
+  title: null,
+  status: null,
+  turn_id: null,
+  source: null,
+  command: null,
+  exit_code: null,
+  path: null,
+  language: null,
+  created_at: null,
+  sequence: null,
+  metadata: {},
+  ...overrides,
+});
+
+describe("workLogPresentation", () => {
+  it("merges adjacent empty successful tool results into the command entry", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "call-1",
+        kind: "tool_call",
+        title: "shell_command",
+        command: "git status --short --branch",
+        status: "running",
+        metadata: { tool_name: "shell_command" },
+        sequence: 1,
+      }),
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        sequence: 2,
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("event");
+    if (rows[0].kind !== "event") throw new Error("expected event row");
+    const entry = rows[0].entry;
+    if (!entry) throw new Error("expected presented work entry");
+    expect(entry.primary_event.id).toBe("call-1");
+    expect(entry.merged_result_events.map((merged) => merged.id)).toEqual(["result-1"]);
+    expect(entry.summary).toBe("git status --short --branch");
+    expect(entry.details).toContain("succeeded");
+    expect(entry.details).toContain("exit 0");
+    expect(entry.block.tone).toBe("success");
+  });
+
+  it("merges linked empty results into the matching pending call when calls overlap", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "call-a",
+        kind: "tool_call",
+        title: "shell_command",
+        command: "git status --short",
+        status: "running",
+        turn_id: "call-a-link",
+        sequence: 1,
+      }),
+      event({
+        id: "call-b",
+        kind: "tool_call",
+        title: "shell_command",
+        command: "git log -1 --oneline",
+        status: "running",
+        turn_id: "call-b-link",
+        sequence: 2,
+      }),
+      event({
+        id: "result-a",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        turn_id: "call-a-link",
+        sequence: 3,
+      }),
+      event({
+        id: "result-b",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        turn_id: "call-b-link",
+        sequence: 4,
+      }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    rows.forEach((row) => {
+      expect(row.kind).toBe("event");
+      if (row.kind !== "event") throw new Error("expected event row");
+      expect(row.entry?.merged_result_events).toHaveLength(1);
+      expect(row.entry?.block.tone).toBe("success");
+    });
+    if (rows[0].kind !== "event" || rows[1].kind !== "event") throw new Error("expected event rows");
+    expect(rows[0].entry?.merged_result_events[0]?.id).toBe("result-a");
+    expect(rows[1].entry?.merged_result_events[0]?.id).toBe("result-b");
+  });
+
+  it("hides unpaired empty successful results from the visual rows", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        sequence: 1,
+      }),
+    ]);
+
+    expect(rows).toEqual([]);
+  });
+
+  it("hides successful result rows that only contain provider boilerplate", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        text: ["Exit code: 0", "Wall time: 0.8 seconds", "Output:"].join("\n"),
+        sequence: 1,
+      }),
+    ]);
+
+    expect(rows).toEqual([]);
+  });
+
+  it("keeps boilerplate result text visible without explicit success evidence", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        title: "Tool result",
+        text: "ok",
+        sequence: 1,
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("event");
+    if (rows[0].kind !== "event") throw new Error("expected event row");
+    expect(rows[0].event.id).toBe("result-1");
+  });
+
+  it("keeps nonzero exits visible", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "failed",
+        exit_code: 1,
+        text: "1 failed",
+        sequence: 1,
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("event");
+  });
+
+  it("keeps cancelled results visible", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "cancelled",
+        exit_code: 0,
+        sequence: 1,
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("event");
+  });
+
+  it("keeps empty successful results with changed-file metadata visible", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        metadata: { changed_files: ["src/features/grid/AgentChatView.tsx"] },
+        sequence: 1,
+      }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("event");
+  });
+
+  it("keeps structured empty successful results visible", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "json-result",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        language: "json",
+        sequence: 1,
+      }),
+      event({
+        id: "diff-result",
+        kind: "tool_result",
+        title: "Tool result",
+        status: "succeeded",
+        exit_code: 0,
+        language: "diff",
+        sequence: 2,
+      }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => (row.kind === "event" ? row.event.id : row.id))).toEqual(["json-result", "diff-result"]);
+  });
+
+  it("keeps meaningful successful output visible", () => {
+    const rows = derivePresentedChatRows([
+      event({
+        id: "call-1",
+        kind: "tool_call",
+        title: "shell_command",
+        command: "npm run docs:build",
+        sequence: 1,
+      }),
+      event({
+        id: "result-1",
+        kind: "tool_result",
+        status: "succeeded",
+        exit_code: 0,
+        text: "build complete in 7.03s",
+        sequence: 2,
+      }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[1].kind).toBe("event");
+    if (rows[1].kind !== "event") throw new Error("expected event row");
+    const entry = rows[1].entry;
+    if (!entry) throw new Error("expected presented work entry");
+    expect(entry.primary_event.id).toBe("result-1");
+    expect(entry.content).toContain("build complete");
+  });
+
+  it("groups visible work entries and excludes suppressed results from the event count", () => {
+    const rows = derivePresentedChatRows([
+      event({ id: "call-1", kind: "tool_call", title: "shell_command", command: "git status --short --branch", sequence: 1 }),
+      event({ id: "result-1", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, sequence: 2 }),
+      event({ id: "call-2", kind: "tool_call", title: "shell_command", command: "git log -1 --oneline", sequence: 3 }),
+      event({ id: "result-2", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, sequence: 4 }),
+      event({ id: "call-3", kind: "tool_call", title: "shell_command", command: "npm run docs:build", sequence: 5 }),
+      event({ id: "result-3", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, text: "build complete", sequence: 6 }),
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].kind).toBe("work_group");
+    if (rows[0].kind !== "work_group") throw new Error("expected work group");
+    expect(rows[0].entries).toHaveLength(4);
+    expect(rows[0].entries.map((entry) => entry.primary_event.id)).toEqual(["call-1", "call-2", "call-3", "result-3"]);
+  });
+
+  it("does not pair results across assistant messages", () => {
+    const rows = derivePresentedChatRows([
+      event({ id: "call-1", kind: "tool_call", title: "shell_command", command: "npm run test", sequence: 1 }),
+      event({ id: "message-1", kind: "message", role: "assistant", text: "Checking output.", sequence: 2 }),
+      event({ id: "result-1", kind: "tool_result", status: "succeeded", exit_code: 0, sequence: 3 }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].kind).toBe("event");
+    expect(rows[1].kind).toBe("event");
+    if (rows[1].kind !== "event") throw new Error("expected message row");
+    expect(rows[1].event.id).toBe("message-1");
+  });
+
+  it("includes suppressed diagnostic results when copying a group", () => {
+    const rows = derivePresentedChatRows([
+      event({ id: "call-1", kind: "tool_call", title: "shell_command", command: "git status --short --branch", sequence: 1 }),
+      event({ id: "result-1", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, sequence: 2 }),
+      event({ id: "call-2", kind: "tool_call", title: "shell_command", command: "git log -1 --oneline", sequence: 3 }),
+      event({ id: "result-2", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, sequence: 4 }),
+      event({ id: "call-3", kind: "tool_call", title: "shell_command", command: "npm run docs:build", sequence: 5 }),
+      event({ id: "result-3", kind: "tool_result", title: "Tool result", status: "succeeded", exit_code: 0, text: "build complete", sequence: 6 }),
+    ]);
+
+    if (rows[0].kind !== "work_group") throw new Error("expected work group");
+    const copyText = formatPresentedWorkGroupForCopy(rows[0]);
+    expect(copyText).toContain("git status --short --branch");
+    expect(copyText).toContain("Tool result - succeeded - exit 0");
+    expect(copyText).toContain("build complete");
+  });
+});

--- a/src/features/grid/workLogPresentation.ts
+++ b/src/features/grid/workLogPresentation.ts
@@ -108,6 +108,7 @@ export function derivePresentedChatRows(events: AgentChatEvent[]): PresentedChat
 }
 
 export function shouldShowStatusEvent(event: AgentChatEvent): boolean {
+  if (event.metadata?.chat_thinking_indicator === true) return true;
   return event.status === "failed" || event.status === "cancelled" || event.status === "action_required";
 }
 

--- a/src/features/grid/workLogPresentation.ts
+++ b/src/features/grid/workLogPresentation.ts
@@ -1,0 +1,332 @@
+import type { AgentChatEvent } from "../../types";
+import { toActivityBlock, type ActivityBlockModel } from "./activityBlocks";
+
+const WORK_GROUP_MIN_ENTRIES = 4;
+const NON_MEANINGFUL_TEXT = /^(succeeded|success|ok|done|exit code:\s*0)$/i;
+const NON_MEANINGFUL_RESULT_LINE = /^(succeeded|success|ok|done|exit code:\s*0|wall time:\s*\d+(?:\.\d+)?\s*(?:ms|s|seconds?)|output:)$/i;
+
+export type PresentedChatRow =
+  | { kind: "event"; event: AgentChatEvent; entry?: PresentedWorkEntry }
+  | { kind: "work_group"; id: string; entries: PresentedWorkEntry[]; changedPaths: string[] };
+
+export interface PresentedWorkEntry {
+  id: string;
+  primary_event: AgentChatEvent;
+  block: ActivityBlockModel;
+  merged_result_events: AgentChatEvent[];
+  diagnostic_events: AgentChatEvent[];
+  title: string;
+  summary: string;
+  details: string[];
+  content: string;
+  changed_paths: string[];
+}
+
+export function derivePresentedChatRows(events: AgentChatEvent[]): PresentedChatRow[] {
+  const rows: PresentedChatRow[] = [];
+  let pendingWorkEntries: PresentedWorkEntry[] = [];
+  let lastUnpairedCall: PresentedWorkEntry | null = null;
+  const pendingCallsByLink = new Map<string, PresentedWorkEntry>();
+
+  const flushWork = () => {
+    if (pendingWorkEntries.length === 0) return;
+
+    if (pendingWorkEntries.length < WORK_GROUP_MIN_ENTRIES) {
+      pendingWorkEntries.forEach((entry) => rows.push({ kind: "event", event: entry.primary_event, entry }));
+    } else {
+      rows.push({
+        kind: "work_group",
+        id: `work-group-${pendingWorkEntries[0].id}-${pendingWorkEntries[pendingWorkEntries.length - 1].id}`,
+        entries: pendingWorkEntries,
+        changedPaths: uniquePaths(pendingWorkEntries.flatMap((entry) => entry.changed_paths)),
+      });
+    }
+
+    pendingWorkEntries = [];
+  };
+
+  const rememberPendingCall = (entry: PresentedWorkEntry) => {
+    providerLinkKeys(entry.primary_event).forEach((key) => pendingCallsByLink.set(key, entry));
+  };
+
+  const forgetPendingCall = (entry: PresentedWorkEntry) => {
+    providerLinkKeys(entry.primary_event).forEach((key) => {
+      if (pendingCallsByLink.get(key) === entry) pendingCallsByLink.delete(key);
+    });
+    if (lastUnpairedCall === entry) lastUnpairedCall = null;
+  };
+
+  const findLinkedPendingCall = (event: AgentChatEvent): PresentedWorkEntry | null => {
+    for (const key of providerLinkKeys(event)) {
+      const entry = pendingCallsByLink.get(key);
+      if (entry) return entry;
+    }
+    return null;
+  };
+
+  const clearPairingState = () => {
+    lastUnpairedCall = null;
+    pendingCallsByLink.clear();
+  };
+
+  events.forEach((event) => {
+    if (!isWorkEvent(event)) {
+      flushWork();
+      clearPairingState();
+      if (event.kind === "status" && !shouldShowStatusEvent(event)) return;
+      rows.push({ kind: "event", event });
+      return;
+    }
+
+    if (event.kind === "tool_result" && isEmptySuccessfulResult(event)) {
+      const linkedEntry = findLinkedPendingCall(event);
+      if (linkedEntry) {
+        mergeResultIntoEntry(linkedEntry, event);
+        forgetPendingCall(linkedEntry);
+        return;
+      }
+
+      if (providerLinkKeys(event).length === 0 && lastUnpairedCall && canPair(lastUnpairedCall.primary_event, event)) {
+        mergeResultIntoEntry(lastUnpairedCall, event);
+        forgetPendingCall(lastUnpairedCall);
+      }
+      return;
+    }
+
+    const entry = createWorkEntry(event);
+    pendingWorkEntries.push(entry);
+    if (event.kind === "tool_call") {
+      lastUnpairedCall = entry;
+      rememberPendingCall(entry);
+    } else {
+      lastUnpairedCall = null;
+    }
+  });
+
+  flushWork();
+  return rows;
+}
+
+export function shouldShowStatusEvent(event: AgentChatEvent): boolean {
+  return event.status === "failed" || event.status === "cancelled" || event.status === "action_required";
+}
+
+export function isWorkEvent(event: AgentChatEvent): boolean {
+  if (event.status === "action_required") return false;
+  return event.kind === "tool_call" || event.kind === "tool_result" || event.kind === "error";
+}
+
+export function isEmptySuccessfulResult(event: AgentChatEvent): boolean {
+  if (event.kind !== "tool_result") return false;
+  if (event.status === "failed" || event.status === "cancelled" || event.status === "action_required") return false;
+  if (typeof event.exit_code === "number" && event.exit_code !== 0) return false;
+  if (changedPathsFromEvents([event]).length > 0) return false;
+  if (event.language === "diff" || event.language === "json") return false;
+
+  const hasSuccessEvidence = event.status === "succeeded" || event.exit_code === 0;
+  if (!hasSuccessEvidence) return false;
+
+  const text = event.text?.trim() ?? "";
+  if (!text) return true;
+  return isNonMeaningfulResultText(text);
+}
+
+function isNonMeaningfulResultText(text: string): boolean {
+  if (NON_MEANINGFUL_TEXT.test(text)) return true;
+  const lines = text
+    .split(/\r\n|\r|\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.length > 0 && lines.every((line) => NON_MEANINGFUL_RESULT_LINE.test(line));
+}
+
+export function changedPathsFromEvents(events: AgentChatEvent[]): string[] {
+  const paths = new Set<string>();
+
+  events.forEach((event) => {
+    addPath(paths, event.path);
+    extractMetadataPaths(event.metadata).forEach((path) => addPath(paths, path));
+  });
+
+  return Array.from(paths);
+}
+
+export function formatPresentedWorkGroupForCopy(row: Extract<PresentedChatRow, { kind: "work_group" }>): string {
+  const sections = row.entries.map((entry) => formatPresentedEntryForCopy(entry));
+  if (row.changedPaths.length > 0) sections.push(`Changed files\n${row.changedPaths.join("\n")}`);
+  return sections.join("\n\n---\n\n");
+}
+
+export function formatPresentedEntryForCopy(entry: PresentedWorkEntry): string {
+  const header = [entry.title, ...entry.details].filter(Boolean).join(" - ");
+  const content = entry.content.trim();
+  const diagnostics = entry.diagnostic_events
+    .filter((event) => !event.text?.trim())
+    .map(formatDiagnosticEvent)
+    .filter(Boolean);
+
+  return [header, content, diagnostics.length > 0 ? `Diagnostics\n${diagnostics.join("\n")}` : ""].filter(Boolean).join("\n");
+}
+
+function createWorkEntry(event: AgentChatEvent): PresentedWorkEntry {
+  const block = toActivityBlock(event);
+  return {
+    id: event.id,
+    primary_event: event,
+    block,
+    merged_result_events: [],
+    diagnostic_events: [],
+    title: presentedTitle(event, block),
+    summary: workEntrySummary(event, block),
+    details: detailsFromEvents(event, [], block),
+    content: block.content,
+    changed_paths: changedPathsFromEvents([event]),
+  };
+}
+
+function presentedTitle(event: AgentChatEvent, block: ActivityBlockModel): string {
+  const title = event.title?.trim();
+  if (event.kind === "tool_result" && (!title || /^tool result$/i.test(title))) return "Output";
+  return block.title;
+}
+
+function mergeResultIntoEntry(entry: PresentedWorkEntry, result: AgentChatEvent) {
+  entry.merged_result_events.push(result);
+  entry.diagnostic_events.push(result);
+  entry.block = { ...entry.block, tone: "success" };
+  entry.details = detailsFromEvents(entry.primary_event, entry.merged_result_events, entry.block);
+  entry.content = mergedContent(entry);
+  entry.changed_paths = uniquePaths([...entry.changed_paths, ...changedPathsFromEvents([result])]);
+}
+
+function canPair(call: AgentChatEvent, result: AgentChatEvent): boolean {
+  if (call.kind !== "tool_call" || result.kind !== "tool_result") return false;
+  if (call.turn_id && result.turn_id && call.turn_id !== result.turn_id) return false;
+  return true;
+}
+
+function detailsFromEvents(primary: AgentChatEvent, mergedResults: AgentChatEvent[], block: ActivityBlockModel): string[] {
+  const details = new Set<string>();
+
+  [primary, ...mergedResults].forEach((event) => {
+    const status = formatStatus(event.status);
+    if (status && status !== "running" && status !== "processing") details.add(status);
+    if (typeof event.exit_code === "number") details.add(`exit ${event.exit_code}`);
+  });
+
+  if (primary.path) details.add(primary.path);
+  if (block.lineCount > 0) details.add(`${block.lineCount} ${block.lineCount === 1 ? "line" : "lines"}`);
+
+  return Array.from(details);
+}
+
+function mergedContent(entry: PresentedWorkEntry): string {
+  const diagnosticText = entry.merged_result_events
+    .map((event) => event.text?.trimEnd())
+    .filter((text): text is string => Boolean(text?.trim()));
+
+  if (diagnosticText.length === 0) return entry.block.content;
+  return [entry.block.content, ...diagnosticText].filter((part) => part.trim()).join("\n\n");
+}
+
+function workEntrySummary(event: AgentChatEvent, block: ActivityBlockModel): string {
+  const command = event.command?.trim();
+  if (command) return truncate(command);
+
+  const content = firstContentLine(block.content);
+  const status = formatStatus(event.status);
+  if (content && content !== status) return content;
+
+  if (typeof event.exit_code === "number") return `Exit code: ${event.exit_code}`;
+  return "";
+}
+
+function firstContentLine(content: string): string {
+  const line = content
+    .split(/\r\n|\r|\n/)
+    .map((part) => part.trim())
+    .find(Boolean);
+  return line ? truncate(line) : "";
+}
+
+function truncate(value: string): string {
+  return value.length > 140 ? `${value.slice(0, 137)}...` : value;
+}
+
+function formatDiagnosticEvent(event: AgentChatEvent): string {
+  return [
+    event.title?.trim() || "Tool result",
+    formatStatus(event.status),
+    typeof event.exit_code === "number" ? `exit ${event.exit_code}` : null,
+  ]
+    .filter((part): part is string => Boolean(part?.trim()))
+    .join(" - ");
+}
+
+function formatStatus(status: AgentChatEvent["status"]): string | null {
+  if (!status) return null;
+  return status.replace(/_/g, " ");
+}
+
+function providerLinkKeys(event: AgentChatEvent): string[] {
+  const keys = new Set<string>();
+  addProviderLinkKey(keys, event.turn_id);
+  addProviderLinkKey(keys, metadataString(event.metadata, "call_id"));
+  addProviderLinkKey(keys, metadataString(event.metadata, "tool_call_id"));
+  addProviderLinkKey(keys, metadataString(event.metadata, "tool_use_id"));
+  return Array.from(keys);
+}
+
+function addProviderLinkKey(keys: Set<string>, value: string | null | undefined) {
+  const normalized = value?.trim();
+  if (normalized) keys.add(normalized);
+}
+
+function metadataString(metadata: Record<string, unknown>, key: string): string | null {
+  const value = metadata[key];
+  return typeof value === "string" ? value : null;
+}
+
+function uniquePaths(paths: string[]): string[] {
+  return Array.from(new Set(paths));
+}
+
+function extractMetadataPaths(metadata: Record<string, unknown>): string[] {
+  const paths: string[] = [];
+  const pathKeys = new Set(["changed_files", "changedFiles", "file", "file_path", "filePath", "files", "path", "paths"]);
+
+  Object.entries(metadata).forEach(([key, value]) => {
+    if (pathKeys.has(key)) collectPathValues(value, paths);
+  });
+
+  return paths;
+}
+
+function collectPathValues(value: unknown, paths: string[]) {
+  if (typeof value === "string") {
+    if (looksLikePath(value)) paths.push(value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectPathValues(item, paths));
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    ["path", "file", "file_path", "filePath"].forEach((key) => collectPathValues(record[key], paths));
+  }
+}
+
+function addPath(paths: Set<string>, value: string | null) {
+  const path = value?.trim();
+  if (path && looksLikePath(path)) paths.add(path);
+}
+
+function looksLikePath(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 300) return false;
+  if (/^https?:\/\//i.test(trimmed)) return false;
+  return /[\\/]/.test(trimmed) || /(^|[A-Za-z0-9_-])\.[A-Za-z0-9]{1,8}$/.test(trimmed);
+}

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -641,6 +641,49 @@
   animation: float 4s ease-in-out infinite;
 }
 
+/* ── Chat Activity Hints ─────────────────────────────── */
+@keyframes wardian-thinking-dot-2 {
+  0%,
+  32% {
+    opacity: 0;
+  }
+  33%,
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes wardian-thinking-dot-3 {
+  0%,
+  65% {
+    opacity: 0;
+  }
+  66%,
+  100% {
+    opacity: 1;
+  }
+}
+
+.wardian-thinking-dots,
+.wardian-thinking-dot {
+  display: inline;
+}
+
+.wardian-thinking-dot-2 {
+  animation: wardian-thinking-dot-2 1.2s steps(1, end) infinite;
+}
+
+.wardian-thinking-dot-3 {
+  animation: wardian-thinking-dot-3 1.2s steps(1, end) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wardian-thinking-dot-2,
+  .wardian-thinking-dot-3 {
+    animation: none;
+  }
+}
+
 /* ── Workflow Edge Animations ─────────────────────────── */
 @keyframes edge-strobe {
   0% { stroke-width: 2; opacity: 1; }


### PR DESCRIPTION
## Description
Adds the richer chat Markdown renderer and improves grid chat activity signal quality.

- Renders GitHub-flavored Markdown in chat messages, including tables, task lists, blockquotes, links, inline code, fenced code blocks, escaped table pipes, empty table cells, and alignment metadata.
- Reduces low-signal empty successful tool-result blocks by pairing provider-linked results with pending calls while preserving failures, cancellations, structured output, changed-file metadata, and unpaired results.
- Maps Antigravity planner tool calls and model action records into visible chat work-log rows.
- Deduplicates echoed prompt records across provider/watch transcript sources without hiding repeated same-source user messages.
- Adds a subtle latest `Working...` row while an agent is processing or chat mode is awaiting the first response; the ellipsis animates with inline period glyphs so punctuation stays on the normal text baseline.
- Documents the Markdown renderer, Antigravity tool activity mapping, and chat activity feedback policy in the spec and provider guide.
- Applies autoreview fixes for synthetic examples, provider-linked overlapping tool calls, generic activity titles, and table alignment fallback.

## Related Issues
Fixes #525

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` - 114 files / 1069 tests passed
- `npm run build` - passed; retains the existing Vite large chunk warning for `assets/index-DNYYcRI_.js`
- `npm run docs:build`
- `npm run docs:check-llms`
- `git diff --check`
- tracked-file scan for the original real-world example names/addresses returned no hits
- `cargo check` in `src-tauri`
- `cargo clippy` in `src-tauri`
- `cargo test` in `src-tauri` - 895 lib tests, 7 mock-provider E2E tests, 1 workflow executor test passed
- Wardian autoreview workflow run `1780878129361-4ec0fc98` completed with `converged: true`, accepted 7 fixes, unresolved `{}`

## Screenshots
![chat-markdown-table](https://raw.githubusercontent.com/wardian-app/Wardian/pr-527-screenshot-assets/chat-markdown-table.png)

Local capture source: `e2e/screenshots/chat-rendering-quality/2026-06-07T23-06-54-531Z/chat-markdown-table.png`.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable