### PR TITLE
fix(tests): wait for custom clone modal readiness

### DIFF
--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -1502,7 +1502,8 @@ describe("Agent Watchlist Sidebar", () => {
     fireEvent.contextMenu(alphaWatchlistRow);
     fireEvent.mouseEnter(within(screen.getByTestId("agent-context-menu")).getByRole("button", { name: "Clone" }));
     fireEvent.click(await screen.findByRole("button", { name: "Custom Clone" }));
-    fireEvent.click(await screen.findByTestId("custom-clone-submit"));
+    await screen.findByDisplayValue("Alpha-copy");
+    fireEvent.click(screen.getByTestId("custom-clone-submit"));
 
     await waitFor(() => {
       const state = normalizeWatchlistState(currentWatchlists);


### PR DESCRIPTION
## Description
- Wait for the custom clone modal preview to populate before submitting in the App integration test.
- Removes the coverage-only race where the disabled submit button could be clicked before clone form readiness.

## Related Issues
Fixes #594

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] `npm run test:coverage` - 128 test files passed, 1187 tests passed, 1 skipped
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build` - completed with the existing Vite chunk-size warning
- [x] `cd src-tauri && cargo clippy`
- [x] `cd src-tauri && cargo test`
- [x] `cd src-tauri && cargo check`
- [x] `git diff --check`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, or comments were not needed
- [x] I have made corresponding changes to the documentation, or documentation was not needed for this test-only CI fix
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs, or it was not applicable for this test-only CI fix
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable