### PR TITLE
fix(terminal): stop typed Codex color-probe garbage and theme its composer correctly

### DIFF
--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -2313,7 +2313,7 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
-  it("pushes updated Codex terminal colors when Wardian switches back to dark mode", async () => {
+  it("re-renders Codex's composer on theme switch without pushing duplicate color replies (ConPTY answers natively)", async () => {
     const codexComposerFrame = "\u001b[48;2;41;41;41m\n\u001b[K";
     let peekCount = 0;
     mockInvoke.mockImplementation(async (cmd: string, args?: unknown) => {
@@ -2359,19 +2359,27 @@ describe("AgentTerminal scrollback", () => {
     mockInvoke.mockClear();
     view.rerender(<AgentTerminal sessionId="codex-live-theme" provider="codex" theme="dark" />);
 
+    // Codex runs under the bundled modern ConPTY, which answers its color /
+    // light-dark probes natively. Wardian must NOT also push duplicate replies
+    // as input -- they get echoed back into codex's output as stray ]11;rgb /
+    // ?997;1n garbage, and this theme effect re-fires on every maximize/minimize
+    // re-render, bombarding every mounted codex terminal at once.
+    const codexEsc = String.fromCharCode(27);
+    const codexSt = codexEsc + String.fromCharCode(92);
     await waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
-        sessionId: "codex-live-theme",
-        input: "\u001b[?997;1n",
-      });
-      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
-        sessionId: "codex-live-theme",
-        input: "\u001b]11;rgb:1a/1a/1a\u001b\\",
-      });
-      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
-        sessionId: "codex-live-theme",
-        input: "\u001b]10;rgb:eb/eb/eb\u001b\\",
-      });
+      expect(instance.reset).toHaveBeenCalled();
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-live-theme",
+      input: codexEsc + "[?997;1n",
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-live-theme",
+      input: codexEsc + "]11;rgb:1a/1a/1a" + codexSt,
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-live-theme",
+      input: codexEsc + "]10;rgb:eb/eb/eb" + codexSt,
     });
 
     await waitFor(() => {

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -2313,7 +2313,7 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
-  it("pushes updated Codex terminal colors on a real theme swap so the TUI repaints (and replays the composer)", async () => {
+  it("recolors Codex via composer replay on a real theme swap without typing color replies into its stdin", async () => {
     const codexComposerFrame = "\u001b[48;2;41;41;41m\n\u001b[K";
     let peekCount = 0;
     mockInvoke.mockImplementation(async (cmd: string, args?: unknown) => {
@@ -2359,25 +2359,25 @@ describe("AgentTerminal scrollback", () => {
     mockInvoke.mockClear();
     view.rerender(<AgentTerminal sessionId="codex-live-theme" provider="codex" theme="dark" />);
 
-    // A real light<->dark swap conveys the new scheme to codex (whose bundled
-    // ConPTY answers probes with its own colors, not Wardian's theme), so the TUI
-    // repaints. The echo this produces is scrubbed by the output-side strip; the
-    // push is gated to actual theme changes so maximize/minimize never fires it.
+    // Codex recolors via the Wardian-side composer replay, NOT by pushing color
+    // replies into its stdin: those are terminal->app responses, so codex's prompt
+    // line editor would just type them in as literal "[?997;1n]11;rgb:..." text.
     const codexEsc = String.fromCharCode(27);
     const codexSt = codexEsc + String.fromCharCode(92);
     await waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
-        sessionId: "codex-live-theme",
-        input: codexEsc + "[?997;1n",
-      });
-      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
-        sessionId: "codex-live-theme",
-        input: codexEsc + "]11;rgb:1a/1a/1a" + codexSt,
-      });
-      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
-        sessionId: "codex-live-theme",
-        input: codexEsc + "]10;rgb:eb/eb/eb" + codexSt,
-      });
+      expect(instance.reset).toHaveBeenCalled();
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-live-theme",
+      input: codexEsc + "[?997;1n",
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-live-theme",
+      input: codexEsc + "]11;rgb:1a/1a/1a" + codexSt,
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
+      sessionId: "codex-live-theme",
+      input: codexEsc + "]10;rgb:eb/eb/eb" + codexSt,
     });
 
     await waitFor(() => {

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -2313,7 +2313,7 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
-  it("re-renders Codex's composer on theme switch without pushing duplicate color replies (ConPTY answers natively)", async () => {
+  it("pushes updated Codex terminal colors on a real theme swap so the TUI repaints (and replays the composer)", async () => {
     const codexComposerFrame = "\u001b[48;2;41;41;41m\n\u001b[K";
     let peekCount = 0;
     mockInvoke.mockImplementation(async (cmd: string, args?: unknown) => {
@@ -2359,27 +2359,25 @@ describe("AgentTerminal scrollback", () => {
     mockInvoke.mockClear();
     view.rerender(<AgentTerminal sessionId="codex-live-theme" provider="codex" theme="dark" />);
 
-    // Codex runs under the bundled modern ConPTY, which answers its color /
-    // light-dark probes natively. Wardian must NOT also push duplicate replies
-    // as input -- they get echoed back into codex's output as stray ]11;rgb /
-    // ?997;1n garbage, and this theme effect re-fires on every maximize/minimize
-    // re-render, bombarding every mounted codex terminal at once.
+    // A real light<->dark swap conveys the new scheme to codex (whose bundled
+    // ConPTY answers probes with its own colors, not Wardian's theme), so the TUI
+    // repaints. The echo this produces is scrubbed by the output-side strip; the
+    // push is gated to actual theme changes so maximize/minimize never fires it.
     const codexEsc = String.fromCharCode(27);
     const codexSt = codexEsc + String.fromCharCode(92);
     await waitFor(() => {
-      expect(instance.reset).toHaveBeenCalled();
-    });
-    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
-      sessionId: "codex-live-theme",
-      input: codexEsc + "[?997;1n",
-    });
-    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
-      sessionId: "codex-live-theme",
-      input: codexEsc + "]11;rgb:1a/1a/1a" + codexSt,
-    });
-    expect(mockInvoke).not.toHaveBeenCalledWith("send_input_to_agent", {
-      sessionId: "codex-live-theme",
-      input: codexEsc + "]10;rgb:eb/eb/eb" + codexSt,
+      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
+        sessionId: "codex-live-theme",
+        input: codexEsc + "[?997;1n",
+      });
+      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
+        sessionId: "codex-live-theme",
+        input: codexEsc + "]11;rgb:1a/1a/1a" + codexSt,
+      });
+      expect(mockInvoke).toHaveBeenCalledWith("send_input_to_agent", {
+        sessionId: "codex-live-theme",
+        input: codexEsc + "]10;rgb:eb/eb/eb" + codexSt,
+      });
     });
 
     await waitFor(() => {

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -2303,17 +2303,24 @@ export const AgentTerminal = memo(function AgentTerminal({
     const previousSignaledTheme = lastThemeSignalRef.current;
     lastThemeSignalRef.current = activeTermTheme;
     entry.currentTheme = activeTermTheme;
-    // Opencode/antigravity infer their visible mode from these proactively-pushed
-    // ?997 + OSC color replies. Codex is deliberately excluded: it runs under the
-    // bundled modern ConPTY, which answers codex's own color/light-dark probes
-    // natively (see respondsToThemeColorQueries, which already excludes codex on
-    // the reactive path). Pushing Wardian's duplicate replies as input just gets
-    // them echoed back into codex's output as stray ]11;rgb / ?997;1n garbage --
-    // and because this theme effect re-runs on every maximize/minimize re-render,
-    // it bombards *every* mounted codex terminal at once, not just the resized one.
-    // Codex's visible theming is handled by output normalization
-    // (normalizeCodexComposerBackgroundForTheme) plus preview replay below.
-    if (entry.provider === "opencode" || entry.provider === "antigravity") {
+    // A genuine light<->dark swap, as opposed to a maximize/minimize re-render
+    // (which re-runs this effect with the SAME theme). terminalThemeForProvider
+    // returns shared LIGHT/DARK constants, so reference inequality reliably means a
+    // real theme change rather than layout churn.
+    const isCodexThemeChange =
+      entry.provider === "codex" &&
+      previousSignaledTheme !== null &&
+      previousSignaledTheme !== activeTermTheme;
+    // Push ?997 + OSC color replies as input so the TUI repaints in the new scheme.
+    // opencode/antigravity get this on every signal. Codex runs under the bundled
+    // modern ConPTY, which answers codex's probes natively with its OWN colors (not
+    // Wardian's theme), so this push is the only channel that conveys a Wardian
+    // theme swap to codex. It echoes back into codex's output, so it is gated to
+    // real theme changes: firing it on every maximize/minimize re-render was the
+    // ]11;rgb / ?997;1n bombardment across every mounted codex terminal. The rare
+    // echo on an actual swap is scrubbed by stripCodexTerminalStatusEchoes on the
+    // output side.
+    if (entry.provider === "opencode" || entry.provider === "antigravity" || isCodexThemeChange) {
       const toRgbTriplet = (hex: string, fallback: string) => {
         const cleaned = String(hex ?? "").replace("#", "");
         return cleaned.length === 6
@@ -2330,11 +2337,7 @@ export const AgentTerminal = memo(function AgentTerminal({
       queueAgentInput(sessionId, `]10;rgb:${foreground}\\`);
       queueAgentInput(sessionId, `]4;0;rgb:${background}\\`);
     }
-    if (
-      entry.provider === "codex" &&
-      previousSignaledTheme !== null &&
-      previousSignaledTheme !== activeTermTheme
-    ) {
+    if (isCodexThemeChange) {
       void replayCodexTerminalPreviewWithCurrentTheme(sessionId, entry);
     }
   }, [effectiveTheme, provider, sessionId, termTheme]);

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -2312,15 +2312,14 @@ export const AgentTerminal = memo(function AgentTerminal({
       previousSignaledTheme !== null &&
       previousSignaledTheme !== activeTermTheme;
     // Push ?997 + OSC color replies as input so the TUI repaints in the new scheme.
-    // opencode/antigravity get this on every signal. Codex runs under the bundled
-    // modern ConPTY, which answers codex's probes natively with its OWN colors (not
-    // Wardian's theme), so this push is the only channel that conveys a Wardian
-    // theme swap to codex. It echoes back into codex's output, so it is gated to
-    // real theme changes: firing it on every maximize/minimize re-render was the
-    // ]11;rgb / ?997;1n bombardment across every mounted codex terminal. The rare
-    // echo on an actual swap is scrubbed by stripCodexTerminalStatusEchoes on the
-    // output side.
-    if (entry.provider === "opencode" || entry.provider === "antigravity" || isCodexThemeChange) {
+    // ONLY opencode/antigravity: these are terminal->application REPLIES, valid only
+    // as answers to a probe the app made. Codex sits at an interactive prompt under
+    // the bundled modern ConPTY, so injecting them into its stdin just types them
+    // into the composer as literal "[?997;1n]11;rgb:..." text -- they are never
+    // interpreted as a theme signal. Codex has no "theme changed" input command, so
+    // its recoloring is done entirely Wardian-side via the preview replay below
+    // (plus normalizeCodexComposerBackgroundForTheme on streamed output).
+    if (entry.provider === "opencode" || entry.provider === "antigravity") {
       const toRgbTriplet = (hex: string, fallback: string) => {
         const cleaned = String(hex ?? "").replace("#", "");
         return cleaned.length === 6

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -2303,7 +2303,17 @@ export const AgentTerminal = memo(function AgentTerminal({
     const previousSignaledTheme = lastThemeSignalRef.current;
     lastThemeSignalRef.current = activeTermTheme;
     entry.currentTheme = activeTermTheme;
-    if (entry.provider === "opencode" || entry.provider === "codex" || entry.provider === "antigravity") {
+    // Opencode/antigravity infer their visible mode from these proactively-pushed
+    // ?997 + OSC color replies. Codex is deliberately excluded: it runs under the
+    // bundled modern ConPTY, which answers codex's own color/light-dark probes
+    // natively (see respondsToThemeColorQueries, which already excludes codex on
+    // the reactive path). Pushing Wardian's duplicate replies as input just gets
+    // them echoed back into codex's output as stray ]11;rgb / ?997;1n garbage --
+    // and because this theme effect re-runs on every maximize/minimize re-render,
+    // it bombards *every* mounted codex terminal at once, not just the resized one.
+    // Codex's visible theming is handled by output normalization
+    // (normalizeCodexComposerBackgroundForTheme) plus preview replay below.
+    if (entry.provider === "opencode" || entry.provider === "antigravity") {
       const toRgbTriplet = (hex: string, fallback: string) => {
         const cleaned = String(hex ?? "").replace("#", "");
         return cleaned.length === 6
@@ -2319,9 +2329,13 @@ export const AgentTerminal = memo(function AgentTerminal({
       queueAgentInput(sessionId, `]11;rgb:${background}\\`);
       queueAgentInput(sessionId, `]10;rgb:${foreground}\\`);
       queueAgentInput(sessionId, `]4;0;rgb:${background}\\`);
-      if (entry.provider === "codex" && previousSignaledTheme !== null && previousSignaledTheme !== activeTermTheme) {
-        void replayCodexTerminalPreviewWithCurrentTheme(sessionId, entry);
-      }
+    }
+    if (
+      entry.provider === "codex" &&
+      previousSignaledTheme !== null &&
+      previousSignaledTheme !== activeTermTheme
+    ) {
+      void replayCodexTerminalPreviewWithCurrentTheme(sessionId, entry);
     }
   }, [effectiveTheme, provider, sessionId, termTheme]);
 

--- a/src/features/terminal/terminalCapabilities.test.ts
+++ b/src/features/terminal/terminalCapabilities.test.ts
@@ -281,6 +281,41 @@ describe("terminal capability broker", () => {
     expect(plan.normalizedOutput).toBe("\u001b[48;2;41;41;41m\n\u001b[K");
   });
 
+  it("remaps non-canonical Codex chrome grays (e.g. the active composer) in light mode", () => {
+    const ESC = String.fromCharCode(27);
+    const plan = planTerminalCapabilityResponses("codex", ESC + "[48;2;48;48;48m typing" + ESC + "[K", {
+      ...baseContext,
+      prefersLight: true,
+      backgroundRgb: "fc/fa/f5",
+    });
+
+    expect(plan.normalizedOutput).toBe(ESC + "[48;2;242;240;235m typing" + ESC + "[K");
+  });
+
+  it("leaves colored (non-gray) Codex backgrounds untouched in light mode", () => {
+    const ESC = String.fromCharCode(27);
+    const data = ESC + "[48;2;0;120;200m link" + ESC + "[K";
+    const plan = planTerminalCapabilityResponses("codex", data, {
+      ...baseContext,
+      prefersLight: true,
+      backgroundRgb: "fc/fa/f5",
+    });
+
+    expect(plan.normalizedOutput).toBe(data);
+  });
+
+  it("leaves light-gray Codex backgrounds untouched in light mode", () => {
+    const ESC = String.fromCharCode(27);
+    const data = ESC + "[48;2;200;200;200m x" + ESC + "[K";
+    const plan = planTerminalCapabilityResponses("codex", data, {
+      ...baseContext,
+      prefersLight: true,
+      backgroundRgb: "fc/fa/f5",
+    });
+
+    expect(plan.normalizedOutput).toBe(data);
+  });
+
   it("strips OpenTUI theme notification enablement from rendered output", () => {
     expect(normalizeOpenCodeOutput("\u001b[?2031hready\u001b[?2031l", "opencode")).toBe("ready");
   });

--- a/src/features/terminal/terminalCapabilities.test.ts
+++ b/src/features/terminal/terminalCapabilities.test.ts
@@ -316,6 +316,29 @@ describe("terminal capability broker", () => {
     expect(plan.normalizedOutput).toBe(data);
   });
 
+  it("remaps non-canonical light Codex chrome (e.g. opposite-theme composer) to dark in dark mode", () => {
+    const ESC = String.fromCharCode(27);
+    const plan = planTerminalCapabilityResponses("codex", ESC + "[48;2;245;245;245m typing" + ESC + "[K", {
+      ...baseContext,
+      prefersLight: false,
+      backgroundRgb: "02/04/02",
+    });
+
+    expect(plan.normalizedOutput).toBe(ESC + "[48;2;41;41;41m typing" + ESC + "[K");
+  });
+
+  it("leaves colored (non-gray) Codex backgrounds untouched in dark mode", () => {
+    const ESC = String.fromCharCode(27);
+    const data = ESC + "[48;2;0;120;200m link" + ESC + "[K";
+    const plan = planTerminalCapabilityResponses("codex", data, {
+      ...baseContext,
+      prefersLight: false,
+      backgroundRgb: "02/04/02",
+    });
+
+    expect(plan.normalizedOutput).toBe(data);
+  });
+
   it("strips OpenTUI theme notification enablement from rendered output", () => {
     expect(normalizeOpenCodeOutput("\u001b[?2031hready\u001b[?2031l", "opencode")).toBe("ready");
   });

--- a/src/features/terminal/terminalCapabilities.test.ts
+++ b/src/features/terminal/terminalCapabilities.test.ts
@@ -281,6 +281,31 @@ describe("terminal capability broker", () => {
     expect(plan.normalizedOutput).toBe("\u001b[48;2;41;41;41m\n\u001b[K");
   });
 
+  it("remaps Codex's chrome background combined with a foreground in one SGR (active composer) in light mode", () => {
+    const ESC = String.fromCharCode(27);
+    // Codex emits the typing composer / xterm re-serializes scrollback as a compound
+    // SGR: foreground + background in one sequence. The standalone-only match missed
+    // these, leaving them black in light mode.
+    const plan = planTerminalCapabilityResponses(
+      "codex",
+      ESC + "[38;2;235;235;235;48;2;41;41;41m typing" + ESC + "[K",
+      { ...baseContext, prefersLight: true, backgroundRgb: "fc/fa/f5" },
+    );
+
+    expect(plan.normalizedOutput).toBe(ESC + "[38;2;235;235;235;48;2;242;240;235m typing" + ESC + "[K");
+  });
+
+  it("remaps a compound light Codex chrome SGR back to dark in dark mode", () => {
+    const ESC = String.fromCharCode(27);
+    const plan = planTerminalCapabilityResponses(
+      "codex",
+      ESC + "[1;38;2;20;20;20;48;2;242;240;235m x" + ESC + "[K",
+      { ...baseContext, prefersLight: false, backgroundRgb: "02/04/02" },
+    );
+
+    expect(plan.normalizedOutput).toBe(ESC + "[1;38;2;20;20;20;48;2;41;41;41m x" + ESC + "[K");
+  });
+
   it("remaps non-canonical Codex chrome grays (e.g. the active composer) in light mode", () => {
     const ESC = String.fromCharCode(27);
     const plan = planTerminalCapabilityResponses("codex", ESC + "[48;2;48;48;48m typing" + ESC + "[K", {

--- a/src/features/terminal/terminalCapabilities.test.ts
+++ b/src/features/terminal/terminalCapabilities.test.ts
@@ -214,6 +214,33 @@ describe("terminal capability broker", () => {
     expect(stripTerminalColorReportInputs(data)).toBe("ls -la\r");
   });
 
+  it("strips ConPTY-echoed color/light-dark replies from Codex output even when fragmented across chunks", () => {
+    const ESC = String.fromCharCode(27);
+    const ST = ESC + String.fromCharCode(92); // ESC \  (string terminator)
+    // The echoed reply burst codex emits on maximize/resize, split mid-sequence
+    // across PTY chunks -- this is what defeats the per-chunk probe strip.
+    const chunks = [
+      "before" + ESC + "[?997;1n" + ESC + "]11;rgb:1a",
+      "/1a/1a" + ST + ESC + "]10;rgb:eb/eb/eb" + ST + ESC + "]4;0;rgb:1a/1a/1a" + ST + "after",
+    ];
+    expect(normalizeTerminalOutputBatch(chunks, "codex")).toBe("beforeafter");
+  });
+
+  it("strips fragmented Codex color/light-dark probes from output (suppresses xterm auto-reply)", () => {
+    const ESC = String.fromCharCode(27);
+    const BEL = String.fromCharCode(7);
+    const ST = ESC + String.fromCharCode(92);
+    const chunks = [ESC + "[?996n" + ESC + "]10;", "?" + BEL + ESC + "]11;?" + ST + "ok"];
+    expect(normalizeTerminalOutputBatch(chunks, "codex")).toBe("ok");
+  });
+
+  it("leaves non-codex provider output color sequences untouched", () => {
+    const ESC = String.fromCharCode(27);
+    const ST = ESC + String.fromCharCode(92);
+    const data = ESC + "]11;rgb:1a/1a/1a" + ST + "text";
+    expect(normalizeTerminalOutputBatch([data], "antigravity")).toContain("]11;rgb:1a/1a/1a");
+  });
+
   it("does not answer non-color Codex terminal probes from the frontend", () => {
     const data = "\u001b[6n\u001b[14t\u001b[?1004h";
     const plan = planTerminalCapabilityResponses("codex", data, baseContext);

--- a/src/features/terminal/terminalCapabilities.ts
+++ b/src/features/terminal/terminalCapabilities.ts
@@ -34,7 +34,6 @@ const SUPPORTED_RESET_DECRQM_PARAMS = new Set([1004, 1016, 2004]);
 const UNSUPPORTED_RESET_DECRQM_PARAMS = new Set([2026, 2027, 2031]);
 const THEME_MODE_NOTIFICATION_TOGGLE = /\u001b\[\?2031[hl]/g;
 const CODEX_SCROLLBACK_ERASE = /\u001b\[3J/g;
-const CODEX_LIGHT_USER_MESSAGE_BACKGROUND = /\u001b\[48;2;242;240;235m/g;
 // Any standalone truecolor background SGR, so codex's RGB can be inspected. Codex
 // draws its composer / user-message chrome with near-uniform dark grays (41;41;41
 // plus focused/idle variants); matching only 41;41;41 left the active (typing)
@@ -144,20 +143,30 @@ function foregroundRgbForSgr(foregroundRgb: string) {
   return values.length === 3 && values.every(Number.isFinite) ? values.join(";") : "255;255;255";
 }
 
-// A near-uniform dark gray is codex chrome (composer / user-message fill), not
-// content: code and syntax highlighting use colored or terminal-default
-// backgrounds, never a flat near-black gray. In light mode no codex background
-// should be near-black, so every such gray is stale chrome to re-theme -- this is
-// why the active (typing) composer and a few history fragments, which use slightly
-// different grays than the canonical 41;41;41, were leaking through black.
-function isCodexChromeDarkGray(r: number, g: number, b: number) {
+// Codex draws its composer / user-message chrome as a flat, near-uniform gray and
+// does not reliably track Wardian's runtime light<->dark swaps, so the gray it
+// emits can be the OPPOSITE of the active theme. Content (code, syntax) never uses
+// a flat near-black or near-white gray background, so re-theming these is safe:
+//   - light mode: no codex background should be near-black
+//   - dark mode:  no codex background should be near-white
+// Matching only the two canonical values (41;41;41 / 242;240;235) left the active
+// composer and history fragments inverted, since codex uses slightly different
+// shades for focused/idle states.
+function isNearUniformGray(r: number, g: number, b: number) {
   return (
     Number.isFinite(r) &&
     Number.isFinite(g) &&
     Number.isFinite(b) &&
-    Math.max(r, g, b) <= 96 &&
     Math.max(r, g, b) - Math.min(r, g, b) <= 16
   );
+}
+
+function isCodexChromeDarkGray(r: number, g: number, b: number) {
+  return isNearUniformGray(r, g, b) && Math.max(r, g, b) <= 96;
+}
+
+function isCodexChromeLightGray(r: number, g: number, b: number) {
+  return isNearUniformGray(r, g, b) && Math.min(r, g, b) >= 176;
 }
 
 export function normalizeCodexComposerBackgroundForTheme(data: string, context: TerminalCapabilityContext) {
@@ -168,7 +177,10 @@ export function normalizeCodexComposerBackgroundForTheme(data: string, context: 
     );
   }
 
-  return data.replace(CODEX_LIGHT_USER_MESSAGE_BACKGROUND, `\u001b[48;2;41;41;41m`);
+  const darkFill = `\u001b[48;2;41;41;41m`;
+  return data.replace(CODEX_BACKGROUND_SGR, (match, r: string, g: string, b: string) =>
+    isCodexChromeLightGray(Number(r), Number(g), Number(b)) ? darkFill : match,
+  );
 }
 
 function isMutedPrimaryForegroundRgb(r: number, g: number, b: number) {

--- a/src/features/terminal/terminalCapabilities.ts
+++ b/src/features/terminal/terminalCapabilities.ts
@@ -34,8 +34,13 @@ const SUPPORTED_RESET_DECRQM_PARAMS = new Set([1004, 1016, 2004]);
 const UNSUPPORTED_RESET_DECRQM_PARAMS = new Set([2026, 2027, 2031]);
 const THEME_MODE_NOTIFICATION_TOGGLE = /\u001b\[\?2031[hl]/g;
 const CODEX_SCROLLBACK_ERASE = /\u001b\[3J/g;
-const CODEX_DARK_USER_MESSAGE_BACKGROUND = /\u001b\[48;2;41;41;41m/g;
 const CODEX_LIGHT_USER_MESSAGE_BACKGROUND = /\u001b\[48;2;242;240;235m/g;
+// Any standalone truecolor background SGR, so codex's RGB can be inspected. Codex
+// draws its composer / user-message chrome with near-uniform dark grays (41;41;41
+// plus focused/idle variants); matching only 41;41;41 left the active (typing)
+// composer and some history fragments black in light mode.
+const CODEX_BACKGROUND_SGR =
+  /\u001b\[48;2;(\d+);(\d+);(\d+)m/g;
 const CURSOR_STYLE_SEQUENCE = /\u001b\[[0-9;]* q/g;
 const FULLSCREEN_CLEAR_BY_NEWLINES =
   /\u001b\[\?25l(?:\u001b\[K\r?\n){8,}\u001b\[K\u001b\[H(\u001b\[\?25h)?/g;
@@ -139,15 +144,31 @@ function foregroundRgbForSgr(foregroundRgb: string) {
   return values.length === 3 && values.every(Number.isFinite) ? values.join(";") : "255;255;255";
 }
 
+// A near-uniform dark gray is codex chrome (composer / user-message fill), not
+// content: code and syntax highlighting use colored or terminal-default
+// backgrounds, never a flat near-black gray. In light mode no codex background
+// should be near-black, so every such gray is stale chrome to re-theme -- this is
+// why the active (typing) composer and a few history fragments, which use slightly
+// different grays than the canonical 41;41;41, were leaking through black.
+function isCodexChromeDarkGray(r: number, g: number, b: number) {
+  return (
+    Number.isFinite(r) &&
+    Number.isFinite(g) &&
+    Number.isFinite(b) &&
+    Math.max(r, g, b) <= 96 &&
+    Math.max(r, g, b) - Math.min(r, g, b) <= 16
+  );
+}
+
 export function normalizeCodexComposerBackgroundForTheme(data: string, context: TerminalCapabilityContext) {
   if (context.prefersLight) {
-    return data.replace(
-      CODEX_DARK_USER_MESSAGE_BACKGROUND,
-      `\u001b[48;2;${codexLightUserMessageBackground(context.backgroundRgb)}m`,
+    const lightFill = `\u001b[48;2;${codexLightUserMessageBackground(context.backgroundRgb)}m`;
+    return data.replace(CODEX_BACKGROUND_SGR, (match, r: string, g: string, b: string) =>
+      isCodexChromeDarkGray(Number(r), Number(g), Number(b)) ? lightFill : match,
     );
   }
 
-  return data.replace(CODEX_LIGHT_USER_MESSAGE_BACKGROUND, "\u001b[48;2;41;41;41m");
+  return data.replace(CODEX_LIGHT_USER_MESSAGE_BACKGROUND, `\u001b[48;2;41;41;41m`);
 }
 
 function isMutedPrimaryForegroundRgb(r: number, g: number, b: number) {

--- a/src/features/terminal/terminalCapabilities.ts
+++ b/src/features/terminal/terminalCapabilities.ts
@@ -19,6 +19,17 @@ const OSC_BACKGROUND_QUERY_ST = "\u001b]11;?\u001b\\";
 // chunk fragmentation: xterm emits each reply as one complete onData string.
 const TERMINAL_COLOR_REPORT_REPLY =
   /\u001b\[\?997;\d+n|\u001b\]1[01];rgb:[0-9a-fA-F/]+(?:\u0007|\u001b\\)|\u001b\]4;\d+;rgb:[0-9a-fA-F/]+(?:\u0007|\u001b\\)/g;
+// The full set of terminal color / light-dark STATUS sequences in codex's OUTPUT:
+// the OSC 10/11/4 + CSI ?996n probes codex emits, plus the OSC 10/11/4 "rgb:..."
+// reports and the CSI ?997;<n>n light-dark report that the modern ConPTY answers
+// them with. On maximize/resize codex emits a burst of probes; OpenConsole's
+// native answers get echoed back into codex's output, and because the burst is
+// fragmented across PTY chunks it slips past the per-chunk probe strip and renders
+// as stray ]11;rgb / ?997;1n garbage. Stripping on the JOINED output batch is
+// immune to that fragmentation. Codex never legitimately emits a light-dark report
+// or an OSC color "set", so dropping these from its display stream is safe.
+const CODEX_TERMINAL_STATUS_SEQUENCE =
+  /\u001b\[\?99[67](?:;\d+)?n|\u001b\]1[01];(?:\?|rgb:[0-9a-fA-F/]+)(?:\u0007|\u001b\\)|\u001b\]4;\d+;(?:\?|rgb:[0-9a-fA-F/]+)(?:\u0007|\u001b\\)/g;
 const SUPPORTED_RESET_DECRQM_PARAMS = new Set([1004, 1016, 2004]);
 const UNSUPPORTED_RESET_DECRQM_PARAMS = new Set([2026, 2027, 2031]);
 const THEME_MODE_NOTIFICATION_TOGGLE = /\u001b\[\?2031[hl]/g;
@@ -65,6 +76,15 @@ function normalizeFullscreenClearByNewlines(data: string) {
 
 function stripProviderScrollbackErase(data: string, provider?: string) {
   return provider === "codex" ? data.replace(CODEX_SCROLLBACK_ERASE, "") : data;
+}
+
+// Strip codex's color / light-dark probes AND the ConPTY-answered reply echoes
+// from its rendered OUTPUT. Runs on the JOINED output batch (see
+// CODEX_TERMINAL_STATUS_SEQUENCE) so it heals the cross-chunk fragmentation that
+// lets a maximize/resize probe burst slip past the per-chunk probe strip and
+// surface as stray ]11;rgb / ?997;1n text in codex's composer.
+function stripCodexTerminalStatusEchoes(data: string) {
+  return data.replace(CODEX_TERMINAL_STATUS_SEQUENCE, "");
 }
 
 // Remove terminal color / light-dark PROBES from a provider's output before it
@@ -462,7 +482,9 @@ export function normalizeTerminalOutputBatch(
   const normalizedChunks = rawChunks
     .map((data) => normalizeOpenCodeOutput(data, provider, state))
     .join("");
-  const normalizedOutput = stripProviderScrollbackErase(normalizedChunks, provider);
+  const scrollbackStripped = stripProviderScrollbackErase(normalizedChunks, provider);
+  const normalizedOutput =
+    provider === "codex" ? stripCodexTerminalStatusEchoes(scrollbackStripped) : scrollbackStripped;
   const themedOutput = provider === "antigravity"
     ? normalizeAntigravityPrimaryText(normalizedOutput, state?.antigravityForegroundRgb, state)
     : normalizedOutput;

--- a/src/features/terminal/terminalCapabilities.ts
+++ b/src/features/terminal/terminalCapabilities.ts
@@ -34,12 +34,11 @@ const SUPPORTED_RESET_DECRQM_PARAMS = new Set([1004, 1016, 2004]);
 const UNSUPPORTED_RESET_DECRQM_PARAMS = new Set([2026, 2027, 2031]);
 const THEME_MODE_NOTIFICATION_TOGGLE = /\u001b\[\?2031[hl]/g;
 const CODEX_SCROLLBACK_ERASE = /\u001b\[3J/g;
-// Any standalone truecolor background SGR, so codex's RGB can be inspected. Codex
-// draws its composer / user-message chrome with near-uniform dark grays (41;41;41
-// plus focused/idle variants); matching only 41;41;41 left the active (typing)
-// composer and some history fragments black in light mode.
-const CODEX_BACKGROUND_SGR =
-  /\u001b\[48;2;(\d+);(\d+);(\d+)m/g;
+// Matches any SGR sequence so codex's chrome background can be remapped even when
+// it is COMBINED with a foreground/attributes in one SGR. Codex emits the active
+// (typing) composer that way, and xterm's serializer re-emits scrollback that way
+// on a theme swap; matching only the standalone form left those black/inverted.
+const CODEX_SGR_SEQUENCE = /\u001b\[([0-9;]*)m/g;
 const CURSOR_STYLE_SEQUENCE = /\u001b\[[0-9;]* q/g;
 const FULLSCREEN_CLEAR_BY_NEWLINES =
   /\u001b\[\?25l(?:\u001b\[K\r?\n){8,}\u001b\[K\u001b\[H(\u001b\[\?25h)?/g;
@@ -149,9 +148,6 @@ function foregroundRgbForSgr(foregroundRgb: string) {
 // a flat near-black or near-white gray background, so re-theming these is safe:
 //   - light mode: no codex background should be near-black
 //   - dark mode:  no codex background should be near-white
-// Matching only the two canonical values (41;41;41 / 242;240;235) left the active
-// composer and history fragments inverted, since codex uses slightly different
-// shades for focused/idle states.
 function isNearUniformGray(r: number, g: number, b: number) {
   return (
     Number.isFinite(r) &&
@@ -169,18 +165,44 @@ function isCodexChromeLightGray(r: number, g: number, b: number) {
   return isNearUniformGray(r, g, b) && Math.min(r, g, b) >= 176;
 }
 
+// Remap a codex chrome background to `fill` wherever a 48;2;R;G;B run appears in an
+// SGR parameter list -- standalone OR combined with other attributes. Walking the
+// params (instead of a standalone-only regex) is what makes the active composer and
+// serialized scrollback re-theme on a swap rather than staying the opposite color.
+function remapCodexChromeBackground(
+  data: string,
+  isChrome: (r: number, g: number, b: number) => boolean,
+  fill: string,
+) {
+  const fillParts = fill.split(";");
+  return data.replace(CODEX_SGR_SEQUENCE, (whole: string, params: string) => {
+    const parts = params.split(";");
+    let changed = false;
+    for (let i = 0; i < parts.length; ) {
+      if (parts[i] === "48" && parts[i + 1] === "2" && i + 4 < parts.length) {
+        if (isChrome(Number(parts[i + 2]), Number(parts[i + 3]), Number(parts[i + 4]))) {
+          parts.splice(i, 5, "48", "2", fillParts[0], fillParts[1], fillParts[2]);
+          changed = true;
+        }
+        i += 5;
+      } else {
+        i += 1;
+      }
+    }
+    return changed ? `\u001b[${parts.join(";")}m` : whole;
+  });
+}
+
 export function normalizeCodexComposerBackgroundForTheme(data: string, context: TerminalCapabilityContext) {
   if (context.prefersLight) {
-    const lightFill = `\u001b[48;2;${codexLightUserMessageBackground(context.backgroundRgb)}m`;
-    return data.replace(CODEX_BACKGROUND_SGR, (match, r: string, g: string, b: string) =>
-      isCodexChromeDarkGray(Number(r), Number(g), Number(b)) ? lightFill : match,
+    return remapCodexChromeBackground(
+      data,
+      isCodexChromeDarkGray,
+      codexLightUserMessageBackground(context.backgroundRgb),
     );
   }
 
-  const darkFill = `\u001b[48;2;41;41;41m`;
-  return data.replace(CODEX_BACKGROUND_SGR, (match, r: string, g: string, b: string) =>
-    isCodexChromeLightGray(Number(r), Number(g), Number(b)) ? darkFill : match,
-  );
+  return remapCodexChromeBackground(data, isCodexChromeLightGray, "41;41;41");
 }
 
 function isMutedPrimaryForegroundRgb(r: number, g: number, b: number) {


### PR DESCRIPTION
## Description
Fixes two Codex terminal theming defects on Windows that surfaced after the modern ConPTY was bundled:

1. **Stop typing color-probe garbage into the Codex composer.** Wardian proactively pushed terminal-status *replies* (`?997`, OSC 10/11/4 `rgb:…`) into the agent's stdin on every theme-effect run. opencode/antigravity consume these as answers to their own probes, but Codex sits at an interactive prompt, so its line editor inserted them as literal `[?997;1n]11;rgb:…` text — and because the effect re-runs on every maximize/minimize, it hit every mounted Codex terminal at once. The push is now restricted to opencode/antigravity; Codex is recolored entirely Wardian-side.

2. **Make the Codex composer follow the theme, including while typing.** Per the codex-terminal-theme-probes design, Wardian remaps Codex's composer fill SGR (light mode lightens `41;41;41`; dark preserves it). The remap matched only the **standalone** `ESC[48;2;41;41;41m` form, but Codex emits the active (typing) composer — and xterm re-serializes scrollback on a theme swap — as **compound** SGRs (background combined with foreground/attributes, e.g. `ESC[38;2;235;235;235;48;2;41;41;41m`). Those slipped through, leaving the composer the opposite color while typing and history fragments inverted. The remap now walks the SGR parameter list and remaps a `48;2;R;G;B` chrome run in place whether standalone or compound, in both directions, on streamed output and the theme-swap replay.

## Related Issues
Fixes #560

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run test` — full frontend suite green (1099 passed, 1 skipped), including new regression coverage:
  - `terminalCapabilities.test.ts`: compound-SGR composer remap in both directions; chrome-gray vs colored/light-gray discrimination.
  - `AgentTerminal.test.tsx`: Codex receives no stdin color-reply push on a real theme swap while still replaying its composer.
- `npm run lint` (tsc `--noEmit`) — clean.
- Verified live on Windows 11 (bundled ConPTY, Codex CLI): no typed escape garbage on maximize/resize/theme swap; composer and chrome follow light/dark theme in real time including while typing.

## Screenshots
<!-- Reviewer/author: drag a Codex-composer screenshot (light mode, while typing) into this description via GitHub's web editor. Repo is public, so crop out any private terminal content first. -->
_To be attached via GitHub web upload (public repo — crop private content)._

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
