### PR TITLE
ci: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/apt-repository.yml
+++ b/.github/workflows/apt-repository.yml
@@ -40,10 +40,10 @@ jobs:
       WARDIAN_APT_SIGNING_PRIVATE_KEY: ${{ secrets.WARDIAN_APT_SIGNING_PRIVATE_KEY }}
       WARDIAN_APT_SIGNING_KEY_PASSPHRASE: ${{ secrets.WARDIAN_APT_SIGNING_KEY_PASSPHRASE }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -196,7 +196,7 @@ jobs:
           apt-get download wardian
 
       - name: Upload APT repository artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wardian-apt-repository-${{ inputs.release_tag }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Security & Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-audit
@@ -27,11 +27,11 @@ jobs:
     name: Frontend (Lint & Test)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "npm"
@@ -49,7 +49,7 @@ jobs:
       - name: Coverage Report
         run: npm run test:coverage
       - name: Upload Frontend Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/lcov.info
           flags: frontend
@@ -60,7 +60,7 @@ jobs:
     name: Backend (Windows - Lint, Test & Check)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -81,9 +81,9 @@ jobs:
     runs-on: windows-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "npm"
@@ -103,7 +103,7 @@ jobs:
           WARDIAN_HOME: ${{ runner.temp }}\wardian-e2e-test
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-results
           path: e2e/test-results/
@@ -112,7 +112,7 @@ jobs:
     name: Backend (Linux - Test & Coverage)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -140,7 +140,7 @@ jobs:
           mkdir -p coverage
           cargo llvm-cov --workspace --lcov --output-path coverage/rust-lcov.info
       - name: Upload Backend Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/rust-lcov.info
           flags: backend

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,9 +31,9 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "npm"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ steps.release.outputs.prs_created == 'true' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       release_id: ${{ steps.create.outputs.result }}
       is_prerelease: ${{ steps.detect.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Detect prerelease
         id: detect
         run: |
@@ -150,12 +150,12 @@ jobs:
             name: linux
     runs-on: ${{ matrix.platform.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true' && inputs.release_tag || github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag || github.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "npm"
@@ -228,7 +228,7 @@ jobs:
 
       - name: Upload dry-run artifacts
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wardian-${{ matrix.platform.name }}
           path: |

--- a/src/config/ciWorkflow.test.ts
+++ b/src/config/ciWorkflow.test.ts
@@ -18,7 +18,7 @@ describe("CI workflow contract", () => {
   it("uploads frontend coverage on main branch pushes for Codecov branch badges", () => {
     expect(ciWorkflow).toMatch(/- name: Coverage Report\s+run: npm run test:coverage/);
     expect(ciWorkflow).toMatch(
-      /- name: Upload Frontend Coverage\s+uses: codecov\/codecov-action@v4\s+with:\s+files: \.\/coverage\/lcov\.info\s+flags: frontend/,
+      /- name: Upload Frontend Coverage\s+uses: codecov\/codecov-action@v7\s+with:\s+files: \.\/coverage\/lcov\.info\s+flags: frontend/,
     );
   });
 

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -27,7 +27,7 @@ describe("release workflow contract", () => {
     });
     expect(releasePleaseWorkflow).toContain("Sync release PR Cargo lockfile");
     expect(releasePleaseWorkflow).toContain("steps.release.outputs.prs_created == 'true'");
-    expect(releasePleaseWorkflow).toContain("actions/checkout@v4");
+    expect(releasePleaseWorkflow).toContain("actions/checkout@v6");
     expect(releasePleaseWorkflow).toContain("fetch-depth: 0");
     expect(releasePleaseWorkflow).toContain("RELEASE_PLEASE_PRS: ${{ steps.release.outputs.prs }}");
     expect(releasePleaseWorkflow).toContain("headBranchName");


### PR DESCRIPTION
## Description
Updates GitHub-maintained workflow actions to their current Node 24-compatible major versions after CI emitted Node 20 action deprecation warnings.

- \\ctions/checkout\\: v4 -> v6
- \\ctions/setup-node\\: v4 -> v6
- \\ctions/upload-artifact\\: v4 -> v7
- \\codecov/codecov-action\\: v4 -> v7

## Related Issues
Fixes #539

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] CI maintenance

## How Has This Been Tested?
- \\git diff --check\\
- \\
pm run test -- src/config/releaseWorkflow.test.ts src/config/ciWorkflow.test.ts\\
- Verified there are no remaining \\ctions/checkout@v4\\, \\ctions/setup-node@v4\\, \\ctions/upload-artifact@v4\\, or \\codecov/codecov-action@v4\\ references in \\.github/workflows\\ and \\src\\.
- APT repository dry run on this branch passed before the Codecov/test follow-up: https://github.com/wardian-app/Wardian/actions/runs/27391568505

Full local frontend/backend test suites were not rerun because this changes only GitHub workflow action versions; PR CI is the broad validation for the changed behavior.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I checked \\docs/developer/docs-maintenance.md\\ for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings in the targeted local checks
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable