### PR TITLE
fix(topology): persist deleted team-seeded edges

### DIFF
--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -2270,7 +2270,8 @@ mod tests {
 
     #[test]
     fn neighbors_scope_without_session_id_yields_not_in_session_error() {
-        let _guard = TestWardianHome::new(&tempfile::tempdir().unwrap().path().to_path_buf());
+        let temp = tempfile::tempdir().unwrap();
+        let _guard = TestWardianHome::new(temp.path());
         std::env::remove_var("WARDIAN_SESSION_ID");
 
         // Simulate what handle_list does when scope is Neighbors

--- a/crates/wardian-core/src/topology.rs
+++ b/crates/wardian-core/src/topology.rs
@@ -127,7 +127,9 @@ fn canonicalize(topology: &mut Topology) {
 }
 
 impl Topology {
-    /// Returns true if the edge was added (false: invalid pair or duplicate).
+    /// Returns true if topology changed: edge added, or an existing edge's
+    /// seed suppression was cleared. Returns false for invalid pairs or a
+    /// duplicate edge with no suppression to clear.
     pub fn add_edge(&mut self, x: &str, y: &str, created_at: &str) -> bool {
         let Some((a, b)) = canonical_pair(x, y) else {
             return false;
@@ -409,6 +411,35 @@ pub fn needs_team_seed_migration(topology: &Topology) -> bool {
 /// machine that never wrote the file.
 pub fn needs_team_seed_migration_for_home(home: &Path, topology: &Topology) -> bool {
     needs_team_seed_migration(topology) || !crate::paths::topology_path_for_home(home).exists()
+}
+
+/// Version 2 topologies already completed the initial team-edge seed. If a
+/// current team pair is missing from such a file, preserve that absence as a
+/// user deletion before future seed passes can recreate it.
+pub fn needs_seed_suppression_migration(topology: &Topology) -> bool {
+    topology.version >= TEAM_SEED_MIGRATION_VERSION && topology.version < TOPOLOGY_SCHEMA_VERSION
+}
+
+pub fn suppress_missing_team_seed_pairs(
+    topology: &mut Topology,
+    teams: &[TeamMembership],
+) -> usize {
+    let mut added = 0;
+    for team in teams {
+        for i in 0..team.agent_ids.len() {
+            for j in (i + 1)..team.agent_ids.len() {
+                let a = &team.agent_ids[i];
+                let b = &team.agent_ids[j];
+                let has_edge = canonical_pair(a, b)
+                    .map(|(a, b)| topology.edges.iter().any(|edge| edge.a == a && edge.b == b))
+                    .unwrap_or(false);
+                if !has_edge && topology.suppress_seed_pair(a, b) {
+                    added += 1;
+                }
+            }
+        }
+    }
+    added
 }
 
 fn team_memberships_contain_pair(teams: &[TeamMembership], a: &str, b: &str) -> bool {
@@ -1003,6 +1034,41 @@ mod tests {
             suppressed_seed_pairs: vec![],
         };
         assert!(!needs_team_seed_migration(&topology));
+    }
+
+    #[test]
+    fn v2_seed_suppression_migration_tombstones_missing_team_pairs() {
+        let mut topology = Topology {
+            version: 2,
+            edges: vec![TopologyEdge {
+                a: "a".into(),
+                b: "c".into(),
+                created_at: "old".into(),
+            }],
+            ignored_pairs: vec![],
+            suppressed_seed_pairs: vec![],
+        };
+        let teams = vec![TeamMembership {
+            id: "team".to_string(),
+            agent_ids: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        }];
+
+        assert!(needs_seed_suppression_migration(&topology));
+
+        let added = suppress_missing_team_seed_pairs(&mut topology, &teams);
+
+        assert_eq!(added, 2);
+        assert!(topology.is_seed_suppressed("a", "b"));
+        assert!(topology.is_seed_suppressed("b", "c"));
+        assert!(!topology.is_seed_suppressed("a", "c"));
+        assert_eq!(topology.edges.len(), 1);
+    }
+
+    #[test]
+    fn v3_topology_does_not_need_seed_suppression_migration() {
+        let topology = Topology::default();
+
+        assert!(!needs_seed_suppression_migration(&topology));
     }
 
     #[test]

--- a/crates/wardian-core/src/topology.rs
+++ b/crates/wardian-core/src/topology.rs
@@ -3,7 +3,8 @@ use std::collections::BTreeSet;
 use std::io;
 use std::path::Path;
 
-pub const TOPOLOGY_SCHEMA_VERSION: u8 = 2;
+pub const TOPOLOGY_SCHEMA_VERSION: u8 = 3;
+const TEAM_SEED_MIGRATION_VERSION: u8 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TopologyEdge {
@@ -25,11 +26,18 @@ pub struct Topology {
     pub edges: Vec<TopologyEdge>,
     #[serde(default)]
     pub ignored_pairs: Vec<IgnoredPair>,
+    #[serde(default)]
+    pub suppressed_seed_pairs: Vec<IgnoredPair>,
 }
 
 impl Default for Topology {
     fn default() -> Self {
-        Self { version: TOPOLOGY_SCHEMA_VERSION, edges: Vec::new(), ignored_pairs: Vec::new() }
+        Self {
+            version: TOPOLOGY_SCHEMA_VERSION,
+            edges: Vec::new(),
+            ignored_pairs: Vec::new(),
+            suppressed_seed_pairs: Vec::new(),
+        }
     }
 }
 
@@ -77,9 +85,15 @@ fn canonicalize(topology: &mut Topology) {
     let mut seen = BTreeSet::new();
     let mut edges = Vec::new();
     for edge in topology.edges.drain(..) {
-        let Some((a, b)) = canonical_pair(&edge.a, &edge.b) else { continue };
+        let Some((a, b)) = canonical_pair(&edge.a, &edge.b) else {
+            continue;
+        };
         if seen.insert((a.clone(), b.clone())) {
-            edges.push(TopologyEdge { a, b, created_at: edge.created_at });
+            edges.push(TopologyEdge {
+                a,
+                b,
+                created_at: edge.created_at,
+            });
         }
     }
     edges.sort_by(|left, right| (&left.a, &left.b).cmp(&(&right.a, &right.b)));
@@ -88,37 +102,88 @@ fn canonicalize(topology: &mut Topology) {
     let mut seen = BTreeSet::new();
     let mut ignored = Vec::new();
     for pair in topology.ignored_pairs.drain(..) {
-        let Some((a, b)) = canonical_pair(&pair.a, &pair.b) else { continue };
+        let Some((a, b)) = canonical_pair(&pair.a, &pair.b) else {
+            continue;
+        };
         if seen.insert((a.clone(), b.clone())) {
             ignored.push(IgnoredPair { a, b });
         }
     }
     ignored.sort_by(|left, right| (&left.a, &left.b).cmp(&(&right.a, &right.b)));
     topology.ignored_pairs = ignored;
+
+    let mut seen = BTreeSet::new();
+    let mut suppressed = Vec::new();
+    for pair in topology.suppressed_seed_pairs.drain(..) {
+        let Some((a, b)) = canonical_pair(&pair.a, &pair.b) else {
+            continue;
+        };
+        if seen.insert((a.clone(), b.clone())) {
+            suppressed.push(IgnoredPair { a, b });
+        }
+    }
+    suppressed.sort_by(|left, right| (&left.a, &left.b).cmp(&(&right.a, &right.b)));
+    topology.suppressed_seed_pairs = suppressed;
 }
 
 impl Topology {
     /// Returns true if the edge was added (false: invalid pair or duplicate).
     pub fn add_edge(&mut self, x: &str, y: &str, created_at: &str) -> bool {
-        let Some((a, b)) = canonical_pair(x, y) else { return false };
-        if self.edges.iter().any(|edge| edge.a == a && edge.b == b) {
+        let Some((a, b)) = canonical_pair(x, y) else {
             return false;
+        };
+        let before_suppressed = self.suppressed_seed_pairs.len();
+        self.suppressed_seed_pairs
+            .retain(|pair| !(pair.a == a && pair.b == b));
+        let suppression_cleared = self.suppressed_seed_pairs.len() != before_suppressed;
+        if self.edges.iter().any(|edge| edge.a == a && edge.b == b) {
+            return suppression_cleared;
         }
-        self.edges.push(TopologyEdge { a, b, created_at: created_at.to_string() });
+        self.edges.push(TopologyEdge {
+            a,
+            b,
+            created_at: created_at.to_string(),
+        });
         true
     }
 
     /// Returns true if an edge was removed.
     pub fn remove_edge(&mut self, x: &str, y: &str) -> bool {
-        let Some((a, b)) = canonical_pair(x, y) else { return false };
+        let Some((a, b)) = canonical_pair(x, y) else {
+            return false;
+        };
         let before = self.edges.len();
         self.edges.retain(|edge| !(edge.a == a && edge.b == b));
         self.edges.len() != before
     }
 
+    /// Remove an edge and, when that pair is still produced by team
+    /// membership, remember not to recreate it during team-seed migration.
+    pub fn remove_edge_and_suppress_seed_if_team_pair(
+        &mut self,
+        x: &str,
+        y: &str,
+        teams: &[TeamMembership],
+    ) -> bool {
+        let Some((a, b)) = canonical_pair(x, y) else {
+            return false;
+        };
+        let removed = self.remove_edge(&a, &b);
+        if removed && team_memberships_contain_pair(teams, &a, &b) {
+            self.suppress_seed_pair(&a, &b);
+        }
+        removed
+    }
+
     pub fn ignore_pair(&mut self, x: &str, y: &str) -> bool {
-        let Some((a, b)) = canonical_pair(x, y) else { return false };
-        if self.ignored_pairs.iter().any(|pair| pair.a == a && pair.b == b) {
+        let Some((a, b)) = canonical_pair(x, y) else {
+            return false;
+        };
+        if self
+            .ignored_pairs
+            .iter()
+            .any(|pair| pair.a == a && pair.b == b)
+        {
             return false;
         }
         self.ignored_pairs.push(IgnoredPair { a, b });
@@ -126,22 +191,58 @@ impl Topology {
     }
 
     pub fn unignore_pair(&mut self, x: &str, y: &str) -> bool {
-        let Some((a, b)) = canonical_pair(x, y) else { return false };
+        let Some((a, b)) = canonical_pair(x, y) else {
+            return false;
+        };
         let before = self.ignored_pairs.len();
-        self.ignored_pairs.retain(|pair| !(pair.a == a && pair.b == b));
+        self.ignored_pairs
+            .retain(|pair| !(pair.a == a && pair.b == b));
         self.ignored_pairs.len() != before
     }
 
     pub fn is_ignored(&self, x: &str, y: &str) -> bool {
         canonical_pair(x, y)
-            .map(|(a, b)| self.ignored_pairs.iter().any(|pair| pair.a == a && pair.b == b))
+            .map(|(a, b)| {
+                self.ignored_pairs
+                    .iter()
+                    .any(|pair| pair.a == a && pair.b == b)
+            })
             .unwrap_or(false)
+    }
+
+    pub fn is_seed_suppressed(&self, x: &str, y: &str) -> bool {
+        canonical_pair(x, y)
+            .map(|(a, b)| {
+                self.suppressed_seed_pairs
+                    .iter()
+                    .any(|pair| pair.a == a && pair.b == b)
+            })
+            .unwrap_or(false)
+    }
+
+    fn suppress_seed_pair(&mut self, x: &str, y: &str) -> bool {
+        let Some((a, b)) = canonical_pair(x, y) else {
+            return false;
+        };
+        if self
+            .suppressed_seed_pairs
+            .iter()
+            .any(|pair| pair.a == a && pair.b == b)
+        {
+            return false;
+        }
+        self.suppressed_seed_pairs.push(IgnoredPair { a, b });
+        true
     }
 
     /// Drop edges/ignores referencing agents not in `known` (deleted-agent GC).
     pub fn retain_agents(&mut self, known: &BTreeSet<String>) {
-        self.edges.retain(|edge| known.contains(&edge.a) && known.contains(&edge.b));
-        self.ignored_pairs.retain(|pair| known.contains(&pair.a) && known.contains(&pair.b));
+        self.edges
+            .retain(|edge| known.contains(&edge.a) && known.contains(&edge.b));
+        self.ignored_pairs
+            .retain(|pair| known.contains(&pair.a) && known.contains(&pair.b));
+        self.suppressed_seed_pairs
+            .retain(|pair| known.contains(&pair.a) && known.contains(&pair.b));
     }
 
     /// Manual neighbors of `uuid`, sorted, deduped.
@@ -150,9 +251,13 @@ impl Topology {
             .edges
             .iter()
             .filter_map(|edge| {
-                if edge.a == uuid { Some(edge.b.clone()) }
-                else if edge.b == uuid { Some(edge.a.clone()) }
-                else { None }
+                if edge.a == uuid {
+                    Some(edge.b.clone())
+                } else if edge.b == uuid {
+                    Some(edge.a.clone())
+                } else {
+                    None
+                }
             })
             .collect();
         result.sort();
@@ -198,7 +303,10 @@ pub struct NeighborsView {
 
 impl NeighborsView {
     pub fn member_uuids(&self) -> BTreeSet<String> {
-        self.members.iter().map(|member| member.uuid.clone()).collect()
+        self.members
+            .iter()
+            .map(|member| member.uuid.clone())
+            .collect()
     }
 }
 
@@ -217,8 +325,10 @@ pub fn resolve_neighbors(
 ) -> NeighborsView {
     use std::collections::BTreeMap;
 
-    let known: BTreeMap<&str, &AgentRef> =
-        agents.iter().map(|agent| (agent.uuid.as_str(), agent)).collect();
+    let known: BTreeMap<&str, &AgentRef> = agents
+        .iter()
+        .map(|agent| (agent.uuid.as_str(), agent))
+        .collect();
     let mut reasons_by_member: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let push_reason = |uuid: &str, reason: String, map: &mut BTreeMap<String, Vec<String>>| {
         if uuid == agent_uuid || !known.contains_key(uuid) {
@@ -269,10 +379,17 @@ pub fn resolve_neighbors(
 /// Seed team cliques: add pairwise edges among member UUIDs.
 /// Returns the number of edges actually added (excluding pre-existing duplicates).
 /// Uses the existing `add_edge` method (idempotent, canonicalized, dedupes).
-pub fn seed_team_clique(topology: &mut Topology, member_uuids: &[String], created_at: &str) -> usize {
+pub fn seed_team_clique(
+    topology: &mut Topology,
+    member_uuids: &[String],
+    created_at: &str,
+) -> usize {
     let mut added = 0;
     for i in 0..member_uuids.len() {
         for j in (i + 1)..member_uuids.len() {
+            if topology.is_seed_suppressed(&member_uuids[i], &member_uuids[j]) {
+                continue;
+            }
             if topology.add_edge(&member_uuids[i], &member_uuids[j], created_at) {
                 added += 1;
             }
@@ -283,7 +400,7 @@ pub fn seed_team_clique(topology: &mut Topology, member_uuids: &[String], create
 
 /// Check if topology needs one-time migration from version 1.
 pub fn needs_team_seed_migration(topology: &Topology) -> bool {
-    topology.version < 2
+    topology.version < TEAM_SEED_MIGRATION_VERSION
 }
 
 /// Home-aware migration check: a MISSING topology.json also needs migration,
@@ -294,11 +411,23 @@ pub fn needs_team_seed_migration_for_home(home: &Path, topology: &Topology) -> b
     needs_team_seed_migration(topology) || !crate::paths::topology_path_for_home(home).exists()
 }
 
+fn team_memberships_contain_pair(teams: &[TeamMembership], a: &str, b: &str) -> bool {
+    teams.iter().any(|team| {
+        let has_a = team.agent_ids.iter().any(|id| id == a);
+        let has_b = team.agent_ids.iter().any(|id| id == b);
+        has_a && has_b
+    })
+}
+
 /// Read team memberships from `<home>/watchlists/index.json`. Missing/corrupt → empty.
 pub fn load_team_memberships(home: &Path) -> Vec<TeamMembership> {
     let path = home.join("watchlists").join("index.json");
-    let Ok(content) = std::fs::read_to_string(path) else { return Vec::new() };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else { return Vec::new() };
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return Vec::new();
+    };
     value
         .get("teams")
         .and_then(|teams| teams.as_array())
@@ -351,16 +480,22 @@ pub fn pair_activity_from_records(
 
     let mut by_pair: BTreeMap<(String, String), PairActivity> = BTreeMap::new();
     for record in records {
-        let Some(sender) = record.sender_session_id.as_deref() else { continue };
+        let Some(sender) = record.sender_session_id.as_deref() else {
+            continue;
+        };
         for target in &record.target_session_ids {
-            let Some((a, b)) = canonical_pair(sender, target) else { continue };
-            let entry = by_pair.entry((a.clone(), b.clone())).or_insert(PairActivity {
-                a,
-                b,
-                last_message_at: record.created_at.clone(),
-                active_ask: false,
-                awaiting_reply_from: None,
-            });
+            let Some((a, b)) = canonical_pair(sender, target) else {
+                continue;
+            };
+            let entry = by_pair
+                .entry((a.clone(), b.clone()))
+                .or_insert(PairActivity {
+                    a,
+                    b,
+                    last_message_at: record.created_at.clone(),
+                    active_ask: false,
+                    awaiting_reply_from: None,
+                });
             if record.created_at > entry.last_message_at {
                 entry.last_message_at = record.created_at.clone();
             }
@@ -458,8 +593,16 @@ mod tests {
     fn save_and_load_roundtrip_canonicalizes() {
         let temp = tempfile::tempdir().unwrap();
         let mut topology = Topology::default();
-        topology.edges.push(TopologyEdge { a: "z".into(), b: "a".into(), created_at: "t".into() });
-        topology.edges.push(TopologyEdge { a: "a".into(), b: "z".into(), created_at: "t2".into() });
+        topology.edges.push(TopologyEdge {
+            a: "z".into(),
+            b: "a".into(),
+            created_at: "t".into(),
+        });
+        topology.edges.push(TopologyEdge {
+            a: "a".into(),
+            b: "z".into(),
+            created_at: "t2".into(),
+        });
         save_topology(temp.path(), &topology).unwrap();
         let loaded = load_topology(temp.path());
         assert_eq!(loaded.edges.len(), 1);
@@ -469,14 +612,21 @@ mod tests {
     }
 
     fn agent(uuid: &str, workspace: Option<&str>) -> AgentRef {
-        AgentRef { uuid: uuid.to_string(), workspace: workspace.map(str::to_string) }
+        AgentRef {
+            uuid: uuid.to_string(),
+            workspace: workspace.map(str::to_string),
+        }
     }
 
     #[test]
     fn neighbors_returns_manual_edges_only() {
         let mut topology = Topology::default();
         topology.add_edge("me", "friend", "t");
-        let agents = vec![agent("me", None), agent("friend", None), agent("mate", None)];
+        let agents = vec![
+            agent("me", None),
+            agent("friend", None),
+            agent("mate", None),
+        ];
 
         let view = resolve_neighbors("me", &topology, &agents);
 
@@ -579,9 +729,27 @@ mod tests {
         use crate::control::{InteractionKind, InteractionStatus};
         let now_ms = 1782990000000i64; // 2026-07-02T11:00:00Z in epoch ms
         let records = vec![
-            record(InteractionKind::Message, "a", "b", InteractionStatus::Completed, "2026-07-02T10:00:00Z"),
-            record(InteractionKind::Message, "b", "a", InteractionStatus::Completed, "2026-07-02T11:00:00Z"),
-            record(InteractionKind::Task, "a", "c", InteractionStatus::AwaitingReply, "2026-07-02T10:30:00Z"),
+            record(
+                InteractionKind::Message,
+                "a",
+                "b",
+                InteractionStatus::Completed,
+                "2026-07-02T10:00:00Z",
+            ),
+            record(
+                InteractionKind::Message,
+                "b",
+                "a",
+                InteractionStatus::Completed,
+                "2026-07-02T11:00:00Z",
+            ),
+            record(
+                InteractionKind::Task,
+                "a",
+                "c",
+                InteractionStatus::AwaitingReply,
+                "2026-07-02T10:30:00Z",
+            ),
         ];
 
         let mut activity = pair_activity_from_records(&records, now_ms);
@@ -593,7 +761,10 @@ mod tests {
         assert_eq!(ab.last_message_at, "2026-07-02T11:00:00Z");
         assert!(!ab.active_ask);
         let ac = &activity[1];
-        assert!(ac.active_ask, "Task from 10:30:00 should be active as it's within 1 hour of 11:00:00");
+        assert!(
+            ac.active_ask,
+            "Task from 10:30:00 should be active as it's within 1 hour of 11:00:00"
+        );
         assert_eq!(ac.awaiting_reply_from.as_deref(), Some("c"));
     }
 
@@ -601,7 +772,13 @@ mod tests {
     fn pair_activity_skips_senderless_records() {
         use crate::control::{InteractionKind, InteractionStatus};
         let now_ms = 1782990000000i64;
-        let mut senderless = record(InteractionKind::Message, "a", "b", InteractionStatus::Completed, "2026-07-02T11:00:00Z");
+        let mut senderless = record(
+            InteractionKind::Message,
+            "a",
+            "b",
+            InteractionStatus::Completed,
+            "2026-07-02T11:00:00Z",
+        );
         senderless.sender_session_id = None;
         assert!(pair_activity_from_records(&[senderless], now_ms).is_empty());
     }
@@ -642,10 +819,7 @@ mod tests {
     fn ignored_pairs_do_not_affect_fallback_engagement() {
         let mut topology = Topology::default();
         topology.ignore_pair("me", "mate");
-        let agents = vec![
-            agent("me", Some("D:/ws")),
-            agent("mate", Some("D:/ws")),
-        ];
+        let agents = vec![agent("me", Some("D:/ws")), agent("mate", Some("D:/ws"))];
 
         let view = resolve_neighbors("me", &topology, &agents);
 
@@ -654,7 +828,10 @@ mod tests {
         // This tests that engagement is determined from raw input, not filtered by ignores.
         // With only 1 agent in workspace, fallback engagement is determined by emptiness of manual/teams,
         // but members might be empty due to ignores. The key is: fallback_engaged computed correctly.
-        assert!(view.members.is_empty(), "mate is the only fallback candidate, but ignored");
+        assert!(
+            view.members.is_empty(),
+            "mate is the only fallback candidate, but ignored"
+        );
     }
 
     #[test]
@@ -668,19 +845,29 @@ mod tests {
 
         // Convert epoch ms to RFC3339
         let old_dt = chrono::DateTime::<chrono::Utc>::from(
-            std::time::UNIX_EPOCH + std::time::Duration::from_millis(old_timestamp)
+            std::time::UNIX_EPOCH + std::time::Duration::from_millis(old_timestamp),
         );
         let old_timestamp_rfc3339 = old_dt.to_rfc3339();
 
-        let records = vec![
-            record(InteractionKind::Task, "a", "b", InteractionStatus::AwaitingReply, &old_timestamp_rfc3339),
-        ];
+        let records = vec![record(
+            InteractionKind::Task,
+            "a",
+            "b",
+            InteractionStatus::AwaitingReply,
+            &old_timestamp_rfc3339,
+        )];
 
         let activity = pair_activity_from_records(&records, now_ms);
 
         assert_eq!(activity.len(), 1);
-        assert!(!activity[0].active_ask, "old awaiting_reply should not be active_ask");
-        assert_eq!(activity[0].last_message_at, old_timestamp_rfc3339, "last_message_at should still be set");
+        assert!(
+            !activity[0].active_ask,
+            "old awaiting_reply should not be active_ask"
+        );
+        assert_eq!(
+            activity[0].last_message_at, old_timestamp_rfc3339,
+            "last_message_at should still be set"
+        );
     }
 
     #[test]
@@ -690,18 +877,25 @@ mod tests {
         let now_ms = 1782990000000i64; // 2026-07-02T11:00:00Z
         let thirty_min_ago = (now_ms - 30 * 60 * 1000) as u64;
         let dt = chrono::DateTime::<chrono::Utc>::from(
-            std::time::UNIX_EPOCH + std::time::Duration::from_millis(thirty_min_ago)
+            std::time::UNIX_EPOCH + std::time::Duration::from_millis(thirty_min_ago),
         );
         let fresh_timestamp_rfc3339 = dt.to_rfc3339();
 
-        let records = vec![
-            record(InteractionKind::Task, "a", "b", InteractionStatus::AwaitingReply, &fresh_timestamp_rfc3339),
-        ];
+        let records = vec![record(
+            InteractionKind::Task,
+            "a",
+            "b",
+            InteractionStatus::AwaitingReply,
+            &fresh_timestamp_rfc3339,
+        )];
 
         let activity = pair_activity_from_records(&records, now_ms);
 
         assert_eq!(activity.len(), 1);
-        assert!(activity[0].active_ask, "fresh awaiting_reply should be active_ask");
+        assert!(
+            activity[0].active_ask,
+            "fresh awaiting_reply should be active_ask"
+        );
         assert_eq!(activity[0].awaiting_reply_from.as_deref(), Some("b"));
     }
 
@@ -733,14 +927,81 @@ mod tests {
     }
 
     #[test]
+    fn seed_team_clique_skips_suppressed_pairs() {
+        let mut topology: Topology = serde_json::from_str(
+            r#"{
+                "version": 3,
+                "edges": [],
+                "ignored_pairs": [],
+                "suppressed_seed_pairs": [{"a": "a", "b": "b"}]
+            }"#,
+        )
+        .unwrap();
+        let members = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+
+        let added = seed_team_clique(&mut topology, &members, "2026-07-03T00:00:00Z");
+
+        assert_eq!(added, 2);
+        assert!(!topology.neighbors("a").contains(&"b".to_string()));
+        assert!(topology.neighbors("a").contains(&"c".to_string()));
+        assert!(topology.neighbors("b").contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn removing_team_seeded_edge_suppresses_future_seed() {
+        let mut topology = Topology::default();
+        topology.add_edge("a", "b", "old");
+        let teams = vec![TeamMembership {
+            id: "team".to_string(),
+            agent_ids: vec!["b".to_string(), "a".to_string()],
+        }];
+
+        assert!(topology.remove_edge_and_suppress_seed_if_team_pair("a", "b", &teams));
+        assert!(topology.is_seed_suppressed("b", "a"));
+
+        let added = seed_team_clique(&mut topology, &teams[0].agent_ids, "2026-07-03T00:00:00Z");
+
+        assert_eq!(added, 0);
+        assert!(topology.edges.is_empty());
+    }
+
+    #[test]
+    fn manual_edge_add_clears_seed_suppression() {
+        let mut topology = Topology::default();
+        let teams = vec![TeamMembership {
+            id: "team".to_string(),
+            agent_ids: vec!["a".to_string(), "b".to_string()],
+        }];
+        topology.add_edge("a", "b", "old");
+        topology.remove_edge_and_suppress_seed_if_team_pair("a", "b", &teams);
+
+        assert!(topology.is_seed_suppressed("a", "b"));
+
+        assert!(topology.add_edge("a", "b", "manual"));
+
+        assert!(!topology.is_seed_suppressed("a", "b"));
+        assert_eq!(topology.neighbors("a"), vec!["b".to_string()]);
+    }
+
+    #[test]
     fn needs_team_seed_migration_detects_version_1() {
-        let topology = Topology { version: 1, edges: vec![], ignored_pairs: vec![] };
+        let topology = Topology {
+            version: 1,
+            edges: vec![],
+            ignored_pairs: vec![],
+            suppressed_seed_pairs: vec![],
+        };
         assert!(needs_team_seed_migration(&topology));
     }
 
     #[test]
     fn needs_team_seed_migration_false_for_version_2() {
-        let topology = Topology { version: 2, edges: vec![], ignored_pairs: vec![] };
+        let topology = Topology {
+            version: 2,
+            edges: vec![],
+            ignored_pairs: vec![],
+            suppressed_seed_pairs: vec![],
+        };
         assert!(!needs_team_seed_migration(&topology));
     }
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -79,7 +79,7 @@ Wardian maintains a communication topology that shapes which agents you see and 
 - `--scope workspace`: When you need to see all agents in your workspace regardless of edges.
 - `--scope all`: Only for orchestration tasks that genuinely span multiple neighbor sets or workspaces.
 
-When you create a team or add a team member, Wardian automatically wires up edges between all team members in the topology. These connections shape your default visibility and are completely editable through the Graph view. See the [Graph](./graph.md) view for the visual control surface: create and delete connections, view your neighbors, and inspect the topology source at `<WARDIAN_HOME>/topology.json`.
+When you create a team or add a team member, Wardian automatically wires up edges between all team members in the topology. These connections shape your default visibility and are completely editable through the Graph view; deleted team-seeded pairs are recorded so later seed passes do not recreate them unless you draw the connection again. See the [Graph](./graph.md) view for the visual control surface: create and delete connections, view your neighbors, and inspect the topology source at `<WARDIAN_HOME>/topology.json`.
 
 ## Commands
 

--- a/docs/guide/graph.md
+++ b/docs/guide/graph.md
@@ -55,23 +55,26 @@ The graph is backed by `<WARDIAN_HOME>/topology.json` (default: `~/.wardian/topo
 
 ```json
 {
-  "version": 2,
+  "version": 3,
   "edges": [
     { "a": "agent-uuid-1", "b": "agent-uuid-2", "created_at": "2026-07-02T14:30:00Z" }
   ],
   "ignored_pairs": [
     { "a": "agent-uuid-3", "b": "agent-uuid-4" }
+  ],
+  "suppressed_seed_pairs": [
+    { "a": "agent-uuid-5", "b": "agent-uuid-6" }
   ]
 }
 ```
 
-Manual edges include connections you created by dragging plus edges seeded when you created or modified teams. You can edit this file directly (the app reloads on changes), or use the UI. Edges are undirected and canonicalized (`a < b` lexicographically). When you first launch Wardian after upgrading, existing team memberships are automatically seeded into topology.json, and the version advances to 2.
+Manual edges include connections you created by dragging plus edges seeded when you created or modified teams. You can edit this file directly (the app reloads on changes), or use the UI. Edges are undirected and canonicalized (`a < b` lexicographically). `suppressed_seed_pairs` records team-member pairs that should not be recreated by later team-seed passes after you delete a team-born edge. When you first launch Wardian after upgrading, existing team memberships are automatically seeded into topology.json, and the file is saved at the current schema version.
 
 ## Teams and Topology Seeding
 
-When you create a team or add a member to an existing team, Wardian automatically draws manual edges connecting all members of that team (a clique). These are real edges saved to `topology.json` — after seeding, you're free to delete any team-born edge, and it stays deleted even if the team persists. Removing an agent from a team does not delete the edges; connections persist until you explicitly delete them.
+When you create a team or add a member to an existing team, Wardian automatically draws manual edges connecting all members of that team (a clique). These are real edges saved to `topology.json` — after seeding, you're free to delete any team-born edge, and it stays deleted even if the team persists. Wardian records that intent in `suppressed_seed_pairs`; drawing the edge again clears the suppression. Removing an agent from a team does not delete the edges; connections persist until you explicitly delete them.
 
-On first launch, Wardian seeds all existing team memberships as edges and upgrades `topology.json` to version 2. The CLI sees the same edges without needing the app to run first.
+On first launch, Wardian seeds all existing team memberships as edges and saves `topology.json` at the current schema version. Existing version 2 topology files are not reseeded only because version 3 exists, so prior deletes stay deleted. The CLI sees the same edges without needing the app to run first.
 
 ## Graph Layout
 

--- a/docs/specs/2026-07-03-team-edge-deletion-suppression.md
+++ b/docs/specs/2026-07-03-team-edge-deletion-suppression.md
@@ -1,0 +1,50 @@
+# Team Edge Deletion Suppression
+
+- **Status:** Accepted
+- **Date:** 2026-07-03
+- **Issue:** [#633](https://github.com/wardian-app/Wardian/issues/633)
+- **Related:** [#610](https://github.com/wardian-app/Wardian/issues/610)
+- **Decision owner:** Maintainers
+
+## Context
+
+Communication topology stores real, editable edges in
+`<WARDIAN_HOME>/topology.json`. Teams seed clique edges into that topology so a
+newly created team has useful neighbor defaults, but seeded edges become user
+owned once written.
+
+The original schema could not distinguish "this team pair has never been
+seeded" from "this team pair was seeded and the user intentionally deleted it."
+That made later team-seed passes capable of recreating a deleted edge while the
+team membership still existed.
+
+## Decision
+
+Topology schema version 3 adds `suppressed_seed_pairs`, a canonical list of
+agent pairs that team membership must not recreate. Removing an edge whose pair
+is still present in any team deletes the edge and adds the pair to
+`suppressed_seed_pairs`. Adding the edge manually clears that suppression,
+because the user has reconnected the pair.
+
+`ignored_pairs` remains separate. It dismisses ghost communication suggestions
+and workspace-fallback visibility; it must not be reused for team-seed
+suppression because disconnecting a team-born edge should not hide future
+activity or fallback signals for that pair.
+
+## Consequences
+
+- Team-created edges remain fully editable and stay deleted across app restarts
+  and future team-seed passes.
+- Existing version 2 topology files are not reseeded merely because schema
+  version 3 exists. The one-time team seed still applies only to pre-version-2
+  topology files or a missing topology file.
+- `topology.json` remains inspectable Markdown-as-truth-adjacent state: the
+  durable user intent is visible as `suppressed_seed_pairs`.
+
+## Testing
+
+Core topology tests cover:
+
+- team clique seeding skips suppressed pairs;
+- removing a team-backed edge records suppression;
+- manually adding the edge clears suppression.

--- a/docs/specs/communication-topology.md
+++ b/docs/specs/communication-topology.md
@@ -26,15 +26,19 @@ The topology shapes **default visibility and target resolution, never permission
   ],
   "ignored_pairs": [
     { "a": "<agent-uuid>", "b": "<agent-uuid>" }
+  ],
+  "suppressed_seed_pairs": [
+    { "a": "<agent-uuid>", "b": "<agent-uuid>" }
   ]
 }
 ```
 
 - Edges are **undirected and canonical**: `a < b` lexicographically; deduped on save (same canonicalization as `graphProjection.ts` edge keys).
 - Written atomically (temp file + rename), like the watchlist state file.
-- Only **manual** edges are stored. Rule-derived edges are computed at read time — nothing to sync when team membership changes.
+- Only **manual** edges are stored. Workspace fallback is resolved at read time, but team membership seeds ordinary manual edges instead of producing read-time rule edges.
 - Edges reference agent UUIDs. Edges naming deleted agents are ignored at read time and garbage-collected on the next save.
 - `ignored_pairs` holds ghost-edge dismissals (see UI section) so they are durable and inspectable on disk. (rev. 2026-07-03: with team edges seeded as manual, ignores no longer apply to anything but ghosts.)
+- `suppressed_seed_pairs` holds team-seed tombstones. Removing a team-backed edge while both agents remain on a team records the pair here so later seed passes do not recreate it; manually adding the edge clears the tombstone.
 - A missing or corrupt file resolves to an empty topology — it must never block agent listing.
 
 ### Neighbor-set resolution (formerly "community", in `wardian-core`)
@@ -51,7 +55,7 @@ New module `crates/wardian-core/src/topology.rs`:
 neighbors(agent) = manual neighbors, with workspace-fallback when the agent has none
 ```
 
-Teams are no longer a read-time rule. Instead, **teams seed ordinary manual edges**: when a team is created or a member is added, clique edges among its members are written to `topology.json` as plain manual edges (idempotent; existing edges untouched). After seeding, the graph is user-owned — deleting a team-born edge is a real delete and nothing resurrects it, because seeding happens only on membership-change events, never at read time or startup. Removing an agent from a team leaves its edges in place; connections persist until explicitly deleted.
+Teams are no longer a read-time rule. Instead, **teams seed ordinary manual edges**: when a team is created or a member is added, clique edges among its members are written to `topology.json` as plain manual edges (idempotent; existing edges untouched). After seeding, the graph is user-owned — deleting a team-born edge is a real delete and later seed passes skip the pair via `suppressed_seed_pairs`. Removing an agent from a team leaves its edges in place; connections persist until explicitly deleted.
 
 One built-in rule remains:
 
@@ -61,7 +65,7 @@ One built-in rule remains:
 
 Each neighbor is tagged with *why* it is visible: `manual` or `rule:workspace-fallback`. The CLI shows reasons in verbose output.
 
-**Migration:** `topology.json` gains a `version: 2` marker. On app startup, a version-1 (or missing) file triggers a one-time seed of cliques for all current teams, then saves as version 2. The CLI never migrates (read-only consumer); until the app has run once, team-born edges simply don't exist yet.
+**Migration:** `topology.json` gained a `version: 2` marker for the one-time team seed, then `version: 3` for durable team-seed tombstones. On app startup, a pre-version-2 (or missing) file triggers a one-time seed of cliques for all current teams, then saves at the current schema version. Existing version-2 files are not reseeded merely because schema version 3 exists; this preserves any team-born edges the user already deleted. The CLI never migrates (read-only consumer); until the app has run once, team-born edges simply don't exist yet.
 
 **Opt-in moment:** drawing an agent's first manual edge (including team-seeded ones) disengages `workspace-fallback` for that agent — its neighbors become exactly what the graph says. Per-agent, no global mode flag.
 
@@ -104,7 +108,7 @@ Because enforcement is soft, agent-facing documentation is half the feature:
 New commands, thin wrappers over `wardian-core::topology`:
 
 - `get_topology()` → manual edges + ignored pairs. (rev. 2026-07-03: no rule-derived edges in the snapshot; teams seed manual edges instead.)
-- `add_topology_edge(a, b)` / `remove_topology_edge(a, b)` — canonicalize, save atomically, emit `topology_changed`.
+- `add_topology_edge(a, b)` / `remove_topology_edge(a, b)` — canonicalize, save atomically, emit `topology_changed`. Removing a pair that is still produced by team membership writes a `suppressed_seed_pairs` tombstone; adding the pair manually clears that tombstone.
 - `ignore_pair(a, b)` / `unignore_pair(a, b)` — ghost dismissal. `resolve_neighbors` skips workspace-fallback reasons for ignored pairs; manual edges are unaffected (creating one implies intent).
 - `get_pair_activity()` → `[{ pair, last_message_at, active_ask, direction }]`, derived from the conversation store; updated incrementally over the existing conversation event stream (no polling). `active_ask` is **time-bounded**: an unresolved ask older than the recency window (1 hour) no longer counts as ongoing — stale asks must not animate forever.
 
@@ -181,7 +185,7 @@ Per the E2E layer boundary rules, lowest layer that proves each behavior:
 | Team edge visuals | Generic "rule-derived" texture, rule named in inspector | Team-specific styling (rejected: blocks future rule-based relations) |
 | Ghost attention cue | Texture + inspector badge, standard state palette | Amber color (rejected: violated two-channel encoding) |
 | Team edges (rev. 2026-07-02) | Connected by default, deletable via `ignored_pairs` override | Managed/undeletable with deep-link to team editor (rejected after use: users expect direct edge control) |
-| Team edges (rev. 2026-07-03, supersedes above) | Teams **seed** plain manual edges on membership-change events; delete is a real delete; edges persist on team leave | Rule-derived with overrides (rejected after use: resolver/snapshot divergence bugs, dim dual-texture rendering, override UI without visible effect); no team edges at all (rejected: teams would lose topological meaning) |
+| Team edges (rev. 2026-07-03, supersedes above) | Teams **seed** plain manual edges on membership-change events and first migration; delete is a real delete recorded in `suppressed_seed_pairs`; edges persist on team leave | Rule-derived with overrides (rejected after use: resolver/snapshot divergence bugs, dim dual-texture rendering, override UI without visible effect); no team edges at all (rejected: teams would lose topological meaning) |
 | Graph layout (rev. 2026-07-03) | Force-directed over communication edges, re-run on topology change | Team-cluster layout (rejected: manual edges had no visible effect on arrangement) |
 | Dormant edge rendering (rev. 2026-07-03) | Full-legibility neutral color; only activity varies with recency | Heavy alpha fade (rejected: structure was nearly invisible) |
 | Activity animation (rev. 2026-07-02) | Time-bounded `active_ask`; single rAF only while ongoing | Unbounded asks + always-on loop (rejected: stale asks animated forever, parallel rAF chains lagged the view) |

--- a/docs/specs/communication-topology.md
+++ b/docs/specs/communication-topology.md
@@ -65,7 +65,7 @@ One built-in rule remains:
 
 Each neighbor is tagged with *why* it is visible: `manual` or `rule:workspace-fallback`. The CLI shows reasons in verbose output.
 
-**Migration:** `topology.json` gained a `version: 2` marker for the one-time team seed, then `version: 3` for durable team-seed tombstones. On app startup, a pre-version-2 (or missing) file triggers a one-time seed of cliques for all current teams, then saves at the current schema version. Existing version-2 files are not reseeded merely because schema version 3 exists; this preserves any team-born edges the user already deleted. The CLI never migrates (read-only consumer); until the app has run once, team-born edges simply don't exist yet.
+**Migration:** `topology.json` gained a `version: 2` marker for the one-time team seed, then `version: 3` for durable team-seed tombstones. On app startup, a pre-version-2 (or missing) file triggers a one-time seed of cliques for all current teams, then saves at the current schema version. Existing version-2 files are not reseeded merely because schema version 3 exists; instead, current team pairs that are missing from the v2 edge list are recorded in `suppressed_seed_pairs` before the file is saved as v3. This preserves any team-born edges the user already deleted. The CLI never migrates (read-only consumer); until the app has run once, team-born edges simply don't exist yet.
 
 **Opt-in moment:** drawing an agent's first manual edge (including team-seeded ones) disengages `workspace-fallback` for that agent — its neighbors become exactly what the graph says. Per-agent, no global mode flag.
 

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -56,6 +56,10 @@ edges, or your workspace-mates if you have no manual edges). This shapes your de
 attention without restricting capability. Bare-name agent sends resolve within your
 neighbors first, then fall back to global exact match.
 
+Team-seeded edges are ordinary editable topology edges. If you delete one in the
+Graph view, Wardian records that suppression so later team-seed passes do not
+recreate it unless you draw the connection again.
+
 **Scope modes:**
 - `--scope auto` (default): neighbors when inside a Wardian-managed session, else workspace.
 - `--scope neighbors`: self + direct topology neighbors (manual edges or workspace fallback when isolated).

--- a/src-tauri/src/commands/topology.rs
+++ b/src-tauri/src/commands/topology.rs
@@ -10,7 +10,7 @@ use wardian_core::topology::{
 pub struct TopologyEdgeDto {
     pub a: String,
     pub b: String,
-    /// Always "manual" in schema v2: team edges are seeded as manual edges at
+    /// Always "manual" in schema v3: team edges are seeded as manual edges at
     /// write time, never computed from rules at read time.
     pub origin: String,
 }
@@ -26,8 +26,7 @@ pub struct TopologySnapshot {
 }
 
 fn home() -> Result<std::path::PathBuf, String> {
-    crate::utils::fs::get_wardian_home()
-        .ok_or_else(|| "WARDIAN_HOME not resolvable".to_string())
+    crate::utils::fs::get_wardian_home().ok_or_else(|| "WARDIAN_HOME not resolvable".to_string())
 }
 
 #[tauri::command]
@@ -64,10 +63,7 @@ pub async fn get_topology(
             .iter()
             .map(|p| [p.a.clone(), p.b.clone()])
             .collect(),
-        fallback_groups: groups
-            .into_values()
-            .filter(|g| g.len() > 1)
-            .collect(),
+        fallback_groups: groups.into_values().filter(|g| g.len() > 1).collect(),
     })
 }
 
@@ -93,7 +89,11 @@ pub async fn add_topology_edge(app: AppHandle, a: String, b: String) -> Result<b
 
 #[tauri::command]
 pub async fn remove_topology_edge(app: AppHandle, a: String, b: String) -> Result<bool, String> {
-    mutate(&app, |topology| topology.remove_edge(&a, &b))
+    let home = home()?;
+    let teams = wardian_core::topology::load_team_memberships(&home);
+    mutate(&app, |topology| {
+        topology.remove_edge_and_suppress_seed_if_team_pair(&a, &b, &teams)
+    })
 }
 
 #[tauri::command]
@@ -144,6 +144,7 @@ mod tests {
                 created_at: "2026-07-02T00:00:00Z".to_string(),
             }],
             ignored_pairs: vec![],
+            suppressed_seed_pairs: vec![],
         };
 
         let edges = snapshot_edges(&topology);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,7 +180,7 @@ pub fn run() {
         eprintln!("Failed to initialize database: {}", e);
     }
 
-    // One-time topology migration: seed team cliques as manual edges, upgrade to version 2.
+    // One-time topology migration: seed team cliques as manual edges.
     if let Some(home) = crate::utils::fs::get_wardian_home() {
         let mut topology = wardian_core::topology::load_topology(&home);
         // Home-aware check: a missing topology.json loads as a default carrying
@@ -192,11 +192,13 @@ pub fn run() {
             for team in teams {
                 wardian_core::topology::seed_team_clique(&mut topology, &team.agent_ids, &now);
             }
-            topology.version = 2;
+            topology.version = wardian_core::topology::TOPOLOGY_SCHEMA_VERSION;
             if let Err(e) = wardian_core::topology::save_topology(&home, &topology) {
-                crate::manager::log_debug(&format!("[Wardian] topology migration save failed: {e}"));
+                crate::manager::log_debug(&format!(
+                    "[Wardian] topology migration save failed: {e}"
+                ));
             } else {
-                crate::manager::log_debug("[Wardian] topology migrated to version 2 with seeded team cliques");
+                crate::manager::log_debug("[Wardian] topology migrated with seeded team cliques");
             }
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -183,11 +183,11 @@ pub fn run() {
     // One-time topology migration: seed team cliques as manual edges.
     if let Some(home) = crate::utils::fs::get_wardian_home() {
         let mut topology = wardian_core::topology::load_topology(&home);
+        let teams = wardian_core::topology::load_team_memberships(&home);
         // Home-aware check: a missing topology.json loads as a default carrying
         // the CURRENT schema version, but machines with pre-existing teams and
         // no file still need their one-time seed.
         if wardian_core::topology::needs_team_seed_migration_for_home(&home, &topology) {
-            let teams = wardian_core::topology::load_team_memberships(&home);
             let now = chrono::Utc::now().to_rfc3339();
             for team in teams {
                 wardian_core::topology::seed_team_clique(&mut topology, &team.agent_ids, &now);
@@ -199,6 +199,19 @@ pub fn run() {
                 ));
             } else {
                 crate::manager::log_debug("[Wardian] topology migrated with seeded team cliques");
+            }
+        } else if wardian_core::topology::needs_seed_suppression_migration(&topology) {
+            let suppressed =
+                wardian_core::topology::suppress_missing_team_seed_pairs(&mut topology, &teams);
+            topology.version = wardian_core::topology::TOPOLOGY_SCHEMA_VERSION;
+            if let Err(e) = wardian_core::topology::save_topology(&home, &topology) {
+                crate::manager::log_debug(&format!(
+                    "[Wardian] topology seed-suppression migration save failed: {e}"
+                ));
+            } else {
+                crate::manager::log_debug(&format!(
+                    "[Wardian] topology migrated with {suppressed} suppressed team-seed pair(s)"
+                ));
             }
         }
     }

--- a/src-tauri/src/providers/codex.rs
+++ b/src-tauri/src/providers/codex.rs
@@ -706,8 +706,10 @@ mod tests {
             folder: r#"D:\Development\Wardian.wt\wardian-3"#.into(),
             ..Default::default()
         };
-        let mut policy = CodexRuntimePolicy::default();
-        policy.trust_workspaces = true;
+        let policy = CodexRuntimePolicy {
+            trust_workspaces: true,
+            ..Default::default()
+        };
 
         let args = p.spawn_args_with_runtime_policy(&config, false, &policy);
 


### PR DESCRIPTION
## Description
Persist explicit user deletion of team-seeded communication topology edges by adding a schema v3 `suppressed_seed_pairs` tombstone list. Team clique seeding now skips suppressed pairs, and manually reconnecting a pair clears the suppression.

This also updates the Graph and CLI docs plus the communication topology spec so the inspectable `topology.json` contract matches the behavior.

## Related Issues
Fixes #633
Follow-up to #610

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] `cargo test -p wardian-core topology::tests::`
- [x] `cargo test -p Wardian topology::tests::`
- [x] `npm run test -- src/views/GraphView.test.tsx src/features/graph/graphProjection.test.ts`
- [x] `cargo test -p wardian-cli -- --test-threads=1`
- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -- --test-threads=1`
- [x] `npm run lint`
- [x] `npm run test` (first full run hit an isolated `src/main.test.tsx` timeout; the single test passed alone and the full suite passed on rerun)
- [x] `npm run build` (Vite reports the existing large chunk warning)
- [x] `npm run docs:build`
- [x] `git diff --check`
- [x] Diff secrets-pattern scan found no matches

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable