### PR TITLE
docs(providers): mark Gemini CLI as unmaintained, prefer Antigravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 Wardian gives real AI CLI agents durable identity, live terminals, scoped skills, workflow runs, queue evidence, and workspace context in one GUI-first habitat.
 
-Use it to spawn specialized agents, monitor their progress, hand work between them, collect completed output, and automate repeatable flows across providers such as Codex, Claude, Gemini, Antigravity, and OpenCode. The bundled `wardian` CLI gives agents and scripts a textual control surface for discovering identity, coordinating peers, and controlling Wardian without driving the graphical app.
+Use it to spawn specialized agents, monitor their progress, hand work between them, collect completed output, and automate repeatable flows across providers such as Antigravity, Claude, Codex, and OpenCode. The bundled `wardian` CLI gives agents and scripts a textual control surface for discovering identity, coordinating peers, and controlling Wardian without driving the graphical app.
 
 Wardian is built for malleable agent work. Prompts, classes, skills, workflows, queues, and memory-ready evidence are treated as visible, reusable artifacts rather than opaque app state. You can start by supervising live agents, then gradually turn repeated instructions into prompts, reusable roles, deployable skills, workflow templates, and durable project context.
 
@@ -116,11 +116,11 @@ Wardian supports five provider CLIs today and adapts each runtime into the same 
 
 | Provider        | Support       | Runtime Model                                              |
 | :-------------- | :------------ | :--------------------------------------------------------- |
-| **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**  | ✅ Supported  | Real-workspace runtime with patched skill discovery and stream-based turn detection. |
 | **[Antigravity](https://www.antigravity.google/docs/cli-overview)** | ✅ Supported | Real-workspace runtime with native `AGENTS.md` discovery, `agy` conversations, and transcript-based turn detection. |
 | **[Claude Code](https://github.com/anthropics/claude-code)** | ✅ Supported  | Real-workspace runtime with explicit session IDs and permission hooks. |
 | **[Codex](https://github.com/openai/codex)**       | ✅ Supported  | Real-workspace execution via `--cd` with per-agent `CODEX_HOME` habitat state. |
 | **[OpenCode](https://github.com/anomalyco/opencode)**    | ✅ Supported  | Real-workspace runtime with native `AGENTS.md` discovery and injected config for Wardian scope. |
+| **[Gemini CLI](https://github.com/google-gemini/gemini-cli)**  | ⚠️ Unmaintained | Real-workspace runtime with patched skill discovery. Consumer/free access ended June 18, 2026. Use Antigravity for Google-model access. |
 
 > See [Provider Runtime Notes](docs/providers.md) for a deep dive into provider-specific discovery and lifecycle management.
 
@@ -266,7 +266,7 @@ Wardian is built with a focus on modularity, thread safety, and separation of co
 
 1. **Rust**: Install [rustup.rs](https://rustup.rs/) (latest stable).
 2. **Node.js**: Ensure Node.js (v18+) is installed.
-3. **Agent CLIs**: Install at least one supported provider CLI before spawning agents: [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`@google/gemini-cli`), [Antigravity](https://www.antigravity.google/docs/cli-overview) (`agy`), [Claude Code](https://github.com/anthropics/claude-code) (`@anthropic-ai/claude-code`), [Codex](https://github.com/openai/codex) (`@openai/codex`), or [OpenCode](https://github.com/anomalyco/opencode) (`opencode` command, commonly installed from `opencode-ai`). Ensure each provider is authenticated successfully in your terminal first.
+3. **Agent CLIs**: Install at least one supported provider CLI before spawning agents: [Antigravity](https://www.antigravity.google/docs/cli-overview) (`agy`), [Claude Code](https://github.com/anthropics/claude-code) (`@anthropic-ai/claude-code`), [Codex](https://github.com/openai/codex) (`@openai/codex`), or [OpenCode](https://github.com/anomalyco/opencode) (`opencode` command, commonly installed from `opencode-ai`). Ensure each provider is authenticated successfully in your terminal first.
 4. **Clone & Install**:
    ```bash
    git clone https://github.com/wardian-app/Wardian.git

--- a/docs/developer/provider-runtimes.md
+++ b/docs/developer/provider-runtimes.md
@@ -1,6 +1,6 @@
 # Provider Runtime Notes
 
-This document captures the practical runtime differences between Wardian's supported CLI providers: Gemini, Antigravity, Claude, Codex, and OpenCode. It is intended for maintainers working on spawn, resume, workflow execution, skill projection, and status/approval handling.
+This document captures the practical runtime differences between Wardian's supported CLI providers: Antigravity, Claude, Codex, OpenCode, and Gemini (unmaintained). It is intended for maintainers working on spawn, resume, workflow execution, skill projection, and status/approval handling.
 
 ## Shared Wardian Invariants
 
@@ -24,37 +24,11 @@ This document captures the practical runtime differences between Wardian's suppo
 
 | Provider | Working root | Instruction file | Skill model | Session identity |
 | --- | --- | --- | --- | --- |
-| Gemini | Projected habitat workspace for headless runs | `GEMINI.md` | Patched CLI can discover skills from include directories | Discovered from provider output |
 | Antigravity | Real target workspace | `AGENTS.md` | `--add-dir` roots expose Wardian context | Discovered from conversation cache and transcript path |
 | Claude | Real target workspace | `CLAUDE.md` | `.claude/skills` points at Wardian's `.agents/skills` | Wardian assigns `--session-id` up front |
 | Codex | Real target workspace via `--cd`; habitat-backed `CODEX_HOME` | `AGENTS.md` | Per-agent `CODEX_HOME/skills` under habitat | Discovered from provider output, then adopted |
 | OpenCode | Habitat command root with real workspace passed as `--dir` | `AGENTS.md` plus injected runtime config | `skills.paths` built from Wardian include roots | Discovered from provider output |
-
-## Gemini
-
-### Working-root model
-
-Gemini headless runs use a projected habitat workspace so shared, class, and
-agent instructions and skills can be materialized outside Wardian's hidden state
-tree. The real target workspace remains the author-facing workspace, but the
-provider process runs from the habitat workspace path during headless execution.
-
-### Instruction and skill discovery
-
-- Gemini reads `GEMINI.md`.
-- Wardian passes include roots through `--include-directories`.
-- Skill discovery depends on Wardian's Gemini patching flow; see [Gemini CLI Patches](./gemini-cli-patches.md).
-- If Gemini stops seeing Wardian-managed skills, check the patched CLI bundle before changing spawn logic.
-
-### Session and telemetry behavior
-
-- Gemini session identity is learned from provider output rather than assigned before launch.
-- Wardian parses Gemini JSON events into `Init`, `UserQuery`, `Generating`, and `TurnCompleted` states.
-
-### Practical implications
-
-- Gemini regressions are usually about habitat projection, CLI patch drift,
-  include-directory handling, or event parsing.
+| Gemini *(unmaintained)* | Projected habitat workspace for headless runs | `GEMINI.md` | Patched CLI can discover skills from include directories | Discovered from provider output |
 
 ## Antigravity
 
@@ -239,11 +213,39 @@ This is how OpenCode sees Wardian-managed class and agent context without forcin
   wrap that command through the configured shell because npm and PowerShell
   shims need shell dispatch semantics.
 
+## Gemini (Unmaintained)
+
+> **Unmaintained.** Consumer/free Gemini CLI access ended June 18, 2026. Use Antigravity for Google-model access — it is the preferred replacement.
+
+### Working-root model
+
+Gemini headless runs use a projected habitat workspace so shared, class, and
+agent instructions and skills can be materialized outside Wardian's hidden state
+tree. The real target workspace remains the author-facing workspace, but the
+provider process runs from the habitat workspace path during headless execution.
+
+### Instruction and skill discovery
+
+- Gemini reads `GEMINI.md`.
+- Wardian passes include roots through `--include-directories`.
+- Skill discovery depends on Wardian's Gemini patching flow; see [Gemini CLI Patches](./gemini-cli-patches.md).
+- If Gemini stops seeing Wardian-managed skills, check the patched CLI bundle before changing spawn logic.
+
+### Session and telemetry behavior
+
+- Gemini session identity is learned from provider output rather than assigned before launch.
+- Wardian parses Gemini JSON events into `Init`, `UserQuery`, `Generating`, and `TurnCompleted` states.
+
+### Practical implications
+
+- Gemini regressions are usually about habitat projection, CLI patch drift,
+  include-directory handling, or event parsing.
+
 ## Choosing Where to Debug
 
 When provider behavior breaks, start with the provider-specific seam instead of the generic agent UI.
 
-- Gemini problems: inspect patching, include directories, and JSON event parsing.
 - Claude problems: inspect `CLAUDE.md` discovery, permission hooks, and explicit session flags.
 - Codex problems: inspect `CODEX_HOME`, `--cd`, bootstrap migration, and sandbox approval transitions.
 - OpenCode problems: inspect `OPENCODE_CONFIG_CONTENT`, real-workspace `cwd`, and JSON session parsing.
+- Gemini problems (unmaintained): inspect patching, include directories, and JSON event parsing.

--- a/docs/features.md
+++ b/docs/features.md
@@ -116,7 +116,7 @@ Related docs:
 
 ## Provider-Aware Orchestration
 
-- Unified orchestration over Gemini, Antigravity, Claude, Codex, and OpenCode
+- Unified orchestration over Antigravity, Claude, Codex, and OpenCode (Gemini is unmaintained — use Antigravity for Google-model access)
 - Provider-specific lifecycle handling for resume/session identity and skill discovery
 
 Related docs:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -62,11 +62,11 @@ Wardian runs local provider CLIs inside managed terminals. Install and authentic
 
 | Provider | Install command | Basic check |
 | :--- | :--- | :--- |
-| Gemini CLI | `npm install -g @google/gemini-cli` | `gemini --version` |
 | Antigravity | See the [Antigravity CLI overview](https://www.antigravity.google/docs/cli-overview) | `agy --version` |
 | Claude Code | `npm install -g @anthropic-ai/claude-code` | `claude --version` |
 | Codex | `npm install -g @openai/codex` | `codex --version` |
 | OpenCode | Provider package that exposes `opencode` | `opencode --version` |
+| Gemini CLI *(unmaintained)* | `npm install -g @google/gemini-cli` | `gemini --version` |
 
 Run the check from a normal terminal first. If the command is not found there, Wardian usually will not find it either.
 
@@ -75,11 +75,11 @@ Run the check from a normal terminal first. If the command is not found there, W
 Start the provider directly once and complete any sign-in prompt before launching it through Wardian.
 
 ```bash
-gemini
 agy
 claude
 codex
 opencode
+gemini
 ```
 
 Use only the provider you installed. Exit the provider after it reaches its normal ready state.
@@ -87,11 +87,11 @@ Use only the provider you installed. Exit the provider after it reaches its norm
 PowerShell uses the same provider commands:
 
 ```powershell
-gemini
 agy
 claude
 codex
 opencode
+gemini
 ```
 
 If a provider asks you to sign in again inside Wardian, finish that prompt in the agent terminal. For provider-specific runtime details, see [Provider Runtimes](../providers.md).

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,16 +1,16 @@
 # Provider Runtimes
 
-Wardian provides one orchestration layer over five supported CLI providers: Gemini CLI, Antigravity, Claude Code, Codex, and OpenCode. Each provider keeps its native command-line behavior, while Wardian adapts session identity, working roots, skill discovery, status tracking, and workflow execution into a consistent app model.
+Wardian provides one orchestration layer over five supported CLI providers: Antigravity, Claude Code, Codex, OpenCode, and Gemini CLI. Each provider keeps its native command-line behavior, while Wardian adapts session identity, working roots, skill discovery, status tracking, and workflow execution into a consistent app model.
 
 ## Overview
 
 | Provider | Support | Working Root | Instruction Source | Skill and Context Model | Session Identity |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** | Supported | Real target workspace | `GEMINI.md` | Wardian include roots passed through `--include-directories`; Gemini patch enables multi-root skill discovery | Discovered from provider output |
 | **[Antigravity](https://www.antigravity.google/docs/cli-overview)** | Supported | Real target workspace | `AGENTS.md` | Wardian include roots passed through repeated `--add-dir` flags | Discovered from Antigravity conversation state |
 | **[Claude Code](https://github.com/anthropics/claude-code)** | Supported | Real target workspace | `CLAUDE.md` | `--add-dir` instruction roots plus `.claude/skills` links to Wardian-managed skills | Wardian assigns fresh session IDs and resumes explicitly |
 | **[Codex](https://github.com/openai/codex)** | Supported | Real target workspace via `--cd` | `AGENTS.md` | Per-agent `CODEX_HOME` habitat with scoped skill projection | Discovered during bootstrap, then adopted into the final habitat |
 | **[OpenCode](https://github.com/anomalyco/opencode)** | Supported | Real target workspace | `AGENTS.md` plus injected runtime config | `OPENCODE_CONFIG` adds Wardian instructions; `OPENCODE_CONFIG_DIR` exposes projected skills | Discovered from JSON events and resumed with `--session` |
+| **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** | Unmaintained | Real target workspace | `GEMINI.md` | Wardian include roots passed through `--include-directories`; Gemini patch enables multi-root skill discovery | Discovered from provider output |
 
 ## Shared Runtime Model
 
@@ -18,26 +18,6 @@ Wardian provides one orchestration layer over five supported CLI providers: Gemi
 - Regular visible agents use the global session policy unless the agent has an explicit override.
 - Workflow Agent nodes choose one run mode: `ephemeral`, `inherit_fresh`, or `inherit_resume`.
 - Wardian keeps user repositories clean by adapting provider-native discovery instead of copying agent-specific instruction and skill files into the project root.
-
-## Gemini CLI (`@google/gemini-cli`)
-
-Gemini runs directly in the real target workspace.
-
-### Instruction and Skill Discovery
-
-Gemini reads `GEMINI.md`. Wardian passes common, class, and agent include roots through `--include-directories`. The Gemini skill patch lets the CLI discover skills from those additional roots rather than only from the global or project-local Gemini skill folders.
-
-### Session and Status Handling
-
-Wardian learns Gemini session identity from provider output and parses Gemini stream events into lifecycle states such as initialization, user input, generation, and turn completion. Workflow execution uses these structured turn-completion signals instead of waiting for fragile terminal text.
-
-### Debug First
-
-If Gemini misses Wardian-managed skills, check the Gemini patch state and include roots before changing workspace or workflow logic.
-
-### Migration Note
-
-Keep Gemini CLI support while users transition provider choices. Consumer/free Gemini CLI access is scheduled to cut off on June 18, 2026. Antigravity support is a separate provider path and does not reuse the Gemini adapter.
 
 ## Antigravity (`agy`)
 
@@ -108,6 +88,24 @@ Wardian discovers OpenCode session IDs from JSON events emitted by `opencode run
 ### Debug First
 
 If OpenCode misses instructions or skills, inspect the generated `OPENCODE_CONFIG` file and `OPENCODE_CONFIG_DIR` skill projection. On Windows, also verify whether Wardian resolved a native executable or correctly wrapped a command shim through the host shell.
+
+## Gemini CLI (`@google/gemini-cli`) — Unmaintained
+
+> **Unmaintained.** Gemini CLI support is no longer actively maintained. Consumer/free Gemini CLI access cut off on June 18, 2026. For Google-model access, use **Antigravity** (`agy`) instead — it is the preferred replacement, uses the same `AGENTS.md`-based instruction model, and receives active support.
+
+Gemini runs directly in the real target workspace.
+
+### Instruction and Skill Discovery
+
+Gemini reads `GEMINI.md`. Wardian passes common, class, and agent include roots through `--include-directories`. The Gemini skill patch lets the CLI discover skills from those additional roots rather than only from the global or project-local Gemini skill folders.
+
+### Session and Status Handling
+
+Wardian learns Gemini session identity from provider output and parses Gemini stream events into lifecycle states such as initialization, user input, generation, and turn completion. Workflow execution uses these structured turn-completion signals instead of waiting for fragile terminal text.
+
+### Debug First
+
+If Gemini misses Wardian-managed skills, check the Gemini patch state and include roots before changing workspace or workflow logic.
 
 ## Related References
 

--- a/src/features/agents/SpawnAgentPanel.test.tsx
+++ b/src/features/agents/SpawnAgentPanel.test.tsx
@@ -249,7 +249,7 @@ describe("SpawnAgentPanel", () => {
     );
 
     expect(await screen.findByRole("option", { name: "Codex - not installed" })).toBeDisabled();
-    expect(screen.getByRole("option", { name: "Gemini - not installed" })).toBeDisabled();
+    expect(screen.getByRole("option", { name: "Gemini (Unmaintained) - not installed" })).toBeDisabled();
     expect(screen.queryByText(/Only provider CLIs found on this machine are selectable/i)).not.toBeInTheDocument();
   });
 

--- a/src/features/agents/providerOptions.test.ts
+++ b/src/features/agents/providerOptions.test.ts
@@ -15,9 +15,9 @@ describe('provider option helpers', () => {
     expect(buildUngatedProviderOptions()).toEqual([
       { value: 'claude', label: 'Claude', available: true, reason: null },
       { value: 'codex', label: 'Codex', available: true, reason: null },
-      { value: 'gemini', label: 'Gemini', available: true, reason: null },
       { value: 'antigravity', label: 'Antigravity', available: true, reason: null },
       { value: 'opencode', label: 'OpenCode', available: true, reason: null },
+      { value: 'gemini', label: 'Gemini (Unmaintained)', available: true, reason: null },
     ]);
   });
 

--- a/src/features/agents/providerOptions.ts
+++ b/src/features/agents/providerOptions.ts
@@ -1,7 +1,7 @@
 import type { DefaultProviderSetting } from "../../types/settings";
 import type { ProviderReadiness, UserFacingProviderName } from "../../types";
 
-export const PROVIDER_ORDER: UserFacingProviderName[] = ["claude", "codex", "gemini", "antigravity", "opencode"];
+export const PROVIDER_ORDER: UserFacingProviderName[] = ["claude", "codex", "antigravity", "opencode", "gemini"];
 
 export interface ProviderOption {
   value: UserFacingProviderName;
@@ -17,7 +17,7 @@ export function providerDisplayName(provider: UserFacingProviderName): string {
     case "codex":
       return "Codex";
     case "gemini":
-      return "Gemini";
+      return "Gemini (Unmaintained)";
     case "antigravity":
       return "Antigravity";
     case "opencode":


### PR DESCRIPTION
## Summary

- Consumer/free Gemini CLI access ended June 18, 2026; Gemini is now marked **Unmaintained** across all provider lists and moved to last position in every table, dropdown, and code block
- Users directed to **Antigravity** (`agy`) as the preferred replacement for Google-model access
- `PROVIDER_ORDER` updated so Gemini sorts last in auto-selection and the spawn form
- Display name updated to `"Gemini (Unmaintained)"` so the status is visible in the UI without extra context

## Changes

| File | Change |
|---|---|
| `src/features/agents/providerOptions.ts` | `gemini` moved to last in `PROVIDER_ORDER`; display name updated |
| `docs/providers.md` | Overview table reordered; Gemini section moved to end with unmaintained callout |
| `README.md` | Provider table updated (⚠️ Unmaintained); dropped from prose and dev-setup lists |
| `docs/guide/getting-started.md` | Install table and auth code blocks reordered |
| `docs/developer/provider-runtimes.md` | Quick comparison table and section moved to end with notice |
| `docs/features.md` | Provider list reordered, Antigravity preferred note added |
| Tests | Updated to match new order and `"Gemini (Unmaintained)"` label |

## Test plan

- [x] `npm run test` — 116 test files, 1109 tests pass (1 pre-existing skip)
- [x] No new test failures introduced