### PR TITLE
fix(terminal): log Windows ConPTY runtime diagnostics

### DIFF
--- a/docs/specs/2026-07-02-claude-windows-conpty-diagnostics.md
+++ b/docs/specs/2026-07-02-claude-windows-conpty-diagnostics.md
@@ -1,0 +1,46 @@
+# Claude Windows ConPTY Diagnostics
+
+- **Status:** Implemented as a diagnostics and cleanup slice.
+- **Date:** 2026-07-02
+- **Area:** Windows PTY runtime, bundled ConPTY/OpenConsole packaging, frontend terminal rendering.
+- **Issue:** [#623](https://github.com/wardian-app/Wardian/issues/623)
+
+## Context
+
+A Windows Claude Code user reported duplicate terminal lines even after Wardian's modern ConPTY/OpenConsole integration. The issue occurred more often before the OpenConsole bundle landed, so the highest-value question is whether that user's installed Wardian build is actually loading the bundled ConPTY implementation or silently falling back to another backend.
+
+## Findings
+
+- Wardian's direct dev/release build path copies `conpty/x64/conpty.dll` and `OpenConsole.exe` beside `Wardian.exe`.
+- Existing NSIS artifacts inspected locally contain `conpty/x64/conpty.dll` and `conpty/x64/OpenConsole.exe`, so the current installer shape can package the files correctly.
+- The loader still falls back by design: bundled ConPTY, then bare `conpty.dll`, then kernel32. That fallback should remain; the missing surface was runtime proof of which path won.
+- User settings should not expose a switch to disable modern ConPTY. The modern backend is the intended default, and fallback exists for missing or failing bundles.
+- Claude settings and custom CLI options can affect Claude behavior, but they do not select Wardian's frontend terminal implementation or ConPTY backend.
+- The active xterm debug snapshot already exposes `bufferType`, which is the useful frontend signal for normal versus alternate screen buffer state.
+- The old synthetic viewport-redraw path is unreachable because provider redraw routing is disabled. It is a cleanup candidate, but it is not part of this diagnostics slice because this PR should stay focused on proving the Windows ConPTY runtime path.
+
+## Implementation
+
+Wardian now exposes terminal runtime diagnostics with:
+
+- platform;
+- Windows ConPTY load source: `bundled`, `bare`, or `kernel32`;
+- expected bundled `conpty.dll` path and existence;
+- expected bundled `OpenConsole.exe` path and existence;
+- load errors for bundled or bare fallback attempts when present.
+
+The same diagnostics are logged once when an agent PTY or user-terminal PTY starts, so an affected user can provide evidence from their Wardian debug log without guessing whether bundling failed.
+
+## Investigation Use
+
+For a Windows duplicate-line report, collect:
+
+1. The terminal runtime diagnostics entry from the Wardian debug log.
+2. The frontend terminal debug snapshot for the affected session, especially renderer `bufferType`, `baseY`, `viewportY`, and recent write previews.
+3. Whether the duplicate lines appear after resize, maximize/minimize, font/layout changes, or normal output.
+
+If `load_source` is not `bundled`, investigate installer artifact, install directory contents, architecture, or blocked file loading before changing terminal rendering behavior.
+
+If `load_source` is `bundled`, treat the next hypothesis as Claude normal-buffer resize/reflow behavior and require a raw terminal trace before adding any scrollback deduplication, because previous dedup attempts risked deleting legitimate terminal history.
+
+Separately, the unreachable synthetic viewport-redraw path can be deleted in a frontend cleanup PR with its own screenshot-policy handling.

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -3,13 +3,85 @@ use crate::state::{AppState, UserTerminalSession};
 use crate::utils::append_bounded_pty_output;
 use crate::utils::PtyUtf8Decoder;
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 use tauri::State;
 use tauri::{AppHandle, Emitter};
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TerminalRuntimeDiagnostics {
+    pub platform: String,
+    pub conpty: Option<WindowsConptyRuntimeDiagnostics>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct WindowsConptyRuntimeDiagnostics {
+    pub load_source: String,
+    pub bundled_conpty_path: Option<String>,
+    pub bundled_conpty_exists: bool,
+    pub bundled_openconsole_path: Option<String>,
+    pub bundled_openconsole_exists: bool,
+    pub bundled_load_error: Option<String>,
+    pub bare_load_error: Option<String>,
+}
+
+#[tauri::command]
+pub fn get_terminal_runtime_diagnostics() -> TerminalRuntimeDiagnostics {
+    build_terminal_runtime_diagnostics()
+}
+
+pub(crate) fn log_terminal_runtime_diagnostics_once() {
+    static LOGGED: OnceLock<()> = OnceLock::new();
+    if LOGGED.set(()).is_err() {
+        return;
+    }
+
+    let diagnostics = build_terminal_runtime_diagnostics();
+    let message = serde_json::to_string(&diagnostics)
+        .unwrap_or_else(|error| format!("{{\"serialization_error\":\"{}\"}}", error));
+    manager::log_debug(&format!(
+        "[Wardian] Terminal runtime diagnostics: {message}"
+    ));
+}
+
+fn build_terminal_runtime_diagnostics() -> TerminalRuntimeDiagnostics {
+    TerminalRuntimeDiagnostics {
+        platform: std::env::consts::OS.to_string(),
+        conpty: windows_conpty_runtime_diagnostics(),
+    }
+}
+
+#[cfg(windows)]
+fn windows_conpty_runtime_diagnostics() -> Option<WindowsConptyRuntimeDiagnostics> {
+    let diagnostics = portable_pty::win::conpty_load_diagnostics();
+    let load_source = match diagnostics.load_source {
+        portable_pty::win::ConPtyLoadSource::Bundled => "bundled",
+        portable_pty::win::ConPtyLoadSource::Bare => "bare",
+        portable_pty::win::ConPtyLoadSource::Kernel32 => "kernel32",
+    };
+
+    Some(WindowsConptyRuntimeDiagnostics {
+        load_source: load_source.to_string(),
+        bundled_conpty_path: diagnostics
+            .bundled_conpty_path
+            .map(|path| path.display().to_string()),
+        bundled_conpty_exists: diagnostics.bundled_conpty_exists,
+        bundled_openconsole_path: diagnostics
+            .bundled_openconsole_path
+            .map(|path| path.display().to_string()),
+        bundled_openconsole_exists: diagnostics.bundled_openconsole_exists,
+        bundled_load_error: diagnostics.bundled_load_error,
+        bare_load_error: diagnostics.bare_load_error,
+    })
+}
+
+#[cfg(not(windows))]
+fn windows_conpty_runtime_diagnostics() -> Option<WindowsConptyRuntimeDiagnostics> {
+    None
+}
 
 #[cfg(test)]
 pub(crate) async fn submit_prompt_to_agent_with_codex_echo_guard(
@@ -480,6 +552,8 @@ fn spawn_user_terminal_session(
     cols: u16,
     rows: u16,
 ) -> Result<UserTerminalSession, String> {
+    log_terminal_runtime_diagnostics_once();
+
     let launch = crate::utils::build_interactive_shell_launch()?;
     let cwd = crate::utils::get_wardian_home().ok_or("Could not find Wardian home")?;
     let session_id = uuid::Uuid::new_v4().to_string();
@@ -798,6 +872,33 @@ mod tests {
         let missing = std::env::temp_dir().join("wardian-missing-user-terminal-dir");
         let err = validate_user_terminal_cwd(&missing.to_string_lossy()).expect_err("missing dir");
         assert!(err.contains("does not exist"));
+    }
+
+    #[test]
+    fn terminal_runtime_diagnostics_reports_platform() {
+        let diagnostics = super::build_terminal_runtime_diagnostics();
+
+        assert!(!diagnostics.platform.is_empty());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn terminal_runtime_diagnostics_reports_windows_conpty_bundle_paths() {
+        let diagnostics = super::build_terminal_runtime_diagnostics();
+        let conpty = diagnostics.conpty.expect("windows conpty diagnostics");
+
+        assert!(matches!(
+            conpty.load_source.as_str(),
+            "bundled" | "bare" | "kernel32"
+        ));
+        assert!(conpty
+            .bundled_conpty_path
+            .as_deref()
+            .is_some_and(|path| path.ends_with(r"conpty\x64\conpty.dll")));
+        assert!(conpty
+            .bundled_openconsole_path
+            .as_deref()
+            .is_some_and(|path| path.ends_with(r"conpty\x64\OpenConsole.exe")));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -487,6 +487,7 @@ pub fn run() {
             commands::terminal::broadcast_input,
             commands::terminal::resize_agent_terminal,
             commands::terminal::read_agent_pty,
+            commands::terminal::get_terminal_runtime_diagnostics,
             commands::terminal::ensure_user_terminal,
             commands::terminal::send_input_to_user_terminal,
             commands::terminal::send_binary_input_to_user_terminal,

--- a/src-tauri/src/manager/spawn.rs
+++ b/src-tauri/src/manager/spawn.rs
@@ -406,6 +406,8 @@ pub async fn spawn_agent(
         cleanup_stale_session_processes(&config.session_id, &config.provider);
     }
 
+    crate::commands::terminal::log_terminal_runtime_diagnostics_once();
+
     let pty_system = NativePtySystem::default();
 
     let (initial_cols, initial_rows) = {

--- a/vendor/portable-pty/src/win/mod.rs
+++ b/vendor/portable-pty/src/win/mod.rs
@@ -15,6 +15,8 @@ pub mod conpty;
 mod procthreadattr;
 mod psuedocon;
 
+pub use psuedocon::{conpty_load_diagnostics, ConPtyLoadDiagnostics, ConPtyLoadSource};
+
 use filedescriptor::OwnedHandle;
 
 #[derive(Debug)]

--- a/vendor/portable-pty/src/win/psuedocon.rs
+++ b/vendor/portable-pty/src/win/psuedocon.rs
@@ -9,7 +9,7 @@ use std::ffi::OsString;
 use std::io::Error as IoError;
 use std::os::windows::ffi::OsStringExt;
 use std::os::windows::io::{AsRawHandle, FromRawHandle};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::{mem, ptr};
 use winapi::shared::minwindef::DWORD;
@@ -48,12 +48,55 @@ shared_library!(ConPtyFuncs,
     pub fn ClosePseudoConsole(hpc: HPCON),
 );
 
-fn load_conpty() -> ConPtyFuncs {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConPtyLoadSource {
+    Bundled,
+    Bare,
+    Kernel32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConPtyLoadDiagnostics {
+    pub load_source: ConPtyLoadSource,
+    pub bundled_conpty_path: Option<PathBuf>,
+    pub bundled_conpty_exists: bool,
+    pub bundled_openconsole_path: Option<PathBuf>,
+    pub bundled_openconsole_exists: bool,
+    pub bundled_load_error: Option<String>,
+    pub bare_load_error: Option<String>,
+}
+
+struct ConPtyLoad {
+    funcs: ConPtyFuncs,
+    diagnostics: ConPtyLoadDiagnostics,
+}
+
+fn bundled_conpty_path_from_exe_dir(exe_dir: &Path) -> PathBuf {
+    exe_dir.join("conpty").join("x64").join("conpty.dll")
+}
+
+fn bundled_openconsole_path_from_exe_dir(exe_dir: &Path) -> PathBuf {
+    exe_dir
+        .join("conpty")
+        .join("x64")
+        .join("OpenConsole.exe")
+}
+
+fn load_conpty() -> ConPtyLoad {
     // If the kernel doesn't export these functions then their system is
     // too old and we cannot run.
     let kernel = ConPtyFuncs::open(Path::new("kernel32.dll")).expect(
         "this system does not support conpty.  Windows 10 October 2018 or newer is required",
     );
+    let mut diagnostics = ConPtyLoadDiagnostics {
+        load_source: ConPtyLoadSource::Kernel32,
+        bundled_conpty_path: None,
+        bundled_conpty_exists: false,
+        bundled_openconsole_path: None,
+        bundled_openconsole_exists: false,
+        bundled_load_error: None,
+        bare_load_error: None,
+    };
 
     // We prefer to use a sideloaded conpty.dll and openconsole.exe host deployed
     // alongside the application.  We check for this after checking for kernel
@@ -70,23 +113,52 @@ fn load_conpty() -> ConPtyFuncs {
         .ok()
         .and_then(|exe| exe.parent().map(|dir| dir.to_path_buf()))
     {
-        let bundled = exe_dir.join("conpty").join("x64").join("conpty.dll");
+        let bundled = bundled_conpty_path_from_exe_dir(&exe_dir);
+        let openconsole = bundled_openconsole_path_from_exe_dir(&exe_dir);
+        diagnostics.bundled_conpty_exists = bundled.exists();
+        diagnostics.bundled_openconsole_exists = openconsole.exists();
+        diagnostics.bundled_conpty_path = Some(bundled.clone());
+        diagnostics.bundled_openconsole_path = Some(openconsole);
         if bundled.exists() {
-            if let Ok(sideloaded) = ConPtyFuncs::open(&bundled) {
-                return sideloaded;
+            match ConPtyFuncs::open(&bundled) {
+                Ok(sideloaded) => {
+                    diagnostics.load_source = ConPtyLoadSource::Bundled;
+                    return ConPtyLoad {
+                        funcs: sideloaded,
+                        diagnostics,
+                    };
+                }
+                Err(error) => {
+                    diagnostics.bundled_load_error = Some(format!("{:?}", error));
+                }
             }
         }
     }
 
-    if let Ok(sideloaded) = ConPtyFuncs::open(Path::new("conpty.dll")) {
-        sideloaded
-    } else {
-        kernel
+    match ConPtyFuncs::open(Path::new("conpty.dll")) {
+        Ok(sideloaded) => {
+            diagnostics.load_source = ConPtyLoadSource::Bare;
+            ConPtyLoad {
+                funcs: sideloaded,
+                diagnostics,
+            }
+        }
+        Err(error) => {
+            diagnostics.bare_load_error = Some(format!("{:?}", error));
+            ConPtyLoad {
+                funcs: kernel,
+                diagnostics,
+            }
+        }
     }
 }
 
 lazy_static! {
-    static ref CONPTY: ConPtyFuncs = load_conpty();
+    static ref CONPTY: ConPtyLoad = load_conpty();
+}
+
+pub fn conpty_load_diagnostics() -> ConPtyLoadDiagnostics {
+    CONPTY.diagnostics.clone()
 }
 
 pub struct PsuedoCon {
@@ -98,7 +170,7 @@ unsafe impl Sync for PsuedoCon {}
 
 impl Drop for PsuedoCon {
     fn drop(&mut self) {
-        unsafe { (CONPTY.ClosePseudoConsole)(self.con) };
+        unsafe { (CONPTY.funcs.ClosePseudoConsole)(self.con) };
     }
 }
 
@@ -106,7 +178,7 @@ impl PsuedoCon {
     pub fn new(size: COORD, input: FileDescriptor, output: FileDescriptor) -> Result<Self, Error> {
         let mut con: HPCON = INVALID_HANDLE_VALUE;
         let result = unsafe {
-            (CONPTY.CreatePseudoConsole)(
+            (CONPTY.funcs.CreatePseudoConsole)(
                 size,
                 input.as_raw_handle() as _,
                 output.as_raw_handle() as _,
@@ -125,7 +197,7 @@ impl PsuedoCon {
     }
 
     pub fn resize(&self, size: COORD) -> Result<(), Error> {
-        let result = unsafe { (CONPTY.ResizePseudoConsole)(self.con, size) };
+        let result = unsafe { (CONPTY.funcs.ResizePseudoConsole)(self.con, size) };
         ensure!(
             result == S_OK,
             "failed to resize console to {}x{}: HRESULT: {}",
@@ -205,6 +277,8 @@ impl PsuedoCon {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     #[test]
     fn conpty_child_process_creation_flags_preserve_extended_startup_info() {
         assert_ne!(
@@ -220,6 +294,33 @@ mod tests {
         assert_eq!(
             super::conpty_child_process_creation_flags() & CREATE_NO_WINDOW,
             0
+        );
+    }
+
+    #[test]
+    fn bundled_conpty_path_is_relative_to_executable_directory() {
+        let path = super::bundled_conpty_path_from_exe_dir(Path::new(r"C:\Program Files\Wardian"));
+
+        assert_eq!(
+            path,
+            Path::new(r"C:\Program Files\Wardian")
+                .join("conpty")
+                .join("x64")
+                .join("conpty.dll")
+        );
+    }
+
+    #[test]
+    fn bundled_openconsole_path_sits_next_to_bundled_conpty() {
+        let path =
+            super::bundled_openconsole_path_from_exe_dir(Path::new(r"C:\Program Files\Wardian"));
+
+        assert_eq!(
+            path,
+            Path::new(r"C:\Program Files\Wardian")
+                .join("conpty")
+                .join("x64")
+                .join("OpenConsole.exe")
         );
     }
 }


### PR DESCRIPTION
## Description
Adds runtime evidence for Windows ConPTY loading so duplicate-line reports from installed Wardian builds can distinguish bundled OpenConsole usage from fallback behavior.

- Records whether portable-pty loaded bundled `conpty/x64/conpty.dll`, bare `conpty.dll`, or kernel32.
- Exposes `get_terminal_runtime_diagnostics` and logs the diagnostics once when an agent PTY or user terminal PTY starts.
- Documents the Claude Windows duplicate-line investigation path and evidence to collect.

## Related Issues
Fixes #623

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run lint`
- [x] `npm run test` (127 files, 1197 passed, 1 skipped)
- [x] `npm run build` (passes; existing large-chunk warning)
- [x] `npm run check:frontend-screenshot -- origin/main HEAD` (no frontend changes detected)
- [x] `cd src-tauri && cargo clippy`
- [x] `cd src-tauri && cargo test` (1027 lib tests, 7 mock-provider tests, 1 workflow test passed)
- [x] `cd src-tauri && cargo check`
- [x] `git diff --check`
- [x] Reviewer pass via Wardian-Reviewer; minor issue-link finding fixed before PR

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable