### PR TITLE
fix(watchlist): preserve individual membership during restore

### DIFF
--- a/src/layout/watchlist/AgentWatchlist.test.tsx
+++ b/src/layout/watchlist/AgentWatchlist.test.tsx
@@ -133,6 +133,28 @@ describe('AgentWatchlist', () => {
     expect(screen.getByText('Beta')).toBeInTheDocument();
   });
 
+  it('does not prune persisted individual watchlist entries before agents load', async () => {
+    render(
+      <AgentWatchlist
+        {...defaultProps}
+        agents={[]}
+        telemetry={{}}
+        watchlists={[
+          {
+            id: 'today',
+            name: 'Today',
+            entries: [{ type: 'agent', agentId: 'agent-1' }],
+          },
+        ]}
+        activeListId="today"
+      />,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockOnWatchlistsChange).not.toHaveBeenCalled();
+  });
+
   it('filters agents by search term', () => {
     render(<AgentWatchlist {...defaultProps} />);
     const searchInput = screen.getByPlaceholderText('Search agents...');

--- a/src/layout/watchlist/AgentWatchlist.tsx
+++ b/src/layout/watchlist/AgentWatchlist.tsx
@@ -196,22 +196,6 @@ export default function AgentWatchlist({
     [onWatchlistsChange],
   );
 
-  // ── Prune stale agent IDs from watchlists when agents change ───────
-  useEffect(() => {
-    const validIds = new Set(agents.map((a) => a.session_id));
-    const pruned = watchlists.map((wl) => ({
-      ...wl,
-      entries: getWatchlistEntries(wl).filter((entry) => entry.type === "team" || validIds.has(entry.agentId)),
-    }));
-    // Only persist if something actually changed
-    const changed = pruned.some(
-      (wl, i) => getWatchlistEntries(wl).length !== getWatchlistEntries(watchlists[i]).length
-    );
-    if (changed) {
-      persistWatchlists(pruned);
-    }
-  }, [agents]); // intentionally omitting watchlists/persistWatchlists to avoid loops
-
   // ── Close context menus on outside click ───────────────────────────
   useEffect(() => {
     const handleClick = () => {

--- a/src/layout/watchlist/watchlistUtils.test.ts
+++ b/src/layout/watchlist/watchlistUtils.test.ts
@@ -23,6 +23,7 @@ import {
   removeAgentFromTeam,
   removeAgentFromTeamAtEntry,
   reorderTeamMember,
+  removeDeletedAgentsFromWatchlistState,
 } from "./watchlistUtils";
 import type { Watchlist, WatchlistEntry, WatchlistPrefs, WatchlistState } from "./types";
 import type { AgentConfig, AgentTelemetry } from "../../types";
@@ -378,6 +379,45 @@ describe("team mutations", () => {
     const next = reorderTeamMember(state, "team-1", "a", "c", "after");
 
     expect(next.teams[0].agentIds).toEqual(["b", "c", "a"]);
+  });
+
+  it("removes deleted agents from direct watchlist entries and teams", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a", "b"] }],
+      watchlists: [
+        {
+          id: "l1",
+          name: "List 1",
+          entries: [
+            { type: "agent", agentId: "x" },
+            { type: "team", teamId: "team-1" },
+            { type: "agent", agentId: "z" },
+          ],
+        },
+      ],
+    });
+
+    const next = removeDeletedAgentsFromWatchlistState(state, ["a", "x"]);
+
+    expect(next.teams).toEqual([{ id: "team-1", name: "Core", agentIds: ["b"] }]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "z" },
+    ]);
+  });
+
+  it("drops team entries when all team members are deleted", () => {
+    const state = normalizeWatchlistState({
+      version: 2,
+      teams: [{ id: "team-1", name: "Core", agentIds: ["a"] }],
+      watchlists: [{ id: "l1", name: "List 1", entries: [{ type: "team", teamId: "team-1" }] }],
+    });
+
+    const next = removeDeletedAgentsFromWatchlistState(state, ["a"]);
+
+    expect(next.teams).toEqual([]);
+    expect(getWatchlistEntries(next.watchlists[0])).toEqual([]);
   });
 
   it("removes a team member after the target solo agent", () => {

--- a/src/layout/watchlist/watchlistUtils.ts
+++ b/src/layout/watchlist/watchlistUtils.ts
@@ -248,6 +248,34 @@ export function removeAgentsFromList(
   };
 }
 
+export function removeDeletedAgentsFromWatchlistState(
+  state: WatchlistState,
+  agentIds: string[],
+): WatchlistState {
+  const deletedIds = new Set(agentIds);
+  if (deletedIds.size === 0) return state;
+
+  const teams = state.teams
+    .map((team) => ({
+      ...team,
+      agentIds: team.agentIds.filter((agentId) => !deletedIds.has(agentId)),
+    }))
+    .filter((team) => team.agentIds.length > 0);
+  const remainingTeamIds = new Set(teams.map((team) => team.id));
+
+  return normalizeWatchlistState({
+    version: 2,
+    teams,
+    watchlists: state.watchlists.map((list) => ({
+      ...list,
+      entries: getWatchlistEntries(list).filter((entry) => {
+        if (entry.type === "agent") return !deletedIds.has(entry.agentId);
+        return remainingTeamIds.has(entry.teamId);
+      }),
+    })),
+  });
+}
+
 /**
  * Filters agents by search term, matching against session_name and agent_class.
  */

--- a/src/views/App.test.tsx
+++ b/src/views/App.test.tsx
@@ -1956,4 +1956,51 @@ describe("Agent Off State Operations", () => {
     });
     expect(screen.queryByTestId("terminal-agent-1")).not.toBeInTheDocument();
   });
+
+  it("removes a deleted agent from persisted watchlists and teams", async () => {
+    setupDefaultMocksWithWatchlists(sampleAgents, defaultClasses, {
+      version: 2,
+      teams: [{ id: "team-1", name: "Core Dev Swarm", agentIds: ["agent-1", "agent-2"] }],
+      watchlists: [
+        {
+          id: "today",
+          name: "Today",
+          entries: [
+            { type: "team", teamId: "team-1" },
+            { type: "agent", agentId: "agent-3" },
+          ],
+        },
+      ],
+    });
+    render(
+      <ConfirmProvider>
+        <App />
+      </ConfirmProvider>,
+    );
+
+    const alphaWatchlistRow = await waitFor(() => {
+      const row = screen
+        .getAllByText("Alpha")
+        .map((node) => node.closest("div.watchlist-row"))
+        .find((candidate): candidate is HTMLElement => Boolean(candidate));
+      if (!row) throw new Error("Alpha watchlist row not found");
+      return row;
+    });
+
+    fireEvent.contextMenu(alphaWatchlistRow);
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("kill_agent", { sessionId: "agent-1" });
+      expect(mockInvoke).toHaveBeenCalledWith("save_watchlists", expect.anything());
+    });
+
+    const state = normalizeWatchlistState(currentWatchlists);
+    expect(state.teams).toEqual([{ id: "team-1", name: "Core Dev Swarm", agentIds: ["agent-2"] }]);
+    expect(state.watchlists[0].entries).toEqual([
+      { type: "team", teamId: "team-1" },
+      { type: "agent", agentId: "agent-3" },
+    ]);
+  });
 });

--- a/src/views/App.tsx
+++ b/src/views/App.tsx
@@ -20,6 +20,7 @@ import {
   removeAgentFromTeam,
   removeAgentFromTeamAtEntry,
   reorderTeamMember,
+  removeDeletedAgentsFromWatchlistState,
 } from "../layout/watchlist/watchlistUtils";
 import type { Watchlist, WatchlistPrefs, AgentInteractions, AgentTeam, WatchlistState, WatchlistEntry } from "../layout/watchlist/types";
 import { DEFAULT_WATCHLIST_PREFS } from "../layout/watchlist/types";
@@ -930,6 +931,10 @@ function AppBody() {
     if (await confirm('Delete this agent?')) {
       try {
         await invoke('kill_agent', { sessionId: id });
+        await persistWatchlistState(removeDeletedAgentsFromWatchlistState(
+          { version: 2, watchlists, teams },
+          [id],
+        ));
         setOffAgentIds(prev => {
           const next = new Set(prev);
           next.delete(id);
@@ -968,6 +973,11 @@ function AppBody() {
     }
 
     if (deletedIds.size === 0) return;
+
+    await persistWatchlistState(removeDeletedAgentsFromWatchlistState(
+      { version: 2, watchlists, teams },
+      [...deletedIds],
+    ));
 
     setOffAgentIds(prev => {
       const next = new Set(prev);


### PR DESCRIPTION
## Description
Fixes watchlist membership loss for individual agents during app reset/startup restore.

- Removes the automatic watchlist prune that persisted transient empty runtime roster snapshots.
- Keeps explicit watchlist/team/delete mutations as the source of membership changes.
- Adds regression coverage for startup restore preservation and explicit delete cleanup.

## Related Issues
Fixes #625

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` (127 files passed, 1203 tests passed, 1 skipped)
- `npm run build` (passes; existing Vite chunk-size warning remains)
- `npm run check:frontend-screenshot`
- Captured feature evidence from a mocked watchlist state showing the individual `Alpha` agent retained in the `Today` watchlist.

Docs note: no public docs changes are needed because this restores existing watchlist persistence behavior without changing labels, navigation, or user-facing workflow.

## Screenshots
![individual-agent-retained.png](https://raw.githubusercontent.com/wardian-app/Wardian/d1d49da14afdf0974e31dd76b39d2dae9ae8e179/e2e/screenshots/watchlist-agent-membership/20260703-023518/individual-agent-retained.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable