### PR TITLE
fix(opencode): launch Windows CLI through PATH

### DIFF
--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -234,11 +234,10 @@ This is how OpenCode sees Wardian-managed class and agent context without forcin
 - OpenCode is closer to Codex than Gemini on instruction naming: it consumes `AGENTS.md` directly.
 - If OpenCode stops seeing Wardian skills or class instructions, inspect the generated `OPENCODE_CONFIG_CONTENT` first.
 - If interactive spawn works but telemetry is thin, that is expected today; OpenCode does not expose one stable per-session JSONL path the way Claude and Codex do.
-- On Windows, Wardian should prefer a native `opencode.exe` or packaged
-  OpenCode binary over `.cmd`/script shims during PATH resolution. If only an
-  extensionless or script shim exists, interactive and headless launch must wrap
-  it through `cmd /d /c ...` because direct process spawning does not get shell
-  dispatch semantics.
+- On Windows, Wardian should launch the `opencode` command resolved from PATH,
+  matching how a user terminal starts OpenCode. Interactive and headless launch
+  wrap that command through the configured shell because npm and PowerShell
+  shims need shell dispatch semantics.
 
 ## Choosing Where to Debug
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7189,9 +7189,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/src-tauri/src/providers/opencode.rs
+++ b/src-tauri/src/providers/opencode.rs
@@ -22,76 +22,14 @@ impl OpenCodeProvider {
     }
 
     #[cfg(target_os = "windows")]
-    fn packaged_windows_binary_from_shim(base_dir: &std::path::Path) -> Option<String> {
-        [
-            base_dir
-                .join("node_modules")
-                .join("opencode-ai")
-                .join("node_modules")
-                .join("opencode-windows-x64")
-                .join("bin")
-                .join("opencode.exe"),
-            base_dir
-                .join("node_modules")
-                .join("opencode-ai")
-                .join("node_modules")
-                .join("opencode-windows-x64-baseline")
-                .join("bin")
-                .join("opencode.exe"),
-            base_dir
-                .join("node_modules")
-                .join("opencode-ai")
-                .join("node_modules")
-                .join("opencode-windows-arm64")
-                .join("bin")
-                .join("opencode.exe"),
-        ]
-        .into_iter()
-        .find(|candidate| candidate.exists())
-        .map(|candidate| candidate.to_string_lossy().to_string())
-    }
-
-    /// Standard npm global install roots on Windows, used as a PATH-independent
-    /// fallback. npm's default prefix is `%APPDATA%\npm`; `npm_config_prefix`
-    /// overrides it. Each returned dir is expected to contain `node_modules`.
-    #[cfg(target_os = "windows")]
-    fn windows_npm_global_dirs() -> Vec<std::path::PathBuf> {
-        let mut dirs = Vec::new();
-        if let Ok(prefix) = std::env::var("npm_config_prefix") {
-            let trimmed = prefix.trim();
-            if !trimmed.is_empty() {
-                dirs.push(std::path::PathBuf::from(trimmed));
-            }
-        }
-        if let Some(appdata) = dirs::config_dir() {
-            let npm = appdata.join("npm");
-            if !dirs.contains(&npm) {
-                dirs.push(npm);
-            }
-        }
-        dirs
-    }
-
-    #[cfg(target_os = "windows")]
     fn find_windows_opencode_in_paths<I>(paths: I, path_exts: &[String]) -> Option<String>
     where
         I: IntoIterator<Item = std::path::PathBuf>,
     {
-        let mut shim_fallback: Option<String> = None;
-
         for path in paths {
             let direct_exe = path.join("opencode.exe");
             if direct_exe.exists() {
-                return Some(direct_exe.to_string_lossy().to_string());
-            }
-
-            // npm can leave the platform binary under node_modules without a
-            // bin shim (interrupted install, or an update that didn't
-            // regenerate opencode.cmd/.ps1). Probe the packaged binary relative
-            // to every PATH entry so a missing shim doesn't hide a working
-            // install — a later native exe still wins via the checks above.
-            if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
-                return Some(executable);
+                return Some("opencode".to_string());
             }
 
             let bare = path.join("opencode");
@@ -99,44 +37,16 @@ impl OpenCodeProvider {
             for ext in path_exts {
                 let candidate = path.join(format!("opencode{ext}"));
                 if candidate.exists() {
-                    if candidate
-                        .extension()
-                        .and_then(|value| value.to_str())
-                        .is_some_and(|value| value.eq_ignore_ascii_case("exe"))
-                    {
-                        return Some(candidate.to_string_lossy().to_string());
-                    }
-
-                    if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
-                        return Some(executable);
-                    }
-                    if shim_fallback.is_none() {
-                        shim_fallback = Some(candidate.to_string_lossy().to_string());
-                    }
-                    break;
+                    return Some("opencode".to_string());
                 }
             }
 
-            if bare.exists() {
-                if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
-                    return Some(executable);
-                }
-                if shim_fallback.is_none() {
-                    shim_fallback = Some("opencode".to_string());
-                }
-            }
-
-            if powershell.exists() {
-                if let Some(executable) = Self::packaged_windows_binary_from_shim(&path) {
-                    return Some(executable);
-                }
-                if shim_fallback.is_none() {
-                    shim_fallback = Some("opencode".to_string());
-                }
+            if bare.exists() || powershell.exists() {
+                return Some("opencode".to_string());
             }
         }
 
-        shim_fallback
+        None
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -214,15 +124,6 @@ impl AgentProvider for OpenCodeProvider {
                 if let Some(executable) =
                     Self::find_windows_opencode_in_paths(std::env::split_paths(&paths), &path_exts)
                 {
-                    return (executable, vec![]);
-                }
-            }
-
-            // PATH may omit the npm global dir when the packaged app is launched
-            // outside a shell, so probe the standard npm global install
-            // locations directly before giving up.
-            for base in Self::windows_npm_global_dirs() {
-                if let Some(executable) = Self::packaged_windows_binary_from_shim(&base) {
                     return (executable, vec![]);
                 }
             }
@@ -464,7 +365,7 @@ mod tests {
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn windows_path_lookup_prefers_packaged_executable_from_shim_dir() {
+    fn windows_path_lookup_prefers_cmd_shim_over_packaged_executable() {
         let temp = tempfile::tempdir().expect("temp dir");
         let cmd = temp.path().join("opencode.cmd");
         std::fs::write(&cmd, "@echo off\r\n").expect("cmd shim");
@@ -484,12 +385,12 @@ mod tests {
             &[".exe".into(), ".cmd".into(), ".bat".into()],
         );
 
-        assert_eq!(resolved, Some(exe.to_string_lossy().to_string()));
+        assert_eq!(resolved, Some("opencode".to_string()));
     }
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn windows_path_lookup_uses_packaged_executable_for_powershell_script() {
+    fn windows_path_lookup_prefers_powershell_shim_over_packaged_executable() {
         let temp = tempfile::tempdir().expect("temp dir");
         let ps1 = temp.path().join("opencode.ps1");
         std::fs::write(&ps1, "Write-Output hi\r\n").expect("ps1 shim");
@@ -509,7 +410,7 @@ mod tests {
             &[".exe".into(), ".cmd".into(), ".bat".into()],
         );
 
-        assert_eq!(resolved, Some(exe.to_string_lossy().to_string()));
+        assert_eq!(resolved, Some("opencode".to_string()));
     }
 
     #[cfg(target_os = "windows")]
@@ -526,12 +427,12 @@ mod tests {
             &[".exe".into(), ".cmd".into(), ".bat".into()],
         );
 
-        assert_eq!(resolved, Some(cmd.to_string_lossy().to_string()));
+        assert_eq!(resolved, Some("opencode".to_string()));
     }
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn windows_path_lookup_prefers_later_native_exe_over_earlier_cmd_shim() {
+    fn windows_path_lookup_uses_bare_command_for_path_matches() {
         let shim_dir = tempfile::tempdir().expect("shim dir");
         let exe_dir = tempfile::tempdir().expect("exe dir");
         let cmd = shim_dir.path().join("opencode.cmd");
@@ -544,15 +445,14 @@ mod tests {
             &[".exe".into(), ".cmd".into(), ".bat".into()],
         );
 
-        assert_eq!(resolved, Some(exe.to_string_lossy().to_string()));
+        assert_eq!(resolved, Some("opencode".to_string()));
     }
 
     #[cfg(target_os = "windows")]
     #[test]
-    fn windows_path_lookup_resolves_packaged_binary_without_a_shim() {
-        // npm left the platform binary under node_modules but no opencode.cmd/
-        // .ps1 shim (interrupted install / update). The npm global dir is on
-        // PATH, so detection must resolve the packaged binary anyway.
+    fn windows_path_lookup_ignores_packaged_binary_without_a_shim() {
+        // The OpenCode package can contain a nested platform binary, but
+        // Wardian should launch the same PATH command a user terminal would.
         let temp = tempfile::tempdir().expect("temp dir");
         let exe = temp
             .path()
@@ -570,7 +470,7 @@ mod tests {
             &[".exe".into(), ".cmd".into(), ".bat".into()],
         );
 
-        assert_eq!(resolved, Some(exe.to_string_lossy().to_string()));
+        assert_eq!(resolved, None);
     }
 
     #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Description
Updates Windows OpenCode executable resolution so Wardian launches the `opencode` command from PATH, matching how a user terminal starts OpenCode, instead of probing npm package internals and directly launching nested `opencode-windows-*` binaries.

## Related Issues
Fixes #568

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test -- --maxWorkers=1`
  - Note: local unconstrained `npm run test` hit Vitest fork worker startup timeouts after reporting 85 test files passed, 582 tests passed, and 1 skipped; the single-worker script run completed 116 test files, 1099 tests passed, and 1 skipped.
- `npm run build`
- `npm run docs:check-llms`
- `npm run docs:build`
- `cd src-tauri && cargo test windows_path_lookup -- --nocapture`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test`
- `cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable