### PR TITLE
fix(explorer): normalize watcher paths for refresh

### DIFF
--- a/docs/developer/explorer-sidebar.md
+++ b/docs/developer/explorer-sidebar.md
@@ -19,6 +19,7 @@ This is the main container component for the file explorer tab.
 A recursive, lazy-loading component responsible for accurately representing nested directory structures.
 - **Lazy Loading**: Instead of indexing the entire workspace at once, it fetches child nodes only when a directory is expanded, ensuring optimal performance for large projects.
 - **Targeted Refresh**: Each mounted tree refetches its directory when the refresh token changes and one of the changed paths directly affects that directory. Expanded state stays local to the component, so refreshes do not collapse the visible tree.
+- **Path Identity**: Explorer path comparisons use `normalizeExplorerPathForCompare` so Windows-specific verbatim watcher paths such as `\\?\<absolute-windows-path>` match ordinary display paths from directory reads.
 - **Theming**: Integrates seamlessly with Wardian typography and spacing. Nested items have fixed padding metrics to align correctly underneath parent elements without succumbing to horizontal flex contraction (`shrink-0`). Directory rows use only their expansion chevron; file rows use `lucide-react` icons with colors mapped explicitly to `wardian-*` CSS variables based on file extensions.
 
 ### 3. Backend Commands (`src-tauri/src/commands/fs.rs`)

--- a/docs/developer/explorer-sidebar.md
+++ b/docs/developer/explorer-sidebar.md
@@ -19,7 +19,7 @@ This is the main container component for the file explorer tab.
 A recursive, lazy-loading component responsible for accurately representing nested directory structures.
 - **Lazy Loading**: Instead of indexing the entire workspace at once, it fetches child nodes only when a directory is expanded, ensuring optimal performance for large projects.
 - **Targeted Refresh**: Each mounted tree refetches its directory when the refresh token changes and one of the changed paths directly affects that directory. Expanded state stays local to the component, so refreshes do not collapse the visible tree.
-- **Path Identity**: Explorer path comparisons use `normalizeExplorerPathForCompare` so Windows-specific verbatim watcher paths such as `\\?\<absolute-windows-path>` match ordinary display paths from directory reads.
+- **Path Identity**: Explorer path comparisons use `normalizeExplorerPathForCompare` so Windows-specific watcher paths such as `\\?\<absolute-windows-path>` match ordinary display paths from directory reads without rewriting POSIX path spelling, case, or significant whitespace.
 - **Theming**: Integrates seamlessly with Wardian typography and spacing. Nested items have fixed padding metrics to align correctly underneath parent elements without succumbing to horizontal flex contraction (`shrink-0`). Directory rows use only their expansion chevron; file rows use `lucide-react` icons with colors mapped explicitly to `wardian-*` CSS variables based on file extensions.
 
 ### 3. Backend Commands (`src-tauri/src/commands/fs.rs`)

--- a/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
+++ b/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
@@ -27,6 +27,12 @@ The watcher excludes high-churn implementation folders such as `.git`,
 `node_modules`, `target`, `.venv`, `dist`, `build`, `.next`, `.turbo`,
 `.cache`, and `.wardian/tmp`.
 
+The frontend normalizes watcher paths before comparing them with rendered tree
+paths. This includes stripping Windows verbatim prefixes such as
+`\\?\<absolute-windows-path>` and `\\?\UNC\<server>\<share>\...`, because
+platform watcher backends can report canonical paths while `get_directory_tree`
+returns display paths.
+
 ## Consequences
 
 * Visible explorer directories update without manual tab switching or polling.

--- a/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
+++ b/docs/specs/2026-06-02-explorer-filesystem-watch-refresh.md
@@ -27,11 +27,12 @@ The watcher excludes high-churn implementation folders such as `.git`,
 `node_modules`, `target`, `.venv`, `dist`, `build`, `.next`, `.turbo`,
 `.cache`, and `.wardian/tmp`.
 
-The frontend normalizes watcher paths before comparing them with rendered tree
-paths. This includes stripping Windows verbatim prefixes such as
+The frontend normalizes Windows-shaped watcher paths before comparing them with
+rendered tree paths. This includes stripping Windows verbatim prefixes such as
 `\\?\<absolute-windows-path>` and `\\?\UNC\<server>\<share>\...`, because
 platform watcher backends can report canonical paths while `get_directory_tree`
-returns display paths.
+returns display paths. Non-Windows path spelling, case, and significant
+whitespace are preserved for comparisons.
 
 ## Consequences
 

--- a/src/features/explorer/ExplorerPanel.test.tsx
+++ b/src/features/explorer/ExplorerPanel.test.tsx
@@ -309,6 +309,35 @@ describe('ExplorerPanel', () => {
     expect(screen.getByTestId('file-tree-changed-paths')).toHaveTextContent('C:\\Users\\test\\repo\\src\\new-file.ts');
   });
 
+  it('passes explorer change events when the watcher reports a Windows verbatim root path', async () => {
+    let handler: ((event: { payload: { root_path: string; changed_paths: string[] } }) => void) | undefined;
+    mockListen.mockImplementation(async (_event, callback) => {
+      handler = callback as typeof handler;
+      return () => {};
+    });
+    vi.mocked(invoke).mockImplementation(async (command) => {
+      if (command === 'get_explorer_root') return 'C:\\Users\\test\\repo';
+      if (command === 'git_status') return { files: [] };
+      return null;
+    });
+
+    render(<ExplorerPanel selectedAgentIds={new Set()} agents={[]} />);
+
+    expect(await screen.findByTestId('file-tree-refresh-token')).toHaveTextContent('0');
+
+    await act(async () => {
+      handler?.({
+        payload: {
+          root_path: '\\\\?\\C:\\Users\\test\\repo',
+          changed_paths: ['\\\\?\\C:\\Users\\test\\repo\\src\\new-file.ts'],
+        },
+      });
+    });
+
+    expect(await screen.findByTestId('file-tree-refresh-token')).toHaveTextContent('1');
+    expect(screen.getByTestId('file-tree-changed-paths')).toHaveTextContent('\\\\?\\C:\\Users\\test\\repo\\src\\new-file.ts');
+  });
+
   it('ignores explorer change events from other roots', async () => {
     let handler: ((event: { payload: { root_path: string; changed_paths: string[] } }) => void) | undefined;
     mockListen.mockImplementation(async (_event, callback) => {

--- a/src/features/explorer/ExplorerPanel.tsx
+++ b/src/features/explorer/ExplorerPanel.tsx
@@ -7,6 +7,7 @@ import { FileTree, FileNode } from './FileTree';
 import { useConfirm } from '../../components/ConfirmDialog';
 import { AgentConfig, GitStatusResult } from '../../types';
 import { useSettingsStore } from '../../store/useSettingsStore';
+import { normalizeExplorerPathForCompare } from './pathUtils';
 
 interface ExplorerPanelProps {
   selectedAgentIds: Set<string>;
@@ -17,11 +18,6 @@ interface ExplorerChangedEvent {
   root_path: string;
   changed_paths: string[];
 }
-
-const normalizeComparablePath = (path: string): string => {
-  const normalized = path.replace(/\\/g, '/').replace(/\/+$/g, '');
-  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
-};
 
 const externalEditorLabel = (editor: string) => {
   switch (editor) {
@@ -117,7 +113,10 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({ selectedAgentIds, 
     let disposed = false;
     let watchActive = false;
     const unlistenPromise = listen<ExplorerChangedEvent>('explorer-changed', (event) => {
-      if (normalizeComparablePath(event.payload.root_path) !== normalizeComparablePath(rootPath)) {
+      if (
+        normalizeExplorerPathForCompare(event.payload.root_path) !==
+        normalizeExplorerPathForCompare(rootPath)
+      ) {
         return;
       }
       setChangedPaths(event.payload.changed_paths);

--- a/src/features/explorer/FileTree.test.tsx
+++ b/src/features/explorer/FileTree.test.tsx
@@ -136,6 +136,55 @@ describe('FileTree Component', () => {
     expect(screen.getByText('src')).toBeInTheDocument();
   });
 
+  it('refetches an expanded directory when a Windows watcher reports a verbatim changed path', async () => {
+    const rootPath = 'C:\\Users\\test\\repo';
+    const srcPath = 'C:\\Users\\test\\repo\\src';
+    const rootNodes = [
+      { name: 'src', path: srcPath, is_dir: true, extension: null },
+    ];
+    const initialSrcNodes = [
+      { name: 'before.ts', path: `${srcPath}\\before.ts`, is_dir: false, extension: 'ts' },
+    ];
+    const refreshedSrcNodes = [
+      { name: 'after.ts', path: `${srcPath}\\after.ts`, is_dir: false, extension: 'ts' },
+    ];
+    let srcReads = 0;
+
+    vi.mocked(invoke).mockImplementation(async (_command, args) => {
+      const path = (args as { path: string }).path;
+      if (path === rootPath) return rootNodes;
+      if (path === srcPath) {
+        srcReads += 1;
+        return srcReads === 1 ? initialSrcNodes : refreshedSrcNodes;
+      }
+      return [];
+    });
+
+    const { rerender } = render(
+      <FileTree
+        path={rootPath}
+        explorerRoot={rootPath}
+        refreshToken={0}
+        changedPaths={[]}
+      />,
+    );
+
+    await userEvent.click(await screen.findByText('src'));
+    expect(await screen.findByText('before.ts')).toBeInTheDocument();
+
+    rerender(
+      <FileTree
+        path={rootPath}
+        explorerRoot={rootPath}
+        refreshToken={1}
+        changedPaths={['\\\\?\\C:\\Users\\test\\repo\\src\\after.ts']}
+      />,
+    );
+
+    expect(await screen.findByText('after.ts')).toBeInTheDocument();
+    expect(screen.queryByText('before.ts')).not.toBeInTheDocument();
+  });
+
   it('does not refetch an expanded directory when a refresh event is unrelated', async () => {
     const rootNodes = [
       { name: 'src', path: '/test/src', is_dir: true, extension: null },

--- a/src/features/explorer/FileTree.tsx
+++ b/src/features/explorer/FileTree.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { ChevronRight, ChevronDown, File, FileText, Image, Code } from 'lucide-react';
+import { normalizeExplorerPathForCompare } from './pathUtils';
 
 export interface FileNode {
   name: string;
@@ -36,14 +37,9 @@ function toRelativePath(nodePath: string, root: string): string {
   return n.startsWith(r) ? n.slice(r.length).replace(/^\//, '') : n;
 }
 
-function normalizePathForCompare(path: string): string {
-  const normalized = path.replace(/\\/g, '/').replace(/\/+$/g, '');
-  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
-}
-
 function pathAffectsDirectory(changedPath: string, directoryPath: string): boolean {
-  const changed = normalizePathForCompare(changedPath);
-  const directory = normalizePathForCompare(directoryPath);
+  const changed = normalizeExplorerPathForCompare(changedPath);
+  const directory = normalizeExplorerPathForCompare(directoryPath);
   const changedParent = changed.includes('/') ? changed.slice(0, changed.lastIndexOf('/')) : '';
   return changed === directory || changedParent === directory;
 }

--- a/src/features/explorer/pathUtils.test.ts
+++ b/src/features/explorer/pathUtils.test.ts
@@ -16,6 +16,7 @@ describe('normalizeExplorerPathForCompare', () => {
 
   it('preserves POSIX root and significant trailing spaces', () => {
     expect(normalizeExplorerPathForCompare('/', false)).toBe('/');
+    expect(normalizeExplorerPathForCompare('//', false)).toBe('//');
     expect(normalizeExplorerPathForCompare('/tmp/name ', false)).toBe('/tmp/name ');
   });
 

--- a/src/features/explorer/pathUtils.test.ts
+++ b/src/features/explorer/pathUtils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeExplorerPathForCompare } from './pathUtils';
+
+describe('normalizeExplorerPathForCompare', () => {
+  it('normalizes Windows verbatim drive paths reported with backslashes', () => {
+    expect(normalizeExplorerPathForCompare('\\\\?\\C:\\Users\\Test\\Repo', false)).toBe('c:/users/test/repo');
+  });
+
+  it('normalizes Windows verbatim UNC paths reported with backslashes', () => {
+    expect(normalizeExplorerPathForCompare('\\\\?\\UNC\\SERVER\\share\\Repo', false)).toBe('//server/share/repo');
+  });
+
+  it('compares drive-letter paths case-insensitively on Windows hosts', () => {
+    expect(normalizeExplorerPathForCompare('C:/Users/Test/Repo', true)).toBe('c:/users/test/repo');
+  });
+
+  it('preserves POSIX root and significant trailing spaces', () => {
+    expect(normalizeExplorerPathForCompare('/', false)).toBe('/');
+    expect(normalizeExplorerPathForCompare('/tmp/name ', false)).toBe('/tmp/name ');
+  });
+
+  it('preserves non-Windows paths that resemble verbatim or drive-letter paths', () => {
+    expect(normalizeExplorerPathForCompare('//server/share', false)).toBe('//server/share');
+    expect(normalizeExplorerPathForCompare('//?/tmp/project', false)).toBe('//?/tmp/project');
+    expect(normalizeExplorerPathForCompare('//?/UNC/server/share', false)).toBe('//?/UNC/server/share');
+    expect(normalizeExplorerPathForCompare('C:/Case/Sensitive', false)).toBe('C:/Case/Sensitive');
+  });
+});

--- a/src/features/explorer/pathUtils.ts
+++ b/src/features/explorer/pathUtils.ts
@@ -1,10 +1,40 @@
-export const normalizeExplorerPathForCompare = (path: string): string => {
-  const normalized = path
-    .trim()
-    .replace(/\\/g, '/')
-    .replace(/^\/\/\?\/UNC\//i, '//')
-    .replace(/^\/\/\?\//, '')
-    .replace(/\/+$/g, '');
+const isWindowsExplorerHost = (): boolean => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
 
-  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+  return /win/i.test(navigator.platform);
+};
+
+const stripTrailingSeparators = (path: string): string => {
+  if (path === '/' || /^[a-z]:\/$/i.test(path)) {
+    return path;
+  }
+
+  return path.replace(/\/+$/g, '');
+};
+
+const looksLikeWindowsPath = (path: string, isWindowsHost: boolean): boolean => (
+  isWindowsHost
+  || /^\\\\\?\\/.test(path)
+  || /^[a-z]:\\/i.test(path)
+  || /^\\\\[^\\]/.test(path)
+);
+
+export const normalizeExplorerPathForCompare = (
+  path: string,
+  isWindowsHost = isWindowsExplorerHost(),
+): string => {
+  const isWindowsPath = looksLikeWindowsPath(path, isWindowsHost);
+  let normalized = isWindowsPath ? path.replace(/\\/g, '/') : path;
+
+  if (isWindowsPath) {
+    normalized = normalized
+      .replace(/^\/\/\?\/UNC\//i, '//')
+      .replace(/^\/\/\?\/([a-z]:\/)/i, '$1');
+  }
+
+  normalized = stripTrailingSeparators(normalized);
+
+  return isWindowsPath ? normalized.toLowerCase() : normalized;
 };

--- a/src/features/explorer/pathUtils.ts
+++ b/src/features/explorer/pathUtils.ts
@@ -7,7 +7,7 @@ const isWindowsExplorerHost = (): boolean => {
 };
 
 const stripTrailingSeparators = (path: string): string => {
-  if (path === '/' || /^[a-z]:\/$/i.test(path)) {
+  if (path === '/' || path === '//' || /^[a-z]:\/$/i.test(path)) {
     return path;
   }
 

--- a/src/features/explorer/pathUtils.ts
+++ b/src/features/explorer/pathUtils.ts
@@ -1,0 +1,10 @@
+export const normalizeExplorerPathForCompare = (path: string): string => {
+  const normalized = path
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/\/\?\/UNC\//i, '//')
+    .replace(/^\/\/\?\//, '')
+    .replace(/\/+$/g, '');
+
+  return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
+};


### PR DESCRIPTION
## Description
Normalize Explorer watcher paths before comparing them with rendered tree paths so Windows verbatim watcher events (for example, `\\?\<absolute-windows-path>`) still refresh the open sidebar tree.

After independent review, the comparison helper now limits Windows-specific normalization to Windows-shaped paths and preserves non-Windows path spelling, case, and significant whitespace.

## Related Issues
Fixes #546

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run test -- src/features/explorer/pathUtils.test.ts src/features/explorer/ExplorerPanel.test.tsx src/features/explorer/FileTree.test.tsx`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test` attempted with default target; blocked by active `D:\Development\Wardian\target\debug\Wardian.exe` process lock, then passed with `CARGO_TARGET_DIR=D:\Development\Wardian.wt\wardian-3\.tmp\cargo-target-pr`
- [x] `cd src-tauri && cargo clippy` passed with `CARGO_TARGET_DIR=D:\Development\Wardian.wt\wardian-3\.tmp\cargo-target-pr`
- [x] `npm run docs:check-llms`
- [x] `npm run docs:build`
- [x] `git diff --check`
- [x] Secret-pattern scan over touched files

## Screenshots
Explorer panel state, included for frontend PR evidence. This PR changes path matching for refresh behavior and does not alter visual styling.

![Explorer workspace tree](https://github.com/wardian-app/Wardian/blob/main/docs/assets/screenshots/explorer/workspace-tree.png?raw=1)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable