### PR TITLE
fix(remote): handle mobile PWA back swipe

### DIFF
--- a/docs/guide/remote-control.md
+++ b/docs/guide/remote-control.md
@@ -243,7 +243,8 @@ is focused on:
 
 The watchlist itself does not expose inline actions. Tap an agent row to open
 the detail view before sending prompts, pausing, resuming, clearing, or killing
-an agent.
+an agent. Use the back button or the phone/browser back gesture to return from
+agent detail to the watchlist without leaving the installed PWA.
 
 Use the send icon in the watchlist header to open the broadcast prompt. Mobile
 broadcasts require confirmation before Wardian sends the prompt to every

--- a/src/features/remote/RemoteAgentDetailView.tsx
+++ b/src/features/remote/RemoteAgentDetailView.tsx
@@ -456,7 +456,7 @@ export const RemoteAgentDetailView: React.FC<{ agent: RemoteAgentSummary }> = ({
     >
       <header className="shrink-0 border-b border-wardian-border bg-wardian-bg/95 px-3 py-3 backdrop-blur">
         <div className="flex items-center gap-2">
-          <button type="button" aria-label="Back to remote agents" onClick={closeAgent} className={iconButtonClass}>
+          <button type="button" aria-label="Back to remote agents" onClick={() => closeAgent()} className={iconButtonClass}>
             <ArrowLeft className="h-4 w-4" aria-hidden="true" />
           </button>
           <div className="min-w-0 flex-1">

--- a/src/features/remote/RemoteMobileApp.test.tsx
+++ b/src/features/remote/RemoteMobileApp.test.tsx
@@ -367,6 +367,43 @@ describe("RemoteMobileApp", () => {
     expect(screen.getByTestId("remote-watchlist-view")).toBeVisible();
   });
 
+  it("returns from agent detail to the watchlist when browser history goes back", async () => {
+    useRemoteStore.setState({
+      agents: [
+        {
+          session_id: "agent-1",
+          session_name: "Alpha",
+          agent_class: "Coder",
+          provider: "codex",
+          workspace: "<absolute-workspace-path>",
+          status: "Idle",
+          latest_text: null,
+        },
+      ],
+      teams: [],
+      watchlists: [],
+      watchlistPrefs: { columns: [], sort: null, preserve_team_grouping_when_sorted: false, collapsed_team_ids: [] },
+      mobileCollapsedTeamIds: [],
+      activeWatchlistId: "all",
+      activeRemoteTab: "watchlist",
+      activeAgentId: null,
+      status: "ready",
+      load: vi.fn(async () => {}),
+    });
+
+    render(<RemoteMobileApp />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Open Alpha details" }));
+    expect(screen.getByTestId("remote-agent-detail")).toBeVisible();
+
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate", { state: {} }));
+    });
+
+    expect(useRemoteStore.getState().activeAgentId).toBeNull();
+    expect(screen.getByTestId("remote-watchlist-view")).toBeVisible();
+  });
+
   it("updates the active remote tab from the compact mobile bottom nav", async () => {
     useRemoteStore.setState({
       activeRemoteTab: "watchlist",

--- a/src/features/remote/RemoteMobileApp.tsx
+++ b/src/features/remote/RemoteMobileApp.tsx
@@ -27,6 +27,18 @@ export const RemoteMobileApp: React.FC = () => {
   }, [disconnectStatusStream]);
 
   useEffect(() => {
+    const closeDetailOnHistoryBack = () => {
+      const state = useRemoteStore.getState();
+      if (state.activeAgentId) state.closeAgent({ syncHistory: false });
+    };
+
+    window.addEventListener("popstate", closeDetailOnHistoryBack);
+    return () => {
+      window.removeEventListener("popstate", closeDetailOnHistoryBack);
+    };
+  }, []);
+
+  useEffect(() => {
     const refreshOnResume = () => {
       if (document.visibilityState === "hidden") return;
       if (useRemoteStore.getState().status !== "ready") return;

--- a/src/features/remote/useRemoteStore.ts
+++ b/src/features/remote/useRemoteStore.ts
@@ -69,7 +69,7 @@ interface RemoteState {
   setActiveRemoteTab: (tab: ActiveRemoteTab) => void;
   toggleMobileTeamCollapsed: (teamId: string) => void;
   openAgent: (id: string) => Promise<void>;
-  closeAgent: () => void;
+  closeAgent: (options?: { syncHistory?: boolean }) => void;
   setActiveAgentViewMode: (mode: "terminal" | "chat") => Promise<void>;
   refreshActiveAgentTerminal: (options?: { background?: boolean }) => Promise<void>;
   refreshActiveAgentChat: (options?: { background?: boolean }) => Promise<void>;
@@ -89,6 +89,7 @@ const statusFromError = (error: unknown): RemoteStatus =>
   error instanceof RemoteRequestError && error.status === 401 ? "session_expired" : "unreachable";
 
 const REMOTE_ACTIVE_WATCHLIST_STORAGE_KEY = "wardian.remote.activeWatchlistId";
+const REMOTE_HISTORY_DETAIL_VIEW = "agent_detail";
 const BACKGROUND_CHAT_REFRESH_MIN_INTERVAL_MS = 750;
 const STATUS_STREAM_RECONNECT_BASE_DELAY_MS = 250;
 const STATUS_STREAM_RECONNECT_MAX_DELAY_MS = 5_000;
@@ -445,6 +446,40 @@ const clearPairingUrl = () => {
   window.history.replaceState({}, "", `${window.location.pathname}${window.location.hash}`);
 };
 
+const currentHistoryStateObject = () =>
+  typeof window.history.state === "object" && window.history.state !== null && !Array.isArray(window.history.state)
+    ? window.history.state
+    : {};
+
+const isRemoteAgentDetailHistoryState = (state = window.history.state) =>
+  typeof state === "object" &&
+  state !== null &&
+  !Array.isArray(state) &&
+  (state as { wardian_remote_view?: unknown }).wardian_remote_view === REMOTE_HISTORY_DETAIL_VIEW;
+
+const pushRemoteAgentDetailHistory = (agentId: string) => {
+  try {
+    const currentState = currentHistoryStateObject();
+    if (
+      isRemoteAgentDetailHistoryState(currentState) &&
+      (currentState as { wardian_remote_agent_id?: unknown }).wardian_remote_agent_id === agentId
+    ) {
+      return;
+    }
+    window.history.pushState(
+      {
+        ...currentState,
+        wardian_remote_view: REMOTE_HISTORY_DETAIL_VIEW,
+        wardian_remote_agent_id: agentId,
+      },
+      "",
+      `${window.location.pathname}${window.location.search}${window.location.hash}`,
+    );
+  } catch {
+    // Some embedded browsers restrict history writes; explicit in-app back remains available.
+  }
+};
+
 const delay = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
 
 const authenticateDevice = async (identity: StoredRemoteDeviceIdentity) => {
@@ -693,6 +728,7 @@ export const useRemoteStore = create<RemoteState>((set, get) => ({
     clearBackgroundChatRefresh();
     const activeAgent = get().agents.find((agent) => agent.session_id === id);
     lastActiveAgentRefreshKey = activeAgent ? activeAgentRefreshKey(activeAgent) : null;
+    pushRemoteAgentDetailHistory(id);
     set({
       activeAgentId: id,
       activeAgentViewMode: "terminal",
@@ -704,7 +740,14 @@ export const useRemoteStore = create<RemoteState>((set, get) => ({
       chatError: "",
     });
   },
-  closeAgent() {
+  closeAgent(options) {
+    if (options?.syncHistory !== false && isRemoteAgentDetailHistoryState()) {
+      try {
+        window.history.back();
+      } catch {
+        // If browser history cannot move, still close the in-app detail view.
+      }
+    }
     clearBackgroundChatRefresh();
     lastActiveAgentRefreshKey = null;
     set({


### PR DESCRIPTION
## Description
Adds browser-history awareness to the remote mobile PWA agent detail screen so phone/browser back gestures return to the remote watchlist instead of leaving the installed PWA.

## Related Issues
Fixes #607

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run test:e2e -- e2e/tests/remote-pwa.spec.ts`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test`
- [x] `cd src-tauri && cargo clippy`
- [x] `npm run docs:check-llms`
- [x] `npm run docs:build`
- [x] `git diff --check`

## Screenshots
![remote PWA watchlist after browser back from agent detail](https://raw.githubusercontent.com/wardian-app/Wardian/refs/heads/pr-evidence/remote-pwa-back-swipe-607/remote-pwa-back-swipe-history-back-watchlist.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
