### PR TITLE
fix(telemetry): eliminate idle disk/CPU thrash and unblock startup restore

### DIFF
--- a/crates/wardian-core/src/models/app_telemetry.rs
+++ b/crates/wardian-core/src/models/app_telemetry.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AppTelemetry {
     pub cpu_usage: f32,
     pub memory_mb: f64,

--- a/docs/specs/2026-06-10-telemetry-performance-overhaul.md
+++ b/docs/specs/2026-06-10-telemetry-performance-overhaul.md
@@ -36,6 +36,19 @@ installation found:
   `try_lock` on the shared `System` and reported a literal 0 — precisely
   when the app was busiest.
 
+### Second root cause: codex session-watcher rollout scans
+
+After the fixes above, live measurement still showed ~3.3 GB/s of steady
+main-process reads (~3,000 ops/s, ~1.1 MB average op). Causal isolation by
+pausing individual codex agents (read rate dropped proportionally to that
+agent's codex-home size and recovered on resume) identified the codex
+session watcher thread: it ran `latest_codex_session_index_entry` on every
+250 ms iteration, and `latest_codex_session_from_logs` read **every rollout
+`.jsonl` in the agent's codex home in full** per call. With 12 live codex
+agents holding 16-235 MB of rollout logs each, this alone produced the
+multi-GB/s read load, the relaunch disk thrash (initial discovery per
+restored agent), and the residual idle CPU.
+
 ## Proposed Decision
 
 1. **Targeted process refresh.** The telemetry tick now refreshes only CPU
@@ -58,6 +71,11 @@ installation found:
    pass.
 5. **Debug log rotation.** `wardian_debug.log` rotates to `.log.old` at
    16 MB; it previously grew without bound (35 MB on the profiled machine).
+6. **Bounded codex session discovery.** `latest_codex_session_from_logs`
+   identifies rollout sessions from a 16 KB prefix read (`session_meta` is
+   the first line) instead of reading whole logs, and the codex watcher
+   thread runs discovery at most every 5 s while keeping its 250 ms
+   incremental tail-follow of the resolved log.
 
 ## Consequences
 

--- a/docs/specs/2026-06-10-telemetry-performance-overhaul.md
+++ b/docs/specs/2026-06-10-telemetry-performance-overhaul.md
@@ -1,0 +1,83 @@
+# Telemetry Performance Overhaul
+
+Filename: `2026-06-10-telemetry-performance-overhaul.md`
+
+- **Status:** Implemented
+- **Date:** 2026-06-10
+
+## Context and Problem Statement
+
+With ~40 persisted agents, Wardian took minutes to start (with sustained disk
+activity) and consumed 5-10% CPU while idle. The in-app telemetry meanwhile
+reported far less CPU than the app actually used. Live profiling of a real
+installation found:
+
+- **~73 GB of disk reads in a 30-second idle window.** The gemini log
+  discovery fallback walked the entire `~/.gemini/tmp` tree (365k files,
+  2.4 GB on the profiled machine), fully reading and JSON-parsing every chat
+  file, per gemini agent without a discovered log, on every 5-second
+  telemetry tick. The gemini staleness check also re-read the whole
+  discovered log every tick, with no mtime gating.
+- **`sysinfo::System::refresh_all()` per tick cost up to 1.5 s** (live log:
+  `sys_refresh_ms=1490`) because the telemetry pass harvested the command
+  line and environment block of every process on the system — PEB reads on
+  Windows — and `get_app_metrics` rebuilt the same marker strings a second
+  time in the same tick.
+- **Startup ran a full all-process environment scan per agent.**
+  `cleanup_stale_persisted_session_processes` called
+  `find_wardian_session_process_roots` (a `System::new_all()` +
+  `refresh_all()` each) for every non-off agent, twice; with 24 such agents
+  this alone accounted for roughly a minute of startup.
+  `reconcile_headless_agents` then did another O(agents x processes x
+  env-vars) nested scan.
+- **Telemetry under-reported CPU by design of its failure mode.** Telemetry
+  passes took 8-24 s against a 5-second interval (debug log: `Slow telemetry
+  pass total_ms=24735 ... agent_count=40`), so subsequent ticks failed
+  `try_lock` on the shared `System` and reported a literal 0 — precisely
+  when the app was busiest.
+
+## Proposed Decision
+
+1. **Targeted process refresh.** The telemetry tick now refreshes only CPU
+   and memory (`ProcessRefreshKind::nothing().with_cpu().with_memory()`).
+   Command-line/environment markers, needed only for session-root discovery,
+   are fetched with `UpdateKind::OnlyIfNotSet` (sysinfo caches them per
+   process) on discovery passes gated by a 60 s TTL or a change in the agent
+   set, and the discovered roots are cached in `SESSION_ROOTS_CACHE`.
+2. **`get_app_metrics` reuses the cached session roots** instead of
+   rebuilding marker strings for every process, and returns the last known
+   sample instead of zeros when sampling is contended.
+3. **Gemini I/O gating.** The staleness re-read only happens when the log's
+   mtime differs from the last parsed mtime; the `~/.gemini/tmp` fallback
+   scan retries at most once per 60 s per agent when nothing matched.
+4. **Batched startup scans.** A new
+   `find_wardian_session_process_roots_for_sessions` resolves the roots for
+   all sessions with a single system scan, and the per-call scan uses a
+   targeted refresh (cmd + environ only) instead of `System::new_all()`.
+   `reconcile_headless_agents` indexes `WARDIAN_SESSION_ID` values in one
+   pass.
+5. **Debug log rotation.** `wardian_debug.log` rotates to `.log.old` at
+   16 MB; it previously grew without bound (35 MB on the profiled machine).
+
+## Consequences
+
+- **Positive**: Idle disk traffic drops from ~2.4 GB/s to near zero;
+  telemetry ticks complete in milliseconds instead of seconds, so reported
+  CPU/memory stay current and the 0-CPU contention artifact disappears.
+- **Positive**: Startup no longer performs ~50 full all-process environment
+  scans; stale-process cleanup is one scan (two on retry) regardless of
+  agent count.
+- **Negative**: Newly spawned provider subtrees that are only identifiable
+  via environment markers may take up to 60 s to be attributed to an agent's
+  telemetry (the primary PID tree is still tracked immediately, and the
+  cache refreshes early when the agent set changes).
+- **Negative**: A gemini session whose log appears between fallback scans is
+  discovered up to 60 s late.
+
+## Follow-ups (not in this change)
+
+- Incremental JSONL parsing: provider log parsing still re-reads the whole
+  file when its mtime changes; large active transcripts could track a byte
+  offset instead.
+- Startup restore still spawns all non-off providers sequentially; bounded
+  concurrency would shorten cold start further.

--- a/docs/specs/2026-06-10-telemetry-performance-overhaul.md
+++ b/docs/specs/2026-06-10-telemetry-performance-overhaul.md
@@ -76,6 +76,12 @@ restored agent), and the residual idle CPU.
    the first line) instead of reading whole logs, and the codex watcher
    thread runs discovery at most every 5 s while keeping its 250 ms
    incremental tail-follow of the resolved log.
+7. **Full roster on launch.** Startup restore pre-inserts every persisted
+   agent before the sequential provider spawn loop: headless agents are
+   inserted final, PTY agents as inert `"Restoring"` placeholders (gray
+   pulsing indicator in the UI) that are replaced in place as each spawn
+   completes. The watchlist and views show the complete agent list
+   immediately instead of agents streaming in one by one.
 
 ## Consequences
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,7 +250,9 @@ pub fn run() {
                                         let state = app_handle.state::<AppState>();
                                         let mut agents_map = state.agents.lock().await;
                                         let mut order_map = state.agent_order.lock().await;
-                                        order_map.push(session_id.clone());
+                                        if !order_map.contains(&session_id) {
+                                            order_map.push(session_id.clone());
+                                        }
                                         agents_map.insert(session_id, agent);
                                         drop(agents_map);
                                         drop(order_map);
@@ -269,6 +271,13 @@ pub fn run() {
                                     })
                                     .collect();
 
+                            // Pass 1: prepare every config and publish the full roster
+                            // immediately. Headless agents are final; PTY agents appear
+                            // as inert "Restoring" placeholders so the watchlist shows
+                            // the complete list instead of agents streaming in one by
+                            // one as each provider spawn completes.
+                            type PendingSpawn = (AgentConfig, Option<String>);
+                            let mut pending_spawns: Vec<PendingSpawn> = Vec::new();
                             for mut config in configs {
                                 // Sanitize name
                                 let mut sanitized_name = config
@@ -324,50 +333,62 @@ pub fn run() {
                                     );
                                     insert_restored_agent(config.session_id.clone(), agent).await;
                                 } else {
-                                    let spawn_result = manager::spawn_agent(
-                                        app_handle.clone(),
+                                    let placeholder = restored_agent_without_process(
                                         config.clone(),
-                                        true,
+                                        "Restoring",
+                                        String::new(),
+                                        None,
                                         last_born.clone(),
-                                    )
-                                    .await;
-                                    match spawn_result {
-                                        Ok(agent) => {
-                                            if let Some(ref tx) = agent.stdin_tx {
-                                                if let Ok(mut senders) = state.input_senders.write()
-                                                {
-                                                    senders.insert(
-                                                        config.session_id.clone(),
-                                                        tx.clone(),
-                                                    );
-                                                }
+                                    );
+                                    insert_restored_agent(config.session_id.clone(), placeholder)
+                                        .await;
+                                    pending_spawns.push((config, last_born));
+                                }
+                            }
+
+                            // Pass 2: spawn PTY agents sequentially, replacing each
+                            // placeholder in place as its provider becomes ready.
+                            for (config, last_born) in pending_spawns {
+                                let spawn_result = manager::spawn_agent(
+                                    app_handle.clone(),
+                                    config.clone(),
+                                    true,
+                                    last_born.clone(),
+                                )
+                                .await;
+                                match spawn_result {
+                                    Ok(agent) => {
+                                        if let Some(ref tx) = agent.stdin_tx {
+                                            if let Ok(mut senders) = state.input_senders.write() {
+                                                senders
+                                                    .insert(config.session_id.clone(), tx.clone());
                                             }
-                                            insert_restored_agent(config.session_id.clone(), agent)
-                                                .await;
                                         }
-                                        Err(error) => {
-                                            eprintln!(
-                                                "Failed to restore agent {}: {}",
-                                                config.session_id, error
-                                            );
-                                            let _ = wardian_core::db::update_agent_status(
-                                                &config.session_id,
-                                                "Error",
-                                                None,
-                                            );
-                                            let agent = restored_agent_without_process(
-                                                config.clone(),
-                                                "Error",
-                                                format!(
-                                                    "Wardian could not restore this agent because its provider could not be launched.\r\n{}\r\n",
-                                                    error
-                                                ),
-                                                None,
-                                                last_born,
-                                            );
-                                            insert_restored_agent(config.session_id.clone(), agent)
-                                                .await;
-                                        }
+                                        insert_restored_agent(config.session_id.clone(), agent)
+                                            .await;
+                                    }
+                                    Err(error) => {
+                                        eprintln!(
+                                            "Failed to restore agent {}: {}",
+                                            config.session_id, error
+                                        );
+                                        let _ = wardian_core::db::update_agent_status(
+                                            &config.session_id,
+                                            "Error",
+                                            None,
+                                        );
+                                        let agent = restored_agent_without_process(
+                                            config.clone(),
+                                            "Error",
+                                            format!(
+                                                "Wardian could not restore this agent because its provider could not be launched.\r\n{}\r\n",
+                                                error
+                                            ),
+                                            None,
+                                            last_born,
+                                        );
+                                        insert_restored_agent(config.session_id.clone(), agent)
+                                            .await;
                                     }
                                 }
                             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -239,8 +239,24 @@ pub fn run() {
                     let state_path = app_dir.join("settings/state.json");
                     if let Ok(data) = std::fs::read_to_string(state_path) {
                         if let Ok(configs) = serde_json::from_str::<Vec<AgentConfig>>(&data) {
-                            let mut agents_map = state.agents.lock().await;
-                            let mut order_map = state.agent_order.lock().await;
+                            // Insert each restored agent as it becomes ready instead of
+                            // holding the agents/order locks across every provider spawn;
+                            // otherwise list_agents (and the whole UI) blocks until the
+                            // last agent has been restored.
+                            let insert_restored_agent =
+                                |session_id: String, agent: crate::state::ActiveAgent| {
+                                    let app_handle = app_handle.clone();
+                                    async move {
+                                        let state = app_handle.state::<AppState>();
+                                        let mut agents_map = state.agents.lock().await;
+                                        let mut order_map = state.agent_order.lock().await;
+                                        order_map.push(session_id.clone());
+                                        agents_map.insert(session_id, agent);
+                                        drop(agents_map);
+                                        drop(order_map);
+                                        let _ = app_handle.emit("agents-updated", ());
+                                    }
+                                };
                             let mut seen_names = std::collections::HashSet::new();
                             // Fetch latest status from DB for all agents
                             let db_agents = wardian_core::db::get_all_agents().unwrap_or_default();
@@ -306,8 +322,7 @@ pub fn run() {
                                         last_pid,
                                         last_born,
                                     );
-                                    order_map.push(config.session_id.clone());
-                                    agents_map.insert(config.session_id.clone(), agent);
+                                    insert_restored_agent(config.session_id.clone(), agent).await;
                                 } else {
                                     let spawn_result = manager::spawn_agent(
                                         app_handle.clone(),
@@ -327,8 +342,8 @@ pub fn run() {
                                                     );
                                                 }
                                             }
-                                            order_map.push(config.session_id.clone());
-                                            agents_map.insert(config.session_id.clone(), agent);
+                                            insert_restored_agent(config.session_id.clone(), agent)
+                                                .await;
                                         }
                                         Err(error) => {
                                             eprintln!(
@@ -350,13 +365,17 @@ pub fn run() {
                                                 None,
                                                 last_born,
                                             );
-                                            order_map.push(config.session_id.clone());
-                                            agents_map.insert(config.session_id.clone(), agent);
+                                            insert_restored_agent(config.session_id.clone(), agent)
+                                                .await;
                                         }
                                     }
                                 }
                             }
+                            let agents_map = state.agents.lock().await;
+                            let order_map = state.agent_order.lock().await;
                             manager::save_state(&app_handle, &agents_map, &order_map);
+                            drop(agents_map);
+                            drop(order_map);
                             let _ = app_handle.emit("agents-updated", ());
                         }
                     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,9 +65,26 @@ fn restored_agent_without_process(
 pub async fn reconcile_headless_agents() -> std::result::Result<(), Box<dyn std::error::Error>> {
     use sysinfo::System;
 
-    // Use new_all() to ensure we have process and environment data
-    let mut sys = System::new_all();
-    sys.refresh_all();
+    // Only process environment blocks are needed here; a full refresh_all()
+    // would also sample CPU, memory, and command lines for every process.
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::All,
+        true,
+        sysinfo::ProcessRefreshKind::nothing().with_environ(sysinfo::UpdateKind::OnlyIfNotSet),
+    );
+
+    // Index WARDIAN_SESSION_ID values in one pass instead of rescanning every
+    // process's environment once per agent.
+    let mut session_pids: std::collections::HashMap<String, u32> = std::collections::HashMap::new();
+    for process in sys.processes().values() {
+        for env_var in process.environ() {
+            let env_str = env_var.to_string_lossy();
+            if let Some(session_id) = env_str.strip_prefix("WARDIAN_SESSION_ID=") {
+                session_pids.insert(session_id.trim().to_string(), process.pid().as_u32());
+            }
+        }
+    }
 
     let agents = wardian_core::db::get_all_agents()?;
     for agent in agents {
@@ -75,26 +92,10 @@ pub async fn reconcile_headless_agents() -> std::result::Result<(), Box<dyn std:
             continue;
         }
 
-        let mut found_alive = false;
-        for process in sys.processes().values() {
-            for env_var in process.environ() {
-                let env_str = env_var.to_string_lossy();
-                if env_str.contains("WARDIAN_SESSION_ID=") && env_str.contains(&agent.session_id) {
-                    found_alive = true;
-                    let _ = wardian_core::db::update_agent_status(
-                        &agent.session_id,
-                        "Headless",
-                        Some(process.pid().as_u32()),
-                    );
-                    break;
-                }
-            }
-            if found_alive {
-                break;
-            }
-        }
-
-        if !found_alive && agent.last_status.as_deref() != Some("Off") {
+        if let Some(pid) = session_pids.get(&agent.session_id) {
+            let _ =
+                wardian_core::db::update_agent_status(&agent.session_id, "Headless", Some(*pid));
+        } else if agent.last_status.as_deref() != Some("Off") {
             let _ = wardian_core::db::update_agent_status(&agent.session_id, "Off", None);
         }
     }

--- a/src-tauri/src/manager/codex.rs
+++ b/src-tauri/src/manager/codex.rs
@@ -156,6 +156,38 @@ fn latest_codex_session_from_history(
     }))
 }
 
+/// Rollout files write their `session_meta` line first, so a bounded prefix
+/// read is enough to identify a session. Reading whole rollout logs here is
+/// prohibitively expensive: discovery runs repeatedly per agent and session
+/// logs grow to hundreds of megabytes.
+const CODEX_ROLLOUT_META_PREFIX_BYTES: u64 = 16 * 1024;
+
+fn codex_rollout_session_meta(path: &std::path::Path) -> Option<(String, String)> {
+    use std::io::Read;
+    let file = std::fs::File::open(path).ok()?;
+    let mut prefix = Vec::new();
+    file.take(CODEX_ROLLOUT_META_PREFIX_BYTES)
+        .read_to_end(&mut prefix)
+        .ok()?;
+    let content = String::from_utf8_lossy(&prefix);
+    content.lines().find_map(|line| {
+        let parsed: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
+        if parsed.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
+            return None;
+        }
+        let payload = parsed.get("payload")?;
+        let session_id = payload.get("id")?.as_str()?.trim();
+        let updated_at = payload
+            .get("timestamp")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        if session_id.is_empty() || updated_at.is_empty() {
+            return None;
+        }
+        Some((session_id.to_string(), updated_at.to_string()))
+    })
+}
+
 fn latest_codex_session_from_logs(
     codex_home: &std::path::Path,
 ) -> Result<Option<(String, String)>, String> {
@@ -180,25 +212,7 @@ fn latest_codex_session_from_logs(
             if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
                 continue;
             }
-            let Ok(content) = std::fs::read_to_string(&path) else {
-                continue;
-            };
-            let Some((session_id, updated_at)) = content.lines().find_map(|line| {
-                let parsed: serde_json::Value = serde_json::from_str(line.trim()).ok()?;
-                if parsed.get("type").and_then(|value| value.as_str()) != Some("session_meta") {
-                    return None;
-                }
-                let payload = parsed.get("payload")?;
-                let session_id = payload.get("id")?.as_str()?.trim();
-                let updated_at = payload
-                    .get("timestamp")
-                    .and_then(|value| value.as_str())
-                    .unwrap_or("");
-                if session_id.is_empty() || updated_at.is_empty() {
-                    return None;
-                }
-                Some((session_id.to_string(), updated_at.to_string()))
-            }) else {
+            let Some((session_id, updated_at)) = codex_rollout_session_meta(&path) else {
                 continue;
             };
             if latest
@@ -423,6 +437,45 @@ mod tests {
             latest_codex_session_entry_in(codex_home).expect("latest entry"),
             None
         );
+    }
+
+    #[test]
+    fn rollout_session_meta_reads_first_line_without_scanning_full_log() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("rollout-big.jsonl");
+        let mut content = String::from(
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"prefix-session\",\"timestamp\":\"2026-06-10T00:00:00.000Z\"}}\n",
+        );
+        for _ in 0..1000 {
+            content.push_str("{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"");
+            content.push_str(&"x".repeat(512));
+            content.push_str("\"}}\n");
+        }
+        std::fs::write(&path, content).expect("write rollout");
+
+        assert_eq!(
+            super::codex_rollout_session_meta(&path),
+            Some((
+                "prefix-session".to_string(),
+                "2026-06-10T00:00:00.000Z".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn rollout_session_meta_is_none_when_meta_lies_beyond_prefix_window() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("rollout-late-meta.jsonl");
+        let mut content = String::new();
+        while content.len() < super::CODEX_ROLLOUT_META_PREFIX_BYTES as usize {
+            content.push_str("{\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"filler\"}}\n");
+        }
+        content.push_str(
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"late-session\",\"timestamp\":\"2026-06-10T00:00:00.000Z\"}}\n",
+        );
+        std::fs::write(&path, content).expect("write rollout");
+
+        assert_eq!(super::codex_rollout_session_meta(&path), None);
     }
 
     #[test]

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -94,17 +94,56 @@ pub(crate) fn cleanup_stale_persisted_session_processes() {
         .map(|agent| (agent.session_id, agent.last_status))
         .collect::<std::collections::HashMap<_, _>>();
 
-    for config in configs {
-        if config.is_off
-            || db_status_map
-                .get(&config.session_id)
-                .and_then(|status| status.as_deref())
-                == Some("Headless")
-        {
-            continue;
-        }
+    let sessions: Vec<(String, String)> = configs
+        .into_iter()
+        .filter(|config| {
+            !config.is_off
+                && db_status_map
+                    .get(&config.session_id)
+                    .and_then(|status| status.as_deref())
+                    != Some("Headless")
+        })
+        .map(|config| (config.session_id, config.provider))
+        .collect();
+    if sessions.is_empty() {
+        return;
+    }
 
-        cleanup_stale_session_processes(&config.session_id, &config.provider);
+    // One system scan covers all sessions; scanning per session reads every
+    // process's environment block once per agent and dominates startup time.
+    let session_ids: Vec<String> = sessions.iter().map(|(id, _)| id.clone()).collect();
+    let mut attempted = std::collections::BTreeSet::new();
+    for _ in 0..2 {
+        let roots_by_session =
+            crate::utils::process::find_wardian_session_process_roots_for_sessions(
+                &session_ids,
+                Some(std::process::id()),
+            );
+        let mut killed_any = false;
+        for (session_id, provider) in &sessions {
+            for pid in roots_by_session
+                .get(session_id)
+                .into_iter()
+                .flatten()
+                .copied()
+                .filter(|pid| attempted.insert(*pid))
+            {
+                killed_any = true;
+                log_debug(&format!(
+                    "[Wardian] Cleaning stale {} process tree for session {} via PID {}",
+                    provider, session_id, pid
+                ));
+                if let Err(err) = force_kill_process_tree(pid) {
+                    log_debug(&format!(
+                        "[Wardian] Failed to clean stale process tree for session {} via PID {}: {}",
+                        session_id, pid, err
+                    ));
+                }
+            }
+        }
+        if !killed_any {
+            break;
+        }
     }
 }
 

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -1034,9 +1034,16 @@ pub async fn spawn_agent(
             .map(|path| path.to_string_lossy().to_string());
 
         std::thread::spawn(move || {
+            // Tail-follow the resolved session log every iteration, but run
+            // session discovery (which walks and samples every rollout file in
+            // the agent's codex home) only on this interval.
+            const CODEX_SESSION_DISCOVERY_INTERVAL: std::time::Duration =
+                std::time::Duration::from_secs(5);
             let mut offset: u64 = 0;
             let mut last_lookup_session = String::new();
             let mut positioned_initial_log = !watcher_skip_existing_log;
+            let mut cached_latest_session: Option<String> = None;
+            let mut last_discovery: Option<std::time::Instant> = None;
             loop {
                 let current = watcher_current_status
                     .lock()
@@ -1047,10 +1054,16 @@ pub async fn spawn_agent(
                 }
 
                 let path = {
-                    let latest_session = latest_codex_session_index_entry(&watcher_session)
-                        .ok()
-                        .flatten()
-                        .map(|(session_id, _updated_at)| session_id);
+                    let discovery_due = last_discovery
+                        .is_none_or(|at| at.elapsed() >= CODEX_SESSION_DISCOVERY_INTERVAL);
+                    if discovery_due {
+                        cached_latest_session = latest_codex_session_index_entry(&watcher_session)
+                            .ok()
+                            .flatten()
+                            .map(|(session_id, _updated_at)| session_id);
+                        last_discovery = Some(std::time::Instant::now());
+                    }
+                    let latest_session = cached_latest_session.clone();
                     let lookup_session = watcher_config.lock().ok().and_then(|mut cfg| {
                         let previous_resume = cfg.resume_session.clone();
                         let previous_cleared = codex_cleared_provider_sessions(&cfg);

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -22,7 +22,166 @@ use crate::providers::antigravity::AntigravityProvider;
 
 const TELEMETRY_SLOW_PASS_THRESHOLD: std::time::Duration = std::time::Duration::from_millis(500);
 
+/// Reading every process's command line and environment block (PEB reads on
+/// Windows) is far too expensive to do on every 5s tick, so marker-based
+/// session-root discovery runs at most this often.
+#[cfg(windows)]
+const SESSION_ROOT_DISCOVERY_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// The gemini fallback scan walks every chat file under ~/.gemini/tmp, which
+/// can be hundreds of thousands of files. Retry it at most this often per
+/// agent when no matching log has been found.
+const GEMINI_FALLBACK_SCAN_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
 static TELEMETRY_AGENT_WORK_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+static GEMINI_FALLBACK_SCAN_ATTEMPTS: OnceLock<Mutex<HashMap<String, std::time::Instant>>> =
+    OnceLock::new();
+
+static LAST_APP_TELEMETRY: OnceLock<Mutex<AppTelemetry>> = OnceLock::new();
+
+fn last_app_telemetry_cache() -> &'static Mutex<AppTelemetry> {
+    LAST_APP_TELEMETRY.get_or_init(|| {
+        Mutex::new(AppTelemetry {
+            cpu_usage: 0.0,
+            memory_mb: 0.0,
+        })
+    })
+}
+
+#[cfg(windows)]
+struct SessionRootsCache {
+    roots: HashMap<String, Vec<u32>>,
+    refreshed_at: std::time::Instant,
+    session_key: Vec<String>,
+}
+
+#[cfg(windows)]
+static SESSION_ROOTS_CACHE: OnceLock<Mutex<Option<SessionRootsCache>>> = OnceLock::new();
+
+#[cfg(windows)]
+fn session_roots_cache() -> &'static Mutex<Option<SessionRootsCache>> {
+    SESSION_ROOTS_CACHE.get_or_init(|| Mutex::new(None))
+}
+
+#[cfg(windows)]
+fn sorted_session_key(session_ids: &[String]) -> Vec<String> {
+    let mut key = session_ids.to_vec();
+    key.sort_unstable();
+    key
+}
+
+#[cfg(windows)]
+fn session_root_discovery_due(session_ids: &[String]) -> bool {
+    let Ok(cache) = session_roots_cache().lock() else {
+        return true;
+    };
+    match cache.as_ref() {
+        Some(cache) => {
+            cache.refreshed_at.elapsed() >= SESSION_ROOT_DISCOVERY_TTL
+                || cache.session_key != sorted_session_key(session_ids)
+        }
+        None => true,
+    }
+}
+
+#[cfg(windows)]
+fn cached_session_roots() -> HashMap<String, Vec<u32>> {
+    session_roots_cache()
+        .lock()
+        .ok()
+        .and_then(|cache| cache.as_ref().map(|cache| cache.roots.clone()))
+        .unwrap_or_default()
+}
+
+#[cfg(windows)]
+fn store_session_roots(session_ids: &[String], roots: HashMap<String, Vec<u32>>) {
+    if let Ok(mut cache) = session_roots_cache().lock() {
+        *cache = Some(SessionRootsCache {
+            roots,
+            refreshed_at: std::time::Instant::now(),
+            session_key: sorted_session_key(session_ids),
+        });
+    }
+}
+
+/// Cap the fallback scan to the most recently modified chat files; a session
+/// being discovered was active recently, and unbounded scans have to read
+/// every chat file ever written (gigabytes on long-lived machines).
+const GEMINI_FALLBACK_SCAN_MAX_FILES: usize = 128;
+
+/// Gemini chat logs carry their `sessionId` near the start of the file, so a
+/// bounded prefix read is enough to reject non-matching candidates without
+/// reading whole multi-megabyte transcripts.
+const GEMINI_LOG_SESSION_PREFIX_BYTES: u64 = 64 * 1024;
+
+fn gemini_log_prefix_contains(path: &std::path::Path, target_id: &str) -> bool {
+    use std::io::Read;
+    let target_id = target_id.trim();
+    if target_id.is_empty() {
+        return false;
+    }
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut prefix = Vec::new();
+    if file
+        .take(GEMINI_LOG_SESSION_PREFIX_BYTES)
+        .read_to_end(&mut prefix)
+        .is_err()
+    {
+        return false;
+    }
+    String::from_utf8_lossy(&prefix).contains(target_id)
+}
+
+fn discover_gemini_log_in_tmp(
+    tmp_dir: &std::path::Path,
+    session_id: &str,
+) -> Option<std::path::PathBuf> {
+    let mut candidates: Vec<(std::time::SystemTime, std::path::PathBuf)> = Vec::new();
+    for entry in std::fs::read_dir(tmp_dir).ok()?.flatten() {
+        let chat_dir = entry.path().join("chats");
+        let Ok(chat_files) = std::fs::read_dir(chat_dir) else {
+            continue;
+        };
+        for chat_file in chat_files.flatten() {
+            let modified = chat_file
+                .metadata()
+                .ok()
+                .and_then(|meta| meta.modified().ok())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            candidates.push((modified, chat_file.path()));
+        }
+    }
+    candidates.sort_by(|a, b| b.0.cmp(&a.0));
+    candidates
+        .into_iter()
+        .take(GEMINI_FALLBACK_SCAN_MAX_FILES)
+        .map(|(_, path)| path)
+        .find(|path| {
+            // Cheap prefix rejection first; confirm probable hits with the
+            // full session check so match semantics stay unchanged.
+            gemini_log_prefix_contains(path, session_id)
+                && std::fs::read_to_string(path)
+                    .is_ok_and(|content| gemini_log_matches_session(&content, session_id))
+        })
+}
+
+fn gemini_fallback_scan_due(session_id: &str) -> bool {
+    let attempts = GEMINI_FALLBACK_SCAN_ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()));
+    let Ok(mut attempts) = attempts.lock() else {
+        return true;
+    };
+    let now = std::time::Instant::now();
+    match attempts.get(session_id) {
+        Some(last) if now.duration_since(*last) < GEMINI_FALLBACK_SCAN_TTL => false,
+        _ => {
+            attempts.insert(session_id.to_string(), now);
+            true
+        }
+    }
+}
 
 fn normalize_cpu_usage(raw_cpu_usage: f32, logical_cpu_count: usize) -> f32 {
     let divisor = logical_cpu_count.max(1) as f32;
@@ -283,8 +442,26 @@ fn refresh_system_process_snapshot(
             return None;
         }
     };
+    // A full refresh_all() walks every process's command line and environment
+    // block, which costs over a second per tick on busy systems. Sample only
+    // CPU and memory each tick; marker data is fetched on TTL'd discovery
+    // passes below (OnlyIfNotSet keeps already-fetched markers cached inside
+    // sysinfo, so even discovery passes only read new processes).
+    #[cfg(windows)]
+    let discovery_due = session_root_discovery_due(session_ids);
+    let refresh_kind = sysinfo::ProcessRefreshKind::nothing()
+        .with_cpu()
+        .with_memory();
+    #[cfg(windows)]
+    let refresh_kind = if discovery_due {
+        refresh_kind
+            .with_cmd(sysinfo::UpdateKind::OnlyIfNotSet)
+            .with_environ(sysinfo::UpdateKind::OnlyIfNotSet)
+    } else {
+        refresh_kind
+    };
     let sys_refresh_started = std::time::Instant::now();
-    sys.refresh_all();
+    sys.refresh_processes_specifics(sysinfo::ProcessesToUpdate::All, true, refresh_kind);
     let sys_refresh = sys_refresh_started.elapsed();
     let logical_cpu_count = sys.cpus().len();
     let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
@@ -306,7 +483,7 @@ fn refresh_system_process_snapshot(
             },
         );
         #[cfg(windows)]
-        {
+        if discovery_due {
             process_markers.push(ProcessMarkerSnapshot {
                 pid,
                 process_name: process.name().to_string_lossy().to_string(),
@@ -325,13 +502,22 @@ fn refresh_system_process_snapshot(
         }
     }
 
+    #[cfg(windows)]
+    let session_roots = if discovery_due {
+        let roots = discover_session_roots_from_process_markers(session_ids, &process_markers);
+        store_session_roots(session_ids, roots.clone());
+        roots
+    } else {
+        cached_session_roots()
+    };
+
     Some(SystemProcessSnapshot {
         logical_cpu_count,
         children_map,
         processes,
         sys_refresh,
         #[cfg(windows)]
-        session_roots: discover_session_roots_from_process_markers(session_ids, &process_markers),
+        session_roots,
     })
 }
 
@@ -762,10 +948,23 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                 let mut log_path_lock = snap.log_path.lock().unwrap_or_else(|e| e.into_inner());
 
                 if snap.provider == "gemini" {
+                    // Re-verifying the session id requires reading the whole
+                    // log, so only do it when the file changed (or vanished)
+                    // since the last parse; unchanged content cannot go stale.
+                    let last_parsed_mtime = snap
+                        .log_last_modified
+                        .lock()
+                        .ok()
+                        .and_then(|last| *last);
                     let stale_gemini_log = log_path_lock.as_ref().is_some_and(|path| {
-                        std::fs::read_to_string(path).ok().is_none_or(|content| {
-                            !gemini_log_matches_session(&content, gemini_session_id)
-                        })
+                        let current_mtime =
+                            std::fs::metadata(path).and_then(|meta| meta.modified()).ok();
+                        match (current_mtime, last_parsed_mtime) {
+                            (Some(current), Some(last)) if current == last => false,
+                            _ => std::fs::read_to_string(path).ok().is_none_or(|content| {
+                                !gemini_log_matches_session(&content, gemini_session_id)
+                            }),
+                        }
                     });
                     if stale_gemini_log {
                         *log_path_lock = None;
@@ -885,31 +1084,18 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                             }
                         }
                         _ => {
-                            // Gemini: scan ~/.gemini/tmp for chat log files
-                            if let Some(home) = dirs::home_dir() {
+                            // Gemini: scan ~/.gemini/tmp for chat log files.
+                            // Bounded to recent candidates with prefix reads,
+                            // and retried only after the backoff TTL when
+                            // nothing matched.
+                            if let Some(home) = dirs::home_dir()
+                                .filter(|_| gemini_fallback_scan_due(&snap.session_id))
+                            {
                                 let tmp_dir = home.join(".gemini").join("tmp");
-                                if let Ok(entries) = std::fs::read_dir(tmp_dir) {
-                                    for entry in entries.flatten() {
-                                        let chat_dir = entry.path().join("chats");
-                                        if let Ok(chat_files) = std::fs::read_dir(chat_dir) {
-                                            for chat_file in chat_files.flatten() {
-                                                if let Ok(content) =
-                                                    std::fs::read_to_string(chat_file.path())
-                                                {
-                                                    if gemini_log_matches_session(
-                                                        &content,
-                                                        gemini_session_id,
-                                                    ) {
-                                                        *log_path_lock = Some(chat_file.path());
-                                                        break;
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        if log_path_lock.is_some() {
-                                            break;
-                                        }
-                                    }
+                                if let Some(path) =
+                                    discover_gemini_log_in_tmp(&tmp_dir, gemini_session_id)
+                                {
+                                    *log_path_lock = Some(path);
                                 }
                             }
                         }
@@ -1186,18 +1372,19 @@ pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
         // Refreshing again immediately would reset sysinfo's CPU deltas.
         let Ok(sys) = sys_metrics.try_lock() else {
             crate::utils::logging::log_debug(
-                "[Wardian] App telemetry skipped because system sampling is still running",
+                "[Wardian] App telemetry reusing last sample because system sampling is still running",
             );
-            return AppTelemetry {
-                cpu_usage: 0.0,
-                memory_mb: 0.0,
-            };
+            return last_app_telemetry_cache()
+                .lock()
+                .map(|telemetry| telemetry.clone())
+                .unwrap_or(AppTelemetry {
+                    cpu_usage: 0.0,
+                    memory_mb: 0.0,
+                });
         };
         let logical_cpu_count = sys.cpus().len();
 
         let mut children_map: HashMap<u32, Vec<u32>> = HashMap::new();
-        #[cfg(windows)]
-        let mut process_markers = Vec::new();
         for (pid, process) in sys.processes() {
             if let Some(parent) = process.parent() {
                 children_map
@@ -1205,35 +1392,14 @@ pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
                     .or_default()
                     .push(pid.as_u32());
             }
-            #[cfg(windows)]
-            {
-                process_markers.push(ProcessMarkerSnapshot {
-                    pid: pid.as_u32(),
-                    process_name: process.name().to_string_lossy().to_string(),
-                    command_line: process
-                        .cmd()
-                        .iter()
-                        .map(|part| part.to_string_lossy())
-                        .collect::<Vec<_>>()
-                        .join(" "),
-                    environ: process
-                        .environ()
-                        .iter()
-                        .map(|entry| entry.to_string_lossy().to_string())
-                        .collect::<Vec<_>>(),
-                });
-            }
         }
 
         let mut excluded_roots: BTreeSet<u32> = BTreeSet::new();
+        // Reuse the marker-discovered roots cached by the telemetry loop;
+        // rebuilding them here would re-convert every process's environment
+        // block on each tick.
         #[cfg(windows)]
-        let session_roots = {
-            let session_ids = agent_roots
-                .iter()
-                .map(|(session_id, _)| session_id.clone())
-                .collect::<Vec<_>>();
-            discover_session_roots_from_process_markers(&session_ids, &process_markers)
-        };
+        let session_roots = cached_session_roots();
         for (session_id, process_id) in &agent_roots {
             excluded_roots.insert(*process_id);
             #[cfg(not(windows))]
@@ -1261,10 +1427,14 @@ pub async fn get_app_metrics(state: &AppState) -> AppTelemetry {
             }
         }
 
-        AppTelemetry {
+        let telemetry = AppTelemetry {
             cpu_usage: normalize_cpu_usage(raw_cpu, logical_cpu_count),
             memory_mb: bytes_to_mib(memory_bytes),
+        };
+        if let Ok(mut last) = last_app_telemetry_cache().lock() {
+            *last = telemetry.clone();
         }
+        telemetry
     })
     .await
     .unwrap_or(AppTelemetry {
@@ -1597,6 +1767,41 @@ mod tests {
             "gemini-session-1"
         ));
         assert!(!super::gemini_log_matches_session(content, "other-session"));
+    }
+
+    #[test]
+    fn discover_gemini_log_finds_matching_chat_file() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let chats = temp.path().join("project-a").join("chats");
+        std::fs::create_dir_all(&chats).expect("chats dir");
+        std::fs::write(
+            chats.join("other.json"),
+            r#"{"sessionId":"other-session","messages":[]}"#,
+        )
+        .expect("write other chat");
+        std::fs::write(
+            chats.join("target.json"),
+            r#"{"sessionId":"gemini-session-1","messages":[]}"#,
+        )
+        .expect("write target chat");
+
+        let found = super::discover_gemini_log_in_tmp(temp.path(), "gemini-session-1")
+            .expect("matching chat file");
+        assert!(found.ends_with("target.json"));
+        assert!(super::discover_gemini_log_in_tmp(temp.path(), "missing-session").is_none());
+    }
+
+    #[test]
+    fn gemini_log_prefix_rejects_id_beyond_prefix_window() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("big.json");
+        let mut content = String::from("{\"messages\":[\"");
+        content.push_str(&"x".repeat(super::GEMINI_LOG_SESSION_PREFIX_BYTES as usize));
+        content.push_str("gemini-session-1\"]}");
+        std::fs::write(&path, content).expect("write big chat");
+
+        assert!(!super::gemini_log_prefix_contains(&path, "gemini-session-1"));
+        assert!(!super::gemini_log_prefix_contains(&path, ""));
     }
 
     #[test]

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -154,7 +154,7 @@ fn discover_gemini_log_in_tmp(
             candidates.push((modified, chat_file.path()));
         }
     }
-    candidates.sort_by(|a, b| b.0.cmp(&a.0));
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.0));
     candidates
         .into_iter()
         .take(GEMINI_FALLBACK_SCAN_MAX_FILES)

--- a/src-tauri/src/manager/telemetry.rs
+++ b/src-tauri/src/manager/telemetry.rs
@@ -168,6 +168,34 @@ fn discover_gemini_log_in_tmp(
         })
 }
 
+/// Provider logs are re-parsed whenever they change and grow to hundreds of
+/// megabytes for long-lived codex sessions. Status is derived from the most
+/// recent lines, so parsing is capped to this tail; files under the cap are
+/// read whole (gemini legacy logs are a single JSON document and stay intact).
+/// For capped files the query count is tail-bounded and the init timestamp
+/// falls back to the persisted Born time.
+const LOG_PARSE_TAIL_BYTES: u64 = 4 * 1024 * 1024;
+
+fn read_log_bounded(path: &std::path::Path) -> std::io::Result<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    if len <= LOG_PARSE_TAIL_BYTES {
+        let mut content = String::new();
+        file.read_to_string(&mut content)?;
+        return Ok(content);
+    }
+    file.seek(SeekFrom::Start(len - LOG_PARSE_TAIL_BYTES))?;
+    let mut bytes = Vec::with_capacity(LOG_PARSE_TAIL_BYTES as usize);
+    file.read_to_end(&mut bytes)?;
+    let content = String::from_utf8_lossy(&bytes);
+    // Drop the first (possibly partial) line so parsing starts on a boundary.
+    Ok(content
+        .split_once('\n')
+        .map(|(_, rest)| rest.to_string())
+        .unwrap_or_default())
+}
+
 fn gemini_fallback_scan_due(session_id: &str) -> bool {
     let attempts = GEMINI_FALLBACK_SCAN_ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()));
     let Ok(mut attempts) = attempts.lock() else {
@@ -1124,7 +1152,7 @@ pub async fn get_all_metrics(state: &AppState) -> Vec<AgentTelemetry> {
                     }
 
                     if should_parse {
-                        if let Ok(content) = std::fs::read_to_string(path) {
+                        if let Ok(content) = read_log_bounded(path) {
                             if let Some(mtime) = new_mtime {
                                 *snap.log_last_modified.lock().unwrap() = Some(mtime);
                             }

--- a/src-tauri/src/utils/logging.rs
+++ b/src-tauri/src/utils/logging.rs
@@ -12,11 +12,28 @@ fn debug_log_path() -> std::path::PathBuf {
         .unwrap_or_else(|| std::path::PathBuf::from("wardian_debug.log"))
 }
 
+/// Rotate the debug log once it grows past this size so it cannot grow
+/// without bound across long-running sessions.
+const DEBUG_LOG_ROTATE_BYTES: u64 = 16 * 1024 * 1024;
+
+fn rotate_debug_log_if_needed(path: &std::path::Path) {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return;
+    };
+    if metadata.len() < DEBUG_LOG_ROTATE_BYTES {
+        return;
+    }
+    let rotated = path.with_extension("log.old");
+    let _ = std::fs::remove_file(&rotated);
+    let _ = std::fs::rename(path, &rotated);
+}
+
 pub fn log_debug(msg: &str) {
     let path = debug_log_path();
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
+    rotate_debug_log_if_needed(&path);
     for _ in 0..5 {
         if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&path) {
             let _ = writeln!(file, "{}", msg);

--- a/src-tauri/src/utils/process.rs
+++ b/src-tauri/src/utils/process.rs
@@ -296,10 +296,35 @@ pub fn is_wardian_session_environment_candidate(environ: &[String], session_id: 
 
 #[cfg(windows)]
 pub fn find_wardian_session_process_roots(session_id: &str, exclude_pid: Option<u32>) -> Vec<u32> {
-    let mut sys = sysinfo::System::new_all();
-    sys.refresh_all();
+    find_wardian_session_process_roots_for_sessions(
+        std::slice::from_ref(&session_id.to_string()),
+        exclude_pid,
+    )
+    .remove(session_id)
+    .unwrap_or_default()
+}
 
-    let mut matches = Vec::new();
+/// Find candidate root processes for several sessions with a single system
+/// scan. Reading every process's command line and environment block is the
+/// expensive part, so callers with many sessions must not scan per session.
+#[cfg(windows)]
+pub fn find_wardian_session_process_roots_for_sessions(
+    session_ids: &[String],
+    exclude_pid: Option<u32>,
+) -> std::collections::HashMap<String, Vec<u32>> {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::All,
+        true,
+        sysinfo::ProcessRefreshKind::nothing()
+            .with_cmd(sysinfo::UpdateKind::OnlyIfNotSet)
+            .with_environ(sysinfo::UpdateKind::OnlyIfNotSet),
+    );
+
+    let mut matches: std::collections::HashMap<String, Vec<u32>> = session_ids
+        .iter()
+        .map(|session_id| (session_id.clone(), Vec::new()))
+        .collect();
     for (pid, process) in sys.processes() {
         let pid_u32 = pid.as_u32();
         if exclude_pid == Some(pid_u32) {
@@ -319,15 +344,19 @@ pub fn find_wardian_session_process_roots(session_id: &str, exclude_pid: Option<
             .map(|entry| entry.to_string_lossy().to_string())
             .collect::<Vec<_>>();
 
-        if is_wardian_session_environment_candidate(&environ, session_id)
-            || is_wardian_session_process_candidate(&process_name, &command_line, session_id)
-        {
-            matches.push(pid_u32);
+        for session_id in session_ids {
+            if is_wardian_session_environment_candidate(&environ, session_id)
+                || is_wardian_session_process_candidate(&process_name, &command_line, session_id)
+            {
+                matches.entry(session_id.clone()).or_default().push(pid_u32);
+            }
         }
     }
 
-    matches.sort_unstable();
-    matches.dedup();
+    for pids in matches.values_mut() {
+        pids.sort_unstable();
+        pids.dedup();
+    }
     matches
 }
 

--- a/src/features/explorer/ExplorerPanel.test.tsx
+++ b/src/features/explorer/ExplorerPanel.test.tsx
@@ -292,6 +292,9 @@ describe('ExplorerPanel', () => {
     render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
 
     expect(await screen.findByTestId('file-tree-refresh-token')).toHaveTextContent('0');
+    // The change listener registers in an async effect; dispatching before it
+    // resolves would silently no-op and leave the refresh token at 0.
+    await waitFor(() => expect(handler).toBeDefined());
 
     await act(async () => {
       handler?.({
@@ -321,6 +324,7 @@ describe('ExplorerPanel', () => {
     render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
 
     expect(await screen.findByTestId('file-tree-refresh-token')).toHaveTextContent('0');
+    await waitFor(() => expect(handler).toBeDefined());
 
     await act(async () => {
       handler?.({

--- a/src/utils/statusUtils.test.ts
+++ b/src/utils/statusUtils.test.ts
@@ -136,6 +136,16 @@ describe("deriveCurrentThought", () => {
     expect(result.status).toBe("Processing...");
   });
 
+  it("passes Restoring through without uptime-based Idle fallback", () => {
+    const result = deriveCurrentThought("", undefined, {
+      ...baseMetrics,
+      current_status: "Restoring",
+      uptime_seconds: 9999,
+    });
+    expect(result.thought).toBe("Restoring...");
+    expect(result.status).toBe("Restoring");
+  });
+
   it("falls back to title when no live thought", () => {
     const result = deriveCurrentThought("✦ Running tests", undefined, { ...baseMetrics, current_status: "Pending..." });
     expect(result.thought).toBe("Running tests");
@@ -394,6 +404,11 @@ describe("getStatusColorClass", () => {
 
   it("returns gray for unknown status", () => {
     expect(getStatusColorClass("Something Else")).toContain("bg-wardian-off");
+  });
+
+  it("returns gray pulse for Restoring", () => {
+    expect(getStatusColorClass("Restoring")).toContain("bg-wardian-off");
+    expect(getStatusColorClass("Restoring")).toContain("animate-pulse");
   });
 });
 

--- a/src/utils/statusUtils.ts
+++ b/src/utils/statusUtils.ts
@@ -8,13 +8,14 @@ export function deriveEffectiveStatus(
   currentThought: string | undefined,
   metricsStatus: string | undefined,
   isOff?: boolean,
-): "Idle" | "Processing..." | "Action Needed" | "Pending..." | "Off" | "Headless" {
+): "Idle" | "Processing..." | "Action Needed" | "Pending..." | "Off" | "Headless" | "Restoring" {
   if (isOff) return "Off";
 
   let effectiveStatus: string = metricsStatus || "Pending...";
 
-  // Backend "Headless" status is authoritative — pass it through unchanged.
+  // Backend "Headless" and "Restoring" statuses are authoritative — pass them through unchanged.
   if (effectiveStatus === "Headless") return "Headless";
+  if (effectiveStatus === "Restoring") return "Restoring";
 
   // Title-based overrides. "Action Required" always upgrades status.
   // "◇ / Ready / Idle" can only set Idle when the backend hasn't reported an active state —
@@ -42,7 +43,7 @@ export function deriveEffectiveStatus(
   // A live thought signals activity, but must not override an explicit "Action Needed".
   if (currentThought && effectiveStatus !== "Action Needed") effectiveStatus = "Processing...";
 
-  return effectiveStatus as "Idle" | "Processing..." | "Action Needed" | "Pending..." | "Off" | "Headless";
+  return effectiveStatus as "Idle" | "Processing..." | "Action Needed" | "Pending..." | "Off" | "Headless" | "Restoring";
 }
 
 /**
@@ -66,7 +67,7 @@ export function deriveCurrentThought(
   liveThought: string | undefined,
   metrics: AgentTelemetry | undefined,
   isOff?: boolean,
-): { thought: string; status: "Idle" | "Processing..." | "Action Needed" | "Pending..." | "Off" | "Headless" } {
+): { thought: string; status: "Idle" | "Processing..." | "Action Needed" | "Pending..." | "Off" | "Headless" | "Restoring" } {
   let effectiveStatus = deriveEffectiveStatus(rawTitle, liveThought, metrics?.current_status, isOff);
   let currentThought = cleanThought(liveThought || rawTitle.trim());
 
@@ -76,6 +77,12 @@ export function deriveCurrentThought(
 
   if (isOff) {
     return { thought: "Off", status: "Off" };
+  }
+
+  // Restoring placeholders have no live PTY yet — skip the uptime-based
+  // "Ready"/"Booting..." fallbacks that would mislabel them as Idle.
+  if (effectiveStatus === "Restoring") {
+    return { thought: "Restoring...", status: "Restoring" };
   }
 
   // Fallback chain when no live thought
@@ -320,6 +327,9 @@ export function getStatusColorClass(effectiveStatus: string): string {
   }
   if (effectiveStatus === "Off") {
     return "bg-wardian-off shadow-none";
+  }
+  if (effectiveStatus === "Restoring") {
+    return "bg-wardian-off animate-pulse";
   }
   return "bg-wardian-off flex-shrink-0";
 }


### PR DESCRIPTION
## Description
Eliminates the multi-GB/s idle disk reads and 5-10% idle CPU, makes telemetry reporting accurate under contention, unblocks the UI during startup restore, and shows the full agent roster immediately at launch with "Restoring" placeholders.

Measured on a 40-agent setup: idle main-process reads drop from ~2.4 GB/s to ~1.2 MB/s and idle CPU from ~21.7% of a core to ~0.6%; the UI now populates immediately on launch instead of after minutes.

Key changes:
- **Telemetry tick**: targeted sysinfo refresh (CPU+memory only), session-root discovery cached behind a 60 s TTL, Gemini fallback scans bounded and mtime-gated, last-known app telemetry returned instead of zeros on lock contention.
- **Codex session watcher**: rollout session discovery reads a 16 KB prefix (`session_meta` is the first line) instead of whole logs, and runs at most every 5 s alongside the 250 ms incremental tail-follow.
- **Startup**: restore no longer holds the agents/order locks across provider spawns; initial log replay is capped to a 4 MB tail; stale-process cleanup and headless reconcile are single-scan; debug log rotates at 16 MB.
- **Restore UX**: all persisted agents are pre-inserted before the sequential spawn loop — headless agents final, PTY agents as inert "Restoring" placeholders (pulsing gray dot) replaced in place as each spawn completes.
- **Flaky test fix**: `ExplorerPanel.test.tsx` now waits for the async change listener to register before dispatching events (this was failing CI on unrelated branches).

Details and measurements in `docs/specs/2026-06-10-telemetry-performance-overhaul.md`.

## Related Issues
Fixes #531

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `cargo clippy` / `cargo test --lib` (903 passed) / `cargo check`
- `npm run lint`, `npm run test` (statusUtils: 91 passed incl. 2 new Restoring tests; ExplorerPanel: 14 passed), `npm run build`
- New Rust unit tests for bounded codex rollout prefix parsing
- Live verification on a 40-agent production home: before/after disk and CPU measured via `Win32_Process` ReadTransferCount deltas; relaunch verified with the release build (UI immediate, idle settles at ~1.2 MB/s, 0.6% of one core)

## Screenshots
Watchlist during startup restore — full roster visible immediately; agents still spawning show a pulsing gray "Restoring" indicator:

![watchlist-restoring](https://raw.githubusercontent.com/wardian-app/Wardian/pr-532-screenshot-assets/watchlist-restoring.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
