### PR TITLE
fix(terminal): align OpenCode mouse input behavior

### DIFF
--- a/docs/specs/2026-06-24-terminal-device-attributes-reply-filter.md
+++ b/docs/specs/2026-06-24-terminal-device-attributes-reply-filter.md
@@ -21,9 +21,10 @@ back into provider output and appear as visible report text.
 
 A separate OpenCode path is not spawn-bound: OpenCode owns its in-TUI scrolling
 surface and xterm can emit mouse/wheel protocol input while the pointer merely
-passes over an OpenCode terminal card. When that card is not selected, the user
-intent is viewport navigation, not provider interaction, so passive xterm stdin
-must not reach the provider.
+passes over an OpenCode terminal card. Earlier mitigation disabled OpenCode
+xterm stdin while the card was not selected. That behavior was superseded by the
+provider-scoped input guard described below, which removes passive mouse-motion
+garbage without making OpenCode interactivity depend on selection.
 
 ## Decision
 
@@ -42,12 +43,11 @@ Codex output normalization also strips echoed primary Device Attributes replies,
 matching the existing output-side cleanup for echoed color and light-dark report
 replies.
 
-OpenCode terminal cards disable xterm stdin while the card is not selected.
-xterm documents that `disableStdin` also prevents mouse events from being
-emitted by the terminal, which blocks passive wheel/mouse reports while the user
-scrolls around the grid. Wardian-originated injections still call the Tauri input
-commands directly, so capability-broker replies, control sends, and CLI sends do
-not depend on xterm stdin and remain active for unselected cards.
+OpenCode terminal cards keep xterm stdin enabled even when the card is not
+selected, matching other providers. Wardian-originated injections still call the
+Tauri input commands directly, and frontend terminal input is filtered before
+PTY forwarding when a provider-specific terminal report or passive mouse-motion
+guard applies.
 
 ## Update 2026-07-02: OpenCode mouse-motion input guard
 
@@ -66,6 +66,15 @@ mouse packets such as wheel reports so OpenCode-owned scrolling remains
 available. Remote terminal attach uses the same filter before sending input
 frames over the attach websocket.
 
+## Update 2026-07-03: OpenCode selection gate removed
+
+OpenCode no longer has a selection-only stdin exception. Terminal cards now keep
+the existing Wardian default behavior: mouse and wheel input can reach both the
+main app's viewport handling and the terminal input path without requiring the
+terminal card to be selected first. OpenCode passive mouse-motion reports remain
+filtered by `filterProviderTerminalInput`, so preserving direct terminal
+scrolling does not reintroduce composer garbage characters.
+
 ## Verification
 
 Focused regression coverage lives in
@@ -77,8 +86,8 @@ Focused regression coverage lives in
   providers retain them;
 - echoed Codex primary Device Attributes replies are stripped from rendered
   output;
-- unselected OpenCode terminals disable xterm stdin while Wardian's capability
-  broker still injects required terminal replies.
+- OpenCode terminal stdin remains enabled even when the card is not selected,
+  while Wardian's capability broker still injects required terminal replies.
 - OpenCode passive mouse-motion reports, including bare binary triplets that
   match the visible composer garbage pattern, are dropped before PTY forwarding
   while wheel packets and non-OpenCode provider input are preserved.

--- a/docs/specs/2026-07-03-opencode-terminal-selection-consistency.md
+++ b/docs/specs/2026-07-03-opencode-terminal-selection-consistency.md
@@ -1,0 +1,41 @@
+# OpenCode terminal selection consistency
+
+- **Status:** Implemented
+- **Date:** 2026-07-03
+- **Area:** Frontend terminal input, OpenCode provider behavior
+
+## Context
+
+PR 589 added an OpenCode-only exception that disabled xterm stdin when an
+OpenCode terminal card was not selected. The intent was to keep passive
+mouse/wheel protocol reports from reaching OpenCode while users moved around the
+grid.
+
+PR 618 later added a provider-scoped input guard that filters OpenCode passive
+mouse-motion reports before Wardian forwards frontend `onData` or `onBinary`
+input to the PTY. That guard fixes the observed composer garbage characters
+without disabling terminal stdin.
+
+## Decision
+
+Wardian keeps the existing default terminal interaction model for OpenCode:
+terminal stdin remains enabled regardless of grid selection. This preserves
+direct terminal scrolling and keeps OpenCode behavior consistent with the other
+providers.
+
+Selection remains a grid concern for card chrome, actions, and focus routing. It
+does not change xterm stdin. OpenCode-specific safety remains in
+`filterProviderTerminalInput`, which strips passive mouse-motion reports while
+preserving typed input and non-motion mouse packets such as wheel reports.
+
+## Verification
+
+Regression coverage lives in:
+
+- `src/features/terminal/AgentTerminal.test.tsx`: unselected OpenCode terminals
+  keep `disableStdin` false, capability replies are still sent, and passive
+  mouse-motion bytes are not forwarded.
+- `src/views/GridView.test.tsx`: grid selection state is no longer passed into
+  `AgentTerminal` input props.
+- `src/features/terminal/terminalCapabilities.test.ts`: OpenCode motion reports
+  are filtered while wheel packets and non-OpenCode inputs are preserved.

--- a/src/features/terminal/AgentTerminal.test.tsx
+++ b/src/features/terminal/AgentTerminal.test.tsx
@@ -227,14 +227,14 @@ describe("AgentTerminal scrollback", () => {
     });
   });
 
-  it("disables OpenCode terminal stdin until the card is selected", async () => {
-    const view = render(<AgentTerminal sessionId="opencode-passive" provider="opencode" theme="dark" isSelected={false} />);
+  it("keeps OpenCode terminal stdin enabled when the card is not selected", async () => {
+    const view = render(<AgentTerminal sessionId="opencode-passive" provider="opencode" theme="dark" />);
 
     await waitFor(() => {
-      expect(getLatestTerminalInstance().options.disableStdin).toBe(true);
+      expect(getLatestTerminalInstance().options.disableStdin).toBe(false);
     });
 
-    view.rerender(<AgentTerminal sessionId="opencode-passive" provider="opencode" theme="dark" isSelected />);
+    view.rerender(<AgentTerminal sessionId="opencode-passive" provider="opencode" theme="dark" />);
 
     await waitFor(() => {
       expect(getLatestTerminalInstance().options.disableStdin).toBe(false);
@@ -2115,7 +2115,7 @@ describe("AgentTerminal scrollback", () => {
     }
   });
 
-  it("replies to OpenCode terminal capability probes before rendering the PTY output", async () => {
+  it("replies to OpenCode terminal capability probes while keeping terminal stdin enabled", async () => {
     let readCount = 0;
     mockInvoke.mockImplementation(async (cmd: string) => {
       switch (cmd) {
@@ -2132,11 +2132,11 @@ describe("AgentTerminal scrollback", () => {
       }
     });
 
-    render(<AgentTerminal sessionId="opencode-1" provider="opencode" theme="dark" isSelected={false} />);
+    render(<AgentTerminal sessionId="opencode-1" provider="opencode" theme="dark" />);
 
     await waitFor(() => {
       const instance = getLatestTerminalInstance();
-      expect(instance.options.disableStdin).toBe(true);
+      expect(instance.options.disableStdin).toBe(false);
       expect(instance.write).toHaveBeenCalledWith(
         "\u001b[6n\u001b[>0q\u001b[?u\u001b[?996n\u001b[?1004h\u001b[14t\u001b]4;0;?\u0007\u001b]10;?\u0007\u001b]11;?\u001b\\",
         expect.any(Function),

--- a/src/features/terminal/AgentTerminal.tsx
+++ b/src/features/terminal/AgentTerminal.tsx
@@ -114,7 +114,6 @@ type TerminalOptionTarget = {
     scrollOnEraseInDisplay?: boolean;
     minimumContrastRatio?: number;
     windowsPty?: { backend?: "conpty" | "winpty"; buildNumber?: number };
-    disableStdin?: boolean;
   };
 };
 
@@ -131,10 +130,6 @@ function applyProviderTerminalOptions(term: TerminalOptionTarget, provider?: str
   // native rendering.
   term.options.scrollOnEraseInDisplay = false;
   term.options.minimumContrastRatio = terminalMinimumContrastRatio(provider);
-}
-
-function applyTerminalInputInteractivity(term: TerminalOptionTarget, provider: string | undefined, isSelected: boolean) {
-  term.options.disableStdin = provider === "opencode" && !isSelected;
 }
 
 function providerFromAgentConfig(agent: AgentConfig | undefined) {
@@ -2064,7 +2059,6 @@ export const AgentTerminal = memo(function AgentTerminal({
   sessionId,
   provider,
   isMaximized,
-  isSelected = true,
   theme,
   workspacePath,
   onTitleChange,
@@ -2073,7 +2067,6 @@ export const AgentTerminal = memo(function AgentTerminal({
   sessionId: string;
   provider?: string;
   isMaximized?: boolean;
-  isSelected?: boolean;
   theme: "dark" | "light" | "system";
   workspacePath?: string | null;
   onTitleChange?: (title: string) => void;
@@ -2085,7 +2078,6 @@ export const AgentTerminal = memo(function AgentTerminal({
   const onTitleChangeRef = useRef(onTitleChange);
   const wheelRowRemainderRef = useRef(0);
   const lastThemeSignalRef = useRef<WardianTerminalTheme | null>(null);
-  const isSelectedRef = useRef(isSelected);
   const [initError, setInitError] = useState<string | null>(null);
   const [linkOpenError, setLinkOpenError] = useState<string | null>(null);
   const terminalFontSize = useSettingsStore((state) => state.terminalFontSize);
@@ -2187,7 +2179,6 @@ export const AgentTerminal = memo(function AgentTerminal({
         }
 
         renderer.term.options.theme = sessionTermTheme;
-        applyTerminalInputInteractivity(renderer.term, session.provider ?? provider, isSelectedRef.current);
         attachRendererHost(session, terminalRef.current);
 
         xtermRef.current = renderer.term;
@@ -2311,17 +2302,6 @@ export const AgentTerminal = memo(function AgentTerminal({
       fitAddonRef.current = null;
     };
   }, [performFit, provider, sessionId, workspacePath]);
-
-  useEffect(() => {
-    isSelectedRef.current = isSelected;
-    const entry = terminalSessionMap.get(sessionId);
-    const term = entry?.renderer?.term;
-    if (!term) {
-      return;
-    }
-
-    applyTerminalInputInteractivity(term, entry.provider ?? provider, isSelected);
-  }, [isSelected, provider, sessionId]);
 
   useEffect(() => {
     const entry = terminalSessionMap.get(sessionId);

--- a/src/views/GridView.test.tsx
+++ b/src/views/GridView.test.tsx
@@ -13,7 +13,6 @@ vi.mock('../features/terminal/AgentTerminal', async () => {
   return {
     AgentTerminal: React.memo((props: {
       sessionId: string;
-      isSelected?: boolean;
       onTerminalFocus?: () => void;
     }) => {
       terminalRenderSpy(props);
@@ -169,19 +168,20 @@ describe('GridView maximize behavior', () => {
     expect(onTerminalFocus).toHaveBeenCalledWith('agent-2');
   });
 
-  it('passes grid selection state through to terminal cards', () => {
+  it('keeps grid selection state out of terminal input props', () => {
     renderGrid(null, agents, vi.fn(), {
       selectedAgentIds: new Set(['agent-1']),
     });
 
     expect(terminalRenderSpy).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 'agent-1',
-      isSelected: true,
     }));
     expect(terminalRenderSpy).toHaveBeenCalledWith(expect.objectContaining({
       sessionId: 'agent-2',
-      isSelected: false,
     }));
+    for (const [props] of terminalRenderSpy.mock.calls) {
+      expect(props).not.toHaveProperty('isSelected');
+    }
   });
 
   it('does not size each mobile card to the full viewport height', () => {

--- a/src/views/GridView.tsx
+++ b/src/views/GridView.tsx
@@ -68,7 +68,6 @@ interface AgentTerminalSlotProps {
   sessionId: string;
   provider?: string;
   isMaximized: boolean;
-  isSelected: boolean;
   theme: "dark" | "light" | "system";
   workspacePath?: string;
   onTerminalFocus?: (agentId: string) => void;
@@ -79,7 +78,6 @@ const AgentTerminalSlot = React.memo(function AgentTerminalSlot({
   sessionId,
   provider,
   isMaximized,
-  isSelected,
   theme,
   workspacePath,
   onTerminalFocus,
@@ -98,7 +96,6 @@ const AgentTerminalSlot = React.memo(function AgentTerminalSlot({
       sessionId={sessionId}
       provider={provider}
       isMaximized={isMaximized}
-      isSelected={isSelected}
       theme={theme}
       workspacePath={workspacePath}
       onTerminalFocus={handleTerminalFocus}
@@ -409,7 +406,6 @@ export const GridView: React.FC<GridViewProps> = ({
                     sessionId={agentId}
                     provider={agent.provider}
                     isMaximized={isAgentMaximized}
-                    isSelected={isSelected}
                     theme={theme}
                     workspacePath={visibleWorkspacePath}
                     onTerminalFocus={onTerminalFocus}


### PR DESCRIPTION
## Description
Removes the OpenCode-only terminal selection gate introduced in PR #589 now that PR #618 filters OpenCode passive mouse-motion reports at the input boundary.

- Keep OpenCode xterm stdin enabled regardless of grid selection, matching other providers.
- Stop forwarding grid selection state into `AgentTerminal` input props.
- Update regression coverage and specs for the new OpenCode terminal interaction contract.

## Related Issues
Fixes #630

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `npm run test -- src/features/terminal/AgentTerminal.test.tsx` (red before implementation, green after)
- [x] `npm run test -- src/features/terminal/terminalCapabilities.test.ts`
- [x] `npm run test -- src/views/GridView.test.tsx`
- [x] `npm run lint`
- [x] `npm run test` (`127 passed`, `1203 passed | 1 skipped`)
- [x] `npm run build` (passes; existing Vite chunk-size warning remains)
- [x] `npm run docs:check-llms`
- [x] `npm run docs:build`
- [x] `git diff --check`
- [x] Changed-file secret scan: no matches for common key/secret patterns.

## Screenshots
This change has no distinct visual delta; it changes terminal input routing for the OpenCode terminal surface. Representative terminal surface evidence from the related OpenCode mouse-motion fix:

![opencode-terminal-input-surface](https://raw.githubusercontent.com/wardian-app/Wardian/49c42ac2/e2e/screenshots/opencode-mouse-motion/2026-07-02/opencode-mouse-motion-filter.png)

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable
