### PR TITLE
docs(packaging): publish APT install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ Choose the asset for your operating system and CPU:
 
 `x64` and `amd64` both mean 64-bit Intel/AMD CPUs. On macOS, Apple Silicon uses `aarch64`, not `x64`. Ignore updater-only assets such as `latest.json`, `.app.tar.gz`, or `.sig` files when installing manually.
 
+Debian/Ubuntu users who want package-manager updates can use the optional
+[Wardian APT repository](docs/developer/package-manager-distribution.md#linux-apt-repository).
+
 > **Note:** Wardian binaries are currently unsigned. On first launch:
 > - **Windows:** SmartScreen will show a warning. Click "More info" → "Run anyway."
 > - **macOS:** Gatekeeper will refuse to open the app. Right-click the app and choose "Open," or run `xattr -cr /Applications/Wardian.app` from Terminal.
-> - **Linux:** `.AppImage` is portable (`chmod +x` and run); `.deb` installs via `sudo apt install ./Wardian_*.deb`.
+> - **Linux:** APT installs update through the system package manager. `.AppImage` is portable (`chmod +x` and run); direct `.deb` downloads install via `sudo apt install ./Wardian_*.deb`.
 
 ---
 

--- a/docs/developer/package-manager-distribution.md
+++ b/docs/developer/package-manager-distribution.md
@@ -10,7 +10,8 @@ Phase 1 covers:
 
 - winget for Windows, using the NSIS `.exe`.
 - Homebrew Cask for macOS, using the Apple Silicon and Intel `.dmg` files.
-- Linux direct-install docs for `.deb` and AppImage artifacts.
+- A signed APT repository for Debian/Ubuntu x64, using the stable `.deb`.
+- Linux direct-install fallback docs for `.deb` and AppImage artifacts.
 
 npm bootstrap and standalone CLI-only distribution are out of scope for Phase 1.
 Linux package-manager publishing is tracked in
@@ -108,8 +109,9 @@ they must never point at prerelease or draft artifacts.
 ## Linux Direct Install
 
 Use `dist/package-managers/v0.3.6/linux/install.md` as the hash-verified Linux
-install snippet for release notes and documentation until the APT repository is
-published. Do not present it as Flatpak, Snap, or AppImageUpdate.
+install fallback for release notes and documentation. Debian/Ubuntu users should
+prefer the signed APT repository. Do not present direct `.deb` downloads as
+Flatpak, Snap, or AppImageUpdate.
 
 ## Linux APT Repository
 
@@ -119,13 +121,26 @@ canonical artifact source; APT metadata is the Linux package-manager integrity
 surface and must be generated only after the stable release assets and updater
 metadata have been published and validated.
 
-The intended public repository contract is `https://packages.wardian.org/apt`.
-The package host can later add sibling package-manager paths such as `/rpm`
-without changing the APT URL. The first backend may be any static host that
-preserves that URL contract, such as GitHub Pages behind the custom domain or
-object storage behind the same domain. Do not publish user-facing APT install
-instructions until the public URL, archive signing key, key fingerprint, and
-first validated repository tree are live.
+The public repository is `https://packages.wardian.org/apt`. The package host
+can later add sibling package-manager paths such as `/rpm` without changing the
+APT URL. The first backend is GitHub Pages behind `packages.wardian.org`.
+
+Public Debian/Ubuntu install instructions:
+
+```bash
+curl -fsSL https://packages.wardian.org/apt/wardian-archive-keyring.gpg \
+  | sudo install -D -m 0644 /dev/stdin /etc/apt/keyrings/wardian.gpg
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/wardian.gpg] https://packages.wardian.org/apt stable main" \
+  | sudo tee /etc/apt/sources.list.d/wardian.list >/dev/null
+sudo apt update
+sudo apt install wardian
+```
+
+Archive key fingerprint:
+
+```text
+C956 3C05 D88D B483 748A 5F8B 66E5 FF51 0BCE 9193
+```
 
 Local dry runs from Windows should use WSL Ubuntu or another Linux environment
 for Debian tooling. Published automation runs in the separate

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -30,11 +30,14 @@ Choose the asset for your operating system and CPU:
 
 `x64` and `amd64` both mean 64-bit Intel/AMD CPUs. On macOS, Apple Silicon uses `aarch64`, not `x64`. Ignore updater-only assets such as `latest.json`, `.app.tar.gz`, or `.sig` files when installing manually.
 
+Debian/Ubuntu users who want package-manager updates can use the optional
+[Wardian APT repository](../developer/package-manager-distribution.md#linux-apt-repository).
+
 Wardian binaries are currently unsigned:
 
 - **Windows:** SmartScreen can show a warning. Choose **More info**, then **Run anyway**.
 - **macOS:** Gatekeeper can block the first launch. Right-click Wardian and choose **Open**.
-- **Linux:** Make the AppImage executable before running it.
+- **Linux:** APT installs update through the system package manager. Make the AppImage executable before running it.
 
 ```bash
 chmod +x Wardian*.AppImage

--- a/docs/specs/2026-06-11-linux-package-manager-distribution.md
+++ b/docs/specs/2026-06-11-linux-package-manager-distribution.md
@@ -1,7 +1,8 @@
 # Linux Package Manager Distribution
 
-- **Status:** Proposed
+- **Status:** Accepted and implemented
 - **Date:** 2026-06-11
+- **Implemented:** 2026-06-12
 - **Issue:** [#324](https://github.com/wardian-app/Wardian/issues/324)
 - **Decision owner:** Maintainers
 
@@ -27,13 +28,12 @@ GitHub Releases remain the canonical release artifact source. The APT repository
 is a package-manager mirror of the published stable `.deb`, not an independent
 build system and not a replacement for the Tauri updater artifacts.
 
-The intended public repository contract is `https://packages.wardian.org/apt`.
-The package host can later add sibling package-manager paths such as `/rpm`
-without changing the APT URL. The initial backend can be any static host that
-preserves that URL contract, such as GitHub Pages behind the custom domain or
-object storage behind the same domain. Do not publish user-facing APT install
-instructions until the domain, signing key, fingerprint, and first validated
-repository tree are live.
+The public repository contract is `https://packages.wardian.org/apt`. The
+package host can later add sibling package-manager paths such as `/rpm` without
+changing the APT URL. The initial backend is GitHub Pages behind
+`packages.wardian.org`. User-facing APT install instructions may be published
+only after the domain, signing key, fingerprint, and first validated repository
+tree are live; that gate was satisfied on 2026-06-12.
 
 The first public APT repository should publish:
 


### PR DESCRIPTION
## Description
Documents the now-live Wardian APT repository as an optional Debian/Ubuntu package-manager update path while keeping first-run install docs focused on direct downloads.

- Keeps `README.md` and `docs/guide/getting-started.md` clean: Windows and macOS get one-line package-manager commands; Linux defaults to the direct `.deb` / AppImage release assets.
- Adds a small optional APT repository pointer for Debian/Ubuntu users who specifically want package-manager updates.
- Updates the package-manager developer guide from provisioned/pending language to live APT repository language, with the full setup commands and archive key fingerprint.
- Marks the Linux package-manager distribution spec accepted and implemented.

## Related Issues
Refs #324

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] CI/release maintenance

## How Has This Been Tested?
- `npm run docs:check-llms`
- `npm run docs:build`
- `git diff --check`
- Verified GitHub Pages reports `https_enforced=true` for `packages.wardian.org`.
- Verified `https://packages.wardian.org/apt/dists/stable/InRelease` returns HTTP 200.
- Verified the compact `.list` install form in a temporary WSL APT state; `apt update` sees `wardian` candidate `0.4.0` from `https://packages.wardian.org/apt`.

No frontend/backend runtime suites were rerun because this is documentation-only.

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings in the targeted checks
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing targeted checks pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
