### PR TITLE
chore(packaging): publish APT under packages host

### DIFF
--- a/.github/workflows/apt-repository.yml
+++ b/.github/workflows/apt-repository.yml
@@ -6,22 +6,6 @@ on:
       release_tag:
         description: "Stable release tag to publish, for example v0.4.0"
         required: true
-      publish:
-        description: "Push the generated repository to the configured static host repository"
-        required: true
-        type: boolean
-        default: false
-  workflow_call:
-    inputs:
-      release_tag:
-        description: "Stable release tag to publish, for example v0.4.0"
-        required: true
-        type: string
-      publish:
-        description: "Push the generated repository to the configured static host repository"
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   contents: read
@@ -32,13 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
-      PUBLISH: ${{ inputs.publish }}
-      APT_REPOSITORY_REPOSITORY: ${{ vars.APT_REPOSITORY_REPOSITORY }}
-      APT_REPOSITORY_BRANCH: ${{ vars.APT_REPOSITORY_BRANCH }}
-      APT_REPOSITORY_CNAME: ${{ vars.APT_REPOSITORY_CNAME }}
-      APT_REPOSITORY_DEPLOY_TOKEN: ${{ secrets.APT_REPOSITORY_DEPLOY_TOKEN }}
-      WARDIAN_APT_SIGNING_PRIVATE_KEY: ${{ secrets.WARDIAN_APT_SIGNING_PRIVATE_KEY }}
-      WARDIAN_APT_SIGNING_KEY_PASSPHRASE: ${{ secrets.WARDIAN_APT_SIGNING_KEY_PASSPHRASE }}
     steps:
       - uses: actions/checkout@v6
 
@@ -58,30 +35,6 @@ jobs:
           if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "release_tag must be a stable semver tag like v0.4.0" >&2
             exit 1
-          fi
-
-      - name: Resolve publish mode
-        id: publish_mode
-        run: |
-          set -euo pipefail
-          if [[ "$PUBLISH" != "true" ]]; then
-            echo "effective_publish=false" >> "$GITHUB_OUTPUT"
-            echo "APT_EFFECTIVE_PUBLISH=false" >> "$GITHUB_ENV"
-            exit 0
-          fi
-
-          missing=()
-          [[ -n "$APT_REPOSITORY_REPOSITORY" ]] || missing+=("APT_REPOSITORY_REPOSITORY")
-          [[ -n "$APT_REPOSITORY_DEPLOY_TOKEN" ]] || missing+=("APT_REPOSITORY_DEPLOY_TOKEN")
-          [[ -n "$WARDIAN_APT_SIGNING_PRIVATE_KEY" ]] || missing+=("WARDIAN_APT_SIGNING_PRIVATE_KEY")
-
-          if (( ${#missing[@]} > 0 )); then
-            echo "::notice::APT publishing requested, but missing ${missing[*]}; generating a signed dry-run artifact instead."
-            echo "effective_publish=false" >> "$GITHUB_OUTPUT"
-            echo "APT_EFFECTIVE_PUBLISH=false" >> "$GITHUB_ENV"
-          else
-            echo "effective_publish=true" >> "$GITHUB_OUTPUT"
-            echo "APT_EFFECTIVE_PUBLISH=true" >> "$GITHUB_ENV"
           fi
 
       - name: Fetch release asset metadata
@@ -122,12 +75,7 @@ jobs:
           export GNUPGHOME="$RUNNER_TEMP/gnupg"
           mkdir -p "$GNUPGHOME"
           chmod 700 "$GNUPGHOME"
-          if [[ -n "$WARDIAN_APT_SIGNING_PRIVATE_KEY" ]]; then
-            printf '%s' "$WARDIAN_APT_SIGNING_PRIVATE_KEY" | gpg --batch --import
-          else
-            echo "::notice::WARDIAN_APT_SIGNING_PRIVATE_KEY is not configured; using a temporary dry-run signing key."
-            gpg --batch --passphrase '' --quick-gen-key "Wardian APT Dry Run <apt-dry-run@wardian.local>" ed25519 sign 1d
-          fi
+          gpg --batch --passphrase '' --quick-gen-key "Wardian APT Dry Run <apt-dry-run@wardian.local>" ed25519 sign 1d
           signing_key="$(gpg --batch --list-secret-keys --with-colons | awk -F: '/^fpr:/ { print $10; exit }')"
           if [[ -z "$signing_key" ]]; then
             echo "No secret signing key is available" >&2
@@ -142,20 +90,9 @@ jobs:
         id: prepare_repository
         run: |
           set -euo pipefail
-          if [[ "$APT_EFFECTIVE_PUBLISH" == "true" ]]; then
-            branch="${APT_REPOSITORY_BRANCH:-main}"
-            git clone --branch "$branch" "https://x-access-token:${APT_REPOSITORY_DEPLOY_TOKEN}@github.com/${APT_REPOSITORY_REPOSITORY}.git" "$RUNNER_TEMP/package-repository"
-            mkdir -p "$RUNNER_TEMP/package-repository/apt"
-            echo "APT_REPOSITORY_BRANCH=$branch" >> "$GITHUB_ENV"
-            echo "PACKAGE_REPO_ROOT=$RUNNER_TEMP/package-repository" >> "$GITHUB_ENV"
-            echo "APT_REPO_OUT=$RUNNER_TEMP/package-repository/apt" >> "$GITHUB_ENV"
-            echo "repo_out=$RUNNER_TEMP/package-repository" >> "$GITHUB_OUTPUT"
-          else
-            mkdir -p "$GITHUB_WORKSPACE/dist/packages/apt"
-            echo "PACKAGE_REPO_ROOT=$GITHUB_WORKSPACE/dist/packages" >> "$GITHUB_ENV"
-            echo "APT_REPO_OUT=$GITHUB_WORKSPACE/dist/packages/apt" >> "$GITHUB_ENV"
-            echo "repo_out=$GITHUB_WORKSPACE/dist/packages" >> "$GITHUB_OUTPUT"
-          fi
+          mkdir -p "$GITHUB_WORKSPACE/dist/packages/apt"
+          echo "APT_REPO_OUT=$GITHUB_WORKSPACE/dist/packages/apt" >> "$GITHUB_ENV"
+          echo "repo_out=$GITHUB_WORKSPACE/dist/packages" >> "$GITHUB_OUTPUT"
 
       - name: Generate APT repository
         run: |
@@ -165,9 +102,6 @@ jobs:
             --deb "$RUNNER_TEMP/apt-release/$WARDIAN_DEB_NAME" \
             --out "$APT_REPO_OUT" \
             --signing-key "$WARDIAN_APT_SIGNING_KEY"
-          if [[ -n "${APT_REPOSITORY_CNAME:-}" ]]; then
-            printf '%s\n' "$APT_REPOSITORY_CNAME" > "$PACKAGE_REPO_ROOT/CNAME"
-          fi
 
       - name: Verify repository signatures
         run: |
@@ -204,19 +138,3 @@ jobs:
           name: wardian-apt-repository-${{ inputs.release_tag }}
           path: |
             ${{ steps.prepare_repository.outputs.repo_out }}
-            !${{ steps.prepare_repository.outputs.repo_out }}/.git/**
-
-      - name: Publish APT repository
-        if: steps.publish_mode.outputs.effective_publish == 'true'
-        run: |
-          set -euo pipefail
-          cd "$PACKAGE_REPO_ROOT"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add .
-          if git diff --cached --quiet; then
-            echo "APT repository is already up to date."
-          else
-            git commit -m "chore(apt): publish ${RELEASE_TAG}"
-            git push origin "HEAD:${APT_REPOSITORY_BRANCH}"
-          fi

--- a/.github/workflows/apt-repository.yml
+++ b/.github/workflows/apt-repository.yml
@@ -144,14 +144,17 @@ jobs:
           set -euo pipefail
           if [[ "$APT_EFFECTIVE_PUBLISH" == "true" ]]; then
             branch="${APT_REPOSITORY_BRANCH:-main}"
-            git clone --branch "$branch" "https://x-access-token:${APT_REPOSITORY_DEPLOY_TOKEN}@github.com/${APT_REPOSITORY_REPOSITORY}.git" "$RUNNER_TEMP/apt-repository"
+            git clone --branch "$branch" "https://x-access-token:${APT_REPOSITORY_DEPLOY_TOKEN}@github.com/${APT_REPOSITORY_REPOSITORY}.git" "$RUNNER_TEMP/package-repository"
+            mkdir -p "$RUNNER_TEMP/package-repository/apt"
             echo "APT_REPOSITORY_BRANCH=$branch" >> "$GITHUB_ENV"
-            echo "APT_REPO_OUT=$RUNNER_TEMP/apt-repository" >> "$GITHUB_ENV"
-            echo "repo_out=$RUNNER_TEMP/apt-repository" >> "$GITHUB_OUTPUT"
+            echo "PACKAGE_REPO_ROOT=$RUNNER_TEMP/package-repository" >> "$GITHUB_ENV"
+            echo "APT_REPO_OUT=$RUNNER_TEMP/package-repository/apt" >> "$GITHUB_ENV"
+            echo "repo_out=$RUNNER_TEMP/package-repository" >> "$GITHUB_OUTPUT"
           else
-            mkdir -p "$GITHUB_WORKSPACE/dist/apt"
-            echo "APT_REPO_OUT=$GITHUB_WORKSPACE/dist/apt" >> "$GITHUB_ENV"
-            echo "repo_out=$GITHUB_WORKSPACE/dist/apt" >> "$GITHUB_OUTPUT"
+            mkdir -p "$GITHUB_WORKSPACE/dist/packages/apt"
+            echo "PACKAGE_REPO_ROOT=$GITHUB_WORKSPACE/dist/packages" >> "$GITHUB_ENV"
+            echo "APT_REPO_OUT=$GITHUB_WORKSPACE/dist/packages/apt" >> "$GITHUB_ENV"
+            echo "repo_out=$GITHUB_WORKSPACE/dist/packages" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Generate APT repository
@@ -163,7 +166,7 @@ jobs:
             --out "$APT_REPO_OUT" \
             --signing-key "$WARDIAN_APT_SIGNING_KEY"
           if [[ -n "${APT_REPOSITORY_CNAME:-}" ]]; then
-            printf '%s\n' "$APT_REPOSITORY_CNAME" > "$APT_REPO_OUT/CNAME"
+            printf '%s\n' "$APT_REPOSITORY_CNAME" > "$PACKAGE_REPO_ROOT/CNAME"
           fi
 
       - name: Verify repository signatures
@@ -207,7 +210,7 @@ jobs:
         if: steps.publish_mode.outputs.effective_publish == 'true'
         run: |
           set -euo pipefail
-          cd "$APT_REPO_OUT"
+          cd "$PACKAGE_REPO_ROOT"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -385,43 +385,62 @@ jobs:
               draft: false,
             });
 
-  update-homebrew-cask:
-    name: Update Homebrew cask
+  dispatch-package-workflows:
+    name: Dispatch package workflows
     needs: [create-release, resolve-release, publish]
     if: always() && needs.publish.result == 'success' && ((github.event_name == 'push' && needs.create-release.outputs.is_prerelease == 'false') || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true' && needs.resolve-release.outputs.is_prerelease == 'false'))
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.release_tag }}
-      TAP_DISPATCH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+      RELEASE_DISPATCH_APP_ID: ${{ vars.WARDIAN_RELEASE_DISPATCH_APP_ID }}
+      RELEASE_DISPATCH_PRIVATE_KEY: ${{ secrets.WARDIAN_RELEASE_DISPATCH_PRIVATE_KEY }}
     steps:
-      - name: Skip tap dispatch when token is unavailable
-        if: env.TAP_DISPATCH_TOKEN == ''
+      - name: Skip package dispatch when GitHub App is unavailable
+        if: env.RELEASE_DISPATCH_APP_ID == '' || env.RELEASE_DISPATCH_PRIVATE_KEY == ''
         run: |
-          echo "::notice::HOMEBREW_TAP_DISPATCH_TOKEN is not configured; skipping homebrew-tap update dispatch."
+          echo "::notice::WARDIAN_RELEASE_DISPATCH_APP_ID or WARDIAN_RELEASE_DISPATCH_PRIVATE_KEY is not configured; skipping package workflow dispatch."
+
+      - name: Create package dispatch token
+        id: app-token
+        if: env.RELEASE_DISPATCH_APP_ID != '' && env.RELEASE_DISPATCH_PRIVATE_KEY != ''
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ vars.WARDIAN_RELEASE_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.WARDIAN_RELEASE_DISPATCH_PRIVATE_KEY }}
+          owner: wardian-app
+          repositories: |
+            homebrew-tap
+            packages
+          permission-actions: write
 
       - name: Dispatch tap cask update
-        if: env.TAP_DISPATCH_TOKEN != ''
+        if: steps.app-token.outputs.token != ''
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            await github.rest.repos.createDispatchEvent({
+            await github.rest.actions.createWorkflowDispatch({
               owner: 'wardian-app',
               repo: 'homebrew-tap',
-              event_type: 'wardian-release-published',
-              client_payload: {
+              workflow_id: 'update-cask.yml',
+              ref: 'main',
+              inputs: {
                 tag: process.env.RELEASE_TAG,
-                source_repo: context.repo.repo,
-                source_run_id: String(context.runId),
               },
             });
 
-  update-apt-repository:
-    name: Update APT repository
-    needs: [create-release, resolve-release, publish]
-    if: always() && needs.publish.result == 'success' && ((github.event_name == 'push' && needs.create-release.outputs.is_prerelease == 'false') || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true' && needs.resolve-release.outputs.is_prerelease == 'false'))
-    uses: ./.github/workflows/apt-repository.yml
-    with:
-      release_tag: ${{ github.event_name == 'push' && github.ref_name || inputs.release_tag }}
-      publish: true
-    secrets: inherit
+      - name: Dispatch APT repository update
+        if: steps.app-token.outputs.token != ''
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'wardian-app',
+              repo: 'packages',
+              workflow_id: 'publish-apt.yml',
+              ref: 'main',
+              inputs: {
+                release_tag: process.env.RELEASE_TAG,
+              },
+            });

--- a/docs/developer/package-manager-distribution.md
+++ b/docs/developer/package-manager-distribution.md
@@ -117,11 +117,13 @@ canonical artifact source; APT metadata is the Linux package-manager integrity
 surface and must be generated only after the stable release assets and updater
 metadata have been published and validated.
 
-The intended public repository contract is `https://apt.wardian.org`. The first
-backend may be any static host that preserves that URL contract, such as GitHub
-Pages behind the custom domain or object storage behind the same domain. Do not
-publish user-facing APT install instructions until the public URL, archive
-signing key, key fingerprint, and first validated repository tree are live.
+The intended public repository contract is `https://packages.wardian.org/apt`.
+The package host can later add sibling package-manager paths such as `/rpm`
+without changing the APT URL. The first backend may be any static host that
+preserves that URL contract, such as GitHub Pages behind the custom domain or
+object storage behind the same domain. Do not publish user-facing APT install
+instructions until the public URL, archive signing key, key fingerprint, and
+first validated repository tree are live.
 
 Do not add upload automation until the APT hosting target, public install URL,
 archive signing key custody model, key-rotation procedure, and dry-run output
@@ -152,23 +154,24 @@ host. After the host repository and real signing key are configured, manual
 Publishing requires these repository variables and secrets:
 
 - `APT_REPOSITORY_REPOSITORY`: external static-host repository to push, for
-  example `wardian-app/apt-repository`.
+  example `wardian-app/packages`.
 - `APT_REPOSITORY_BRANCH`: branch to push, defaulting to `main` when omitted.
 - `APT_REPOSITORY_CNAME`: optional custom domain file content, expected to be
-  `apt.wardian.org` when using GitHub Pages for the APT host.
+  `packages.wardian.org` when using GitHub Pages for the package host.
 - `APT_REPOSITORY_DEPLOY_TOKEN`: token with push access to the external
   static-host repository.
 - `WARDIAN_APT_SIGNING_PRIVATE_KEY`: armored private archive signing key.
 - `WARDIAN_APT_SIGNING_KEY_PASSPHRASE`: optional passphrase for the archive
   signing key.
 
-Do not use this repository's GitHub Pages deployment for the APT repository; the
-Wardian docs site already owns that deployment. Use a separate static host or a
-separate repository with Pages enabled behind `https://apt.wardian.org`.
+Do not use this repository's GitHub Pages deployment for the package repository;
+the Wardian docs site already owns that deployment. Use a separate static host
+or a separate repository with Pages enabled behind `https://packages.wardian.org`.
 
-Expected repository shape:
+Expected static host shape:
 
 ```text
+CNAME
 apt/
   pool/main/w/wardian/Wardian_X.Y.Z_amd64.deb
   dists/stable/main/binary-amd64/Packages
@@ -251,11 +254,11 @@ End-to-end install validation in a disposable Debian or Ubuntu container or VM:
 
 ```bash
 sudo install -d -m 0755 /etc/apt/keyrings
-curl -fsSL https://apt.wardian.org/wardian-archive-keyring.gpg \
+curl -fsSL https://packages.wardian.org/apt/wardian-archive-keyring.gpg \
   | sudo tee /etc/apt/keyrings/wardian.gpg >/dev/null
 sudo tee /etc/apt/sources.list.d/wardian.sources >/dev/null <<'EOF'
 Types: deb
-URIs: https://apt.wardian.org
+URIs: https://packages.wardian.org/apt
 Suites: stable
 Components: main
 Architectures: amd64

--- a/docs/developer/package-manager-distribution.md
+++ b/docs/developer/package-manager-distribution.md
@@ -82,9 +82,11 @@ Submit through the normal `microsoft/winget-pkgs` PR flow or with
 The `wardian-app/homebrew-tap` repository owns the published Homebrew Cask.
 After a stable release, its **Update Wardian Cask** workflow can be run with a
 release tag such as `v0.3.6`. The main Wardian release workflow also dispatches
-that tap workflow after stable publication when the Wardian repository has a
-`HOMEBREW_TAP_DISPATCH_TOKEN` secret with access to create dispatch events in
-the tap repository.
+that tap workflow after stable publication when the Wardian repository has the
+Wardian release dispatch GitHub App configured. Set
+`WARDIAN_RELEASE_DISPATCH_APP_ID` as a repository variable and
+`WARDIAN_RELEASE_DISPATCH_PRIVATE_KEY` as a repository secret. The app must be
+installed on `wardian-app/homebrew-tap` with Actions write permission.
 
 The tap workflow reads the published Wardian release assets, rewrites
 `Casks/wardian.rb`, runs Homebrew audit, and opens a pull request in the tap.
@@ -125,11 +127,9 @@ object storage behind the same domain. Do not publish user-facing APT install
 instructions until the public URL, archive signing key, key fingerprint, and
 first validated repository tree are live.
 
-Do not add upload automation until the APT hosting target, public install URL,
-archive signing key custody model, key-rotation procedure, and dry-run output
-directory are provisioned. Local dry runs from Windows should use WSL Ubuntu or
-another Linux environment for Debian tooling. Published automation should run on
-a Linux CI runner after stable release publication and:
+Local dry runs from Windows should use WSL Ubuntu or another Linux environment
+for Debian tooling. Published automation runs in the separate
+`wardian-app/packages` repository after stable release publication and:
 
 1. read `gh release view vX.Y.Z --json tagName,assets`;
 2. verify the `Wardian_X.Y.Z_amd64.deb` asset name, tag URL, and SHA-256 digest;
@@ -139,30 +139,28 @@ a Linux CI runner after stable release publication and:
 6. sign `Release` as both `InRelease` and `Release.gpg`;
 7. validate the repository before upload.
 
-The repository includes an **APT Repository** GitHub Actions workflow for this
-path. It can be run manually, and the stable release workflow also calls it
-after the release is published. The release caller requests `publish=true`; if
-the real static host or archive signing configuration is absent, the workflow
-logs a notice, generates a signed dry-run repository with a temporary key,
-validates it with local `file://` APT sources, and uploads the repository tree as
-a workflow artifact instead of failing the release.
+This repository includes an **APT Repository** GitHub Actions workflow for
+manual validation. It generates a signed dry-run repository with a temporary
+key, validates it with local `file://` APT sources, and uploads the repository
+tree as a workflow artifact. It does not publish to the public package host.
 
-Run the workflow manually with `publish=false` before enabling the production
-host. After the host repository and real signing key are configured, manual
-`publish=true` runs and post-release calls publish to the external static host.
+Publishing is owned by `wardian-app/packages`. That repository's
+`publish-apt.yml` workflow consumes the published Wardian release assets, signs
+the repository with the real archive signing key, writes `CNAME`, commits the
+`apt/` tree, and publishes `https://packages.wardian.org/apt` through GitHub
+Pages. Configure these in `wardian-app/packages`:
 
-Publishing requires these repository variables and secrets:
-
-- `APT_REPOSITORY_REPOSITORY`: external static-host repository to push, for
-  example `wardian-app/packages`.
-- `APT_REPOSITORY_BRANCH`: branch to push, defaulting to `main` when omitted.
-- `APT_REPOSITORY_CNAME`: optional custom domain file content, expected to be
-  `packages.wardian.org` when using GitHub Pages for the package host.
-- `APT_REPOSITORY_DEPLOY_TOKEN`: token with push access to the external
-  static-host repository.
 - `WARDIAN_APT_SIGNING_PRIVATE_KEY`: armored private archive signing key.
 - `WARDIAN_APT_SIGNING_KEY_PASSPHRASE`: optional passphrase for the archive
   signing key.
+
+Configure these in `wardian-app/Wardian` so stable releases can dispatch the
+package repository workflow:
+
+- `WARDIAN_RELEASE_DISPATCH_APP_ID`: release dispatch GitHub App ID.
+- `WARDIAN_RELEASE_DISPATCH_PRIVATE_KEY`: release dispatch GitHub App private
+  key. The app must be installed on `wardian-app/packages` with Actions write
+  permission.
 
 Do not use this repository's GitHub Pages deployment for the package repository;
 the Wardian docs site already owns that deployment. Use a separate static host
@@ -209,21 +207,20 @@ npm run release:apt-repo -- \
   --signing-key "$WARDIAN_APT_SIGNING_KEY"
 ```
 
-Manual GitHub Actions dry run:
+Manual Wardian repository validation:
 
 ```bash
 gh workflow run apt-repository.yml \
-  -f release_tag=vX.Y.Z \
-  -f publish=false
+  -f release_tag=vX.Y.Z
 ```
 
-Manual GitHub Actions publish run, after the host repository and signing key
+Manual package repository publish run, after the package workflow and signing
 secrets are configured:
 
 ```bash
-gh workflow run apt-repository.yml \
-  -f release_tag=vX.Y.Z \
-  -f publish=true
+gh workflow run publish-apt.yml \
+  --repo wardian-app/packages \
+  -f release_tag=vX.Y.Z
 ```
 
 The underlying metadata generation commands are:

--- a/docs/developer/release-updates.md
+++ b/docs/developer/release-updates.md
@@ -28,7 +28,8 @@ Configure GitHub Actions secrets:
 
 - `TAURI_SIGNING_PRIVATE_KEY`: the private key content, or use `TAURI_SIGNING_PRIVATE_KEY_PATH` in a controlled runner environment.
 - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`: optional, only when the private key was generated with a password.
-- `HOMEBREW_TAP_DISPATCH_TOKEN`: optional fine-grained GitHub token or GitHub App token that can create `repository_dispatch` events in `wardian-app/homebrew-tap`. When present, stable releases trigger the tap cask update workflow after publication. When absent, the release workflow logs a notice and leaves the tap update as a manual post-release step.
+- `WARDIAN_RELEASE_DISPATCH_APP_ID`: optional GitHub App ID for dispatching package repository workflows after stable release publication.
+- `WARDIAN_RELEASE_DISPATCH_PRIVATE_KEY`: optional GitHub App private key for the release dispatch app. The app must be installed on `wardian-app/homebrew-tap` and `wardian-app/packages` with Actions write permission.
 
 For this repository's GitHub Actions workflow, store the private key file content in `TAURI_SIGNING_PRIVATE_KEY`. Do not store the public `.pub` file, the committed `plugins.updater.pubkey`, or a local filesystem path. The generated private key file is base64 text; when decoded it starts with `untrusted comment:` and contains `secret key`.
 
@@ -62,21 +63,19 @@ Stable tag-push and stable manual backfill builds set `WARDIAN_UPDATE_CHANNEL=st
 
 After a stable release is published, generate winget and Linux direct-install
 metadata from the published release assets. Stable releases also dispatch the
-`wardian-app/homebrew-tap` cask update workflow when
-`HOMEBREW_TAP_DISPATCH_TOKEN` is configured. See
+`wardian-app/homebrew-tap` cask update workflow and the `wardian-app/packages`
+APT publish workflow when the Wardian release dispatch GitHub App is configured.
+See
 [Package Manager Distribution](./package-manager-distribution.md) for the
 post-release package-manager workflow. Package-manager metadata must consume the
 published release asset URLs and SHA-256 digests; it must not depend on release
 titles.
 
-The Linux APT repository is handled by the separate **APT Repository** workflow.
-Stable releases call it after publication with `publish=true`. Until
-`https://packages.wardian.org/apt`, archive signing key custody, and the
-external static host are provisioned, that called workflow logs a notice,
-performs a signed dry-run with a temporary key, and uploads the generated
-repository as an artifact instead of failing the release. Run the same workflow
-manually with `publish=false` to validate changes, then with `publish=true`
-after the package host repository and signing secrets are configured.
+The Wardian repository's **APT Repository** workflow is validation-only. It
+builds a signed dry-run repository with a temporary key and uploads the generated
+repository as an artifact. Published APT repository updates are owned by the
+separate `wardian-app/packages` workflow, which stores the real archive signing
+key, writes `CNAME`, commits the `apt/` tree, and publishes through GitHub Pages.
 
 `latest.json` must contain all stable platform keys:
 

--- a/docs/developer/release-updates.md
+++ b/docs/developer/release-updates.md
@@ -71,12 +71,12 @@ titles.
 
 The Linux APT repository is handled by the separate **APT Repository** workflow.
 Stable releases call it after publication with `publish=true`. Until
-`https://apt.wardian.org`, archive signing key custody, and the external static
-host are provisioned, that called workflow logs a notice, performs a signed
-dry-run with a temporary key, and uploads the generated repository as an
-artifact instead of failing the release. Run the same workflow manually with
-`publish=false` to validate changes, then with `publish=true` after the APT host
-repository and signing secrets are configured.
+`https://packages.wardian.org/apt`, archive signing key custody, and the
+external static host are provisioned, that called workflow logs a notice,
+performs a signed dry-run with a temporary key, and uploads the generated
+repository as an artifact instead of failing the release. Run the same workflow
+manually with `publish=false` to validate changes, then with `publish=true`
+after the package host repository and signing secrets are configured.
 
 `latest.json` must contain all stable platform keys:
 

--- a/docs/specs/2026-06-11-linux-package-manager-distribution.md
+++ b/docs/specs/2026-06-11-linux-package-manager-distribution.md
@@ -27,11 +27,13 @@ GitHub Releases remain the canonical release artifact source. The APT repository
 is a package-manager mirror of the published stable `.deb`, not an independent
 build system and not a replacement for the Tauri updater artifacts.
 
-The intended public repository contract is `https://apt.wardian.org`. The
-initial backend can be any static host that preserves that URL contract, such as
-GitHub Pages behind the custom domain or object storage behind the same domain.
-Do not publish user-facing APT install instructions until the domain, signing
-key, fingerprint, and first validated repository tree are live.
+The intended public repository contract is `https://packages.wardian.org/apt`.
+The package host can later add sibling package-manager paths such as `/rpm`
+without changing the APT URL. The initial backend can be any static host that
+preserves that URL contract, such as GitHub Pages behind the custom domain or
+object storage behind the same domain. Do not publish user-facing APT install
+instructions until the domain, signing key, fingerprint, and first validated
+repository tree are live.
 
 The first public APT repository should publish:
 
@@ -98,9 +100,11 @@ outside the package database.
 
 ## Repository Shape
 
-The generated repository should use a conventional minimal layout:
+The package host should keep APT metadata under `/apt` so sibling package
+manager paths can be added later without changing the APT URL:
 
 ```text
+CNAME
 apt/
   pool/main/w/wardian/Wardian_X.Y.Z_amd64.deb
   dists/stable/main/binary-amd64/Packages
@@ -125,7 +129,7 @@ instead of reusing the same version string.
 Do not add upload/publish automation until the maintainers have provisioned:
 
 - the APT repository hosting location;
-- the public install URL, expected to be `https://apt.wardian.org`;
+- the public install URL, expected to be `https://packages.wardian.org/apt`;
 - the private archive signing key custody model;
 - a rotation and recovery procedure for the archive signing key;
 - a dry-run repository output directory that can be validated without publishing.
@@ -141,8 +145,8 @@ default to `publish=false`. Stable release runs can call the workflow after
 release publication with `publish=true`, but the workflow must skip effective
 publication and upload a signed dry-run artifact when the real archive signing
 key or host repository credentials are absent. The existing Wardian docs Pages
-deployment must remain separate; if GitHub Pages hosts APT, use a separate
-repository behind `https://apt.wardian.org`.
+deployment must remain separate; if GitHub Pages hosts packages, use a separate
+repository behind `https://packages.wardian.org`.
 
 Once those exist, the release job can add a Linux-only post-publish step that:
 
@@ -195,11 +199,11 @@ container or VM. Once the public repository is live, use deb822 source syntax:
 
 ```bash
 sudo install -d -m 0755 /etc/apt/keyrings
-curl -fsSL https://apt.wardian.org/wardian-archive-keyring.gpg \
+curl -fsSL https://packages.wardian.org/apt/wardian-archive-keyring.gpg \
   | sudo tee /etc/apt/keyrings/wardian.gpg >/dev/null
 sudo tee /etc/apt/sources.list.d/wardian.sources >/dev/null <<'EOF'
 Types: deb
-URIs: https://apt.wardian.org
+URIs: https://packages.wardian.org/apt
 Suites: stable
 Components: main
 Architectures: amd64

--- a/docs/specs/2026-06-11-linux-package-manager-distribution.md
+++ b/docs/specs/2026-06-11-linux-package-manager-distribution.md
@@ -126,29 +126,30 @@ instead of reusing the same version string.
 
 ## Release Automation Gate
 
-Do not add upload/publish automation until the maintainers have provisioned:
+APT publication requires:
 
-- the APT repository hosting location;
+- a separate package host repository, currently `wardian-app/packages`;
 - the public install URL, expected to be `https://packages.wardian.org/apt`;
 - the private archive signing key custody model;
 - a rotation and recovery procedure for the archive signing key;
-- a dry-run repository output directory that can be validated without publishing.
+- a dry-run repository output directory that can be validated without publishing;
+- a release dispatch GitHub App installed on the package repository with Actions
+  write permission.
 
 Local dry runs from Windows should use WSL Ubuntu or another Linux environment
-for Debian tooling. The long-term publishing job should run on a Linux CI runner
-so repository generation is reproducible and does not depend on a maintainer's
-workstation.
+for Debian tooling. Production publishing should run on a Linux CI runner in the
+package host repository so repository generation is reproducible and does not
+depend on a maintainer's workstation.
 
-The first automation step is a reusable GitHub Actions workflow that builds and
-validates the APT repository from a published stable release. Manual runs should
-default to `publish=false`. Stable release runs can call the workflow after
-release publication with `publish=true`, but the workflow must skip effective
-publication and upload a signed dry-run artifact when the real archive signing
-key or host repository credentials are absent. The existing Wardian docs Pages
-deployment must remain separate; if GitHub Pages hosts packages, use a separate
-repository behind `https://packages.wardian.org`.
+The Wardian repository keeps a manual **APT Repository** validation workflow
+that builds and validates a signed dry-run repository from a published stable
+release. It uses a temporary signing key and uploads the repository tree as an
+artifact. Public publishing is owned by the package host repository workflow,
+which holds the real archive signing key, commits the `apt/` tree, and publishes
+through the package host. The existing Wardian docs Pages deployment must remain
+separate.
 
-Once those exist, the release job can add a Linux-only post-publish step that:
+The package host publish workflow:
 
 1. reads `gh release view vX.Y.Z --json tagName,assets`;
 2. verifies the `.deb` asset name, tag URL, and SHA-256 digest;

--- a/src/config/releaseWorkflow.test.ts
+++ b/src/config/releaseWorkflow.test.ts
@@ -130,18 +130,28 @@ describe("release workflow contract", () => {
     expect(releaseWorkflow).toContain("needs: [create-release, resolve-release, build, cleanup-updater-signatures, validate-updater-metadata]");
   });
 
-  it("dispatches Homebrew tap updates after stable releases publish", () => {
-    expect(releaseWorkflow).toContain("update-homebrew-cask:");
-    expect(releaseWorkflow).toContain("Update Homebrew cask");
+  it("dispatches package repository workflows after stable releases publish", () => {
+    expect(releaseWorkflow).toContain("dispatch-package-workflows:");
+    expect(releaseWorkflow).toContain("Dispatch package workflows");
     expect(releaseWorkflow).toContain("needs: [create-release, resolve-release, publish]");
     expect(releaseWorkflow).toContain("needs.publish.result == 'success'");
     expect(releaseWorkflow).toContain("needs.create-release.outputs.is_prerelease == 'false'");
     expect(releaseWorkflow).toContain("needs.resolve-release.outputs.is_prerelease == 'false'");
-    expect(releaseWorkflow).toContain("HOMEBREW_TAP_DISPATCH_TOKEN");
-    expect(releaseWorkflow).toContain("wardian-release-published");
+    expect(releaseWorkflow).toContain("actions/create-github-app-token@v3.2.0");
+    expect(releaseWorkflow).toContain("WARDIAN_RELEASE_DISPATCH_APP_ID");
+    expect(releaseWorkflow).toContain("WARDIAN_RELEASE_DISPATCH_PRIVATE_KEY");
+    expect(releaseWorkflow).toContain("actions.createWorkflowDispatch");
     expect(releaseWorkflow).toContain("owner: 'wardian-app'");
     expect(releaseWorkflow).toContain("repo: 'homebrew-tap'");
+    expect(releaseWorkflow).toContain("workflow_id: 'update-cask.yml'");
     expect(releaseWorkflow).toContain("tag: process.env.RELEASE_TAG");
+    expect(releaseWorkflow).toContain("repo: 'packages'");
+    expect(releaseWorkflow).toContain("workflow_id: 'publish-apt.yml'");
+    expect(releaseWorkflow).toContain("release_tag: process.env.RELEASE_TAG");
+    expect(releaseWorkflow).not.toContain("HOMEBREW_TAP_DISPATCH_TOKEN");
+    expect(releaseWorkflow).not.toContain("wardian-release-published");
+    expect(releaseWorkflow).not.toContain("update-apt-repository:");
+    expect(releaseWorkflow).not.toContain("uses: ./.github/workflows/apt-repository.yml");
   });
 
   it("publishes unified installers that carry the staged CLI", () => {


### PR DESCRIPTION
## Description
Switches Linux package publishing to the extensible `packages.wardian.org/apt` host and the GitHub App dispatch model.

- Updates Wardian release automation to create a short-lived GitHub App token and dispatch `wardian-app/homebrew-tap` plus `wardian-app/packages` workflows after stable release publication.
- Converts Wardian's local `apt-repository.yml` workflow to validation-only dry-run artifact generation.
- Documents that published APT repository ownership lives in `wardian-app/packages`, with Wardian responsible for release dispatch.
- Updates maintainer docs and the Linux package-manager spec to use `https://packages.wardian.org/apt`.

Package repository dependency: https://github.com/wardian-app/packages/pull/1

## Related Issues
Refs #324

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] CI/release maintenance

## How Has This Been Tested?
- `npm run test -- src/config/releaseWorkflow.test.ts src/config/aptRepoGenerator.test.ts`
- `npm run lint`
- `npm run docs:check-llms`
- `npm run docs:build`
- `git diff --check`
- Verified `actions/create-github-app-token@v3.2.0` exists.
- Verified `wardian-app/homebrew-tap/.github/workflows/update-cask.yml` accepts workflow_dispatch input `tag`.
- Verified `wardian-app/packages` PR #1 is open and mergeable with workflow_dispatch input `release_tag`.
- APT Repository dry run previously passed on this branch: https://github.com/wardian-app/Wardian/actions/runs/27393104406

Attempted but unavailable locally:
- YAML parser check via `require("yaml")`: package not installed in this worktree.
- Ruby YAML parser: `ruby` not installed.
- `actionlint`: not installed.

Full backend Rust suites were not rerun because this changes release workflows, docs, and workflow contract tests only.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings in the targeted checks
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing targeted unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
