### PR TITLE
fix(grid): restore terminal selection prop forwarding

### DIFF
--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -13,9 +13,10 @@ vi.mock('../features/terminal/AgentTerminal', async () => {
   return {
     AgentTerminal: React.memo((props: {
       sessionId: string;
+      isSelected?: boolean;
       onTerminalFocus?: () => void;
     }) => {
-      terminalRenderSpy(props.sessionId);
+      terminalRenderSpy(props);
       return React.createElement(
         'div',
         {
@@ -155,6 +156,21 @@ describe('GridView maximize behavior', () => {
     screen.getByTestId('terminal-agent-2').focus();
 
     expect(onTerminalFocus).toHaveBeenCalledWith('agent-2');
+  });
+
+  it('passes grid selection state through to terminal cards', () => {
+    renderGrid(null, agents, vi.fn(), {
+      selectedAgentIds: new Set(['agent-1']),
+    });
+
+    expect(terminalRenderSpy).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'agent-1',
+      isSelected: true,
+    }));
+    expect(terminalRenderSpy).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'agent-2',
+      isSelected: false,
+    }));
   });
 
   it('does not size each mobile card to the full viewport height', () => {

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -68,6 +68,7 @@ interface AgentTerminalSlotProps {
   sessionId: string;
   provider?: string;
   isMaximized: boolean;
+  isSelected: boolean;
   theme: "dark" | "light" | "system";
   workspacePath?: string;
   onTerminalFocus?: (agentId: string) => void;
@@ -78,6 +79,7 @@ const AgentTerminalSlot = React.memo(function AgentTerminalSlot({
   sessionId,
   provider,
   isMaximized,
+  isSelected,
   theme,
   workspacePath,
   onTerminalFocus,
@@ -96,6 +98,7 @@ const AgentTerminalSlot = React.memo(function AgentTerminalSlot({
       sessionId={sessionId}
       provider={provider}
       isMaximized={isMaximized}
+      isSelected={isSelected}
       theme={theme}
       workspacePath={workspacePath}
       onTerminalFocus={handleTerminalFocus}


### PR DESCRIPTION
## Description
Fixes the `main` TypeScript compile failure introduced when `GridView` began rendering terminals through `AgentTerminalSlot`.

Root cause: the new memoized wrapper accepted `isMaximized` but omitted `isSelected` from `AgentTerminalSlotProps` and did not forward it to `AgentTerminal`. The grid call site still passed `isSelected`, and `AgentTerminal` still uses that prop to control terminal input interactivity, especially for non-selected Opencode terminals.

This PR restores the wrapper contract and adds a regression test that proves grid selection state reaches terminal cards.

## Related Issues
Fixes #592

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run test -- src/views/GridView.test.tsx -t "passes grid selection state through to terminal cards"` - red before the fix, passing after
- `npm run lint`
- `npm run test` - 128 files, 1187 passed, 1 skipped
- `npm run build` - passed with existing Vite chunk-size warning
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test` - 997 unit tests, 7 mock-provider tests, 1 workflow executor test passed
- `cd src-tauri && cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

## Screenshots
Non-visual compile/prop-forwarding hotfix. Existing Grid terminal context screenshot for frontend evidence policy:

![grid-active-agent-state](https://raw.githubusercontent.com/wardian-app/Wardian/main/docs/assets/screenshots/grid/active-agent-state.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Additional comments are not needed for this prop-forwarding fix
- [x] User-facing docs are not applicable; `docs/developer/docs-maintenance.md` says internal-only changes do not need user docs when public workflows are unchanged
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Screenshot evidence is embedded above for the CI frontend evidence policy; no visual delta is expected
