### PR TITLE
fix(agent): clean deleted agent references

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -3,6 +3,7 @@ use crate::providers::ProviderFactory;
 use crate::state::conversation_archive::effective_conversation_logging;
 use crate::state::{ActiveAgent, AppState};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::Path;
 use tauri::{AppHandle, Emitter, State};
 use wardian_core::conversations::{ConversationBoundaryReason, ConversationLoggingSetting};
 use wardian_core::models::{
@@ -158,6 +159,35 @@ fn detach_agent_for_kill(
     }
     order.retain(|id| id != session_id);
     Some(agent)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DeletedAgentReferenceCleanup {
+    watchlists_changed: bool,
+    topology_changed: bool,
+}
+
+impl DeletedAgentReferenceCleanup {
+    fn run(home: &Path, remaining_agent_ids: &BTreeSet<String>) -> Result<Self, String> {
+        let watchlists_changed =
+            crate::commands::watchlist::retain_known_agent_references_in_home(
+                home,
+                remaining_agent_ids,
+            )?;
+
+        let mut topology = wardian_core::topology::load_topology(home);
+        let before_topology = topology.clone();
+        topology.retain_agents(remaining_agent_ids);
+        let topology_changed = topology != before_topology;
+        if topology_changed {
+            wardian_core::topology::save_topology(home, &topology).map_err(|e| e.to_string())?;
+        }
+
+        Ok(Self {
+            watchlists_changed,
+            topology_changed,
+        })
+    }
 }
 
 async fn lock_agent_lifecycle(
@@ -2339,7 +2369,7 @@ pub async fn kill_agent(
         session_id
     ));
     let _lifecycle_guard = lock_agent_lifecycle(&state, &session_id).await;
-    let (agent, state_snapshot) = {
+    let (agent, state_snapshot, remaining_agent_ids) = {
         let mut agents = state.agents.lock().await;
         let mut order = state.agent_order.lock().await;
         let agent =
@@ -2347,7 +2377,10 @@ pub async fn kill_agent(
         let state_snapshot = agent
             .is_some()
             .then(|| manager::state_configs_snapshot(&agents, &order));
-        (agent, state_snapshot)
+        let remaining_agent_ids = agent
+            .is_some()
+            .then(|| agents.keys().cloned().collect::<BTreeSet<_>>());
+        (agent, state_snapshot, remaining_agent_ids)
     };
     if let Some(snapshot) = state_snapshot {
         manager::save_state_snapshot(&app, &snapshot);
@@ -2364,8 +2397,25 @@ pub async fn kill_agent(
         let _ = wardian_core::db::delete_agent(&session_id);
         let _ = app.emit("agents-updated", ());
 
-        // Cleanup: remove the agent's private directory
+        // Cleanup: remove persisted references and the agent's private directory.
         if let Some(home) = crate::utils::fs::get_wardian_home() {
+            if let Some(remaining_agent_ids) = remaining_agent_ids.as_ref() {
+                match DeletedAgentReferenceCleanup::run(&home, remaining_agent_ids) {
+                    Ok(cleanup) => {
+                        if cleanup.watchlists_changed {
+                            let _ = app.emit("watchlists-updated", ());
+                        }
+                        if cleanup.topology_changed {
+                            let _ = app.emit("topology-changed", ());
+                        }
+                    }
+                    Err(error) => manager::log_debug(&format!(
+                        "[WARDIAN] Failed to clean deleted agent references for {}: {}",
+                        session_id, error
+                    )),
+                }
+            }
+
             let agent_dir = home.join("agents").join(&session_id);
             if agent_dir.exists() {
                 if let Err(e) = std::fs::remove_dir_all(&agent_dir) {
@@ -3442,7 +3492,8 @@ mod tests {
         take_agent_runtime_for_termination, terminal_cleared_payload,
         validate_assignable_worktree_for_agent, validate_deletable_agent_worktree,
         workspace_paths_match, AgentOrderPlacement, AgentWorktreeSummary, CloneProfileCopyPlan,
-        CloneProfileSelection, DiscoveredGitWorktree, GIT_WORKTREE_DISCOVERY_CONCURRENCY,
+        CloneProfileSelection, DeletedAgentReferenceCleanup, DiscoveredGitWorktree,
+        GIT_WORKTREE_DISCOVERY_CONCURRENCY,
     };
     use crate::providers::GeminiProvider;
     use crate::state::{ActiveAgent, AppState};
@@ -6615,6 +6666,72 @@ Add-Content -LiteralPath $env:WARDIAN_COMMAND_SMOKE_LOG -Value $lines
             conversation_boundary_for_clear_reason(Some("worktree_switch")),
             wardian_core::conversations::ConversationBoundaryReason::WorktreeSwitch
         );
+    }
+
+    #[test]
+    fn deleted_agent_reference_cleanup_prunes_watchlists_and_topology() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let watchlists_dir = temp.path().join("watchlists");
+        std::fs::create_dir_all(&watchlists_dir).expect("watchlists dir");
+        std::fs::write(
+            watchlists_dir.join("index.json"),
+            serde_json::json!({
+                "version": 2,
+                "teams": [{ "id": "team-a", "name": "Core", "agentIds": ["deleted", "kept", "stale"] }],
+                "watchlists": [{
+                    "id": "main",
+                    "name": "Main",
+                    "entries": [
+                        { "type": "agent", "agentId": "deleted" },
+                        { "type": "agent", "agentId": "stale" },
+                        { "type": "agent", "agentId": "kept" },
+                        { "type": "team", "teamId": "team-a" }
+                    ]
+                }]
+            })
+            .to_string(),
+        )
+        .expect("seed watchlist");
+
+        let mut topology = wardian_core::topology::Topology::default();
+        topology.add_edge("deleted", "kept", "2026-07-05T00:00:00Z");
+        topology.add_edge("kept", "other-kept", "2026-07-05T00:00:01Z");
+        topology.ignore_pair("deleted", "other-kept");
+        topology.ignore_pair("kept", "other-kept");
+        wardian_core::topology::save_topology(temp.path(), &topology).expect("save topology");
+        let remaining_agent_ids =
+            std::collections::BTreeSet::from(["kept".to_string(), "other-kept".to_string()]);
+
+        let cleanup = DeletedAgentReferenceCleanup::run(temp.path(), &remaining_agent_ids)
+            .expect("cleanup");
+
+        assert!(cleanup.watchlists_changed);
+        assert!(cleanup.topology_changed);
+
+        let saved_watchlists =
+            std::fs::read_to_string(watchlists_dir.join("index.json")).expect("watchlists saved");
+        let watchlist_state: serde_json::Value =
+            serde_json::from_str(&saved_watchlists).expect("watchlist json");
+        assert_eq!(
+            watchlist_state["teams"][0]["agentIds"],
+            serde_json::json!(["kept"])
+        );
+        assert_eq!(
+            watchlist_state["watchlists"][0]["entries"],
+            serde_json::json!([
+                { "type": "agent", "agentId": "kept" },
+                { "type": "team", "teamId": "team-a" }
+            ])
+        );
+
+        let saved_topology = wardian_core::topology::load_topology(temp.path());
+        assert_eq!(saved_topology.neighbors("deleted"), Vec::<String>::new());
+        assert_eq!(
+            saved_topology.neighbors("kept"),
+            vec!["other-kept".to_string()]
+        );
+        assert!(saved_topology.is_ignored("kept", "other-kept"));
+        assert!(!saved_topology.is_ignored("deleted", "other-kept"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/watchlist.rs
+++ b/src-tauri/src/commands/watchlist.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::Path;
 use tauri::{AppHandle, Emitter};
 
@@ -159,10 +160,147 @@ pub(crate) fn preserve_clone_team_placement_in_home(
     Ok(true)
 }
 
+pub(crate) fn retain_known_agent_references_in_home(
+    home: &Path,
+    known_agent_ids: &BTreeSet<String>,
+) -> Result<bool, String> {
+    let path = watchlist_index_path(home);
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let data = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
+    let mut state = serde_json::from_str::<serde_json::Value>(&data).map_err(|e| e.to_string())?;
+    if !retain_known_agent_references_in_watchlist_state(&mut state, known_agent_ids) {
+        return Ok(false);
+    }
+
+    let json = serde_json::to_string_pretty(&state).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
+pub(crate) fn retain_known_agent_references_in_watchlist_state(
+    state: &mut serde_json::Value,
+    known_agent_ids: &BTreeSet<String>,
+) -> bool {
+    let before = state.clone();
+    let remaining_team_ids = retain_known_agents_in_teams(state, known_agent_ids);
+    retain_known_agents_in_watchlists(state, known_agent_ids, &remaining_team_ids);
+    *state != before
+}
+
+fn retain_known_agents_in_teams(
+    state: &mut serde_json::Value,
+    known_agent_ids: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let Some(teams) = state
+        .get_mut("teams")
+        .and_then(|value| value.as_array_mut())
+    else {
+        return BTreeSet::new();
+    };
+
+    for team in teams.iter_mut() {
+        let agent_ids = team_agent_ids(team)
+            .into_iter()
+            .filter(|id| known_agent_ids.contains(id))
+            .collect::<Vec<_>>();
+        if let Some(object) = team.as_object_mut() {
+            object.remove("agent_ids");
+            object.insert(
+                "agentIds".to_string(),
+                serde_json::Value::Array(agent_ids.into_iter().map(Into::into).collect()),
+            );
+        }
+    }
+    teams.retain(|team| !team_agent_ids(team).is_empty());
+
+    teams
+        .iter()
+        .filter_map(|team| {
+            team.get("id")
+                .and_then(|id| id.as_str())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+fn retain_known_agents_in_watchlists(
+    state: &mut serde_json::Value,
+    known_agent_ids: &BTreeSet<String>,
+    remaining_team_ids: &BTreeSet<String>,
+) {
+    let Some(watchlists) = state
+        .get_mut("watchlists")
+        .and_then(|value| value.as_array_mut())
+    else {
+        return;
+    };
+
+    for watchlist in watchlists {
+        retain_known_agents_in_watchlist(watchlist, known_agent_ids, remaining_team_ids);
+    }
+}
+
+fn retain_known_agents_in_watchlist(
+    watchlist: &mut serde_json::Value,
+    known_agent_ids: &BTreeSet<String>,
+    remaining_team_ids: &BTreeSet<String>,
+) {
+    let Some(object) = watchlist.as_object_mut() else {
+        return;
+    };
+
+    let direct_agent_ids = object
+        .get("agentIds")
+        .or_else(|| object.get("agent_ids"))
+        .and_then(|value| value.as_array())
+        .map(|ids| {
+            ids.iter()
+                .filter_map(|id| id.as_str())
+                .filter(|id| known_agent_ids.contains(*id))
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        });
+
+    if let Some(agent_ids) = direct_agent_ids {
+        object.remove("agent_ids");
+        object.insert(
+            "agentIds".to_string(),
+            serde_json::Value::Array(agent_ids.into_iter().map(Into::into).collect()),
+        );
+    }
+
+    if let Some(entries) = object
+        .get_mut("entries")
+        .and_then(|value| value.as_array_mut())
+    {
+        entries.retain(|entry| {
+            let entry_type = entry.get("type").and_then(|value| value.as_str());
+            match entry_type {
+                Some("agent") => entry
+                    .get("agentId")
+                    .or_else(|| entry.get("agent_id"))
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|id| known_agent_ids.contains(id)),
+                Some("team") => entry
+                    .get("teamId")
+                    .or_else(|| entry.get("team_id"))
+                    .and_then(|value| value.as_str())
+                    .is_some_and(|id| remaining_team_ids.contains(id)),
+                _ => true,
+            }
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::preserve_clone_team_placement_in_home;
     use super::preserve_clone_team_placement_in_watchlist_state;
+    use super::retain_known_agent_references_in_watchlist_state;
+    use std::collections::BTreeSet;
 
     #[test]
     fn clone_team_placement_inserts_clone_after_source_and_removes_from_other_teams() {
@@ -233,6 +371,51 @@ mod tests {
         assert_eq!(
             state["teams"][0]["agentIds"],
             serde_json::json!(["source", "clone", "beta"])
+        );
+    }
+
+    #[test]
+    fn deleted_agent_cleanup_prunes_persisted_watchlists_and_teams() {
+        let mut state = serde_json::json!({
+            "version": 2,
+            "teams": [
+                { "id": "team-a", "name": "Core", "agentIds": ["deleted", "kept"] },
+                { "id": "team-empty", "name": "Empty", "agent_ids": ["deleted"] }
+            ],
+            "watchlists": [
+                {
+                    "id": "main",
+                    "name": "Main",
+                    "agent_ids": ["deleted", "kept"],
+                    "entries": [
+                        { "type": "agent", "agentId": "deleted" },
+                        { "type": "agent", "agentId": "kept" },
+                        { "type": "team", "teamId": "team-a" },
+                        { "type": "team", "teamId": "team-empty" }
+                    ]
+                }
+            ]
+        });
+        let known_ids = BTreeSet::from(["kept".to_string()]);
+
+        let changed = retain_known_agent_references_in_watchlist_state(&mut state, &known_ids);
+
+        assert!(changed);
+        assert_eq!(
+            state["teams"],
+            serde_json::json!([{ "id": "team-a", "name": "Core", "agentIds": ["kept"] }])
+        );
+        assert_eq!(
+            state["watchlists"][0]["agentIds"],
+            serde_json::json!(["kept"])
+        );
+        assert!(state["watchlists"][0].get("agent_ids").is_none());
+        assert_eq!(
+            state["watchlists"][0]["entries"],
+            serde_json::json!([
+                { "type": "agent", "agentId": "kept" },
+                { "type": "team", "teamId": "team-a" }
+            ])
         );
     }
 }


### PR DESCRIPTION
## Description
Cleans stale references when an agent is deleted so persisted graph/watchlist state does not keep pointing at removed agents.

- Prunes deleted or stale agent IDs from persisted watchlist teams and direct watchlist agent lists.
- Removes watchlist entries that point at deleted agents or now-empty teams.
- Retains topology edges and ignored pairs only for known remaining agents.
- Emits watchlist/topology refresh events when cleanup changes persisted files.

Docs are not applicable: this is internal persisted-state cleanup after an existing delete action, with no public workflow, UI, or CLI contract change.

## Related Issues
Fixes #640

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- `cd src-tauri && cargo test deleted_agent`
- `cd src-tauri && cargo clippy`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo test --quiet`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable