### PR TITLE
docs: refresh roadmap and post-0.4 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Debian/Ubuntu users who want package-manager updates can use the optional
 - [Why Wardian?](#why-wardian)
 - [Core Features](#core-features)
 - [Platform Support](#platform-support)
-- [Project Roadmap](#project-roadmap)
+- [Product Direction](#product-direction)
 - [Tech Stack](#tech-stack)
 - [Architecture](#architecture)
 - [Development Setup](#development-setup)
@@ -216,13 +216,15 @@ Wardian leverages native OS capabilities for high-performance terminal emulation
 
 ---
 
-## Project Roadmap
+## Product Direction
 
 Wardian is evolving toward a malleable home for your agents: a local environment where agent capabilities, workflows, evidence, and project context can be inspected, rearranged, and extended over time.
 
-- **Phase 1-2**: Dual-Sidebar UI, PTY Grid, Shared Habitat, CLI Utility, live CLI control, agent cloning, worktrees, and scheduled workflow foundations. [DONE]
-- **Phase 3-4**: Agent-to-Agent IPC, HITL approval queue expansion, workflow hardening, and cross-platform runtime polish. [ACTIVE]
-- **Phase 5**: Swarm Visualization, Plugins, and File-System Watcher Hooks. [PLANNED]
+- **Runtime reliability and provider fidelity**: keep real PTY behavior, provider-specific delivery, transcript capture, and cross-platform process supervision stable as provider CLIs change.
+- **Reusable context and capabilities**: continue tightening the Library around prompts, skills, classes, workflow blueprints, MCP configuration, and inspectable filesystem-backed artifacts.
+- **Coordination surfaces**: improve Graph topology, teams, watchlists, Queue evidence, structured asks/replies, and CLI automation so multi-agent work stays visible and bounded.
+- **Workflow operations**: harden workflow authoring, scheduling, run observation, history, and failure evidence for repeatable local automation.
+- **Remote and distribution polish**: improve the mobile remote surface, installer/update paths, package-manager channels, and first-run documentation.
 
 Full details available in [ROADMAP.md](ROADMAP.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,90 +1,73 @@
-# Wardian Project Roadmap
+# Wardian Product Direction
 
-Wardian is an advanced Agent Terminal Manager designed for managing multiple autonomous agents through a unified, high-performance interface. This document outlines the development phases for implementing the core features.
+Wardian is a local-first desktop habitat for live agents, workflows, reusable
+context, and durable evidence. The early phase-based roadmap has served its
+purpose; major foundations such as the multi-view shell, PTY-backed agents,
+the Wardian CLI, worktrees, workflows, Queue evidence, Graph topology, remote
+mobile control, and package-manager distribution are now part of the product.
 
-## Phase 1: Layout & Terminal Management
+This roadmap describes current product direction without promising a strict
+phase sequence. Priorities can move as provider CLIs, release infrastructure,
+and user workflows change.
 
-_Goal: Provide a professional-grade local habitat for live agent work._
+## Current Priorities
 
-- [x] **Dual-Sidebar Habitat Shell**
-  - **Left Sidebar (Primary)**:
-    - A thin **Icon Bar** for switching between views (Explorer, Connections, Workflows, Settings).
-    - A collapsible **Content Pane** that displays the menu for the active icon (e.g., Spawn Instance form, SSH hosts).
-  - **Right Sidebar (Secondary)**:
-    - A **collapsible, searchable agent list** for rapid selection, status monitoring, and drag-drop reordering.
-  - Support for multi-select in the right sidebar and main grid views.
-- [x] **Dynamic Grid Layouts**
-  - Implement predefined grid templates (Single, 2x2, 1+2, etc.).
-  - Support for drag-and-drop reordering of terminals.
-  - Ability to "move" selected agents between grid slots or view layers.
-  - Perspective/Layout saving and restoration across sessions.
-- [x] **Dashboard Command Matrix Refresh**
-  - Replace generic buttons with standard action set:
-    - **Delete**: Terminates the active process and removes it from the roster.
-    - **Pause**: Suspends the terminal process but preserves agent session and metadata in `Wardian_state.json`.
-    - **Query**: A versatile prompt injection tool (evolution of "Summarize") for rapid context extraction.
-    - **Restart**: Resets the PTY session and re-initializes the agent from its current configuration.
-- [x] **Selection-Based Orchestration**
-  - Target broadcasting to only selected agents.
-  - Bulk actions (terminate, restart, group) for selected instances.
-  - "Pinning" agents to specific grid slots from the sidebar list.
-- [x] **Identity & Customization**
-  - Support for renaming agents (display names vs. session IDs).
-  - Custom color coding and icons for different agent roles.
+### Runtime Reliability and Provider Fidelity
 
-## Phase 2: Agent Infrastructure & CLI Utility
+- Keep real PTY behavior stable across Windows ConPTY, macOS, and Linux.
+- Preserve provider-specific launch policy, delivery evidence, transcript
+  capture, status transitions, and terminal rendering as provider CLIs change.
+- Make failures inspectable through Queue, workflow history, conversation
+  archives, logs, and native E2E evidence.
 
-_Goal: Empower agents with local persistence and self-awareness._
+### Reusable Context and Capabilities
 
-- [x] **Home Directories**
-  - Automate creation of per-agent state under the Wardian home for each instance.
-  - Isolate temporary and permanent files per agent.
-- [x] **Wardian CLI Utility**
-  - Implement a lightweight binary accessible from terminals and managed agent processes.
-  - `wardian agent`: Returns the current managed session when `WARDIAN_SESSION_ID` is set.
-  - `wardian agent list --scope all`: Lists live or persisted agents for coordination.
-  - `wardian send`, `wardian ask`, `wardian agent wait`, and `wardian agent watch`: Provide terminal-native coordination and response evidence.
-  - `wardian workflow list/show/run/stop`: Expose workflow inspection and live run control from the shell.
-- [x] **Session Branching (Forking)**
-  - Support cloning an agent configuration into a new parallel session.
-- [x] **Agent-Specific Include Directories**
-  - Ability to specify additional `include` paths for each agent to monitor or reference beyond its base `folder`.
-- [x] **CLI Portability Tools**
-  - Expose agent identity, workspace, provider, status, and worktree state through scriptable CLI commands.
-  - Keep direct provider resume commands as provider-runtime implementation details rather than the primary user contract.
-- [x] **Session Lifecycle Management**
-  - Preserve inactive agents in the roster and allow users to start, pause, resume, kill, clone, and reassign sessions explicitly.
-- [x] **Scheduled Task Engine**
-  - Implement scheduled workflow triggers and scheduled run instances.
-  - Support interval, daily, weekly, and one-time scheduled workflow launches.
-  - Provide UI and backend commands for managing, pausing, running, and deleting scheduled executions.
+- Continue making the Library the home for prompts, skills, classes, workflow
+  blueprints, and future MCP definitions.
+- Keep reusable artifacts filesystem-backed and inspectable under the Wardian
+  home instead of hiding them in opaque app state.
+- Expand safe deployment and synchronization of skills and context across
+  global, class, agent, workflow, workspace, and team scopes.
 
-## Phase 3: Communication & Orchestration
+### Coordination Surfaces
 
-_Goal: Enable collaborative workflows between isolated agent instances._
+- Improve Graph topology as the visible control surface for agent-to-agent
+  communication boundaries.
+- Tighten teams, watchlists, structured asks/replies, CLI coordination, and
+  Queue triage so multi-agent work remains bounded and reviewable.
+- Preserve operator control over manually drawn connections, team-seeded
+  topology, and workspace fallback behavior.
 
-- [ ] **Agent-to-Agent IPC & Routing**
-  - Implement a message bus (Pub/Sub) in the Rust backend.
-  - **Deterministic Routing Engine**: Define UI-based rules for routing JSON outputs between agents.
-- [ ] **Human-in-the-Loop (HITL) Queue**
-  - Expand the current completion Queue into a centralized approval and interruption surface for sensitive agent actions.
-- [ ] **Context Janitor (Memory Management)**
-  - Automated summarization workflows to compress context windows when token limits are approached.
+### Workflow Operations
 
-## Phase 4: Connectivity & Remote Management
+- Harden workflow authoring, validation, launch dialogs, schedules, run
+  observation, history, and failure records.
+- Keep the Rust workflow engine deterministic and testable while exposing
+  higher-level workflow ergonomics in the desktop app and CLI.
+- Make workflow outcomes easy to review, reuse, and promote into durable
+  context.
 
-_Goal: Expand the reach of Wardian across environments._
+### Remote, Packaging, and First-Run Polish
 
-- [ ] **Native SSH & Multiplexing**
-  - Support spawning agents on remote hosts via SSH.
-  - Integrate with `tmux` for persistent remote sessions that survive disconnection.
-- [ ] **Cross-Platform Compatibility**
-  - Hardening PTY implementation for Linux and macOS.
+- Improve the mobile remote PWA while keeping the desktop app the authority for
+  agents, PTYs, provider CLIs, filesystem access, and workflow execution.
+- Keep installer, updater, winget, Homebrew, APT, `.deb`, and AppImage guidance
+  aligned with actual release artifacts.
+- Reduce first-run friction through better provider readiness checks,
+  troubleshooting, and cross-platform documentation.
 
-## Phase 5: Polish & Ecosystem
+## Later Directions
 
-- [ ] **High-Fidelity Interaction Visualization**
-  - A dynamic, node-link swarm visualization of agents interacting in real-time.
-  - Visualizes message passing, task delegation, and collective thought processes.
-- [ ] **File-System Watcher Hooks**: Trigger agent tasks based on local file changes.
-- [ ] **Theme Engine**: Support for system-wide themes, OLED black mode, and a functional **Light Mode** toggle.
+- Richer Garden spatial organization and persistent workspace layouts.
+- MCP configuration and deployment from the Library.
+- Remote Queue hydration from desktop-owned Queue storage.
+- Broader package-manager coverage after sandbox and permission tradeoffs are
+  understood.
+- More automation around file-watch, listener, and project-context workflows.
+
+## What Is Not a Roadmap Contract
+
+This document is not a release schedule. Historical specs in `docs/specs/`
+remain useful design records, but their phase names and deferred sections
+should not be read as the current delivery order. Use the current README,
+public docs, changelog, and open issues for up-to-date release context.

--- a/docs/developer/architecture.md
+++ b/docs/developer/architecture.md
@@ -9,10 +9,11 @@ invariants:
 
 - **Canonical state has an owner.** The backend owns live agent runtime truth;
   workflow files own workflow templates; workflow run logs own run evidence;
-  library files own reusable prompts and skills; watchlist/team records own
-  roster organization until a broader project-scope model exists.
-- **Views are lenses, not state silos.** Grid, Dashboard, Graph, future spatial
-  views, Library, Workflows, Explorer, Queue, and the CLI should resolve and
+  library files own reusable prompts, skills, classes, and workflow blueprints;
+  watchlist/team records own roster organization until a broader project-scope
+  model exists.
+- **Views are lenses, not state silos.** Grid, Dashboard, Graph, Garden,
+  Library, Workflows, Explorer, Queue, and the CLI should resolve and
   mutate canonical Wardian records through shared commands or file contracts.
 - **Artifacts stay inspectable where practical.** User-shapable prompts,
   classes, skills, workflows, evidence, and memory-ready context should remain

--- a/docs/developer/package-manager-distribution.md
+++ b/docs/developer/package-manager-distribution.md
@@ -6,23 +6,20 @@ install surfaces that reuse the same desktop installers.
 
 ## Scope
 
-Phase 1 covers:
+Current package-manager support covers:
 
 - winget for Windows, using the NSIS `.exe`.
 - Homebrew Cask for macOS, using the Apple Silicon and Intel `.dmg` files.
 - A signed APT repository for Debian/Ubuntu x64, using the stable `.deb`.
 - Linux direct-install fallback docs for `.deb` and AppImage artifacts.
 
-npm bootstrap and standalone CLI-only distribution are out of scope for Phase 1.
-Linux package-manager publishing is tracked in
-[#324](https://github.com/wardian-app/Wardian/issues/324). The Phase 2 decision
-is documented in
+npm bootstrap and standalone CLI-only distribution are out of scope for the
+current desktop distribution model. Linux package-manager publishing uses the
+signed APT repository decision documented in
 [Linux Package Manager Distribution](https://github.com/wardian-app/Wardian/blob/main/docs/specs/2026-06-11-linux-package-manager-distribution.md):
 use a signed APT repository as the first Linux package-manager channel, defer
 Flathub and Snap until Wardian has a deliberate sandbox/permission design, and
 keep AppImage as a direct-download artifact.
-The Phase 1 implementation is tracked in
-[#325](https://github.com/wardian-app/Wardian/issues/325).
 
 ## Generate Manifests
 
@@ -30,26 +27,26 @@ Run this only after the stable release workflow has published the GitHub
 Release and validated updater metadata.
 
 ```bash
-mkdir -p dist/package-managers/v0.3.6
-gh release view v0.3.6 --json tagName,assets > dist/package-managers/v0.3.6/assets.json
-npm run release:package-manifests -- --release-assets dist/package-managers/v0.3.6/assets.json --out dist/package-managers/v0.3.6
+mkdir -p dist/package-managers/vX.Y.Z
+gh release view vX.Y.Z --json tagName,assets > dist/package-managers/vX.Y.Z/assets.json
+npm run release:package-manifests -- --release-assets dist/package-managers/vX.Y.Z/assets.json --out dist/package-managers/vX.Y.Z
 ```
 
 PowerShell:
 
 ```powershell
-New-Item -ItemType Directory -Force dist/package-managers/v0.3.6 | Out-Null
-gh release view v0.3.6 --json tagName,assets > dist/package-managers/v0.3.6/assets.json
-npm run release:package-manifests -- --release-assets dist/package-managers/v0.3.6/assets.json --out dist/package-managers/v0.3.6
+New-Item -ItemType Directory -Force dist/package-managers/vX.Y.Z | Out-Null
+gh release view vX.Y.Z --json tagName,assets > dist/package-managers/vX.Y.Z/assets.json
+npm run release:package-manifests -- --release-assets dist/package-managers/vX.Y.Z/assets.json --out dist/package-managers/vX.Y.Z
 ```
 
 Generated files:
 
-- `dist/package-managers/v0.3.6/winget/WardianApp.Wardian.yaml`
-- `dist/package-managers/v0.3.6/winget/WardianApp.Wardian.locale.en-US.yaml`
-- `dist/package-managers/v0.3.6/winget/WardianApp.Wardian.installer.yaml`
-- `dist/package-managers/v0.3.6/homebrew/wardian.rb`
-- `dist/package-managers/v0.3.6/linux/install.md`
+- `dist/package-managers/vX.Y.Z/winget/WardianApp.Wardian.yaml`
+- `dist/package-managers/vX.Y.Z/winget/WardianApp.Wardian.locale.en-US.yaml`
+- `dist/package-managers/vX.Y.Z/winget/WardianApp.Wardian.installer.yaml`
+- `dist/package-managers/vX.Y.Z/homebrew/wardian.rb`
+- `dist/package-managers/vX.Y.Z/linux/install.md`
 
 The generator fails if a required asset is missing, lacks a SHA-256 digest, or
 does not point at the requested release tag.
@@ -60,19 +57,19 @@ Copy the generated winget files into a local clone of
 `microsoft/winget-pkgs` under:
 
 ```text
-manifests/w/WardianApp/Wardian/0.3.6/
+manifests/w/WardianApp/Wardian/X.Y.Z/
 ```
 
 Validate before submitting:
 
 ```bash
-winget validate manifests/w/WardianApp/Wardian/0.3.6
+winget validate manifests/w/WardianApp/Wardian/X.Y.Z
 ```
 
 PowerShell:
 
 ```powershell
-winget validate manifests\w\WardianApp\Wardian\0.3.6
+winget validate manifests\w\WardianApp\Wardian\X.Y.Z
 ```
 
 Submit through the normal `microsoft/winget-pkgs` PR flow or with
@@ -82,7 +79,7 @@ Submit through the normal `microsoft/winget-pkgs` PR flow or with
 
 The `wardian-app/homebrew-tap` repository owns the published Homebrew Cask.
 After a stable release, its **Update Wardian Cask** workflow can be run with a
-release tag such as `v0.3.6`. The main Wardian release workflow also dispatches
+release tag such as `vX.Y.Z`. The main Wardian release workflow also dispatches
 that tap workflow after stable publication when the Wardian repository has the
 Wardian release dispatch GitHub App configured. Set
 `WARDIAN_RELEASE_DISPATCH_APP_ID` as a repository variable and
@@ -91,7 +88,7 @@ installed on `wardian-app/homebrew-tap` with Actions write permission.
 
 The tap workflow reads the published Wardian release assets, rewrites
 `Casks/wardian.rb`, runs Homebrew audit, and opens a pull request in the tap.
-The generated `dist/package-managers/v0.3.6/homebrew/wardian.rb` file remains a
+The generated `dist/package-managers/vX.Y.Z/homebrew/wardian.rb` file remains a
 local fallback and a useful comparison artifact, but maintainers should prefer
 the tap workflow for published cask updates.
 
@@ -108,7 +105,7 @@ they must never point at prerelease or draft artifacts.
 
 ## Linux Direct Install
 
-Use `dist/package-managers/v0.3.6/linux/install.md` as the hash-verified Linux
+Use `dist/package-managers/vX.Y.Z/linux/install.md` as the hash-verified Linux
 install fallback for release notes and documentation. Debian/Ubuntu users should
 prefer the signed APT repository. Do not present direct `.deb` downloads as
 Flatpak, Snap, or AppImageUpdate.

--- a/docs/developer/tauri-command-reference.md
+++ b/docs/developer/tauri-command-reference.md
@@ -70,12 +70,15 @@ evidence or queue the interaction.
 
 - `load_watchlists`
 - `save_watchlists`
+- `load_watchlist_prefs`
+- `save_watchlist_prefs`
 - `load_queue_items`
 - `save_queue_items`
 - `load_queue_preferences`
 - `save_queue_preferences`
 - `load_agent_interactions`
 - `save_agent_interactions`
+- `load_opencode_last_assistant_text`
 
 The CLI `team` and `watchlist` commands read and write `watchlists/index.json` directly. They normalize the current v2 state shape and legacy flat watchlist arrays for reads, write canonical v2 JSON for mutations, and best-effort notify the running app when the local control endpoint is available. Team create/add/split operations also seed communication-topology edges while preserving existing seed-suppression tombstones.
 
@@ -120,15 +123,21 @@ workflow system. Do not add new frontend behavior against those names.
 
 ## Library (`commands/library.rs`)
 
-- `get_library_tree`
+- `get_library_index`
+- `read_library_item`
 - `save_library_item`
 - `update_library_metadata`
+- `create_library_folder`
+- `rename_library_entry`
+- `delete_library_entry`
 - `open_library_folder`
 - `deploy_skill`
 - `remove_deployed_skill`
 - `list_deployed_skills`
 - `list_deployed_skill_refs`
 - `list_skill_deployments`
+- `set_skill_deployments`
+- `remove_orphan_deployment`
 - `library_watch`
 - `library_unwatch`
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ This page maps Wardian's major capabilities to their detailed guides.
 ## Malleable Agent Environment
 
 - Local-first agent habitat where prompts, classes, skills, workflows, queue evidence, and memory-ready context are inspectable artifacts rather than opaque app-only state
-- Multiple lenses over shared Wardian state: desktop UI, CLI, Library, Workflows, Explorer, Queue, Graph, and future spatial views operate against the same canonical records
+- Multiple lenses over shared Wardian state: desktop UI, CLI, Library, Workflows, Explorer, Queue, Graph, and Garden operate against the same canonical records
 - Gentle slope from use to creation: run an agent, save a prompt, tune a class, deploy a skill, automate a workflow, then promote durable evidence into memory or project context
 - Explicit scopes for global, class, agent, team/project, workspace, and workflow-run context so reusable capabilities can be shared without losing provenance
 
@@ -23,7 +23,7 @@ Related docs:
 - Left control rail for spawning, commands, workflows, Explorer, and settings
 - Right roster with status lights, thought snippets, and agent working sets
 - Queue tab for unread agent completions and workflow outcomes
-- Roadmap direction: Sites, Cohorts, movable surfaces, Garden spatial organization, and Graph communication topology
+- Roadmap direction: Sites, Cohorts, movable surfaces, richer Garden spatial organization, and Graph communication topology
 
 Related docs:
 
@@ -37,7 +37,7 @@ Related docs:
 ## Agent Classes and Reusable Library
 
 - Class blueprints with instruction files and assigned skills
-- Prompt and skill management from a filesystem-backed library
+- Prompt, skill, class, and workflow-blueprint management from a filesystem-backed library
 - Starred prompts for one-click execution from the Command panel
 
 Related docs:

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -128,7 +128,7 @@ Open the **Agent Configuration** rail item and fill in the spawn form:
 
 ![Wardian spawn agent form with agent name, class, workspace, provider, and initialize controls](../assets/screenshots/spawn-agent/spawn-form.png)
 
-1. Choose an agent class, such as **Coder** or **Researcher**. Classes are reusable blueprints; see [Class Management](./class-management.md) when you want to inspect or customize them.
+1. Choose an agent class, such as **Coder** or **Researcher**. Classes are reusable blueprints; see [Class Management](./class-management.md) for the model and the [Library](./library.md#3-classes) when you want to inspect or customize them.
 2. Select the provider you installed and authenticated.
 3. Enter a short agent name.
 4. Set the workspace to `<absolute-workspace-path>`.
@@ -209,8 +209,8 @@ Related docs:
 
 - Learn the main windows in [UI Overview](./ui-overview.md).
 - Recover from first-run launch, provider, terminal, Queue, and CLI failures in [First-Run Troubleshooting](./first-run-troubleshooting.md).
-- Manage reusable prompts and skills in [Library](./library.md).
-- Inspect or customize agent classes in [Class Management](./class-management.md).
+- Manage reusable prompts, skills, classes, and workflow blueprints in [Library](./library.md).
+- Use [Class Management](./class-management.md) for class concepts; edit class instructions and class-level skills from the Library's Classes section.
 - Browse your agent's local files in [Explorer](./explorer.md).
 - Send one instruction to multiple agents with [Command Panel](./command-panel.md).
 - Use the agent-facing [Wardian CLI](./cli.md) for scripted coordination.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -16,11 +16,11 @@ Use this index to find the guide that matches the task you are trying to finish.
 - [Graph](./graph.md): inspect team, workspace, and worktree relationships between agents.
 - [Watchlists](./watchlists.md): group, select, sort, and monitor agents in the right roster.
 - [Queue](./queue.md): triage completed agent and workflow outcomes.
-- [Class Management](./class-management.md): define the blueprints used when spawning agents.
+- [Class Management](./class-management.md): understand class blueprints; edit them from the Library's Classes section.
 
 ## Reuse and Direct Work
 
-- [Library](./library.md): manage reusable prompts and skills.
+- [Library](./library.md): manage reusable prompts, skills, classes, workflow blueprints, and MCP placeholders.
 - [Command Panel](./command-panel.md): send one-off broadcasts or starred prompts to selected agents.
 - [Wardian CLI](./cli.md): let agents and automation inspect or control Wardian from a shell.
 

--- a/docs/guide/settings.md
+++ b/docs/guide/settings.md
@@ -55,7 +55,7 @@ notes that **Auto** prefers Claude when available.
 ## Updates
 
 The General category shows the currently running Wardian version, such as
-`Wardian v0.3.6`.
+`Wardian vX.Y.Z`.
 
 Wardian checks for updates silently when Settings loads. If no newer stable
 release is available, Settings shows that Wardian is up to date. If a newer

--- a/docs/guide/ui-overview.md
+++ b/docs/guide/ui-overview.md
@@ -14,14 +14,14 @@ The fixed header at the top of the application acts as the global navigation and
 - **Center (View Switcher)**: Quickly toggle between primary workspace modes:
   - **GRID**: The primary terminal workspace for live agent interaction.
   - **DASHBOARD**: A summary view of system health and active agent status.
-  - **LIBRARY**: Management center for prompts and skills.
+  - **LIBRARY**: Management center for prompts, skills, classes, workflow blueprints, and future MCP definitions.
   - **WORKFLOWS**: Visual canvas for building automated agent sequences.
   - **QUEUE / GRAPH / GARDEN**: Specialized views for completion triage, communication topology, and spatial agent organization.
 - **Right (Telemetry)**: Real-time monitoring of aggregate **CPU**, **Memory**, and **Active Agent** count.
 
 ![Wardian Dashboard view showing compact agent status rows and quick controls](../assets/screenshots/dashboard/system-summary.png)
 
-The **Graph** mode maps agents as status-colored nodes with relationship edges for same team, same project (same repository, following worktrees back to their source), and same folder (same physical checkout). Use the centered relationship lenses to focus the map, and open the inspector or context menu from any node to use the same agent actions available in the roster.
+The **Graph** mode maps agents as status-colored nodes with topology edges for manual connections and team-seeded communication links. It also offers read-only relationship lenses for same team, same project (same repository, following worktrees back to their source), and same folder (same physical checkout). Open the inspector or context menu from any node to use the same agent actions available in the roster.
 
 The **Garden** mode is a spatial canvas for organizing agents and workflows as draggable units (living orbs / pods) you arrange freely. Agent units display live status color; workflow units cluster in a shelf and show run state. Unit positions persist locally across restart. Only actively-processing units animate with a gentle pulse — the default is calm. Full agent session inspection still happens by opening the agent in Grid (Garden routes there), not inside Garden.
 


### PR DESCRIPTION
## Description
Refreshes Wardian's live documentation after the 0.4.x releases by replacing the early phase-based roadmap with current product direction and cleaning up stale references in public and developer docs.

Key changes:
- Replace README phase roadmap with non-phase product priorities.
- Rewrite ROADMAP.md as current product direction rather than historical phase tracking.
- Update live docs for Library scope, Garden status, Settings version examples, package-manager release examples, and the current Tauri Library command surface.

## Related Issues
Fixes #661

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run docs:build`
- `npm run docs:check-llms`
- `npm run lint`
- `npm run test` (first full run had a non-reproducible `src/main.test.tsx` timeout; isolated rerun passed, second full run passed: 134 files, 1479 passed, 1 skipped)
- `npm run build`
- `cd src-tauri && cargo check`
- `cd src-tauri && cargo clippy`
- `cd src-tauri && cargo test`
- `git diff --check`

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Feature-specific screenshot evidence is embedded above, or not applicable