### PR TITLE
feat(cli): add Library agent capabilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,11 @@ Before requesting a commit or finalizing a task, ensure the following steps are 
    - [ ] **Git Status**: Run `git status` to ensure only intended files are staged.
    - [ ] **Commit Message**: Use a clear, semantic commit message (e.g., `feat(workflows): implement parallel execution`).
 
+### PowerShell Home Safety
+- PowerShell variable names are case-insensitive: `$home` is the built-in `$HOME` variable and points to the OS user profile. Never assign to or reuse `$home` as a scratch, test, temporary, or Wardian-home variable. Use a descriptive name such as `$testHome`, `$wardianHome`, or `$tempRoot`.
+- Never pass `$HOME`, `$home`, `$env:USERPROFILE`, `~`, or a path derived only from one of them to a recursive delete or move. Commands such as `Remove-Item $home -Recurse -Force` are forbidden under all circumstances.
+- Before any recursive delete or move, resolve the intended target to an absolute path, verify that it is inside the workspace or an explicitly created temporary directory, and abort if assignment or path resolution failed. Filesystem mutation scripts must fail closed instead of continuing after a setup error.
+
 ### Cross-Platform Documentation
 - User-facing docs, bundled skills, examples, and agent instructions must be cross-OS and cross-computer by default.
 - Use placeholders such as `<absolute-workspace-path>` instead of local machine paths, drive-letter paths, or user-home paths.

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -552,6 +552,17 @@ pub enum AgentCommand {
         #[arg(long)]
         workspace: Option<String>,
     },
+    /// Update live agent configuration without restarting the provider process.
+    Update {
+        /// Agent name or UUID.
+        target: String,
+        /// Assign an existing class and regenerate its instruction include directories.
+        #[arg(long, required_unless_present = "workspace")]
+        class: Option<String>,
+        /// Move an ordinary agent workspace to an existing path.
+        #[arg(long, required_unless_present = "class")]
+        workspace: Option<String>,
+    },
     Clone {
         target: String,
         #[arg(long)]
@@ -616,6 +627,40 @@ mod tests {
     fn parses_agent_target_shorthand() {
         let cli = Cli::try_parse_from(["wardian", "agent", "coder-a1"]).unwrap();
         assert!(matches!(cli.command, Command::Agent(_)));
+    }
+
+    #[test]
+    fn parses_agent_update_and_requires_a_change() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "agent",
+            "update",
+            "coder-a1",
+            "--class",
+            "Reviewer",
+            "--workspace",
+            "D:/Development/Wardian",
+        ])
+        .unwrap();
+        let Command::Agent(args) = cli.command else {
+            panic!("expected Agent")
+        };
+        assert!(matches!(
+            args.command,
+            Some(AgentCommand::Update {
+                ref target,
+                class: Some(ref class),
+                workspace: Some(ref workspace),
+            }) if target == "coder-a1"
+                && class == "Reviewer"
+                && workspace == "D:/Development/Wardian"
+        ));
+
+        let error = Cli::try_parse_from(["wardian", "agent", "update", "coder-a1"]).unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
     }
 
     #[test]

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -83,8 +83,10 @@ pub enum LibraryCommand {
     },
     Deploy {
         skill_ref: String,
-        #[arg(long)]
-        targets: String,
+        #[arg(long, required_unless_present = "clear", conflicts_with = "clear")]
+        targets: Option<String>,
+        #[arg(long, required_unless_present = "targets", conflicts_with = "targets")]
+        clear: bool,
     },
     Orphans,
     Orphan {
@@ -738,8 +740,9 @@ mod tests {
         };
         assert!(matches!(
             args.command,
-            LibraryCommand::Deploy { ref skill_ref, ref targets }
-                if skill_ref == "skills/planner" && targets == "user:global,class:Reviewer"
+            LibraryCommand::Deploy { ref skill_ref, ref targets, clear: false }
+                if skill_ref == "skills/planner"
+                    && targets.as_deref() == Some("user:global,class:Reviewer")
         ));
 
         let cli = Cli::try_parse_from([
@@ -762,6 +765,36 @@ mod tests {
                 command: LibraryOrphanCommand::Delete { ref target, ref skill }
             } if target == "class:Reviewer" && skill == "planner"
         ));
+    }
+
+    #[test]
+    fn parses_library_deploy_clear_as_explicit_empty_set() {
+        let cli =
+            Cli::try_parse_from(["wardian", "library", "deploy", "skills/planner", "--clear"])
+                .unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::Deploy {
+                ref skill_ref,
+                targets: None,
+                clear: true
+            } if skill_ref == "skills/planner"
+        ));
+
+        assert!(Cli::try_parse_from(["wardian", "library", "deploy", "skills/planner",]).is_err());
+        assert!(Cli::try_parse_from([
+            "wardian",
+            "library",
+            "deploy",
+            "skills/planner",
+            "--clear",
+            "--targets",
+            "user:global",
+        ])
+        .is_err());
     }
 
     #[test]

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -11,6 +11,7 @@ pub struct Cli {
 pub enum Command {
     Agent(AgentArgs),
     Conversation(ConversationArgs),
+    Library(LibraryArgs),
     Workflow(WorkflowArgs),
     Team(TeamArgs),
     Watchlist(WatchlistArgs),
@@ -18,6 +19,91 @@ pub enum Command {
     Send(SendArgs),
     Ask(AskArgs),
     Reply(ReplyArgs),
+}
+
+// ---------------------------------------------------------------------------
+// wardian library
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct LibraryArgs {
+    #[command(subcommand)]
+    pub command: LibraryCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LibraryCommand {
+    List {
+        section: Option<String>,
+        #[arg(long)]
+        flat: bool,
+    },
+    Show {
+        entry_ref: String,
+        #[arg(long)]
+        content: bool,
+    },
+    Read {
+        entry_ref: String,
+    },
+    Create {
+        entry_ref: String,
+        #[arg(long, conflicts_with = "file")]
+        stdin: bool,
+        #[arg(long, conflicts_with = "stdin")]
+        file: Option<String>,
+    },
+    Write {
+        entry_ref: String,
+        #[arg(long, conflicts_with = "file")]
+        stdin: bool,
+        #[arg(long, conflicts_with = "stdin")]
+        file: Option<String>,
+    },
+    Move {
+        from_ref: String,
+        to_ref: String,
+    },
+    Delete {
+        entry_ref: String,
+    },
+    Star {
+        entry_ref: String,
+    },
+    Unstar {
+        entry_ref: String,
+    },
+    Tags {
+        entry_ref: String,
+        #[arg(long = "set", required = true)]
+        set: Vec<String>,
+    },
+    Deployments {
+        skill_ref: String,
+    },
+    Deploy {
+        skill_ref: String,
+        #[arg(long)]
+        targets: String,
+    },
+    Orphans,
+    Orphan {
+        #[command(subcommand)]
+        command: LibraryOrphanCommand,
+    },
+    RestoreDefault {
+        entry_ref: String,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LibraryOrphanCommand {
+    Delete {
+        #[arg(long)]
+        target: String,
+        #[arg(long)]
+        skill: String,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -519,6 +605,163 @@ mod tests {
     fn parses_agent_target_shorthand() {
         let cli = Cli::try_parse_from(["wardian", "agent", "coder-a1"]).unwrap();
         assert!(matches!(cli.command, Command::Agent(_)));
+    }
+
+    #[test]
+    fn parses_library_list_show_and_read() {
+        let cli = Cli::try_parse_from(["wardian", "library", "list", "skills", "--flat"]).unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::List {
+                section: Some(ref section),
+                flat: true
+            } if section == "skills"
+        ));
+
+        let cli =
+            Cli::try_parse_from(["wardian", "library", "show", "workflows/audit.md"]).unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::Show {
+                ref entry_ref,
+                content: false
+            } if entry_ref == "workflows/audit.md"
+        ));
+
+        let cli = Cli::try_parse_from(["wardian", "library", "read", "classes/Reviewer"]).unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::Read { ref entry_ref } if entry_ref == "classes/Reviewer"
+        ));
+    }
+
+    #[test]
+    fn library_create_rejects_stdin_and_file_together() {
+        let error = Cli::try_parse_from([
+            "wardian",
+            "library",
+            "create",
+            "prompts/triage.md",
+            "--stdin",
+            "--file",
+            "triage.md",
+        ])
+        .unwrap_err();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn parses_library_mutations_metadata_and_deployments() {
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "library",
+            "create",
+            "prompts/triage.md",
+            "--stdin",
+        ])
+        .unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::Create {
+                ref entry_ref,
+                stdin: true,
+                file: None
+            } if entry_ref == "prompts/triage.md"
+        ));
+
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "library",
+            "write",
+            "skills/planner",
+            "--file",
+            "SKILL.md",
+        ])
+        .unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::Write {
+                ref entry_ref,
+                stdin: false,
+                ref file
+            } if entry_ref == "skills/planner" && file.as_deref() == Some("SKILL.md")
+        ));
+
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "library",
+            "tags",
+            "skills/planner",
+            "--set",
+            "review",
+            "--set",
+            "daily",
+        ])
+        .unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::Tags { ref entry_ref, ref set }
+                if entry_ref == "skills/planner"
+                    && set == &vec!["review".to_string(), "daily".to_string()]
+        ));
+
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "library",
+            "deploy",
+            "skills/planner",
+            "--targets",
+            "user:global,class:Reviewer",
+        ])
+        .unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::Deploy { ref skill_ref, ref targets }
+                if skill_ref == "skills/planner" && targets == "user:global,class:Reviewer"
+        ));
+
+        let cli = Cli::try_parse_from([
+            "wardian",
+            "library",
+            "orphan",
+            "delete",
+            "--target",
+            "class:Reviewer",
+            "--skill",
+            "planner",
+        ])
+        .unwrap();
+        let Command::Library(args) = cli.command else {
+            panic!("expected Library")
+        };
+        assert!(matches!(
+            args.command,
+            LibraryCommand::Orphan {
+                command: LibraryOrphanCommand::Delete { ref target, ref skill }
+            } if target == "class:Reviewer" && skill == "planner"
+        ));
     }
 
     #[test]

--- a/crates/wardian-cli/src/args.rs
+++ b/crates/wardian-cli/src/args.rs
@@ -33,19 +33,24 @@ pub struct LibraryArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum LibraryCommand {
+    /// List Library entries as a tree or agent-friendly flat rows.
     List {
+        /// Optional section: skills, prompts, classes, workflows, or mcps.
         section: Option<String>,
+        /// Emit entries only, without tree, deployment, or orphan payloads.
         #[arg(long)]
         flat: bool,
     },
+    /// Show one entry's metadata, resolved path, and optional content.
     Show {
+        /// Section-qualified ref such as skills/review/planner.
         entry_ref: String,
         #[arg(long)]
         content: bool,
     },
-    Read {
-        entry_ref: String,
-    },
+    /// Print one entry's raw content without a JSON envelope.
+    Read { entry_ref: String },
+    /// Create an entry. Workflow files are authored here; use wardian workflow for operations.
     Create {
         entry_ref: String,
         #[arg(long, conflicts_with = "file")]
@@ -53,6 +58,7 @@ pub enum LibraryCommand {
         #[arg(long, conflicts_with = "stdin")]
         file: Option<String>,
     },
+    /// Replace the content of an existing entry.
     Write {
         entry_ref: String,
         #[arg(long, conflicts_with = "file")]
@@ -60,49 +66,52 @@ pub enum LibraryCommand {
         #[arg(long, conflicts_with = "stdin")]
         file: Option<String>,
     },
-    Move {
-        from_ref: String,
-        to_ref: String,
-    },
-    Delete {
-        entry_ref: String,
-    },
-    Star {
-        entry_ref: String,
-    },
-    Unstar {
-        entry_ref: String,
-    },
+    /// Rename or move an entry within its current section.
+    Move { from_ref: String, to_ref: String },
+    /// Delete an entry and its associated Library metadata.
+    Delete { entry_ref: String },
+    /// Mark an entry as starred.
+    Star { entry_ref: String },
+    /// Remove an entry's starred state.
+    Unstar { entry_ref: String },
+    /// Replace all tags on an entry.
     Tags {
         entry_ref: String,
+        /// Complete tag set; repeat --set for multiple tags.
         #[arg(long = "set", required = true)]
         set: Vec<String>,
     },
-    Deployments {
-        skill_ref: String,
-    },
+    /// Show every current deployment target for one skill.
+    Deployments { skill_ref: String },
+    /// Reconcile a skill to the complete desired target set.
     Deploy {
         skill_ref: String,
+        /// Non-empty comma-separated user, class, and agent target refs.
         #[arg(long, required_unless_present = "clear", conflicts_with = "clear")]
         targets: Option<String>,
+        /// Reconcile to an empty desired set, removing every deployment.
         #[arg(long, required_unless_present = "targets", conflicts_with = "targets")]
         clear: bool,
     },
+    /// List deployed skill directories whose Library source is missing.
     Orphans,
+    /// Manage unresolved deployed skill directories.
     Orphan {
         #[command(subcommand)]
         command: LibraryOrphanCommand,
     },
-    RestoreDefault {
-        entry_ref: String,
-    },
+    /// Restore the bundled instructions for a default class.
+    RestoreDefault { entry_ref: String },
 }
 
 #[derive(Debug, Subcommand)]
 pub enum LibraryOrphanCommand {
+    /// Delete one deployment only if it is currently reported as orphaned.
     Delete {
+        /// Target ref such as user:global or class:Reviewer.
         #[arg(long)]
         target: String,
+        /// Deployed skill directory name.
         #[arg(long)]
         skill: String,
     },
@@ -795,6 +804,25 @@ mod tests {
             "user:global",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn library_help_describes_agent_contracts() {
+        let library_help = Cli::try_parse_from(["wardian", "library", "--help"])
+            .unwrap_err()
+            .to_string();
+        assert!(library_help.contains("List Library entries"));
+
+        let deploy_help = Cli::try_parse_from(["wardian", "library", "deploy", "--help"])
+            .unwrap_err()
+            .to_string();
+        assert!(deploy_help.contains("complete desired target set"));
+        assert!(deploy_help.contains("--clear"));
+
+        let create_help = Cli::try_parse_from(["wardian", "library", "create", "--help"])
+            .unwrap_err()
+            .to_string();
+        assert!(create_help.contains("wardian workflow"));
     }
 
     #[test]

--- a/crates/wardian-cli/src/errors.rs
+++ b/crates/wardian-cli/src/errors.rs
@@ -74,6 +74,16 @@ impl CliError {
         }
     }
 
+    pub fn library_not_found(entry_ref: &str) -> Self {
+        Self {
+            exit_code: ExitCode::NotFound,
+            code: "not_found",
+            message: format!("Library entry was not found: {entry_ref}"),
+            hint: Some("Run `wardian library list --flat` to inspect known entries.".to_string()),
+            details: Some(Box::new(serde_json::json!({ "entry_ref": entry_ref }))),
+        }
+    }
+
     pub fn db_unavailable(message: impl Into<String>) -> Self {
         Self {
             exit_code: ExitCode::DbUnavailable,
@@ -94,6 +104,59 @@ impl CliError {
             message: format!("Unknown field: {field}"),
             hint: Some("Use one of: name, uuid, class, provider, workspace, status, status_source, pid, started_at, last_status_at.".to_string()),
             details: Some(Box::new(serde_json::json!({ "field": field }))),
+        }
+    }
+
+    pub fn invalid_ref(message: impl Into<String>) -> Self {
+        Self {
+            exit_code: ExitCode::Generic,
+            code: "invalid_ref",
+            message: message.into(),
+            hint: Some(
+                "Use a section-qualified ref such as skills/review/planner or classes/Reviewer."
+                    .to_string(),
+            ),
+            details: None,
+        }
+    }
+
+    pub fn unknown_section(section: &str) -> Self {
+        Self {
+            exit_code: ExitCode::Generic,
+            code: "unknown_section",
+            message: format!("Unknown library section: {section}"),
+            hint: Some("Use one of: skills, prompts, classes, workflows, mcps.".to_string()),
+            details: Some(Box::new(serde_json::json!({ "section": section }))),
+        }
+    }
+
+    pub fn already_exists(entry_ref: &str) -> Self {
+        Self {
+            exit_code: ExitCode::Generic,
+            code: "already_exists",
+            message: format!("Library entry already exists: {entry_ref}"),
+            hint: Some("Use `wardian library write` to update an existing entry.".to_string()),
+            details: Some(Box::new(serde_json::json!({ "entry_ref": entry_ref }))),
+        }
+    }
+
+    pub fn not_supported(message: impl Into<String>) -> Self {
+        Self {
+            exit_code: ExitCode::Generic,
+            code: "not_supported",
+            message: message.into(),
+            hint: None,
+            details: None,
+        }
+    }
+
+    pub fn invalid_target(target: &str) -> Self {
+        Self {
+            exit_code: ExitCode::Generic,
+            code: "invalid_target",
+            message: format!("Invalid library deployment target: {target}"),
+            hint: Some("Use user:global, class:<ClassName>, or agent:<agent-id>.".to_string()),
+            details: Some(Box::new(serde_json::json!({ "target": target }))),
         }
     }
 

--- a/crates/wardian-cli/src/library.rs
+++ b/crates/wardian-cli/src/library.rs
@@ -1,0 +1,767 @@
+use crate::{
+    args::{LibraryArgs, LibraryCommand, LibraryOrphanCommand},
+    errors::CliError,
+};
+use std::io::Read as _;
+use std::path::{Component, Path, PathBuf};
+use wardian_core::library::{self, LibrarySectionId, DEPLOYED_SKILL_SOURCE_FILE};
+use wardian_core::models::{LibraryEntry, LibraryIndexNode, LibraryItemMetadata, SkillDeployment};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LibraryRef {
+    section: LibrarySectionId,
+    rel_path: String,
+    entry_ref: String,
+}
+
+pub fn handle_library(args: LibraryArgs) -> Result<String, CliError> {
+    match args.command {
+        LibraryCommand::List { section, flat } => handle_list(section.as_deref(), flat),
+        LibraryCommand::Show { entry_ref, content } => handle_show(&entry_ref, content),
+        LibraryCommand::Read { entry_ref } => handle_read(&entry_ref),
+        LibraryCommand::Create {
+            entry_ref,
+            stdin,
+            file,
+        } => handle_create(&entry_ref, stdin, file.as_deref()),
+        LibraryCommand::Write {
+            entry_ref,
+            stdin,
+            file,
+        } => handle_write(&entry_ref, stdin, file.as_deref()),
+        LibraryCommand::Move { from_ref, to_ref } => handle_move(&from_ref, &to_ref),
+        LibraryCommand::Delete { entry_ref } => handle_delete(&entry_ref),
+        LibraryCommand::RestoreDefault { entry_ref } => handle_restore_default(&entry_ref),
+        LibraryCommand::Star { entry_ref } => handle_star(&entry_ref, true),
+        LibraryCommand::Unstar { entry_ref } => handle_star(&entry_ref, false),
+        LibraryCommand::Tags { entry_ref, set } => handle_tags(&entry_ref, set),
+        LibraryCommand::Deployments { skill_ref } => handle_deployments(&skill_ref),
+        LibraryCommand::Deploy { skill_ref, targets } => handle_deploy(&skill_ref, &targets),
+        LibraryCommand::Orphans => handle_orphans(),
+        LibraryCommand::Orphan { command } => match command {
+            LibraryOrphanCommand::Delete { target, skill } => handle_orphan_delete(&target, &skill),
+        },
+    }
+}
+
+fn handle_list(section: Option<&str>, flat: bool) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let index = library::build_library_index(&home).map_err(CliError::generic)?;
+    if let Some(section_id) = parse_section(section)? {
+        let section_name = section_id.as_str();
+        let section = index
+            .sections
+            .get(section_name)
+            .ok_or_else(|| CliError::unknown_section(section_name))?;
+        let mut body = serde_json::json!({
+            "schema": 1,
+            "section": section_name,
+            "tree": section.tree,
+            "stubbed": section.stubbed,
+        });
+        if flat {
+            let mut entries = Vec::new();
+            flatten_entries(&section.tree.children, &mut entries);
+            body["entries"] = serde_json::json!(entries);
+        }
+        return render_json(body);
+    }
+
+    let body = serde_json::json!({
+        "schema": 1,
+        "sections": index.sections,
+        "deployments": index.deployments,
+        "orphans": index.orphans,
+    });
+    render_json(body)
+}
+
+fn handle_show(entry_ref: &str, include_content: bool) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let entry_ref = parse_library_ref(entry_ref)?;
+    reject_mcps(&entry_ref)?;
+    if !entry_exists(&home, &entry_ref) {
+        return Err(CliError::library_not_found(&entry_ref.entry_ref));
+    }
+
+    let entry = find_entry(&home, &entry_ref.entry_ref)?
+        .ok_or_else(|| CliError::library_not_found(&entry_ref.entry_ref))?;
+    let absolute_path = target_path_for_ref(&home, &entry_ref)?;
+    let absolute_path = display_path(&absolute_path);
+    let mut body =
+        serde_json::to_value(&entry).map_err(|error| CliError::generic(error.to_string()))?;
+    body["schema"] = serde_json::json!(1);
+    body["absolute_path"] = serde_json::json!(absolute_path.clone());
+    if entry_ref.section == LibrarySectionId::Workflows {
+        body["workflow_path"] = serde_json::json!(absolute_path);
+    }
+    if include_content {
+        body["content"] =
+            serde_json::json!(
+                library::read_item(&home, entry_ref.section, &entry_ref.rel_path)
+                    .map_err(CliError::generic)?
+            );
+    }
+    render_json(body)
+}
+
+fn handle_read(entry_ref: &str) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let entry_ref = parse_library_ref(entry_ref)?;
+    reject_mcps(&entry_ref)?;
+    if !entry_exists(&home, &entry_ref) {
+        return Err(CliError::library_not_found(&entry_ref.entry_ref));
+    }
+    library::read_item(&home, entry_ref.section, &entry_ref.rel_path).map_err(CliError::generic)
+}
+
+fn handle_create(entry_ref: &str, stdin: bool, file: Option<&str>) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let entry_ref = parse_library_ref(entry_ref)?;
+    reject_mcps(&entry_ref)?;
+    if entry_exists(&home, &entry_ref) {
+        return Err(CliError::already_exists(&entry_ref.entry_ref));
+    }
+    let content = read_content_arg(stdin, file)?;
+    if entry_ref.section == LibrarySectionId::Classes {
+        let description = class_description_from_content(&content);
+        wardian_core::classes::create_class(
+            &home,
+            &entry_ref.rel_path,
+            &description,
+            Some(&content),
+        )
+        .map_err(CliError::generic)?;
+    } else {
+        library::save_item(&home, entry_ref.section, &entry_ref.rel_path, &content)
+            .map_err(CliError::generic)?;
+    }
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "entry_ref": entry_ref.entry_ref,
+    }))
+}
+
+fn handle_write(entry_ref: &str, stdin: bool, file: Option<&str>) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let entry_ref = parse_library_ref(entry_ref)?;
+    reject_mcps(&entry_ref)?;
+    if !entry_exists(&home, &entry_ref) {
+        return Err(CliError::library_not_found(&entry_ref.entry_ref));
+    }
+    let content = read_content_arg(stdin, file)?;
+    library::save_item(&home, entry_ref.section, &entry_ref.rel_path, &content)
+        .map_err(CliError::generic)?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "entry_ref": entry_ref.entry_ref,
+    }))
+}
+
+fn handle_move(from_ref: &str, to_ref: &str) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let from_ref = parse_library_ref(from_ref)?;
+    let to_ref = parse_library_ref(to_ref)?;
+    reject_mcps(&from_ref)?;
+    reject_mcps(&to_ref)?;
+    if from_ref.section != to_ref.section {
+        return Err(CliError::invalid_ref(
+            "Moving library entries across sections is not supported",
+        ));
+    }
+    if from_ref.section == LibrarySectionId::Classes {
+        return Err(CliError::not_supported(
+            "Moving classes is not supported; create a new class and delete the old one if needed.",
+        ));
+    }
+    if !entry_exists(&home, &from_ref) {
+        return Err(CliError::library_not_found(&from_ref.entry_ref));
+    }
+    if entry_exists(&home, &to_ref) {
+        return Err(CliError::already_exists(&to_ref.entry_ref));
+    }
+    library::rename_entry(
+        &home,
+        from_ref.section,
+        &from_ref.rel_path,
+        &to_ref.rel_path,
+    )
+    .map_err(CliError::generic)?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "from_ref": from_ref.entry_ref,
+        "to_ref": to_ref.entry_ref,
+    }))
+}
+
+fn handle_delete(entry_ref: &str) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let entry_ref = parse_library_ref(entry_ref)?;
+    reject_mcps(&entry_ref)?;
+    if entry_ref.section == LibrarySectionId::Classes {
+        wardian_core::classes::delete_class(&home, &entry_ref.rel_path)
+            .map_err(CliError::generic)?;
+    } else {
+        if !entry_exists(&home, &entry_ref) {
+            return Err(CliError::library_not_found(&entry_ref.entry_ref));
+        }
+        library::delete_entry(&home, entry_ref.section, &entry_ref.rel_path)
+            .map_err(CliError::generic)?;
+    }
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "entry_ref": entry_ref.entry_ref,
+    }))
+}
+
+fn handle_restore_default(entry_ref: &str) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let entry_ref = parse_library_ref(entry_ref)?;
+    if entry_ref.section != LibrarySectionId::Classes {
+        return Err(CliError::invalid_ref(
+            "restore-default requires a classes/<Name> ref",
+        ));
+    }
+    wardian_core::classes::restore_default_instruction(&home, &entry_ref.rel_path)
+        .map_err(CliError::generic)?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "entry_ref": entry_ref.entry_ref,
+    }))
+}
+
+fn handle_star(entry_ref: &str, is_starred: bool) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let entry_ref = parse_library_ref(entry_ref)?;
+    reject_mcps(&entry_ref)?;
+    if !entry_exists(&home, &entry_ref) {
+        return Err(CliError::library_not_found(&entry_ref.entry_ref));
+    }
+
+    let mut metadata = current_metadata(&home, &entry_ref);
+    metadata.is_starred = is_starred;
+    write_metadata(&home, &entry_ref, metadata.clone())?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "entry_ref": entry_ref.entry_ref,
+        "is_starred": metadata.is_starred,
+        "tags": metadata.tags,
+    }))
+}
+
+fn handle_tags(entry_ref: &str, tags: Vec<String>) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let entry_ref = parse_library_ref(entry_ref)?;
+    reject_mcps(&entry_ref)?;
+    if !entry_exists(&home, &entry_ref) {
+        return Err(CliError::library_not_found(&entry_ref.entry_ref));
+    }
+
+    let mut metadata = current_metadata(&home, &entry_ref);
+    metadata.tags = tags
+        .into_iter()
+        .map(|tag| tag.trim().to_string())
+        .filter(|tag| !tag.is_empty())
+        .collect();
+    metadata.tags.sort();
+    metadata.tags.dedup();
+    write_metadata(&home, &entry_ref, metadata.clone())?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "entry_ref": entry_ref.entry_ref,
+        "is_starred": metadata.is_starred,
+        "tags": metadata.tags,
+    }))
+}
+
+fn handle_deployments(skill_ref: &str) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let skill_ref = parse_skill_ref(skill_ref)?;
+    if !entry_exists(&home, &skill_ref) {
+        return Err(CliError::library_not_found(&skill_ref.entry_ref));
+    }
+
+    let sources = library::collect_skill_sources(&home);
+    let scan = library::scan_deployments(&home, &sources);
+    let targets = scan
+        .deployments
+        .get(&skill_ref.rel_path)
+        .cloned()
+        .unwrap_or_default();
+    render_json(serde_json::json!({
+        "schema": 1,
+        "skill_ref": skill_ref.entry_ref,
+        "targets": targets,
+    }))
+}
+
+fn handle_deploy(skill_ref: &str, targets: &str) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let skill_ref = parse_skill_ref(skill_ref)?;
+    if !entry_exists(&home, &skill_ref) {
+        return Err(CliError::library_not_found(&skill_ref.entry_ref));
+    }
+    let targets = parse_target_refs(targets)?;
+    validate_deployment_targets(&home, &targets)?;
+    let outcome = library::set_skill_deployments(&home, &skill_ref.rel_path, &targets)
+        .map_err(CliError::generic)?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "skill_ref": skill_ref.entry_ref,
+        "targets": targets,
+        "outcome": outcome,
+    }))
+}
+
+fn handle_orphans() -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let sources = library::collect_skill_sources(&home);
+    let scan = library::scan_deployments(&home, &sources);
+    render_json(serde_json::json!({
+        "schema": 1,
+        "orphans": scan.orphans,
+    }))
+}
+
+fn handle_orphan_delete(target: &str, skill: &str) -> Result<String, CliError> {
+    let home = wardian_home()?;
+    let (target_type, target_id) = parse_target_ref(target)?;
+    library::remove_orphan_deployment(&home, &target_type, &target_id, skill)
+        .map_err(CliError::generic)?;
+    render_json(serde_json::json!({
+        "schema": 1,
+        "ok": true,
+        "target_type": target_type,
+        "target_id": target_id,
+        "skill": skill,
+    }))
+}
+
+fn parse_section(section: Option<&str>) -> Result<Option<LibrarySectionId>, CliError> {
+    section
+        .map(|section| {
+            LibrarySectionId::parse(section).ok_or_else(|| CliError::unknown_section(section))
+        })
+        .transpose()
+}
+
+fn parse_library_ref(value: &str) -> Result<LibraryRef, CliError> {
+    let trimmed = value.trim();
+    let (section_name, rel_path) = trimmed.split_once('/').ok_or_else(|| {
+        CliError::invalid_ref(format!("Library ref must include a section: {value}"))
+    })?;
+    let section = LibrarySectionId::parse(section_name)
+        .ok_or_else(|| CliError::unknown_section(section_name))?;
+    let rel_path = normalize_entry_path(rel_path)?;
+    Ok(LibraryRef {
+        section,
+        entry_ref: format!("{}/{}", section.as_str(), rel_path),
+        rel_path,
+    })
+}
+
+fn normalize_entry_path(rel_path: &str) -> Result<String, CliError> {
+    let normalized = rel_path.replace('\\', "/");
+    if normalized.trim().is_empty() {
+        return Err(CliError::invalid_ref(
+            "Library entry path must not be empty",
+        ));
+    }
+
+    let path = Path::new(&normalized);
+    if path.is_absolute() {
+        return Err(CliError::invalid_ref(format!(
+            "Library entry path must be relative: {rel_path}"
+        )));
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => {
+                let text = part.to_string_lossy();
+                if text.eq_ignore_ascii_case(DEPLOYED_SKILL_SOURCE_FILE) {
+                    return Err(CliError::invalid_ref(format!(
+                        "Reserved name in library entry path: {text}"
+                    )));
+                }
+            }
+            _ => {
+                return Err(CliError::invalid_ref(format!(
+                    "Invalid library entry path: {rel_path}"
+                )))
+            }
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn target_path_for_ref(home: &Path, entry: &LibraryRef) -> Result<PathBuf, CliError> {
+    library::resolve_entry_path(home, entry.section, &entry.rel_path).map_err(CliError::invalid_ref)
+}
+
+fn entry_exists(home: &Path, entry: &LibraryRef) -> bool {
+    match entry.section {
+        LibrarySectionId::Skills => target_path_for_ref(home, entry)
+            .map(|path| path.join("SKILL.md").is_file())
+            .unwrap_or(false),
+        LibrarySectionId::Prompts | LibrarySectionId::Workflows => target_path_for_ref(home, entry)
+            .map(|path| path.is_file())
+            .unwrap_or(false),
+        LibrarySectionId::Classes => target_path_for_ref(home, entry)
+            .map(|path| path.join("AGENTS.md").is_file())
+            .unwrap_or(false),
+        LibrarySectionId::Mcps => false,
+    }
+}
+
+fn parse_target_refs(value: &str) -> Result<Vec<SkillDeployment>, CliError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(CliError::invalid_target(value));
+    }
+
+    let mut targets = Vec::new();
+    for target in trimmed.split(',').map(str::trim) {
+        if target.is_empty() {
+            return Err(CliError::invalid_target(value));
+        }
+        let (target_type, target_id) = target
+            .split_once(':')
+            .ok_or_else(|| CliError::invalid_target(target))?;
+        match target_type {
+            "user" if target_id == "global" => targets.push(SkillDeployment {
+                target_type: "user".to_string(),
+                target_id: "global".to_string(),
+            }),
+            "class" if library::is_single_normal_component(target_id) => {
+                targets.push(SkillDeployment {
+                    target_type: "class".to_string(),
+                    target_id: target_id.to_string(),
+                });
+            }
+            "agent" if library::is_single_normal_component(target_id) => {
+                targets.push(SkillDeployment {
+                    target_type: "agent".to_string(),
+                    target_id: target_id.to_string(),
+                });
+            }
+            _ => return Err(CliError::invalid_target(target)),
+        }
+    }
+
+    Ok(targets)
+}
+
+fn parse_target_ref(value: &str) -> Result<(String, String), CliError> {
+    let mut targets = parse_target_refs(value)?;
+    if targets.len() != 1 {
+        return Err(CliError::invalid_target(value));
+    }
+    let target = targets.remove(0);
+    Ok((target.target_type, target.target_id))
+}
+
+fn parse_skill_ref(value: &str) -> Result<LibraryRef, CliError> {
+    let entry_ref = parse_library_ref(value)?;
+    if entry_ref.section != LibrarySectionId::Skills {
+        return Err(CliError::invalid_ref(
+            "Skill deployment commands require a skills/<path> ref",
+        ));
+    }
+    Ok(entry_ref)
+}
+
+fn validate_deployment_targets(home: &Path, targets: &[SkillDeployment]) -> Result<(), CliError> {
+    for target in targets {
+        let target_ref = format!("{}:{}", target.target_type, target.target_id);
+        match target.target_type.as_str() {
+            "user" if target.target_id == "global" => {}
+            "class" if class_target_exists(home, &target.target_id) => {}
+            "agent" if agent_target_exists(home, &target.target_id) => {}
+            _ => return Err(CliError::invalid_target(&target_ref)),
+        }
+    }
+    Ok(())
+}
+
+fn class_target_exists(home: &Path, class_name: &str) -> bool {
+    wardian_core::classes::load_class_definitions(home)
+        .map(|classes| {
+            classes
+                .iter()
+                .any(|class| class.name.eq_ignore_ascii_case(class_name))
+        })
+        .unwrap_or(false)
+        || home
+            .join("classes")
+            .join(class_name)
+            .join("AGENTS.md")
+            .is_file()
+}
+
+fn agent_target_exists(home: &Path, agent_id: &str) -> bool {
+    home.join("agents").join(agent_id).is_dir()
+        || persisted_agent_exists(home, agent_id)
+        || live_agent_exists(agent_id)
+}
+
+fn persisted_agent_exists(home: &Path, agent_id: &str) -> bool {
+    let path = home.join("state.db");
+    if !path.is_file() {
+        return false;
+    }
+    let Ok(conn) =
+        rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+    else {
+        return false;
+    };
+    wardian_core::db::get_agent_by_session_id_with_conn(&conn, agent_id)
+        .map(|agent| agent.is_some())
+        .unwrap_or(false)
+}
+
+fn live_agent_exists(agent_id: &str) -> bool {
+    crate::live::list_agents()
+        .map(|agents| agents.iter().any(|agent| agent.uuid == agent_id))
+        .unwrap_or(false)
+}
+
+fn current_metadata(home: &Path, entry_ref: &LibraryRef) -> LibraryItemMetadata {
+    library::MetadataStore::load(home)
+        .get(&entry_ref.entry_ref)
+        .cloned()
+        .unwrap_or_else(|| LibraryItemMetadata {
+            id: entry_ref.entry_ref.clone(),
+            tags: Vec::new(),
+            is_starred: false,
+            last_used: None,
+        })
+}
+
+fn write_metadata(
+    home: &Path,
+    entry_ref: &LibraryRef,
+    metadata: LibraryItemMetadata,
+) -> Result<(), CliError> {
+    library::update_metadata(home, &entry_ref.entry_ref, metadata).map_err(CliError::generic)
+}
+
+fn wardian_home() -> Result<PathBuf, CliError> {
+    wardian_core::paths::wardian_home()
+        .ok_or_else(|| CliError::generic("Could not resolve Wardian home directory"))
+}
+
+fn read_content_arg(stdin: bool, file: Option<&str>) -> Result<String, CliError> {
+    if stdin {
+        let mut content = String::new();
+        std::io::stdin()
+            .read_to_string(&mut content)
+            .map_err(|error| CliError::generic(error.to_string()))?;
+        return Ok(content);
+    }
+    if let Some(file) = file {
+        return std::fs::read_to_string(file).map_err(|error| CliError::generic(error.to_string()));
+    }
+    Err(CliError::generic("Specify --stdin or --file <path>"))
+}
+
+fn render_json(body: serde_json::Value) -> Result<String, CliError> {
+    serde_json::to_string_pretty(&body)
+        .map(|json| format!("{json}\n"))
+        .map_err(|error| CliError::generic(error.to_string()))
+}
+
+fn reject_mcps(entry_ref: &LibraryRef) -> Result<(), CliError> {
+    if entry_ref.section == LibrarySectionId::Mcps {
+        return Err(CliError::not_supported(
+            "The library mcps section is not implemented yet",
+        ));
+    }
+    Ok(())
+}
+
+fn find_entry(home: &Path, entry_ref: &str) -> Result<Option<LibraryEntry>, CliError> {
+    let index = library::build_library_index(home).map_err(CliError::generic)?;
+    Ok(index
+        .sections
+        .values()
+        .find_map(|section| find_entry_in_nodes(&section.tree.children, entry_ref)))
+}
+
+fn find_entry_in_nodes(nodes: &[LibraryIndexNode], entry_ref: &str) -> Option<LibraryEntry> {
+    for node in nodes {
+        match node {
+            LibraryIndexNode::Entry(entry) if entry.entry_ref == entry_ref => {
+                return Some(entry.clone());
+            }
+            LibraryIndexNode::Entry(_) => {}
+            LibraryIndexNode::Folder(folder) => {
+                if let Some(entry) = find_entry_in_nodes(&folder.children, entry_ref) {
+                    return Some(entry);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn flatten_entries(nodes: &[LibraryIndexNode], entries: &mut Vec<LibraryEntry>) {
+    for node in nodes {
+        match node {
+            LibraryIndexNode::Entry(entry) => entries.push(entry.clone()),
+            LibraryIndexNode::Folder(folder) => flatten_entries(&folder.children, entries),
+        }
+    }
+}
+
+fn class_description_from_content(content: &str) -> String {
+    content
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| line.trim_start_matches('#').trim().to_string())
+        .filter(|line| !line.is_empty())
+        .unwrap_or_else(|| "Custom agent class".to_string())
+}
+
+fn display_path(path: &Path) -> String {
+    path.components()
+        .collect::<PathBuf>()
+        .to_string_lossy()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wardian_core::library::LibrarySectionId;
+    use wardian_core::models::SkillDeployment;
+
+    #[test]
+    fn parse_library_ref_requires_known_section_and_relative_path() {
+        let parsed = parse_library_ref("skills/review/planner").expect("skill ref");
+
+        assert_eq!(parsed.section, LibrarySectionId::Skills);
+        assert_eq!(parsed.rel_path, "review/planner");
+        assert_eq!(parsed.entry_ref, "skills/review/planner");
+
+        assert_eq!(
+            parse_library_ref("planner").unwrap_err().code,
+            "invalid_ref"
+        );
+        assert_eq!(
+            parse_library_ref("plugins/planner").unwrap_err().code,
+            "unknown_section"
+        );
+        assert_eq!(
+            parse_library_ref("skills/../planner").unwrap_err().code,
+            "invalid_ref"
+        );
+    }
+
+    #[test]
+    fn parse_section_accepts_optional_known_sections() {
+        assert_eq!(parse_section(None).unwrap(), None);
+        assert_eq!(
+            parse_section(Some("classes")).unwrap(),
+            Some(LibrarySectionId::Classes)
+        );
+        assert_eq!(
+            parse_section(Some("plugins")).unwrap_err().code,
+            "unknown_section"
+        );
+    }
+
+    #[test]
+    fn target_path_and_entry_exists_respect_section_layout() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path();
+
+        std::fs::create_dir_all(home.join("library").join("skills").join("review"))
+            .expect("skills dir");
+        std::fs::write(
+            home.join("library")
+                .join("skills")
+                .join("review")
+                .join("planner")
+                .join("SKILL.md"),
+            "skill",
+        )
+        .expect_err("parent should not exist yet");
+        std::fs::create_dir_all(
+            home.join("library")
+                .join("skills")
+                .join("review")
+                .join("planner"),
+        )
+        .expect("skill dir");
+        std::fs::write(
+            home.join("library")
+                .join("skills")
+                .join("review")
+                .join("planner")
+                .join("SKILL.md"),
+            "skill",
+        )
+        .expect("skill file");
+        std::fs::create_dir_all(home.join("classes").join("Reviewer")).expect("class dir");
+        std::fs::write(
+            home.join("classes").join("Reviewer").join("AGENTS.md"),
+            "class",
+        )
+        .expect("class file");
+
+        let skill = parse_library_ref("skills/review/planner").unwrap();
+        let class = parse_library_ref("classes/Reviewer").unwrap();
+        let missing = parse_library_ref("workflows/missing.md").unwrap();
+
+        assert!(target_path_for_ref(home, &skill)
+            .unwrap()
+            .ends_with("library/skills/review/planner"));
+        assert!(entry_exists(home, &skill));
+        assert!(entry_exists(home, &class));
+        assert!(!entry_exists(home, &missing));
+    }
+
+    #[test]
+    fn parse_target_refs_accepts_user_class_and_agent_targets() {
+        assert_eq!(
+            parse_target_refs("user:global,class:Reviewer,agent:agent-1").unwrap(),
+            vec![
+                SkillDeployment {
+                    target_type: "user".to_string(),
+                    target_id: "global".to_string(),
+                },
+                SkillDeployment {
+                    target_type: "class".to_string(),
+                    target_id: "Reviewer".to_string(),
+                },
+                SkillDeployment {
+                    target_type: "agent".to_string(),
+                    target_id: "agent-1".to_string(),
+                },
+            ]
+        );
+        assert_eq!(parse_target_refs("").unwrap_err().code, "invalid_target");
+        assert_eq!(
+            parse_target_refs("user:global,").unwrap_err().code,
+            "invalid_target"
+        );
+        assert_eq!(
+            parse_target_refs("team:Review").unwrap_err().code,
+            "invalid_target"
+        );
+        assert_eq!(
+            parse_target_refs("class:../Reviewer").unwrap_err().code,
+            "invalid_target"
+        );
+    }
+}

--- a/crates/wardian-cli/src/library.rs
+++ b/crates/wardian-cli/src/library.rs
@@ -51,25 +51,51 @@ pub fn handle_library(args: LibraryArgs) -> Result<String, CliError> {
 
 fn handle_list(section: Option<&str>, flat: bool) -> Result<String, CliError> {
     let home = wardian_home()?;
+    let requested_section = parse_section(section)?;
+    if requested_section.is_none() || requested_section == Some(LibrarySectionId::Classes) {
+        initialize_classes(&home)?;
+    }
     let index = library::build_library_index(&home).map_err(CliError::generic)?;
-    if let Some(section_id) = parse_section(section)? {
+    if let Some(section_id) = requested_section {
         let section_name = section_id.as_str();
         let section = index
             .sections
             .get(section_name)
             .ok_or_else(|| CliError::unknown_section(section_name))?;
-        let mut body = serde_json::json!({
+        if flat {
+            let mut entries = Vec::new();
+            flatten_entries(&section.tree.children, &mut entries);
+            return render_json(serde_json::json!({
+                "schema": 1,
+                "section": section_name,
+                "stubbed": section.stubbed,
+                "entries": flat_entry_values(section_name, entries)?,
+            }));
+        }
+        return render_json(serde_json::json!({
             "schema": 1,
             "section": section_name,
             "tree": section.tree,
             "stubbed": section.stubbed,
-        });
-        if flat {
-            let mut entries = Vec::new();
-            flatten_entries(&section.tree.children, &mut entries);
-            body["entries"] = serde_json::json!(entries);
+        }));
+    }
+
+    if flat {
+        let mut entries = Vec::new();
+        for section_id in LibrarySectionId::ALL {
+            let section_name = section_id.as_str();
+            let section = index
+                .sections
+                .get(section_name)
+                .ok_or_else(|| CliError::unknown_section(section_name))?;
+            let mut section_entries = Vec::new();
+            flatten_entries(&section.tree.children, &mut section_entries);
+            entries.extend(flat_entry_values(section_name, section_entries)?);
         }
-        return render_json(body);
+        return render_json(serde_json::json!({
+            "schema": 1,
+            "entries": entries,
+        }));
     }
 
     let body = serde_json::json!({
@@ -84,6 +110,7 @@ fn handle_list(section: Option<&str>, flat: bool) -> Result<String, CliError> {
 fn handle_show(entry_ref: &str, include_content: bool) -> Result<String, CliError> {
     let home = wardian_home()?;
     let entry_ref = parse_library_ref(entry_ref)?;
+    initialize_class_ref(&home, &entry_ref)?;
     reject_mcps(&entry_ref)?;
     if !entry_exists(&home, &entry_ref) {
         return Err(CliError::library_not_found(&entry_ref.entry_ref));
@@ -113,6 +140,7 @@ fn handle_show(entry_ref: &str, include_content: bool) -> Result<String, CliErro
 fn handle_read(entry_ref: &str) -> Result<String, CliError> {
     let home = wardian_home()?;
     let entry_ref = parse_library_ref(entry_ref)?;
+    initialize_class_ref(&home, &entry_ref)?;
     reject_mcps(&entry_ref)?;
     if !entry_exists(&home, &entry_ref) {
         return Err(CliError::library_not_found(&entry_ref.entry_ref));
@@ -123,6 +151,7 @@ fn handle_read(entry_ref: &str) -> Result<String, CliError> {
 fn handle_create(entry_ref: &str, stdin: bool, file: Option<&str>) -> Result<String, CliError> {
     let home = wardian_home()?;
     let entry_ref = parse_library_ref(entry_ref)?;
+    initialize_class_ref(&home, &entry_ref)?;
     reject_mcps(&entry_ref)?;
     if entry_exists(&home, &entry_ref) {
         return Err(CliError::already_exists(&entry_ref.entry_ref));
@@ -153,6 +182,7 @@ fn handle_create(entry_ref: &str, stdin: bool, file: Option<&str>) -> Result<Str
 fn handle_write(entry_ref: &str, stdin: bool, file: Option<&str>) -> Result<String, CliError> {
     let home = wardian_home()?;
     let entry_ref = parse_library_ref(entry_ref)?;
+    initialize_class_ref(&home, &entry_ref)?;
     reject_mcps(&entry_ref)?;
     if !entry_exists(&home, &entry_ref) {
         return Err(CliError::library_not_found(&entry_ref.entry_ref));
@@ -173,6 +203,8 @@ fn handle_move(from_ref: &str, to_ref: &str) -> Result<String, CliError> {
     let home = wardian_home()?;
     let from_ref = parse_library_ref(from_ref)?;
     let to_ref = parse_library_ref(to_ref)?;
+    initialize_class_ref(&home, &from_ref)?;
+    initialize_class_ref(&home, &to_ref)?;
     reject_mcps(&from_ref)?;
     reject_mcps(&to_ref)?;
     if from_ref.section != to_ref.section {
@@ -211,6 +243,7 @@ fn handle_move(from_ref: &str, to_ref: &str) -> Result<String, CliError> {
 fn handle_delete(entry_ref: &str) -> Result<String, CliError> {
     let home = wardian_home()?;
     let entry_ref = parse_library_ref(entry_ref)?;
+    initialize_class_ref(&home, &entry_ref)?;
     reject_mcps(&entry_ref)?;
     if entry_ref.section == LibrarySectionId::Classes {
         wardian_core::classes::delete_class(&home, &entry_ref.rel_path)
@@ -232,6 +265,7 @@ fn handle_delete(entry_ref: &str) -> Result<String, CliError> {
 fn handle_restore_default(entry_ref: &str) -> Result<String, CliError> {
     let home = wardian_home()?;
     let entry_ref = parse_library_ref(entry_ref)?;
+    initialize_class_ref(&home, &entry_ref)?;
     if entry_ref.section != LibrarySectionId::Classes {
         return Err(CliError::invalid_ref(
             "restore-default requires a classes/<Name> ref",
@@ -249,6 +283,7 @@ fn handle_restore_default(entry_ref: &str) -> Result<String, CliError> {
 fn handle_star(entry_ref: &str, is_starred: bool) -> Result<String, CliError> {
     let home = wardian_home()?;
     let entry_ref = parse_library_ref(entry_ref)?;
+    initialize_class_ref(&home, &entry_ref)?;
     reject_mcps(&entry_ref)?;
     if !entry_exists(&home, &entry_ref) {
         return Err(CliError::library_not_found(&entry_ref.entry_ref));
@@ -269,6 +304,7 @@ fn handle_star(entry_ref: &str, is_starred: bool) -> Result<String, CliError> {
 fn handle_tags(entry_ref: &str, tags: Vec<String>) -> Result<String, CliError> {
     let home = wardian_home()?;
     let entry_ref = parse_library_ref(entry_ref)?;
+    initialize_class_ref(&home, &entry_ref)?;
     reject_mcps(&entry_ref)?;
     if !entry_exists(&home, &entry_ref) {
         return Err(CliError::library_not_found(&entry_ref.entry_ref));
@@ -500,6 +536,9 @@ fn parse_skill_ref(value: &str) -> Result<LibraryRef, CliError> {
 }
 
 fn validate_deployment_targets(home: &Path, targets: &[SkillDeployment]) -> Result<(), CliError> {
+    if targets.iter().any(|target| target.target_type == "class") {
+        initialize_classes(home)?;
+    }
     for target in targets {
         let target_ref = format!("{}:{}", target.target_type, target.target_id);
         match target.target_type.as_str() {
@@ -657,6 +696,34 @@ fn display_path(path: &Path) -> String {
         .collect::<PathBuf>()
         .to_string_lossy()
         .to_string()
+}
+
+fn initialize_classes(home: &Path) -> Result<(), CliError> {
+    wardian_core::classes::initialize_classes(home)
+        .map(|_| ())
+        .map_err(CliError::generic)
+}
+
+fn initialize_class_ref(home: &Path, entry_ref: &LibraryRef) -> Result<(), CliError> {
+    if entry_ref.section == LibrarySectionId::Classes {
+        initialize_classes(home)?;
+    }
+    Ok(())
+}
+
+fn flat_entry_values(
+    section: &str,
+    entries: Vec<LibraryEntry>,
+) -> Result<Vec<serde_json::Value>, CliError> {
+    entries
+        .into_iter()
+        .map(|entry| {
+            let mut value = serde_json::to_value(entry)
+                .map_err(|error| CliError::generic(error.to_string()))?;
+            value["section"] = serde_json::json!(section);
+            Ok(value)
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/wardian-cli/src/library.rs
+++ b/crates/wardian-cli/src/library.rs
@@ -122,6 +122,8 @@ fn handle_create(entry_ref: &str, stdin: bool, file: Option<&str>) -> Result<Str
     if entry_exists(&home, &entry_ref) {
         return Err(CliError::already_exists(&entry_ref.entry_ref));
     }
+    library::validate_entry_destination(&home, entry_ref.section, &entry_ref.rel_path)
+        .map_err(CliError::invalid_ref)?;
     let content = read_content_arg(stdin, file)?;
     if entry_ref.section == LibrarySectionId::Classes {
         let description = class_description_from_content(&content);
@@ -150,6 +152,8 @@ fn handle_write(entry_ref: &str, stdin: bool, file: Option<&str>) -> Result<Stri
     if !entry_exists(&home, &entry_ref) {
         return Err(CliError::library_not_found(&entry_ref.entry_ref));
     }
+    library::validate_entry_destination(&home, entry_ref.section, &entry_ref.rel_path)
+        .map_err(CliError::invalid_ref)?;
     let content = read_content_arg(stdin, file)?;
     library::save_item(&home, entry_ref.section, &entry_ref.rel_path, &content)
         .map_err(CliError::generic)?;
@@ -176,6 +180,8 @@ fn handle_move(from_ref: &str, to_ref: &str) -> Result<String, CliError> {
             "Moving classes is not supported; create a new class and delete the old one if needed.",
         ));
     }
+    library::validate_entry_destination(&home, to_ref.section, &to_ref.rel_path)
+        .map_err(CliError::invalid_ref)?;
     if !entry_exists(&home, &from_ref) {
         return Err(CliError::library_not_found(&from_ref.entry_ref));
     }

--- a/crates/wardian-cli/src/library.rs
+++ b/crates/wardian-cli/src/library.rs
@@ -2,6 +2,7 @@ use crate::{
     args::{LibraryArgs, LibraryCommand, LibraryOrphanCommand},
     errors::CliError,
 };
+use std::collections::HashSet;
 use std::io::Read as _;
 use std::path::{Component, Path, PathBuf};
 use wardian_core::library::{self, LibrarySectionId, DEPLOYED_SKILL_SOURCE_FILE};
@@ -36,7 +37,11 @@ pub fn handle_library(args: LibraryArgs) -> Result<String, CliError> {
         LibraryCommand::Unstar { entry_ref } => handle_star(&entry_ref, false),
         LibraryCommand::Tags { entry_ref, set } => handle_tags(&entry_ref, set),
         LibraryCommand::Deployments { skill_ref } => handle_deployments(&skill_ref),
-        LibraryCommand::Deploy { skill_ref, targets } => handle_deploy(&skill_ref, &targets),
+        LibraryCommand::Deploy {
+            skill_ref,
+            targets,
+            clear,
+        } => handle_deploy(&skill_ref, targets.as_deref(), clear),
         LibraryCommand::Orphans => handle_orphans(),
         LibraryCommand::Orphan { command } => match command {
             LibraryOrphanCommand::Delete { target, skill } => handle_orphan_delete(&target, &skill),
@@ -308,13 +313,17 @@ fn handle_deployments(skill_ref: &str) -> Result<String, CliError> {
     }))
 }
 
-fn handle_deploy(skill_ref: &str, targets: &str) -> Result<String, CliError> {
+fn handle_deploy(skill_ref: &str, targets: Option<&str>, clear: bool) -> Result<String, CliError> {
     let home = wardian_home()?;
     let skill_ref = parse_skill_ref(skill_ref)?;
     if !entry_exists(&home, &skill_ref) {
         return Err(CliError::library_not_found(&skill_ref.entry_ref));
     }
-    let targets = parse_target_refs(targets)?;
+    let targets = if clear {
+        Vec::new()
+    } else {
+        parse_target_refs(targets.unwrap_or_default())?
+    };
     validate_deployment_targets(&home, &targets)?;
     let outcome = library::set_skill_deployments(&home, &skill_ref.rel_path, &targets)
         .map_err(CliError::generic)?;
@@ -340,8 +349,13 @@ fn handle_orphans() -> Result<String, CliError> {
 fn handle_orphan_delete(target: &str, skill: &str) -> Result<String, CliError> {
     let home = wardian_home()?;
     let (target_type, target_id) = parse_target_ref(target)?;
-    library::remove_orphan_deployment(&home, &target_type, &target_id, skill)
+    let removed = library::remove_orphan_deployment(&home, &target_type, &target_id, skill)
         .map_err(CliError::generic)?;
+    if !removed {
+        return Err(CliError::library_not_found(&format!(
+            "orphan/{target}/{skill}"
+        )));
+    }
     render_json(serde_json::json!({
         "schema": 1,
         "ok": true,
@@ -435,6 +449,7 @@ fn parse_target_refs(value: &str) -> Result<Vec<SkillDeployment>, CliError> {
     }
 
     let mut targets = Vec::new();
+    let mut seen = HashSet::new();
     for target in trimmed.split(',').map(str::trim) {
         if target.is_empty() {
             return Err(CliError::invalid_target(value));
@@ -442,24 +457,23 @@ fn parse_target_refs(value: &str) -> Result<Vec<SkillDeployment>, CliError> {
         let (target_type, target_id) = target
             .split_once(':')
             .ok_or_else(|| CliError::invalid_target(target))?;
-        match target_type {
-            "user" if target_id == "global" => targets.push(SkillDeployment {
+        let deployment = match target_type {
+            "user" if target_id == "global" => SkillDeployment {
                 target_type: "user".to_string(),
                 target_id: "global".to_string(),
-            }),
-            "class" if library::is_single_normal_component(target_id) => {
-                targets.push(SkillDeployment {
-                    target_type: "class".to_string(),
-                    target_id: target_id.to_string(),
-                });
-            }
-            "agent" if library::is_single_normal_component(target_id) => {
-                targets.push(SkillDeployment {
-                    target_type: "agent".to_string(),
-                    target_id: target_id.to_string(),
-                });
-            }
+            },
+            "class" if library::is_single_normal_component(target_id) => SkillDeployment {
+                target_type: "class".to_string(),
+                target_id: target_id.to_string(),
+            },
+            "agent" if library::is_single_normal_component(target_id) => SkillDeployment {
+                target_type: "agent".to_string(),
+                target_id: target_id.to_string(),
+            },
             _ => return Err(CliError::invalid_target(target)),
+        };
+        if seen.insert((deployment.target_type.clone(), deployment.target_id.clone())) {
+            targets.push(deployment);
         }
     }
 

--- a/crates/wardian-cli/src/live.rs
+++ b/crates/wardian-cli/src/live.rs
@@ -5,11 +5,11 @@ use std::{
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
-    AgentListResponse, AgentResponse, AgentWatchResponse, AgentWorktreeListResponse,
-    AgentWorktreeMutationResponse, AgentWorktreeSummary, ApprovalAction, AskResponse,
-    ControlRequest, ConversationListResponse, ConversationShowResponse, DeliveryDetail,
-    MessageInputMode, MessageOrigin, QueuePolicy, ReplyResponse, ReplyStatus, SendMessageResponse,
-    StructuredReply, WatchEvent, WatchEvidenceError, WorkflowRunResponse,
+    AgentListResponse, AgentResponse, AgentUpdateResponse, AgentWatchResponse,
+    AgentWorktreeListResponse, AgentWorktreeMutationResponse, AgentWorktreeSummary, ApprovalAction,
+    AskResponse, ControlRequest, ConversationListResponse, ConversationShowResponse,
+    DeliveryDetail, MessageInputMode, MessageOrigin, QueuePolicy, ReplyResponse, ReplyStatus,
+    SendMessageResponse, StructuredReply, WatchEvent, WatchEvidenceError, WorkflowRunResponse,
 };
 use wardian_core::identity::AgentIdentity;
 
@@ -70,6 +70,7 @@ enum ControlOperation {
     AgentPause,
     AgentResume,
     AgentSpawn,
+    AgentUpdate,
     AgentClone,
     AgentWorktreeList,
     AgentWorktreeEnable,
@@ -304,6 +305,24 @@ pub fn agent_spawn(
     let resp: AgentResponse =
         serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))?;
     Ok(resp.agent)
+}
+
+pub fn agent_update(
+    target: &str,
+    class: Option<&str>,
+    workspace: Option<&str>,
+) -> io::Result<AgentUpdateResponse> {
+    let runtime = build_runtime()?;
+    let value = timeout_block(
+        &runtime,
+        ControlOperation::AgentUpdate,
+        send_request(ControlRequest::AgentUpdate {
+            target: target.to_string(),
+            class: class.map(str::to_string),
+            workspace: workspace.map(str::to_string),
+        }),
+    )?;
+    serde_json::from_value(value).map_err(|e| io::Error::other(e.to_string()))
 }
 
 pub fn agent_clone(target: &str, name: Option<&str>) -> io::Result<AgentIdentity> {
@@ -776,6 +795,7 @@ fn operation_timeout(operation: &ControlOperation) -> Duration {
         | ControlOperation::AgentPause
         | ControlOperation::AgentResume
         | ControlOperation::AgentSpawn
+        | ControlOperation::AgentUpdate
         | ControlOperation::AgentClone
         | ControlOperation::AgentWorktreeEnable
         | ControlOperation::AgentWorktreeJoin
@@ -1067,8 +1087,12 @@ mod tests {
     }
 
     #[test]
-    fn spawn_and_clone_use_longer_control_timeout() {
+    fn agent_mutations_use_longer_control_timeout() {
         assert!(operation_timeout(&ControlOperation::AgentSpawn) > CONTROL_TIMEOUT);
+        assert_eq!(
+            operation_timeout(&ControlOperation::AgentUpdate),
+            CONTROL_MUTATION_TIMEOUT
+        );
         assert!(operation_timeout(&ControlOperation::AgentClone) > CONTROL_TIMEOUT);
     }
 

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -197,6 +197,11 @@ fn handle_agent(args: AgentArgs) -> Result<String, CliError> {
             workspace.as_deref(),
             &args,
         ),
+        Some(AgentCommand::Update {
+            target,
+            class,
+            workspace,
+        }) => handle_agent_update(target, class.as_deref(), workspace.as_deref()),
         Some(AgentCommand::Clone { target, name }) => {
             handle_agent_clone(target, name.as_deref(), &args)
         }
@@ -272,6 +277,17 @@ fn handle_agent_spawn(
 ) -> Result<String, CliError> {
     let agent = live::agent_spawn(provider, class, name, workspace).map_err(control_error)?;
     render_show(&agent, &render_options(args))
+}
+
+fn handle_agent_update(
+    target: &str,
+    class: Option<&str>,
+    workspace: Option<&str>,
+) -> Result<String, CliError> {
+    let response = live::agent_update(target, class, workspace).map_err(control_error)?;
+    serde_json::to_string_pretty(&response)
+        .map(|json| format!("{json}\n"))
+        .map_err(|e| CliError::generic(e.to_string()))
 }
 
 fn handle_agent_clone(
@@ -1241,6 +1257,7 @@ fn control_error(e: std::io::Error) -> CliError {
         match endpoint_error.code() {
             "not_supported" => backend_error(ExitCode::Generic, "not_supported"),
             "not_found" => backend_error(ExitCode::NotFound, "not_found"),
+            "bad_request" => backend_error(ExitCode::Generic, "bad_request"),
             "request_failed" => backend_error(ExitCode::Generic, "request_failed"),
             "not_managed_worktree" => backend_error(ExitCode::Generic, "not_managed_worktree"),
             "watch_timeout" => backend_error(ExitCode::Generic, "watch_timeout"),
@@ -1764,6 +1781,20 @@ mod tests {
         assert_eq!(cli_error.code, "not_found");
         assert_eq!(cli_error.code_i32(), 2);
         assert!(cli_error.message.contains("ghost"));
+    }
+
+    #[test]
+    fn control_error_preserves_backend_bad_request_code() {
+        let error = std::io::Error::other(live::ControlEndpointError::new(
+            "bad_request",
+            "workspace must be an absolute directory",
+        ));
+
+        let cli_error = control_error(error);
+
+        assert_eq!(cli_error.code, "bad_request");
+        assert_eq!(cli_error.code_i32(), 1);
+        assert!(cli_error.message.contains("absolute directory"));
     }
 
     #[test]

--- a/crates/wardian-cli/src/main.rs
+++ b/crates/wardian-cli/src/main.rs
@@ -2,6 +2,7 @@ mod args;
 mod disk;
 mod errors;
 mod graph;
+mod library;
 mod live;
 mod output;
 mod watchlist;
@@ -47,6 +48,7 @@ fn run() -> i32 {
     let result = match cli.command {
         Command::Agent(args) => handle_agent(args),
         Command::Conversation(args) => handle_conversation(args),
+        Command::Library(args) => library::handle_library(args),
         Command::Workflow(args) => handle_workflow(args),
         Command::Team(args) => watchlist::handle_team(args),
         Command::Watchlist(args) => watchlist::handle_watchlist(args),

--- a/crates/wardian-cli/tests/library_cli.rs
+++ b/crates/wardian-cli/tests/library_cli.rs
@@ -1,0 +1,585 @@
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use tempfile::TempDir;
+
+fn bin() -> std::path::PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian-cli") {
+        return path.into();
+    }
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_wardian_cli") {
+        return path.into();
+    }
+
+    let exe = if cfg!(windows) {
+        "wardian-cli.exe"
+    } else {
+        "wardian-cli"
+    };
+    std::env::current_exe()
+        .unwrap()
+        .parent()
+        .and_then(|deps| deps.parent())
+        .unwrap()
+        .join(exe)
+}
+
+fn run(home: &std::path::Path, args: &[&str], stdin: Option<&str>) -> std::process::Output {
+    let mut command = Command::new(bin());
+    command
+        .args(args)
+        .env("WARDIAN_HOME", home)
+        .env_remove("WARDIAN_SESSION_ID");
+    if stdin.is_some() {
+        command.stdin(Stdio::piped());
+    }
+    command.output_with_stdin(stdin)
+}
+
+trait CommandWithStdin {
+    fn output_with_stdin(&mut self, stdin: Option<&str>) -> std::process::Output;
+}
+
+impl CommandWithStdin for Command {
+    fn output_with_stdin(&mut self, stdin: Option<&str>) -> std::process::Output {
+        self.stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut child = self.spawn().unwrap();
+        if let Some(stdin) = stdin {
+            let mut pipe = child.stdin.take().expect("stdin pipe");
+            pipe.write_all(stdin.as_bytes()).unwrap();
+        }
+        child.wait_with_output().unwrap()
+    }
+}
+
+fn assert_success_json(output: std::process::Output) -> serde_json::Value {
+    assert!(
+        output.status.success(),
+        "status: {:?}\nstderr: {}\nstdout: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+fn assert_success_text(output: std::process::Output) -> String {
+    assert!(
+        output.status.success(),
+        "status: {:?}\nstderr: {}\nstdout: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+fn assert_failure_json(output: std::process::Output) -> serde_json::Value {
+    assert!(
+        !output.status.success(),
+        "command unexpectedly succeeded: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    serde_json::from_slice(&output.stderr).unwrap()
+}
+
+fn seed_default_classes(home: &Path) {
+    let defaults = wardian_core::classes::default_class_definitions();
+    wardian_core::classes::save_class_definitions(home, &defaults).unwrap();
+}
+
+fn seed_agent(home: &Path, session_id: &str) {
+    let conn = rusqlite::Connection::open(home.join("state.db")).unwrap();
+    wardian_core::db::run_migrations(&conn).unwrap();
+    wardian_core::db::upsert_agent_with_conn(
+        &conn,
+        &wardian_core::db::AgentUpsert {
+            session_id,
+            session_name: "reviewer-a1",
+            agent_class: "Reviewer",
+            provider: "codex",
+            workspace: Some("<absolute-workspace-path>"),
+            project: Some("Wardian"),
+            is_off: false,
+            created_at: Some("2026-07-08T00:00:00.000Z"),
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn prompt_create_show_read_write_move_delete_round_trip() {
+    let home = TempDir::new().unwrap();
+
+    let created = assert_success_json(run(
+        home.path(),
+        &["library", "create", "prompts/triage.md", "--stdin"],
+        Some("# Triage\n\nInitial prompt\n"),
+    ));
+    assert_eq!(created["ok"], true);
+    assert_eq!(created["entry_ref"], "prompts/triage.md");
+
+    let duplicate = assert_failure_json(run(
+        home.path(),
+        &["library", "create", "prompts/triage.md", "--stdin"],
+        Some("duplicate"),
+    ));
+    assert_eq!(duplicate["error"]["code"], "already_exists");
+
+    let shown = assert_success_json(run(
+        home.path(),
+        &["library", "show", "prompts/triage.md", "--content"],
+        None,
+    ));
+    assert_eq!(shown["entry_ref"], "prompts/triage.md");
+    assert_eq!(shown["kind"], "prompt");
+    assert_eq!(shown["content"], "# Triage\n\nInitial prompt\n");
+
+    let read = assert_success_text(run(
+        home.path(),
+        &["library", "read", "prompts/triage.md"],
+        None,
+    ));
+    assert_eq!(read, "# Triage\n\nInitial prompt\n");
+
+    let written = assert_success_json(run(
+        home.path(),
+        &["library", "write", "prompts/triage.md", "--stdin"],
+        Some("# Triage\n\nUpdated prompt\n"),
+    ));
+    assert_eq!(written["ok"], true);
+
+    let moved = assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "move",
+            "prompts/triage.md",
+            "prompts/daily-triage.md",
+        ],
+        None,
+    ));
+    assert_eq!(moved["from_ref"], "prompts/triage.md");
+    assert_eq!(moved["to_ref"], "prompts/daily-triage.md");
+
+    let old_read = assert_failure_json(run(
+        home.path(),
+        &["library", "read", "prompts/triage.md"],
+        None,
+    ));
+    assert_eq!(old_read["error"]["code"], "not_found");
+
+    let deleted = assert_success_json(run(
+        home.path(),
+        &["library", "delete", "prompts/daily-triage.md"],
+        None,
+    ));
+    assert_eq!(deleted["ok"], true);
+    assert!(!home
+        .path()
+        .join("library")
+        .join("prompts")
+        .join("daily-triage.md")
+        .exists());
+}
+
+#[test]
+fn list_flat_outputs_section_entries() {
+    let home = TempDir::new().unwrap();
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/review/planner", "--stdin"],
+        Some("---\ndescription: Plans reviews\n---\n# Planner\n"),
+    ));
+
+    let listed = assert_success_json(run(
+        home.path(),
+        &["library", "list", "skills", "--flat"],
+        None,
+    ));
+
+    assert_eq!(listed["schema"], 1);
+    assert_eq!(listed["section"], "skills");
+    assert_eq!(listed["entries"][0]["entry_ref"], "skills/review/planner");
+    assert_eq!(listed["entries"][0]["description"], "Plans reviews");
+}
+
+#[test]
+fn workflow_show_includes_absolute_workflow_path_but_does_not_validate() {
+    let home = TempDir::new().unwrap();
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "workflows/review/audit.md", "--stdin"],
+        Some("not valid workflow yaml"),
+    ));
+
+    let shown = assert_success_json(run(
+        home.path(),
+        &["library", "show", "workflows/review/audit.md"],
+        None,
+    ));
+
+    let workflow_path = shown["workflow_path"].as_str().unwrap();
+    assert!(
+        workflow_path.ends_with("library/workflows/review/audit.md")
+            || workflow_path.ends_with("library\\workflows\\review\\audit.md")
+    );
+    assert_eq!(shown["entry_ref"], "workflows/review/audit.md");
+    assert!(shown.get("diagnostics").is_none());
+}
+
+#[test]
+fn star_unstar_and_tags_update_metadata() {
+    let home = TempDir::new().unwrap();
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "prompts/triage.md", "--stdin"],
+        Some("# Triage\n"),
+    ));
+
+    let starred = assert_success_json(run(
+        home.path(),
+        &["library", "star", "prompts/triage.md"],
+        None,
+    ));
+    assert_eq!(starred["is_starred"], true);
+
+    let tagged = assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "tags",
+            "prompts/triage.md",
+            "--set",
+            "ops",
+            "--set",
+            "review",
+            "--set",
+            "ops",
+        ],
+        None,
+    ));
+    assert_eq!(tagged["tags"], serde_json::json!(["ops", "review"]));
+
+    let shown = assert_success_json(run(
+        home.path(),
+        &["library", "show", "prompts/triage.md"],
+        None,
+    ));
+    assert_eq!(shown["is_starred"], true);
+    assert_eq!(shown["tags"], serde_json::json!(["ops", "review"]));
+
+    let unstarred = assert_success_json(run(
+        home.path(),
+        &["library", "unstar", "prompts/triage.md"],
+        None,
+    ));
+    assert_eq!(unstarred["is_starred"], false);
+}
+
+#[test]
+fn deploy_reconciles_complete_target_set() {
+    let home = TempDir::new().unwrap();
+    seed_default_classes(home.path());
+    seed_agent(home.path(), "agent-1");
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/review/planner", "--stdin"],
+        Some("# Planner\n"),
+    ));
+
+    let deployed = assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "user:global,class:Reviewer,agent:agent-1",
+        ],
+        None,
+    ));
+    assert_eq!(deployed["ok"], true);
+    assert_eq!(deployed["outcome"]["added"], 3);
+    assert!(home
+        .path()
+        .join("common")
+        .join(".agents")
+        .join("skills")
+        .join("planner")
+        .join("SKILL.md")
+        .exists());
+    assert!(home
+        .path()
+        .join("classes")
+        .join("Reviewer")
+        .join(".agents")
+        .join("skills")
+        .join("planner")
+        .join("SKILL.md")
+        .exists());
+    assert!(home
+        .path()
+        .join("agents")
+        .join("agent-1")
+        .join(".agents")
+        .join("skills")
+        .join("planner")
+        .join("SKILL.md")
+        .exists());
+
+    let deployments = assert_success_json(run(
+        home.path(),
+        &["library", "deployments", "skills/review/planner"],
+        None,
+    ));
+    assert_eq!(deployments["targets"].as_array().unwrap().len(), 3);
+
+    let narrowed = assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "class:Reviewer",
+        ],
+        None,
+    ));
+    assert_eq!(narrowed["outcome"]["removed"], 2);
+    assert!(!home
+        .path()
+        .join("common")
+        .join(".agents")
+        .join("skills")
+        .join("planner")
+        .exists());
+    assert!(!home
+        .path()
+        .join("agents")
+        .join("agent-1")
+        .join(".agents")
+        .join("skills")
+        .join("planner")
+        .exists());
+    assert!(home
+        .path()
+        .join("classes")
+        .join("Reviewer")
+        .join(".agents")
+        .join("skills")
+        .join("planner")
+        .exists());
+}
+
+#[test]
+fn deploy_rejects_unknown_targets_without_creating_directories() {
+    let home = TempDir::new().unwrap();
+    seed_default_classes(home.path());
+    seed_agent(home.path(), "agent-1");
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/review/planner", "--stdin"],
+        Some("# Planner\n"),
+    ));
+
+    let unknown_class = assert_failure_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "class:Reveiwer",
+        ],
+        None,
+    ));
+    assert_eq!(unknown_class["error"]["code"], "invalid_target");
+    assert!(!home.path().join("classes").join("Reveiwer").exists());
+
+    let unknown_agent = assert_failure_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "agent:missing-agent",
+        ],
+        None,
+    ));
+    assert_eq!(unknown_agent["error"]["code"], "invalid_target");
+    assert!(!home.path().join("agents").join("missing-agent").exists());
+
+    let agent_name = assert_failure_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "agent:reviewer-a1",
+        ],
+        None,
+    ));
+    assert_eq!(agent_name["error"]["code"], "invalid_target");
+    assert!(!home.path().join("agents").join("reviewer-a1").exists());
+}
+
+#[test]
+fn deploy_rejects_empty_target_list_without_removing_existing_deployments() {
+    let home = TempDir::new().unwrap();
+    seed_default_classes(home.path());
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/review/planner", "--stdin"],
+        Some("# Planner\n"),
+    ));
+    assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "user:global,class:Reviewer",
+        ],
+        None,
+    ));
+
+    let empty_targets = assert_failure_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "",
+        ],
+        None,
+    ));
+    assert_eq!(empty_targets["error"]["code"], "invalid_target");
+
+    let deployments = assert_success_json(run(
+        home.path(),
+        &["library", "deployments", "skills/review/planner"],
+        None,
+    ));
+    assert_eq!(deployments["targets"].as_array().unwrap().len(), 2);
+    assert!(home
+        .path()
+        .join("common")
+        .join(".agents")
+        .join("skills")
+        .join("planner")
+        .exists());
+    assert!(home
+        .path()
+        .join("classes")
+        .join("Reviewer")
+        .join(".agents")
+        .join("skills")
+        .join("planner")
+        .exists());
+}
+
+#[test]
+fn orphans_list_and_delete_remove_unresolved_deployment() {
+    let home = TempDir::new().unwrap();
+    let orphan = home
+        .path()
+        .join("classes")
+        .join("Reviewer")
+        .join(".agents")
+        .join("skills")
+        .join("ghost");
+    std::fs::create_dir_all(&orphan).unwrap();
+    std::fs::write(orphan.join("SKILL.md"), "stale").unwrap();
+
+    let orphans = assert_success_json(run(home.path(), &["library", "orphans"], None));
+    assert_eq!(orphans["orphans"][0]["target_type"], "class");
+    assert_eq!(orphans["orphans"][0]["target_id"], "Reviewer");
+    assert_eq!(orphans["orphans"][0]["skill_name"], "ghost");
+
+    let deleted = assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "orphan",
+            "delete",
+            "--target",
+            "class:Reviewer",
+            "--skill",
+            "ghost",
+        ],
+        None,
+    ));
+    assert_eq!(deleted["ok"], true);
+    assert!(!orphan.exists());
+}
+
+#[test]
+fn class_create_delete_and_restore_default_are_class_aware() {
+    let home = TempDir::new().unwrap();
+
+    let created = assert_success_json(run(
+        home.path(),
+        &["library", "create", "classes/PairProgrammer", "--stdin"],
+        Some("# Pair Programmer\n\nCollaborates on code.\n"),
+    ));
+    assert_eq!(created["entry_ref"], "classes/PairProgrammer");
+    assert!(home
+        .path()
+        .join("classes")
+        .join("PairProgrammer")
+        .join("AGENTS.md")
+        .is_file());
+
+    let class_move = assert_failure_json(run(
+        home.path(),
+        &[
+            "library",
+            "move",
+            "classes/PairProgrammer",
+            "classes/NewName",
+        ],
+        None,
+    ));
+    assert_eq!(class_move["error"]["code"], "not_supported");
+
+    let deleted = assert_success_json(run(
+        home.path(),
+        &["library", "delete", "classes/PairProgrammer"],
+        None,
+    ));
+    assert_eq!(deleted["ok"], true);
+    assert!(!home.path().join("classes").join("PairProgrammer").exists());
+
+    let defaults = wardian_core::classes::default_class_definitions();
+    wardian_core::classes::save_class_definitions(home.path(), &defaults).unwrap();
+    std::fs::create_dir_all(home.path().join("classes").join("Reviewer")).unwrap();
+    std::fs::write(
+        home.path()
+            .join("classes")
+            .join("Reviewer")
+            .join("AGENTS.md"),
+        "# Edited",
+    )
+    .unwrap();
+
+    let restored = assert_success_json(run(
+        home.path(),
+        &["library", "restore-default", "classes/Reviewer"],
+        None,
+    ));
+    assert_eq!(restored["ok"], true);
+    assert!(std::fs::read_to_string(
+        home.path()
+            .join("classes")
+            .join("Reviewer")
+            .join("AGENTS.md")
+    )
+    .unwrap()
+    .contains("Skeptical Auditor"));
+}

--- a/crates/wardian-cli/tests/library_cli.rs
+++ b/crates/wardian-cli/tests/library_cli.rs
@@ -185,6 +185,59 @@ fn prompt_create_show_read_write_move_delete_round_trip() {
 }
 
 #[test]
+fn rejects_unindexable_entry_shapes_without_hiding_existing_entries() {
+    let home = TempDir::new().unwrap();
+
+    for entry_ref in ["prompts/audit", "workflows/audit.txt"] {
+        let rejected = assert_failure_json(run(
+            home.path(),
+            &["library", "create", entry_ref, "--stdin"],
+            Some("body"),
+        ));
+        assert_eq!(rejected["error"]["code"], "invalid_ref");
+    }
+    assert!(!home.path().join("library/prompts/audit").exists());
+    assert!(!home.path().join("library/workflows/audit.txt").exists());
+
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/parent", "--stdin"],
+        Some("# Parent\n"),
+    ));
+    let nested = assert_failure_json(run(
+        home.path(),
+        &["library", "create", "skills/parent/child", "--stdin"],
+        Some("# Child\n"),
+    ));
+    assert_eq!(nested["error"]["code"], "invalid_ref");
+
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/group/child", "--stdin"],
+        Some("# Group child\n"),
+    ));
+    let promoted = assert_failure_json(run(
+        home.path(),
+        &["library", "create", "skills/group", "--stdin"],
+        Some("# Group parent\n"),
+    ));
+    assert_eq!(promoted["error"]["code"], "invalid_ref");
+
+    let listed = assert_success_json(run(
+        home.path(),
+        &["library", "list", "skills", "--flat"],
+        None,
+    ));
+    let refs: Vec<&str> = listed["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|entry| entry["entry_ref"].as_str())
+        .collect();
+    assert_eq!(refs, vec!["skills/group/child", "skills/parent"]);
+}
+
+#[test]
 fn list_flat_outputs_section_entries() {
     let home = TempDir::new().unwrap();
     assert_success_json(run(

--- a/crates/wardian-cli/tests/library_cli.rs
+++ b/crates/wardian-cli/tests/library_cli.rs
@@ -254,8 +254,44 @@ fn list_flat_outputs_section_entries() {
 
     assert_eq!(listed["schema"], 1);
     assert_eq!(listed["section"], "skills");
+    assert!(listed.get("tree").is_none());
+    assert_eq!(listed["entries"][0]["section"], "skills");
     assert_eq!(listed["entries"][0]["entry_ref"], "skills/review/planner");
     assert_eq!(listed["entries"][0]["description"], "Plans reviews");
+}
+
+#[test]
+fn list_flat_without_section_combines_entries_without_index_payloads() {
+    let home = TempDir::new().unwrap();
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/planner", "--stdin"],
+        Some("# Planner\n"),
+    ));
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "prompts/triage.md", "--stdin"],
+        Some("# Triage\n"),
+    ));
+
+    let listed = assert_success_json(run(home.path(), &["library", "list", "--flat"], None));
+
+    let refs: Vec<&str> = listed["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|entry| entry["entry_ref"].as_str())
+        .collect();
+    assert!(refs.contains(&"skills/planner"));
+    assert!(refs.contains(&"prompts/triage.md"));
+    assert!(listed["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|entry| entry["section"].is_string()));
+    for omitted in ["sections", "tree", "deployments", "orphans"] {
+        assert!(listed.get(omitted).is_none(), "unexpected key: {omitted}");
+    }
 }
 
 #[test]
@@ -708,4 +744,68 @@ fn class_create_delete_and_restore_default_are_class_aware() {
     )
     .unwrap()
     .contains("Skeptical Auditor"));
+}
+
+#[test]
+fn fresh_home_default_classes_support_cli_access_and_deployment() {
+    let home = TempDir::new().unwrap();
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/review/planner", "--stdin"],
+        Some("# Planner\n"),
+    ));
+
+    let deployed = assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "class:Reviewer",
+        ],
+        None,
+    ));
+    assert_eq!(deployed["outcome"]["added"], 1);
+
+    let listed = assert_success_json(run(
+        home.path(),
+        &["library", "list", "classes", "--flat"],
+        None,
+    ));
+    assert!(listed["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|entry| entry["entry_ref"] == "classes/Reviewer"));
+    assert_success_json(run(
+        home.path(),
+        &["library", "show", "classes/Reviewer"],
+        None,
+    ));
+    assert!(assert_success_text(run(
+        home.path(),
+        &["library", "read", "classes/Reviewer"],
+        None,
+    ))
+    .contains("Skeptical Auditor"));
+    assert_success_json(run(
+        home.path(),
+        &["library", "write", "classes/Reviewer", "--stdin"],
+        Some("# Edited Reviewer\n"),
+    ));
+
+    let root = home.path().join("classes/Reviewer");
+    assert_eq!(
+        std::fs::read_to_string(root.join("AGENTS.md")).unwrap(),
+        "# Edited Reviewer\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(root.join("GEMINI.md")).unwrap(),
+        "@AGENTS.md\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(root.join("CLAUDE.md")).unwrap(),
+        "@AGENTS.md\n"
+    );
 }

--- a/crates/wardian-cli/tests/library_cli.rs
+++ b/crates/wardian-cli/tests/library_cli.rs
@@ -199,6 +199,15 @@ fn rejects_unindexable_entry_shapes_without_hiding_existing_entries() {
     assert!(!home.path().join("library/prompts/audit").exists());
     assert!(!home.path().join("library/workflows/audit.txt").exists());
 
+    std::fs::create_dir_all(home.path().join("library/skills")).unwrap();
+    std::fs::write(home.path().join("library/skills/occupied"), "not a skill").unwrap();
+    let occupied = assert_failure_json(run(
+        home.path(),
+        &["library", "create", "skills/occupied", "--stdin"],
+        Some("# Occupied\n"),
+    ));
+    assert_eq!(occupied["error"]["code"], "invalid_ref");
+
     assert_success_json(run(
         home.path(),
         &["library", "create", "skills/parent", "--stdin"],

--- a/crates/wardian-cli/tests/library_cli.rs
+++ b/crates/wardian-cli/tests/library_cli.rs
@@ -427,6 +427,39 @@ fn deploy_reconciles_complete_target_set() {
 }
 
 #[test]
+fn deploy_deduplicates_targets_and_clear_removes_the_final_deployment() {
+    let home = TempDir::new().unwrap();
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/review/planner", "--stdin"],
+        Some("# Planner\n"),
+    ));
+
+    let deployed = assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "user:global,user:global",
+        ],
+        None,
+    ));
+    assert_eq!(deployed["targets"].as_array().unwrap().len(), 1);
+    assert_eq!(deployed["outcome"]["added"], 1);
+
+    let cleared = assert_success_json(run(
+        home.path(),
+        &["library", "deploy", "skills/review/planner", "--clear"],
+        None,
+    ));
+    assert_eq!(cleared["targets"], serde_json::json!([]));
+    assert_eq!(cleared["outcome"]["removed"], 1);
+    assert!(!home.path().join("common/.agents/skills/planner").exists());
+}
+
+#[test]
 fn deploy_rejects_unknown_targets_without_creating_directories() {
     let home = TempDir::new().unwrap();
     seed_default_classes(home.path());
@@ -570,6 +603,46 @@ fn orphans_list_and_delete_remove_unresolved_deployment() {
     ));
     assert_eq!(deleted["ok"], true);
     assert!(!orphan.exists());
+}
+
+#[test]
+fn orphan_delete_rejects_healthy_deployment_without_removing_it() {
+    let home = TempDir::new().unwrap();
+    assert_success_json(run(
+        home.path(),
+        &["library", "create", "skills/review/planner", "--stdin"],
+        Some("# Planner\n"),
+    ));
+    assert_success_json(run(
+        home.path(),
+        &[
+            "library",
+            "deploy",
+            "skills/review/planner",
+            "--targets",
+            "user:global",
+        ],
+        None,
+    ));
+
+    let rejected = assert_failure_json(run(
+        home.path(),
+        &[
+            "library",
+            "orphan",
+            "delete",
+            "--target",
+            "user:global",
+            "--skill",
+            "planner",
+        ],
+        None,
+    ));
+    assert_eq!(rejected["error"]["code"], "not_found");
+    assert!(home
+        .path()
+        .join("common/.agents/skills/planner/SKILL.md")
+        .is_file());
 }
 
 #[test]

--- a/crates/wardian-core/src/atomic_file.rs
+++ b/crates/wardian-core/src/atomic_file.rs
@@ -1,0 +1,87 @@
+use serde::Serialize;
+#[cfg(windows)]
+use std::{ffi::OsStr, os::windows::ffi::OsStrExt};
+use std::{
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+pub(crate) fn write_json_atomic<T: Serialize + ?Sized>(path: &Path, value: &T) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let tmp_path = tmp_path_for(path);
+    {
+        let mut file = fs::File::create(&tmp_path)?;
+        serde_json::to_writer_pretty(&mut file, value).map_err(io::Error::other)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+    }
+    replace_file(&tmp_path, path)
+}
+
+pub(crate) fn tmp_path_for(path: &Path) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("wardian");
+    path.with_file_name(format!(".{file_name}.tmp"))
+}
+
+#[cfg(not(windows))]
+pub(crate) fn replace_file(from: &Path, to: &Path) -> io::Result<()> {
+    fs::rename(from, to)
+}
+
+#[cfg(windows)]
+pub(crate) fn replace_file(from: &Path, to: &Path) -> io::Result<()> {
+    let from = wide_null(from.as_os_str());
+    let to = wide_null(to.as_os_str());
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+
+    // Windows std::fs::rename does not replace an existing destination.
+    let replaced = unsafe {
+        MoveFileExW(
+            from.as_ptr(),
+            to.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if replaced == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn wide_null(value: &OsStr) -> Vec<u16> {
+    value.encode_wide().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+extern "system" {
+    fn MoveFileExW(existing_file_name: *const u16, new_file_name: *const u16, flags: u32) -> i32;
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn write_json_atomic_replaces_existing_json_and_removes_temp_file() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("state.json");
+        std::fs::write(&path, r#"{"old":true}"#).expect("old json");
+
+        super::write_json_atomic(&path, &serde_json::json!({"new": true})).expect("atomic write");
+
+        let value: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).expect("replacement json"))
+                .expect("valid json");
+        assert_eq!(value, serde_json::json!({"new": true}));
+        assert!(!temp.path().join(".state.json.tmp").exists());
+    }
+}

--- a/crates/wardian-core/src/classes.rs
+++ b/crates/wardian-core/src/classes.rs
@@ -1,0 +1,316 @@
+use std::path::Path;
+
+use crate::library::is_single_normal_component;
+use crate::models::AgentClassDefinition;
+
+const DEFAULT_CLASSES_JSON: &str = include_str!("../../../src-tauri/src/default_classes.json");
+const DEFAULT_CLASS_PROMPTS: &[(&str, &str)] = &[
+    (
+        "Architect",
+        include_str!("../../../src-tauri/agent_prompts/Architect.md"),
+    ),
+    (
+        "Coder",
+        include_str!("../../../src-tauri/agent_prompts/Coder.md"),
+    ),
+    (
+        "Editor",
+        include_str!("../../../src-tauri/agent_prompts/Editor.md"),
+    ),
+    (
+        "Evolver",
+        include_str!("../../../src-tauri/agent_prompts/Evolver.md"),
+    ),
+    (
+        "Generalist",
+        include_str!("../../../src-tauri/agent_prompts/Generalist.md"),
+    ),
+    (
+        "Orchestrator",
+        include_str!("../../../src-tauri/agent_prompts/Orchestrator.md"),
+    ),
+    (
+        "Personal Assistant",
+        include_str!("../../../src-tauri/agent_prompts/Personal Assistant.md"),
+    ),
+    ("QA", include_str!("../../../src-tauri/agent_prompts/QA.md")),
+    (
+        "Researcher",
+        include_str!("../../../src-tauri/agent_prompts/Researcher.md"),
+    ),
+    (
+        "Reviewer",
+        include_str!("../../../src-tauri/agent_prompts/Reviewer.md"),
+    ),
+];
+
+pub fn default_class_definitions() -> Vec<AgentClassDefinition> {
+    let mut defaults: Vec<AgentClassDefinition> =
+        serde_json::from_str(DEFAULT_CLASSES_JSON).unwrap_or_default();
+    for class in &mut defaults {
+        class.is_default = true;
+        class.instruction_content = None;
+    }
+    defaults
+}
+
+pub fn default_class_instruction(name: &str) -> Option<&'static str> {
+    DEFAULT_CLASS_PROMPTS
+        .iter()
+        .find(|(class_name, _)| class_name.eq_ignore_ascii_case(name))
+        .map(|(_, content)| *content)
+}
+
+pub fn load_class_definitions(home: &Path) -> Result<Vec<AgentClassDefinition>, String> {
+    let classes_path = home.join("classes.json");
+    if !classes_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let data = std::fs::read_to_string(&classes_path).map_err(|error| error.to_string())?;
+    serde_json::from_str::<Vec<AgentClassDefinition>>(&data).map_err(|error| error.to_string())
+}
+
+pub fn save_class_definitions(home: &Path, classes: &[AgentClassDefinition]) -> Result<(), String> {
+    std::fs::create_dir_all(home).map_err(|error| error.to_string())?;
+    let json = serde_json::to_string_pretty(classes).map_err(|error| error.to_string())?;
+    std::fs::write(home.join("classes.json"), json).map_err(|error| error.to_string())
+}
+
+pub fn ensure_class_directory(
+    home: &Path,
+    class: &AgentClassDefinition,
+    instruction_content: Option<&str>,
+) -> Result<(), String> {
+    validate_class_name(&class.name)?;
+
+    let role_dir = home.join("classes").join(&class.name);
+    std::fs::create_dir_all(&role_dir).map_err(|error| error.to_string())?;
+
+    let agents_md_path = role_dir.join("AGENTS.md");
+    if !agents_md_path.exists() {
+        let content = instruction_content
+            .filter(|content| !content.trim().is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                class
+                    .is_default
+                    .then(|| default_class_instruction(&class.name).map(ToOwned::to_owned))
+                    .flatten()
+            })
+            .unwrap_or_else(|| format!("# Role: {}\n\n{}\n", class.name, class.description));
+        std::fs::write(agents_md_path, content).map_err(|error| error.to_string())?;
+    }
+
+    for stub_name in ["GEMINI.md", "CLAUDE.md"] {
+        let stub_path = role_dir.join(stub_name);
+        if !stub_path.exists() {
+            std::fs::write(stub_path, "@AGENTS.md\n").map_err(|error| error.to_string())?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn create_class(
+    home: &Path,
+    name: &str,
+    description: &str,
+    instruction_content: Option<&str>,
+) -> Result<AgentClassDefinition, String> {
+    let trimmed_name = name.trim();
+    validate_class_name(trimmed_name)?;
+
+    let classes_path = home.join("classes.json");
+    let mut classes = if classes_path.exists() {
+        load_class_definitions(home)?
+    } else {
+        default_class_definitions()
+    };
+
+    if classes
+        .iter()
+        .any(|class| class.name.eq_ignore_ascii_case(trimmed_name))
+    {
+        return Err(format!("A class named '{trimmed_name}' already exists"));
+    }
+
+    let new_class = AgentClassDefinition {
+        name: trimmed_name.to_string(),
+        description: description.trim().to_string(),
+        is_default: false,
+        instruction_content: None,
+        assigned_skills: None,
+    };
+
+    classes.push(new_class.clone());
+    save_class_definitions(home, &classes)?;
+    ensure_class_directory(home, &new_class, instruction_content)?;
+    Ok(new_class)
+}
+
+pub fn delete_class(home: &Path, name: &str) -> Result<(), String> {
+    let mut classes = load_class_definitions(home)?;
+    let found = classes
+        .iter()
+        .find(|class| class.name.eq_ignore_ascii_case(name))
+        .cloned()
+        .ok_or_else(|| format!("Class '{name}' not found"))?;
+
+    if found.is_default {
+        return Err("Cannot delete a default class".to_string());
+    }
+    validate_class_name(&found.name)?;
+
+    classes.retain(|class| !class.name.eq_ignore_ascii_case(name));
+    save_class_definitions(home, &classes)?;
+
+    let role_dir = home.join("classes").join(found.name);
+    if role_dir.exists() {
+        std::fs::remove_dir_all(role_dir).map_err(|error| error.to_string())?;
+    }
+
+    Ok(())
+}
+
+pub fn restore_default_instruction(home: &Path, name: &str) -> Result<(), String> {
+    let classes = load_class_definitions(home)?;
+    let class = classes
+        .iter()
+        .find(|class| class.name.eq_ignore_ascii_case(name))
+        .ok_or_else(|| format!("Class '{name}' not found"))?;
+
+    if !class.is_default {
+        return Err(format!(
+            "'{}' is not a default class and cannot be reset.",
+            class.name
+        ));
+    }
+    validate_class_name(&class.name)?;
+
+    let content = default_class_instruction(&class.name)
+        .ok_or_else(|| format!("System default for '{}' not found", class.name))?;
+    let role_dir = home.join("classes").join(&class.name);
+    std::fs::create_dir_all(&role_dir).map_err(|error| error.to_string())?;
+    std::fs::write(role_dir.join("AGENTS.md"), content).map_err(|error| error.to_string())
+}
+
+fn validate_class_name(name: &str) -> Result<(), String> {
+    if name.trim().is_empty() {
+        return Err("Class name cannot be empty".to_string());
+    }
+    if !is_single_normal_component(name) {
+        return Err(format!("Invalid class name: {name}"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::AgentClassDefinition;
+
+    #[test]
+    fn default_classes_are_marked_default() {
+        let classes = super::default_class_definitions();
+
+        assert!(classes
+            .iter()
+            .any(|class| class.name == "Reviewer" && class.is_default));
+        assert!(classes.iter().all(|class| class.is_default));
+    }
+
+    #[test]
+    fn ensure_class_directory_creates_agents_file_and_provider_stubs() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let class = AgentClassDefinition {
+            name: "Pair Programmer".to_string(),
+            description: "Collaborates on code".to_string(),
+            is_default: false,
+            instruction_content: None,
+            assigned_skills: None,
+        };
+
+        super::ensure_class_directory(temp.path(), &class, Some("# Pair\n"))
+            .expect("class directory");
+
+        let root = temp.path().join("classes").join("Pair Programmer");
+        assert_eq!(
+            std::fs::read_to_string(root.join("AGENTS.md")).expect("agents file"),
+            "# Pair\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("GEMINI.md")).expect("gemini stub"),
+            "@AGENTS.md\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("CLAUDE.md")).expect("claude stub"),
+            "@AGENTS.md\n"
+        );
+    }
+
+    #[test]
+    fn create_class_rejects_duplicate_names_case_insensitively() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let mut classes = super::default_class_definitions();
+        classes.push(AgentClassDefinition {
+            name: "Custom".to_string(),
+            description: "Custom class".to_string(),
+            is_default: false,
+            instruction_content: None,
+            assigned_skills: None,
+        });
+        super::save_class_definitions(temp.path(), &classes).expect("save classes");
+
+        let error = super::create_class(temp.path(), "custom", "duplicate", None)
+            .expect_err("duplicate class should fail");
+
+        assert!(error.contains("already exists"));
+        assert!(!temp.path().join("classes").join("custom").exists());
+    }
+
+    #[test]
+    fn delete_class_removes_custom_class_directory_but_rejects_defaults() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let mut classes = super::default_class_definitions();
+        classes.push(AgentClassDefinition {
+            name: "Custom".to_string(),
+            description: "Custom class".to_string(),
+            is_default: false,
+            instruction_content: None,
+            assigned_skills: None,
+        });
+        super::save_class_definitions(temp.path(), &classes).expect("save classes");
+        std::fs::create_dir_all(temp.path().join("classes").join("Custom")).expect("class dir");
+
+        super::delete_class(temp.path(), "Custom").expect("delete custom");
+        assert!(!temp.path().join("classes").join("Custom").exists());
+
+        let error = super::delete_class(temp.path(), "Reviewer")
+            .expect_err("default class should not be deleted");
+        assert!(error.contains("Cannot delete a default class"));
+    }
+
+    #[test]
+    fn restore_default_instruction_rewrites_only_default_agents_file() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let classes = super::default_class_definitions();
+        super::save_class_definitions(temp.path(), &classes).expect("save classes");
+        let reviewer = classes
+            .iter()
+            .find(|class| class.name == "Reviewer")
+            .expect("reviewer class");
+        super::ensure_class_directory(temp.path(), reviewer, Some("# Edited\n"))
+            .expect("class directory");
+
+        super::restore_default_instruction(temp.path(), "Reviewer").expect("restore default");
+
+        let content = std::fs::read_to_string(
+            temp.path()
+                .join("classes")
+                .join("Reviewer")
+                .join("AGENTS.md"),
+        )
+        .expect("agents file");
+        assert!(content.contains("Skeptical Auditor"));
+    }
+}

--- a/crates/wardian-core/src/classes.rs
+++ b/crates/wardian-core/src/classes.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::library::is_single_normal_component;
+use crate::library::MetadataStore;
 use crate::models::AgentClassDefinition;
 
 const DEFAULT_CLASSES_JSON: &str = include_str!("../../../src-tauri/src/default_classes.json");
@@ -72,9 +73,23 @@ pub fn load_class_definitions(home: &Path) -> Result<Vec<AgentClassDefinition>, 
 }
 
 pub fn save_class_definitions(home: &Path, classes: &[AgentClassDefinition]) -> Result<(), String> {
-    std::fs::create_dir_all(home).map_err(|error| error.to_string())?;
-    let json = serde_json::to_string_pretty(classes).map_err(|error| error.to_string())?;
-    std::fs::write(home.join("classes.json"), json).map_err(|error| error.to_string())
+    crate::atomic_file::write_json_atomic(&home.join("classes.json"), classes)
+        .map_err(|error| error.to_string())
+}
+
+pub fn initialize_classes(home: &Path) -> Result<Vec<AgentClassDefinition>, String> {
+    let classes = if home.join("classes.json").exists() {
+        load_class_definitions(home)?
+    } else {
+        let defaults = default_class_definitions();
+        save_class_definitions(home, &defaults)?;
+        defaults
+    };
+
+    for class in &classes {
+        ensure_class_directory(home, class, None)?;
+    }
+    Ok(classes)
 }
 
 pub fn ensure_class_directory(
@@ -165,10 +180,14 @@ pub fn delete_class(home: &Path, name: &str) -> Result<(), String> {
     classes.retain(|class| !class.name.eq_ignore_ascii_case(name));
     save_class_definitions(home, &classes)?;
 
-    let role_dir = home.join("classes").join(found.name);
+    let role_dir = home.join("classes").join(&found.name);
     if role_dir.exists() {
         std::fs::remove_dir_all(role_dir).map_err(|error| error.to_string())?;
     }
+
+    let mut metadata = MetadataStore::load(home);
+    metadata.remove(&format!("classes/{}", found.name));
+    metadata.save(home)?;
 
     Ok(())
 }
@@ -207,7 +226,8 @@ fn validate_class_name(name: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::models::AgentClassDefinition;
+    use crate::library::MetadataStore;
+    use crate::models::{AgentClassDefinition, LibraryItemMetadata};
 
     #[test]
     fn default_classes_are_marked_default() {
@@ -238,6 +258,25 @@ mod tests {
             std::fs::read_to_string(root.join("AGENTS.md")).expect("agents file"),
             "# Pair\n"
         );
+        assert_eq!(
+            std::fs::read_to_string(root.join("GEMINI.md")).expect("gemini stub"),
+            "@AGENTS.md\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(root.join("CLAUDE.md")).expect("claude stub"),
+            "@AGENTS.md\n"
+        );
+    }
+
+    #[test]
+    fn initialize_classes_materializes_defaults_in_a_fresh_home() {
+        let temp = tempfile::tempdir().expect("temp dir");
+
+        let classes = super::initialize_classes(temp.path()).expect("initialize classes");
+
+        assert!(classes.iter().any(|class| class.name == "Reviewer"));
+        let root = temp.path().join("classes").join("Reviewer");
+        assert!(root.join("AGENTS.md").is_file());
         assert_eq!(
             std::fs::read_to_string(root.join("GEMINI.md")).expect("gemini stub"),
             "@AGENTS.md\n"
@@ -288,6 +327,38 @@ mod tests {
         let error = super::delete_class(temp.path(), "Reviewer")
             .expect_err("default class should not be deleted");
         assert!(error.contains("Cannot delete a default class"));
+    }
+
+    #[test]
+    fn delete_class_removes_metadata_before_same_name_is_recreated() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        super::initialize_classes(temp.path()).expect("initialize classes");
+        super::create_class(temp.path(), "Custom", "Custom class", Some("# Custom\n"))
+            .expect("create class");
+        let mut metadata = MetadataStore::load(temp.path());
+        metadata.set(
+            "classes/Custom".to_string(),
+            LibraryItemMetadata {
+                id: "classes/Custom".to_string(),
+                tags: vec!["stale".to_string()],
+                is_starred: true,
+                last_used: None,
+            },
+        );
+        metadata.save(temp.path()).expect("save metadata");
+
+        super::delete_class(temp.path(), "Custom").expect("delete class");
+        super::create_class(
+            temp.path(),
+            "Custom",
+            "Replacement",
+            Some("# Replacement\n"),
+        )
+        .expect("recreate class");
+
+        assert!(MetadataStore::load(temp.path())
+            .get("classes/Custom")
+            .is_none());
     }
 
     #[test]

--- a/crates/wardian-core/src/control.rs
+++ b/crates/wardian-core/src/control.rs
@@ -27,6 +27,11 @@ pub enum ControlRequest {
         name: Option<String>,
         workspace: Option<String>,
     },
+    AgentUpdate {
+        target: String,
+        class: Option<String>,
+        workspace: Option<String>,
+    },
     AgentClone {
         target: String,
         name: Option<String>,
@@ -154,6 +159,15 @@ pub enum ApprovalAction {
 pub struct AgentListResponse {
     pub schema: u8,
     pub agents: Vec<AgentIdentity>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentUpdateResponse {
+    pub schema: u8,
+    pub ok: bool,
+    pub agent: AgentIdentity,
+    pub updated_fields: Vec<String>,
+    pub restart_required: bool,
 }
 
 impl AgentListResponse {
@@ -661,6 +675,45 @@ mod tests {
         assert!(json.contains(r#""command":"agent_spawn""#));
         assert!(json.contains(r#""provider":"codex""#));
         assert!(json.contains(r#""class":"Reviewer""#));
+    }
+
+    #[test]
+    fn agent_update_request_and_response_serialize_live_changes() {
+        let req = ControlRequest::AgentUpdate {
+            target: "coder-a1".to_string(),
+            class: Some("Reviewer".to_string()),
+            workspace: Some("D:/Development/Wardian".to_string()),
+        };
+        let request_json = serde_json::to_string(&req).unwrap();
+
+        assert!(request_json.contains(r#""command":"agent_update""#));
+        assert!(request_json.contains(r#""target":"coder-a1""#));
+        assert!(request_json.contains(r#""class":"Reviewer""#));
+        assert!(request_json.contains(r#""workspace":"D:/Development/Wardian""#));
+
+        let response = AgentUpdateResponse {
+            schema: CONTROL_SCHEMA,
+            ok: true,
+            agent: AgentIdentity {
+                name: "coder-a1".to_string(),
+                uuid: "uuid-1".to_string(),
+                class: "Reviewer".to_string(),
+                provider: "codex".to_string(),
+                status: "idle".to_string(),
+                pid: None,
+                started_at: None,
+                workspace: Some("D:/Development/Wardian".to_string()),
+                last_status_at: None,
+                status_source: crate::identity::StatusSource::Live,
+                visibility: None,
+            },
+            updated_fields: vec!["class".to_string(), "workspace".to_string()],
+            restart_required: true,
+        };
+        let response_json = serde_json::to_string(&response).unwrap();
+
+        assert!(response_json.contains(r#""updated_fields":["class","workspace"]"#));
+        assert!(response_json.contains(r#""restart_required":true"#));
     }
 
     #[test]

--- a/crates/wardian-core/src/conversations.rs
+++ b/crates/wardian-core/src/conversations.rs
@@ -1,14 +1,13 @@
 //! Public model types for agent-owned conversation archives.
 
+use crate::atomic_file::{replace_file, tmp_path_for};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
     fs::{self, OpenOptions},
     io::{self, BufRead, BufReader, Write},
-    path::{Path, PathBuf},
+    path::Path,
 };
-#[cfg(windows)]
-use std::{ffi::OsStr, os::windows::ffi::OsStrExt};
 
 pub const CONVERSATION_SCHEMA: u8 = 1;
 pub const CONVERSATION_TURNS_SCHEMA: u8 = 3;
@@ -355,18 +354,7 @@ pub fn read_jsonl_records<T: for<'de> Deserialize<'de>>(path: &Path) -> io::Resu
 }
 
 pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    let tmp_path = tmp_path_for(path);
-    let mut file = fs::File::create(&tmp_path)?;
-    serde_json::to_writer_pretty(&mut file, value).map_err(io::Error::other)?;
-    file.write_all(b"\n")?;
-    file.flush()?;
-    drop(file);
-
-    replace_file(&tmp_path, path)
+    crate::atomic_file::write_json_atomic(path, value)
 }
 
 pub fn materialize_text_payload(
@@ -425,42 +413,6 @@ pub fn read_latest_index_entries(path: &Path) -> io::Result<Vec<ConversationInde
     Ok(entries)
 }
 
-fn tmp_path_for(path: &Path) -> PathBuf {
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("wardian");
-    path.with_file_name(format!(".{file_name}.tmp"))
-}
-
-#[cfg(not(windows))]
-fn replace_file(from: &Path, to: &Path) -> io::Result<()> {
-    fs::rename(from, to)
-}
-
-#[cfg(windows)]
-fn replace_file(from: &Path, to: &Path) -> io::Result<()> {
-    let from = wide_null(from.as_os_str());
-    let to = wide_null(to.as_os_str());
-    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
-    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
-
-    // Windows std::fs::rename does not replace an existing destination.
-    // MoveFileExW avoids a pre-delete gap while keeping the operation same-volume.
-    let replaced = unsafe {
-        MoveFileExW(
-            from.as_ptr(),
-            to.as_ptr(),
-            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-        )
-    };
-    if replaced == 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
-}
-
 pub fn write_jsonl_atomic<T: Serialize>(path: &Path, records: &[T]) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -475,17 +427,6 @@ pub fn write_jsonl_atomic<T: Serialize>(path: &Path, records: &[T]) -> io::Resul
         file.sync_all()?;
     }
     replace_file(&tmp_path, path)
-}
-
-#[cfg(windows)]
-fn wide_null(value: &OsStr) -> Vec<u16> {
-    value.encode_wide().chain(std::iter::once(0)).collect()
-}
-
-#[cfg(windows)]
-#[link(name = "kernel32")]
-extern "system" {
-    fn MoveFileExW(existing_file_name: *const u16, new_file_name: *const u16, flags: u32) -> i32;
 }
 
 fn sanitize_artifact_stem(stem: &str) -> String {

--- a/crates/wardian-core/src/conversations.rs
+++ b/crates/wardian-core/src/conversations.rs
@@ -353,7 +353,7 @@ pub fn read_jsonl_records<T: for<'de> Deserialize<'de>>(path: &Path) -> io::Resu
     Ok(records)
 }
 
-pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+pub fn write_json_atomic<T: Serialize + ?Sized>(path: &Path, value: &T) -> io::Result<()> {
     crate::atomic_file::write_json_atomic(path, value)
 }
 

--- a/crates/wardian-core/src/lib.rs
+++ b/crates/wardian-core/src/lib.rs
@@ -1,3 +1,4 @@
+mod atomic_file;
 pub mod classes;
 pub mod control;
 pub mod conversation_lease;

--- a/crates/wardian-core/src/lib.rs
+++ b/crates/wardian-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod classes;
 pub mod control;
 pub mod conversation_lease;
 pub mod conversations;

--- a/crates/wardian-core/src/library/deployments.rs
+++ b/crates/wardian-core/src/library/deployments.rs
@@ -291,6 +291,14 @@ pub fn set_skill_deployments(
 ) -> Result<SetDeploymentsOutcome, String> {
     let rel_norm = source_rel.replace('\\', "/");
     let skill_name = skill_name_from_rel(&rel_norm);
+    let mut seen_desired = HashSet::new();
+    let desired: Vec<SkillDeployment> = desired
+        .iter()
+        .filter(|target| {
+            seen_desired.insert((target.target_type.clone(), target.target_id.clone()))
+        })
+        .cloned()
+        .collect();
 
     let sources = collect_skill_sources(home);
     let scan = scan_deployments(home, &sources);
@@ -325,7 +333,7 @@ pub fn set_skill_deployments(
         }
     }
 
-    for target in desired {
+    for target in &desired {
         let key = (target.target_type.clone(), target.target_id.clone());
         if !current_set.contains(&key) {
             match deploy_skill(home, &rel_norm, &target.target_type, &target.target_id) {
@@ -448,6 +456,29 @@ mod tests {
         // Idempotent.
         let outcome = set_skill_deployments(home, "planner", &narrowed).unwrap();
         assert_eq!((outcome.added, outcome.removed), (0, 0));
+    }
+
+    #[test]
+    fn set_deployments_deduplicates_desired_targets() {
+        let temp = tempfile::tempdir().expect("temp");
+        let home = temp.path();
+        seed_skill(home, "planner");
+        let desired = vec![
+            SkillDeployment {
+                target_type: "user".into(),
+                target_id: "global".into(),
+            },
+            SkillDeployment {
+                target_type: "user".into(),
+                target_id: "global".into(),
+            },
+        ];
+
+        let outcome = set_skill_deployments(home, "planner", &desired).unwrap();
+
+        assert_eq!(outcome.added, 1);
+        let scan = scan_deployments(home, &collect_skill_sources(home));
+        assert_eq!(scan.deployments["planner"].len(), 1);
     }
 
     #[test]

--- a/crates/wardian-core/src/library/metadata.rs
+++ b/crates/wardian-core/src/library/metadata.rs
@@ -2,9 +2,9 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 
+use super::section::LibrarySectionId;
 use crate::models::LibraryItemMetadata;
 use crate::paths::library_metadata_path_for_home;
-use super::section::LibrarySectionId;
 
 const SECTION_PREFIXES: [&str; 4] = ["skills/", "prompts/", "workflows/", "classes/"];
 
@@ -24,7 +24,10 @@ impl MetadataStore {
         let mut items = BTreeMap::new();
         let mut migrated = false;
         for (key, value) in raw {
-            if SECTION_PREFIXES.iter().any(|prefix| key.starts_with(prefix)) {
+            if SECTION_PREFIXES
+                .iter()
+                .any(|prefix| key.starts_with(prefix))
+            {
                 items.insert(key, value);
             } else if let Some(qualified) = qualify_legacy_key(home, &key) {
                 migrated = true;
@@ -61,11 +64,7 @@ impl MetadataStore {
 
     pub fn save(&self, home: &Path) -> Result<(), String> {
         let path = library_metadata_path_for_home(home);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-        }
-        let json = serde_json::to_string_pretty(&self.items).map_err(|e| e.to_string())?;
-        fs::write(&path, json).map_err(|e| e.to_string())
+        crate::atomic_file::write_json_atomic(&path, &self.items).map_err(|e| e.to_string())
     }
 }
 
@@ -88,14 +87,25 @@ mod tests {
     use std::fs;
 
     fn meta(id: &str) -> LibraryItemMetadata {
-        LibraryItemMetadata { id: id.to_string(), tags: vec![], is_starred: true, last_used: None }
+        LibraryItemMetadata {
+            id: id.to_string(),
+            tags: vec![],
+            is_starred: true,
+            last_used: None,
+        }
     }
 
     #[test]
     fn migrates_legacy_keys_by_probing_sections() {
         let temp = tempfile::tempdir().expect("temp");
         let home = temp.path();
-        fs::create_dir_all(home.join("library").join("skills").join("dev").join("planner")).unwrap();
+        fs::create_dir_all(
+            home.join("library")
+                .join("skills")
+                .join("dev")
+                .join("planner"),
+        )
+        .unwrap();
         fs::create_dir_all(home.join("library").join("prompts")).unwrap();
         fs::write(home.join("library").join("prompts").join("greet.md"), "hi").unwrap();
         let legacy = serde_json::json!({
@@ -103,11 +113,21 @@ mod tests {
             "greet.md": {"id": "p1", "tags": [], "is_starred": false, "last_used": null},
             "ghost.md": {"id": "g1", "tags": [], "is_starred": false, "last_used": null}
         });
-        fs::write(home.join("library").join("library.json"), legacy.to_string()).unwrap();
+        fs::write(
+            home.join("library").join("library.json"),
+            legacy.to_string(),
+        )
+        .unwrap();
 
         let store = MetadataStore::load(home);
-        assert_eq!(store.get("skills/dev/planner").expect("skill migrated").id, "s1");
-        assert_eq!(store.get("prompts/greet.md").expect("prompt migrated").id, "p1");
+        assert_eq!(
+            store.get("skills/dev/planner").expect("skill migrated").id,
+            "s1"
+        );
+        assert_eq!(
+            store.get("prompts/greet.md").expect("prompt migrated").id,
+            "p1"
+        );
         assert!(store.get("ghost.md").is_none(), "unresolvable keys drop");
 
         // Migration writes back once: reloading needs no probing.
@@ -125,5 +145,23 @@ mod tests {
         assert_eq!(store.get("skills/new").expect("moved").id, "m1");
         store.save(temp.path()).expect("save");
         assert!(MetadataStore::load(temp.path()).get("skills/new").is_some());
+    }
+
+    #[test]
+    fn save_replaces_metadata_with_complete_pretty_json() {
+        let temp = tempfile::tempdir().expect("temp");
+        let path = temp.path().join("library").join("library.json");
+        fs::create_dir_all(path.parent().expect("parent")).expect("metadata dir");
+        fs::write(&path, "truncated").expect("old metadata");
+        let mut store = MetadataStore::default();
+        store.set("skills/planner".into(), meta("planner"));
+
+        store.save(temp.path()).expect("save metadata");
+
+        let raw = fs::read_to_string(&path).expect("metadata json");
+        assert!(raw.starts_with("{\n"));
+        assert!(raw.ends_with("\n"));
+        serde_json::from_str::<serde_json::Value>(&raw).expect("valid metadata json");
+        assert!(!path.with_file_name(".library.json.tmp").exists());
     }
 }

--- a/crates/wardian-core/src/library/mod.rs
+++ b/crates/wardian-core/src/library/mod.rs
@@ -19,5 +19,5 @@ pub use links::{create_directory_link, copy_dir_all, deploy_skill_dir, remove_ex
 pub use metadata::MetadataStore;
 pub use mutations::{
     create_folder, delete_entry, read_item, remove_orphan_deployment, rename_entry, save_item,
-    update_metadata,
+    update_metadata, validate_entry_destination,
 };

--- a/crates/wardian-core/src/library/mutations.rs
+++ b/crates/wardian-core/src/library/mutations.rs
@@ -26,6 +26,70 @@ pub(crate) fn content_file_path(
     })
 }
 
+/// Validate that a mutation destination can be represented by the Library index.
+pub fn validate_entry_destination(
+    home: &Path,
+    section: LibrarySectionId,
+    rel: &str,
+) -> Result<(), String> {
+    let target = resolve_entry_path(home, section, rel)?;
+    match section {
+        LibrarySectionId::Prompts | LibrarySectionId::Workflows => {
+            let is_markdown = target
+                .extension()
+                .map(|extension| extension.eq_ignore_ascii_case("md"))
+                .unwrap_or(false);
+            if !is_markdown {
+                return Err(format!(
+                    "{} entries must use a .md extension: {rel}",
+                    section.as_str()
+                ));
+            }
+        }
+        LibrarySectionId::Skills => validate_skill_destination(home, &target, rel)?,
+        LibrarySectionId::Classes => {}
+        LibrarySectionId::Mcps => unreachable!("MCP paths are rejected by resolve_entry_path"),
+    }
+    Ok(())
+}
+
+fn validate_skill_destination(home: &Path, target: &Path, rel: &str) -> Result<(), String> {
+    let root = LibrarySectionId::Skills.root_for_home(home);
+    let relative = target
+        .strip_prefix(&root)
+        .map_err(|_| format!("Skill path is outside the Library: {rel}"))?;
+    let mut ancestor = root;
+    let components: Vec<_> = relative.components().collect();
+    for component in components.iter().take(components.len().saturating_sub(1)) {
+        ancestor.push(component.as_os_str());
+        if ancestor.join("SKILL.md").is_file() {
+            return Err(format!(
+                "A skill cannot be nested inside another skill: {rel}"
+            ));
+        }
+    }
+
+    if target.is_dir() && !target.join("SKILL.md").is_file() && directory_contains_skill(target)? {
+        return Err(format!(
+            "A skill group containing other skills cannot also be a skill: {rel}"
+        ));
+    }
+    Ok(())
+}
+
+fn directory_contains_skill(directory: &Path) -> Result<bool, String> {
+    for entry in fs::read_dir(directory).map_err(|error| error.to_string())? {
+        let path = entry.map_err(|error| error.to_string())?.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if path.join("SKILL.md").is_file() || directory_contains_skill(&path)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Read the content of a library item.
 /// - Skills read `<dir>/SKILL.md`
 /// - Classes read `<dir>/AGENTS.md`
@@ -40,7 +104,13 @@ pub fn read_item(home: &Path, section: LibrarySectionId, rel: &str) -> Result<St
 /// - Skills write to `<dir>/SKILL.md`
 /// - Classes write to `<dir>/AGENTS.md`
 /// - Prompts/Workflows write to the file itself
-pub fn save_item(home: &Path, section: LibrarySectionId, rel: &str, content: &str) -> Result<(), String> {
+pub fn save_item(
+    home: &Path,
+    section: LibrarySectionId,
+    rel: &str,
+    content: &str,
+) -> Result<(), String> {
+    validate_entry_destination(home, section, rel)?;
     let path = content_file_path(home, section, rel)?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
@@ -116,6 +186,8 @@ pub fn rename_entry(
         return Err("Renaming classes is not supported".to_string());
     }
 
+    validate_entry_destination(home, section, to_rel)?;
+
     let from_path = resolve_entry_path(home, section, from_rel)?;
     let to_path = resolve_entry_path(home, section, to_rel)?;
     let from_norm = from_rel.replace('\\', "/");
@@ -170,7 +242,8 @@ pub fn rename_entry(
                         if let Some(parent) = new_target_path.parent() {
                             fs::create_dir_all(parent).map_err(|e| e.to_string())?;
                         }
-                        fs::rename(&old_target_path, &new_target_path).map_err(|e| e.to_string())?;
+                        fs::rename(&old_target_path, &new_target_path)
+                            .map_err(|e| e.to_string())?;
                     }
                     fs::write(new_target_path.join(DEPLOYED_SKILL_SOURCE_FILE), &to_norm)
                         .map_err(|e| e.to_string())?;
@@ -258,8 +331,36 @@ mod tests {
         assert!(home.join("library/skills/dev/planner/SKILL.md").exists());
         assert!(home.join("library/prompts/greet.md").exists());
         assert!(home.join("classes/Architect/AGENTS.md").exists());
-        assert_eq!(read_item(home, LibrarySectionId::Skills, "dev/planner").unwrap(), "skill body");
-        assert_eq!(read_item(home, LibrarySectionId::Classes, "Architect").unwrap(), "agents body");
+        assert_eq!(
+            read_item(home, LibrarySectionId::Skills, "dev/planner").unwrap(),
+            "skill body"
+        );
+        assert_eq!(
+            read_item(home, LibrarySectionId::Classes, "Architect").unwrap(),
+            "agents body"
+        );
+    }
+
+    #[test]
+    fn save_rejects_unindexable_entry_shapes() {
+        let temp = tempfile::tempdir().expect("temp");
+        let home = temp.path();
+
+        assert!(save_item(home, LibrarySectionId::Prompts, "audit", "body").is_err());
+        assert!(save_item(home, LibrarySectionId::Workflows, "audit.txt", "body").is_err());
+
+        save_item(home, LibrarySectionId::Skills, "parent", "parent").unwrap();
+        assert!(save_item(home, LibrarySectionId::Skills, "parent/child", "child").is_err());
+
+        save_item(home, LibrarySectionId::Skills, "group/child", "child").unwrap();
+        assert!(save_item(home, LibrarySectionId::Skills, "group", "parent").is_err());
+        assert!(rename_entry(
+            home,
+            LibrarySectionId::Skills,
+            "group/child",
+            "parent/child"
+        )
+        .is_err());
     }
 
     #[test]
@@ -279,7 +380,12 @@ mod tests {
     }
 
     fn meta(id: &str) -> LibraryItemMetadata {
-        LibraryItemMetadata { id: id.to_string(), tags: vec![], is_starred: true, last_used: None }
+        LibraryItemMetadata {
+            id: id.to_string(),
+            tags: vec![],
+            is_starred: true,
+            last_used: None,
+        }
     }
 
     #[test]
@@ -321,22 +427,41 @@ mod tests {
         crate::library::links::create_directory_link(&src, &linked).unwrap();
         let copied = home.join("agents/a1/.agents/skills/planner");
         crate::library::links::copy_dir_all(&src, &copied).unwrap();
-        fs::write(copied.join(crate::library::section::DEPLOYED_SKILL_SOURCE_FILE), "planner").unwrap();
+        fs::write(
+            copied.join(crate::library::section::DEPLOYED_SKILL_SOURCE_FILE),
+            "planner",
+        )
+        .unwrap();
         // starred metadata
-        fs::write(home.join("library/library.json"),
-            r#"{"skills/planner": {"id":"m1","tags":[],"is_starred":true,"last_used":null}}"#).unwrap();
+        fs::write(
+            home.join("library/library.json"),
+            r#"{"skills/planner": {"id":"m1","tags":[],"is_starred":true,"last_used":null}}"#,
+        )
+        .unwrap();
         fs::create_dir_all(home.join("library/prompts")).unwrap();
 
         rename_entry(home, LibrarySectionId::Skills, "planner", "dev/planner").unwrap();
 
         fs::write(home.join("library/skills/dev/planner/SKILL.md"), "v2").unwrap();
-        assert_eq!(fs::read_to_string(linked.join("SKILL.md")).unwrap(), "v2", "junction re-created");
         assert_eq!(
-            fs::read_to_string(copied.join(crate::library::section::DEPLOYED_SKILL_SOURCE_FILE)).unwrap().trim(),
-            "dev/planner", "marker rewritten"
+            fs::read_to_string(linked.join("SKILL.md")).unwrap(),
+            "v2",
+            "junction re-created"
+        );
+        assert_eq!(
+            fs::read_to_string(copied.join(crate::library::section::DEPLOYED_SKILL_SOURCE_FILE))
+                .unwrap()
+                .trim(),
+            "dev/planner",
+            "marker rewritten"
         );
         let store = crate::library::metadata::MetadataStore::load(home);
-        assert!(store.get("skills/dev/planner").expect("metadata migrated").is_starred);
+        assert!(
+            store
+                .get("skills/dev/planner")
+                .expect("metadata migrated")
+                .is_starred
+        );
     }
 
     #[test]

--- a/crates/wardian-core/src/library/mutations.rs
+++ b/crates/wardian-core/src/library/mutations.rs
@@ -307,12 +307,25 @@ pub fn remove_orphan_deployment(
     target_type: &str,
     target_id: &str,
     skill_name: &str,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     if !is_single_normal_component(skill_name) {
         return Err(format!("Invalid skill name: {skill_name}"));
     }
+    let sources = collect_skill_sources(home);
+    let scan = scan_deployments(home, &sources);
+    let is_orphan = scan.orphans.iter().any(|orphan| {
+        orphan.target_type == target_type
+            && orphan.target_id == target_id
+            && orphan.skill_name == skill_name
+    });
+    if !is_orphan {
+        return Ok(false);
+    }
+
     let skills_dir = get_target_skills_dir(home, target_type, target_id)?;
-    remove_existing_deployment(&skills_dir.join(skill_name)).map_err(|e| e.to_string())
+    remove_existing_deployment(&skills_dir.join(skill_name))
+        .map(|()| true)
+        .map_err(|e| e.to_string())
 }
 
 #[cfg(test)]
@@ -487,9 +500,24 @@ mod tests {
         fs::create_dir_all(&orphan).unwrap();
         fs::write(orphan.join("SKILL.md"), "stale").unwrap();
 
-        remove_orphan_deployment(home, "user", "global", "ghost").unwrap();
+        assert!(remove_orphan_deployment(home, "user", "global", "ghost").unwrap());
 
         assert!(!orphan.exists());
+    }
+
+    #[test]
+    fn remove_orphan_deployment_preserves_healthy_deployment() {
+        let temp = tempfile::tempdir().expect("temp");
+        let home = temp.path();
+        let source = home.join("library/skills/planner");
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("SKILL.md"), "healthy").unwrap();
+        let deployed = home.join("common/.agents/skills/planner");
+        crate::library::links::create_directory_link(&source, &deployed).unwrap();
+
+        assert!(!remove_orphan_deployment(home, "user", "global", "planner").unwrap());
+
+        assert!(deployed.join("SKILL.md").is_file());
     }
 
     #[test]

--- a/crates/wardian-core/src/library/mutations.rs
+++ b/crates/wardian-core/src/library/mutations.rs
@@ -54,6 +54,10 @@ pub fn validate_entry_destination(
 }
 
 fn validate_skill_destination(home: &Path, target: &Path, rel: &str) -> Result<(), String> {
+    if target.exists() && !target.is_dir() {
+        return Err(format!("A skill path must be a directory: {rel}"));
+    }
+
     let root = LibrarySectionId::Skills.root_for_home(home);
     let relative = target
         .strip_prefix(&root)

--- a/crates/wardian-core/src/models/library.rs
+++ b/crates/wardian-core/src/models/library.rs
@@ -44,7 +44,7 @@ pub enum LibraryNode {
     Skill(LibrarySkill),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SkillDeployment {
     pub target_type: String,
     pub target_id: String,

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -167,6 +167,7 @@ wardian library star <section/path>
 wardian library unstar <section/path>
 wardian library tags <section/path> --set <tag> [--set <tag>...]
 wardian library deploy <skills/path> --targets user:global,class:Reviewer
+wardian library deploy <skills/path> --clear
 wardian library deployments <skills/path>
 wardian library orphans
 wardian library orphan delete --target class:Reviewer --skill old-planner
@@ -280,8 +281,10 @@ Review the current patch and return findings first.
 EOF
 wardian library star prompts/review.md
 wardian library tags prompts/review.md --set review --set daily
+wardian library list --flat
 wardian library deploy skills/review/planner --targets user:global,class:Reviewer
 wardian library deployments skills/review/planner
+wardian library deploy skills/review/planner --clear
 wardian library read classes/Reviewer
 ```
 
@@ -295,12 +298,14 @@ Review the current patch and return findings first.
 "@ | wardian library create prompts/review.md --stdin
 wardian library star prompts/review.md
 wardian library tags prompts/review.md --set review --set daily
+wardian library list --flat
 wardian library deploy skills/review/planner --targets user:global,class:Reviewer
 wardian library deployments skills/review/planner
+wardian library deploy skills/review/planner --clear
 wardian library read classes/Reviewer
 ```
 
-`wardian library` is a disk-backed authoring surface for reusable assets. It can list, show, read, create, edit, move, delete, tag, star, and deploy Library entries without the desktop app running. `deploy --targets` requires a non-empty list of existing targets, so typos do not create class or agent deployment directories. Workflow entries under `library/workflows` are blueprint files only: use `wardian workflow validate`, `wardian workflow parse`, `wardian workflow normalize`, `wardian workflow exec`, `wardian workflow schedule`, and `wardian workflow runs` for workflow-specific behavior.
+`wardian library` is a disk-backed authoring surface for reusable assets. It can list, show, read, create, edit, move, delete, tag, star, and deploy Library entries without the desktop app running. `list --flat` emits entry rows only, including when no section is supplied. Prompt and workflow refs must end in `.md`, and skills cannot contain other skills. `deploy --targets` requires existing targets and deduplicates repeated refs; use explicit `deploy --clear` to remove the final target safely. Class definitions and instruction files initialize on first class access. Workflow entries under `library/workflows` are blueprint files only: use `wardian workflow validate`, `wardian workflow parse`, `wardian workflow normalize`, `wardian workflow exec`, `wardian workflow schedule`, and `wardian workflow runs` for workflow-specific behavior.
 
 Use `conversation list` and `conversation show <conversation-id>` to inspect durable agent-owned conversation archives. Inside a Wardian-managed agent terminal, `conversation list` defaults to that agent through `WARDIAN_SESSION_ID`. Outside a managed agent terminal, pass `--agent <agent-id-or-name>` or `--scope all`. `show` returns the manifest and agent-readable `conversation.jsonl` narrative, not provider-private raw logs. Wardian refreshes `turns.jsonl` whenever it refreshes the normalized archive, including open conversations, so readers can use `manifest.json` plus `turns.jsonl` as the cheap per-request index and fall back to `conversation.jsonl` only for full detail. A `turns.jsonl` row means one user-originated request plus following assistant, tool, and lifecycle records until the next user-originated request or boundary; provider tool-call IDs do not create separate turn rows. Context rows such as AGENTS.md injections, goal continuations, and lifecycle-only records are typed in `request.kind` so agents can skip them when building summaries. Agents and external tools should use this CLI surface or bounded reads of `agents/<agent-id>/conversations/index.jsonl`; do not recursively crawl under `agents/*`, because agent directories can contain worktrees, provider caches, screenshots, and dependencies. Direct readers must treat `index.jsonl` as append-only upsert history and keep the latest row per `conversation_id`.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -123,6 +123,8 @@ wardian agent kill <name-or-uuid>
 wardian agent pause <name-or-uuid>
 wardian agent resume <name-or-uuid>
 wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace <absolute-workspace-path>
+wardian agent update <name-or-uuid> --class Reviewer
+wardian agent update <name-or-uuid> --workspace <absolute-workspace-path>
 wardian agent clone <name-or-uuid> --name coder-a2
 wardian agent worktree list
 wardian agent worktree enable <name-or-uuid> --name review-fixes
@@ -314,6 +316,17 @@ Mutating commands use Wardian's local control endpoint and require the desktop a
 `workflow validate`, `workflow parse`, `workflow normalize`, `workflow node-types`, `workflow runs`, `workflow run-show`, `workflow replay`, `library`, `conversation list`, `conversation show`, `team`, and `watchlist` can run from disk without the desktop app.
 
 `agent spawn` requires both `--provider` and `--class` so the created agent's runtime and role are explicit.
+
+`agent update <target>` changes an existing agent through the running app. Use
+`--class <ClassName>` to assign an existing class and regenerate the agent's
+instruction include directories. Use `--workspace <absolute-path>` when an
+ordinary agent's workspace folder was moved or renamed; the destination must
+already exist. Both flags can be supplied together and are committed to live
+and persisted state as one update. The JSON response reports `updated_fields`
+and `restart_required`. Wardian does not interrupt a running provider process,
+so restart the agent when `restart_required` is true before relying on the new
+class instructions or working directory. Managed worktree agents must use
+`agent worktree join` or `agent worktree disable` instead.
 
 `agent worktree list` returns the worktrees currently managed by Wardian with source folder, worktree folder, display name, and member agent IDs. `agent worktree enable`, `join`, and `disable` are live-control commands. They reuse the same backend logic as the Source Control panel and force a fresh agent session after changing the runtime workspace. `disable` removes the assignment only; it does not delete the physical worktree folder.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -156,6 +156,21 @@ wardian workflow runs
 wardian workflow run-show <blueprint-id> <run-id>
 wardian workflow replay <blueprint-id> <run-id>
 wardian workflow schedule list
+wardian library list [skills|prompts|classes|workflows|mcps] [--flat]
+wardian library show <section/path> [--content]
+wardian library read <section/path>
+wardian library create <section/path> --stdin
+wardian library write <section/path> --file <path>
+wardian library move <section/path> <section/new-path>
+wardian library delete <section/path>
+wardian library star <section/path>
+wardian library unstar <section/path>
+wardian library tags <section/path> --set <tag> [--set <tag>...]
+wardian library deploy <skills/path> --targets user:global,class:Reviewer
+wardian library deployments <skills/path>
+wardian library orphans
+wardian library orphan delete --target class:Reviewer --skill old-planner
+wardian library restore-default classes/Reviewer
 wardian conversation list
 wardian conversation list --agent <agent-id-or-name>
 wardian conversation list --scope all
@@ -255,11 +270,43 @@ By default, `workflow exec` is a live-control command: it requires the desktop a
 
 Use `workflow runs`, `workflow run-show <blueprint-id> <run-id>`, and `workflow replay <blueprint-id> <run-id>` to inspect durable run artifacts under `<wardian-home>/logs/workflows`.
 
+Author and deploy Library assets from an agent terminal:
+
+```bash
+cat <<'EOF' | wardian library create prompts/review.md --stdin
+# Review
+
+Review the current patch and return findings first.
+EOF
+wardian library star prompts/review.md
+wardian library tags prompts/review.md --set review --set daily
+wardian library deploy skills/review/planner --targets user:global,class:Reviewer
+wardian library deployments skills/review/planner
+wardian library read classes/Reviewer
+```
+
+PowerShell:
+
+```powershell
+@"
+# Review
+
+Review the current patch and return findings first.
+"@ | wardian library create prompts/review.md --stdin
+wardian library star prompts/review.md
+wardian library tags prompts/review.md --set review --set daily
+wardian library deploy skills/review/planner --targets user:global,class:Reviewer
+wardian library deployments skills/review/planner
+wardian library read classes/Reviewer
+```
+
+`wardian library` is a disk-backed authoring surface for reusable assets. It can list, show, read, create, edit, move, delete, tag, star, and deploy Library entries without the desktop app running. `deploy --targets` requires a non-empty list of existing targets, so typos do not create class or agent deployment directories. Workflow entries under `library/workflows` are blueprint files only: use `wardian workflow validate`, `wardian workflow parse`, `wardian workflow normalize`, `wardian workflow exec`, `wardian workflow schedule`, and `wardian workflow runs` for workflow-specific behavior.
+
 Use `conversation list` and `conversation show <conversation-id>` to inspect durable agent-owned conversation archives. Inside a Wardian-managed agent terminal, `conversation list` defaults to that agent through `WARDIAN_SESSION_ID`. Outside a managed agent terminal, pass `--agent <agent-id-or-name>` or `--scope all`. `show` returns the manifest and agent-readable `conversation.jsonl` narrative, not provider-private raw logs. Wardian refreshes `turns.jsonl` whenever it refreshes the normalized archive, including open conversations, so readers can use `manifest.json` plus `turns.jsonl` as the cheap per-request index and fall back to `conversation.jsonl` only for full detail. A `turns.jsonl` row means one user-originated request plus following assistant, tool, and lifecycle records until the next user-originated request or boundary; provider tool-call IDs do not create separate turn rows. Context rows such as AGENTS.md injections, goal continuations, and lifecycle-only records are typed in `request.kind` so agents can skip them when building summaries. Agents and external tools should use this CLI surface or bounded reads of `agents/<agent-id>/conversations/index.jsonl`; do not recursively crawl under `agents/*`, because agent directories can contain worktrees, provider caches, screenshots, and dependencies. Direct readers must treat `index.jsonl` as append-only upsert history and keep the latest row per `conversation_id`.
 
 Mutating commands use Wardian's local control endpoint and require the desktop app to be running for the same `WARDIAN_HOME`. This includes agent lifecycle commands, agent worktree commands, live `workflow exec`, and `send`.
 
-`workflow validate`, `workflow parse`, `workflow normalize`, `workflow node-types`, `workflow runs`, `workflow run-show`, `workflow replay`, `conversation list`, `conversation show`, `team`, and `watchlist` can run from disk without the desktop app.
+`workflow validate`, `workflow parse`, `workflow normalize`, `workflow node-types`, `workflow runs`, `workflow run-show`, `workflow replay`, `library`, `conversation list`, `conversation show`, `team`, and `watchlist` can run from disk without the desktop app.
 
 `agent spawn` requires both `--provider` and `--class` so the created agent's runtime and role are explicit.
 

--- a/docs/guide/library.md
+++ b/docs/guide/library.md
@@ -115,6 +115,32 @@ with the same scoping skills use. It ships empty and read-only in this
 release — selecting it shows an explanatory stub instead of a list or editor.
 No `library/mcps` directory is created until the real feature lands.
 
+## Agent CLI Access
+
+Agents can use `wardian library` to inspect and edit reusable Library assets
+from a terminal without opening the desktop app:
+
+```bash
+wardian library list skills --flat
+wardian library show prompts/review.md --content
+wardian library read classes/Reviewer
+wardian library create skills/review/planner --stdin
+wardian library write prompts/review.md --file <prompt-file.md>
+wardian library tags prompts/review.md --set review --set daily
+wardian library deploy skills/review/planner --targets user:global,class:Reviewer,agent:<agent-id>
+wardian library orphans
+wardian library restore-default classes/Reviewer
+```
+
+`read` emits raw markdown for the entry. `show` emits JSON metadata and
+resolved paths, with optional content via `--content`. `deploy --targets`
+reconciles the supplied non-empty target list as the complete desired
+deployment set for that skill; class and agent targets must already exist.
+
+Library workflow commands author blueprint files only. Use the `wardian
+workflow` namespace to validate, parse, normalize, execute, schedule, or
+inspect workflow runs.
+
 ## Folder Organization and Drag-to-Move
 
 Skills, prompts, and workflows can be organized into folders on disk:

--- a/docs/guide/library.md
+++ b/docs/guide/library.md
@@ -121,6 +121,7 @@ Agents can use `wardian library` to inspect and edit reusable Library assets
 from a terminal without opening the desktop app:
 
 ```bash
+wardian library list --flat
 wardian library list skills --flat
 wardian library show prompts/review.md --content
 wardian library read classes/Reviewer
@@ -128,14 +129,21 @@ wardian library create skills/review/planner --stdin
 wardian library write prompts/review.md --file <prompt-file.md>
 wardian library tags prompts/review.md --set review --set daily
 wardian library deploy skills/review/planner --targets user:global,class:Reviewer,agent:<agent-id>
+wardian library deploy skills/review/planner --clear
 wardian library orphans
 wardian library restore-default classes/Reviewer
 ```
 
 `read` emits raw markdown for the entry. `show` emits JSON metadata and
-resolved paths, with optional content via `--content`. `deploy --targets`
-reconciles the supplied non-empty target list as the complete desired
-deployment set for that skill; class and agent targets must already exist.
+resolved paths, with optional content via `--content`. `list --flat` emits only
+entry rows; without a section it combines every section. Prompt and workflow
+refs must end in `.md`, and a skill cannot contain another skill.
+
+`deploy --targets` deduplicates and reconciles the supplied non-empty target
+list as the complete desired deployment set for that skill; class and agent
+targets must already exist. Use explicit `deploy --clear` to remove every
+deployment. Empty `--targets` remains invalid. Default class definitions and
+instruction files initialize automatically on first CLI class access.
 
 Library workflow commands author blueprint files only. Use the `wardian
 workflow` namespace to validate, parse, normalize, execute, schedule, or

--- a/docs/guide/library.md
+++ b/docs/guide/library.md
@@ -145,6 +145,16 @@ targets must already exist. Use explicit `deploy --clear` to remove every
 deployment. Empty `--targets` remains invalid. Default class definitions and
 instruction files initialize automatically on first CLI class access.
 
+Library class commands author class definitions; they do not assign a class to
+an existing agent. With the desktop app running, use
+`wardian agent update <name-or-uuid> --class <ClassName>` to update live and
+persisted agent state.
+The response tells you whether the provider process must be restarted before it
+uses the new instructions. The same command accepts
+`--workspace <absolute-workspace-path>` when an ordinary agent's workspace
+folder was moved or renamed. Managed worktrees remain on the
+`wardian agent worktree` surface.
+
 Library workflow commands author blueprint files only. Use the `wardian
 workflow` namespace to validate, parse, normalize, execute, schedule, or
 inspect workflow runs.

--- a/docs/specs/2026-07-08-library-cli-agent-capabilities.md
+++ b/docs/specs/2026-07-08-library-cli-agent-capabilities.md
@@ -1,0 +1,269 @@
+# Library CLI Agent Capabilities
+
+- **Status:** Proposed
+- **Date:** 2026-07-08
+
+## Context and Problem Statement
+
+The unified Library now stores Wardian's reusable agent capabilities in one
+place: skills, prompts, classes, workflow blueprints, and the stubbed MCP
+section. The desktop UI can inspect and edit these sections, but agents still
+lack a first-class textual surface for the same work.
+
+Agents need to turn useful work into durable Library assets without driving the
+desktop UI. The CLI should let them contribute prompts and skills, edit class
+instructions, deploy skills to the right scopes, and inspect workflow blueprint
+files. It should do that without creating a second workflow runner, duplicating
+Library business logic, or adding several aliases for the same behavior.
+
+The prior Library redesign intentionally moved the core engine into
+`wardian-core::library`. This slice uses that engine from `wardian-cli` instead
+of reimplementing filesystem rules in the CLI.
+
+## Decisions
+
+### 1. One Library Namespace
+
+All Library commands live under one namespace:
+
+```bash
+wardian library ...
+```
+
+Entries are addressed by section-qualified refs:
+
+```text
+skills/review/planner
+prompts/triage.md
+classes/Reviewer
+workflows/audit.md
+```
+
+The supported sections are `skills`, `prompts`, `classes`, `workflows`, and
+`mcps`. The MCP section remains read-only and stubbed until the MCP feature has
+its own implementation.
+
+### 2. Lean Command Surface
+
+The first CLI slice intentionally avoids convenience aliases. Each command maps
+to one durable behavior.
+
+```bash
+wardian library list [section] [--flat]
+wardian library show <entry-ref> [--content]
+wardian library read <entry-ref>
+
+wardian library create <entry-ref> --stdin|--file <path>
+wardian library write <entry-ref> --stdin|--file <path>
+wardian library move <from-ref> <to-ref>
+wardian library delete <entry-ref>
+
+wardian library star <entry-ref>
+wardian library unstar <entry-ref>
+wardian library tags <entry-ref> --set <tag>...
+
+wardian library deployments <skills/path>
+wardian library deploy <skills/path> --targets <target-list>
+wardian library orphans
+wardian library orphan delete --target <target> --skill <name>
+
+wardian library restore-default <classes/name>
+```
+
+`<target-list>` is comma-separated and uses explicit target refs:
+
+```text
+user:global,class:Reviewer,agent:<agent-id>
+```
+
+An empty target list means the skill should have no deployments:
+
+```bash
+wardian library deploy skills/review/planner --targets ""
+```
+
+PowerShell:
+
+```powershell
+wardian library deploy skills/review/planner --targets ""
+```
+
+### 3. Read, Show, Create, and Write Semantics
+
+`list` returns Library index data. Without `--flat`, it returns tree-shaped JSON
+for the requested section or all sections. With `--flat`, it returns agent-
+friendly rows with `entry_ref`, `section`, `kind`, `name`, `description`,
+`tags`, `is_starred`, `deployment_count`, and any entry error.
+
+`show <entry-ref>` returns JSON metadata and resolved paths. It does not emit raw
+content unless `--content` is set. For workflow entries, the response includes an
+absolute `workflow_path` that can be passed to `wardian workflow ...`.
+
+`read <entry-ref>` emits raw markdown content only. It has no JSON wrapper so it
+can be piped directly into tools or another command.
+
+`create <entry-ref>` creates a new entry and fails with `already_exists` if the
+entry exists. Parent directories are created as needed for nested skills,
+prompts, and workflows.
+
+`write <entry-ref>` replaces content for an existing entry and fails with
+`not_found` if the entry does not exist. There is no separate `save` command.
+
+### 4. Section-Specific Rules
+
+Skills are directories containing `SKILL.md`. `create skills/...` writes the
+provided content to that file through the core Library content mapping.
+
+Prompts and workflows are markdown files. The CLI writes the file content
+directly at the section-relative path.
+
+Classes are flat Library entries backed by `<wardian-home>/classes/<Name>/`.
+`create classes/<Name>` creates the class directory, writes `AGENTS.md`, and
+creates provider compatibility stubs in the same shape the desktop app uses.
+`move classes/...` is not supported in this slice because class identity is
+referenced by agents and runtime configuration. `delete classes/<Name>` must be
+class-aware and reject default classes. `restore-default classes/<Name>` only
+restores the default `AGENTS.md` for a built-in class; it does not change tags,
+deployments, schedules, or agent assignments.
+
+MCP entries are read-only. Mutations under `mcps` return `not_supported`.
+
+### 5. Workflow Boundary
+
+Workflow blueprints are stored in the Library, but workflow behavior remains in
+the existing workflow CLI surface.
+
+`wardian library` can:
+
+- list, show, and read workflow blueprint files as `workflows/<path>.md`;
+- create, write, move, and delete workflow blueprint files;
+- return Library metadata and a `workflow_path` for handoff.
+
+`wardian library` does not validate, parse, normalize, execute, replay,
+schedule, inspect runs, or resolve workflow blueprints by declared id. Those
+belong to:
+
+```bash
+wardian workflow validate <path-to-workflow.md>
+wardian workflow parse <path-to-workflow.md>
+wardian workflow normalize <path-to-workflow.md> --write
+wardian workflow exec <path-to-workflow.md>
+wardian workflow schedule ...
+wardian workflow runs
+```
+
+This keeps Library authoring separate from workflow execution and monitoring.
+
+### 6. Deployment Model
+
+Skill deployment is set-based. The command:
+
+```bash
+wardian library deploy skills/review/planner --targets user:global,class:Reviewer
+```
+
+means "make these the complete desired targets for this skill." The CLI calls
+`wardian_core::library::set_skill_deployments`, so it adds missing targets and
+removes targets not present in the supplied list.
+
+`wardian library deployments <skills/path>` reports the current target list for
+one skill. `wardian library orphans` reports unresolved deployed skill
+directories. `wardian library orphan delete` removes one unresolved deployment
+directory and requires both the target and deployed skill directory name.
+
+The CLI does not add separate `deployments add`, `deployments remove`, or
+`undeploy` verbs in this slice.
+
+### 7. Metadata Model
+
+The first slice exposes only common metadata edits:
+
+- `star`
+- `unstar`
+- `tags --set <tag>...`
+
+`show` and `list` expose metadata for reading. Raw metadata JSON get/set is
+deferred until there is a concrete use case that cannot be expressed through
+these stable verbs.
+
+### 8. Output and Errors
+
+All non-`read` commands emit JSON on stdout with `schema: 1`. Mutation responses
+include `ok`, the affected `entry_ref` where applicable, and operation-specific
+fields such as deployment reconciliation counts.
+
+Errors use the existing CLI error envelope on stderr. The Library CLI adds or
+reuses these stable codes:
+
+- `invalid_ref`
+- `unknown_section`
+- `not_supported`
+- `not_found`
+- `already_exists`
+- `invalid_target`
+- `request_failed`
+
+Most Library commands operate directly on disk and do not require the desktop
+app. A live app will pick up CLI-driven filesystem changes through the existing
+Library watcher.
+
+### 9. Implementation Boundary
+
+`crates/wardian-cli` adds a `library` module that adapts arguments to the
+existing core engine:
+
+- `build_library_index`
+- `read_item`
+- `save_item`
+- `rename_entry`
+- `delete_entry`
+- `update_metadata`
+- `set_skill_deployments`
+- `remove_orphan_deployment`
+
+The CLI resolves `WARDIAN_HOME` with `wardian_core::paths::wardian_home()` and
+passes explicit `home: &Path` values into `wardian-core`. No Tauri types or app
+state enter the CLI path.
+
+Class create, class delete, and restore-default need reusable class-management
+helpers in `wardian-core` or another non-Tauri module before the CLI wires them.
+The CLI should not copy logic from `src-tauri/src/commands/class.rs` directly.
+
+### 10. Testing and Verification
+
+Rust unit tests cover:
+
+- ref parsing and section validation;
+- create/write existence rules;
+- class mutation constraints;
+- workflow boundary fields, especially `workflow_path`;
+- flat vs tree `list` output;
+- raw `read` output;
+- tag/star metadata mutation;
+- set-based deployment parsing and reconciliation;
+- orphan listing and deletion;
+- JSON error envelopes.
+
+CLI integration tests seed an isolated `WARDIAN_HOME`, run the built
+`wardian-cli` binary, and assert disk results plus stdout/stderr contracts.
+
+Native E2E coverage is required only for deployment claims that depend on real
+junction or symlink behavior. Browser E2E cannot prove those filesystem details.
+
+## Consequences
+
+- **Positive:** Agents gain the same Library authoring powers as users without
+  driving the desktop UI.
+- **Positive:** A single section-qualified grammar covers skills, prompts,
+  classes, and workflow files while preserving each section's real constraints.
+- **Positive:** Workflow execution remains centralized in `wardian workflow`, so
+  the Library CLI does not become a second workflow runtime.
+- **Positive:** Set-based deployment matches the core engine and avoids a
+  proliferation of add/remove/undeploy aliases.
+- **Negative:** `deploy --targets ""` is a little awkward for undeploy-all, but
+  it preserves one canonical deployment behavior.
+- **Negative:** Raw metadata JSON mutation is deferred, so unusual metadata
+  edits may still require direct file editing until a real use case justifies a
+  broader command.
+- **Negative:** Class create/delete requires moving or extracting some
+  app-adjacent class logic before the CLI can remain thin and testable.

--- a/docs/specs/2026-07-08-library-cli-agent-capabilities.md
+++ b/docs/specs/2026-07-08-library-cli-agent-capabilities.md
@@ -76,17 +76,9 @@ wardian library restore-default <classes/name>
 user:global,class:Reviewer,agent:<agent-id>
 ```
 
-An empty target list means the skill should have no deployments:
-
-```bash
-wardian library deploy skills/review/planner --targets ""
-```
-
-PowerShell:
-
-```powershell
-wardian library deploy skills/review/planner --targets ""
-```
+The target list must name at least one existing target. `class:<ClassName>`
+must match a saved or initialized class, and `agent:<agent-id>` must match a
+known persisted or live agent id.
 
 ### 3. Read, Show, Create, and Write Semantics
 
@@ -164,7 +156,7 @@ wardian library deploy skills/review/planner --targets user:global,class:Reviewe
 
 means "make these the complete desired targets for this skill." The CLI calls
 `wardian_core::library::set_skill_deployments`, so it adds missing targets and
-removes targets not present in the supplied list.
+removes targets not present in the supplied non-empty list.
 
 `wardian library deployments <skills/path>` reports the current target list for
 one skill. `wardian library orphans` reports unresolved deployed skill
@@ -172,7 +164,8 @@ directories. `wardian library orphan delete` removes one unresolved deployment
 directory and requires both the target and deployed skill directory name.
 
 The CLI does not add separate `deployments add`, `deployments remove`, or
-`undeploy` verbs in this slice.
+`undeploy` verbs in this slice. It also rejects empty target lists so an unset
+shell variable cannot accidentally clear every deployment for a skill.
 
 ### 7. Metadata Model
 
@@ -260,8 +253,9 @@ junction or symlink behavior. Browser E2E cannot prove those filesystem details.
   the Library CLI does not become a second workflow runtime.
 - **Positive:** Set-based deployment matches the core engine and avoids a
   proliferation of add/remove/undeploy aliases.
-- **Negative:** `deploy --targets ""` is a little awkward for undeploy-all, but
-  it preserves one canonical deployment behavior.
+- **Negative:** Undeploy-all is deferred instead of being encoded as an empty
+  `--targets` value, which keeps typo and unset-variable failures safer for
+  agents.
 - **Negative:** Raw metadata JSON mutation is deferred, so unusual metadata
   edits may still require direct file editing until a real use case justifies a
   broader command.

--- a/docs/specs/2026-07-08-library-cli-agent-capabilities.md
+++ b/docs/specs/2026-07-08-library-cli-agent-capabilities.md
@@ -127,6 +127,21 @@ class-aware and reject default classes. `restore-default classes/<Name>` only
 restores the default `AGENTS.md` for a built-in class; it does not change tags,
 deployments, schedules, or agent assignments.
 
+Class authoring and agent assignment are separate operations. Library commands
+create and edit reusable class definitions.
+`wardian agent update <target> --class <ClassName>` routes assignment through
+the running app so the live roster, persisted state, instruction include
+directories, and derived agent metadata stay aligned. The update response
+reports whether the provider must be restarted before it consumes the new
+instructions.
+
+The same live update accepts `--workspace <absolute-workspace-path>` for an
+ordinary agent whose workspace folder was moved or renamed. The destination
+must exist, and class plus workspace can be changed atomically. Managed
+worktree agents are rejected and remain on the dedicated
+`wardian agent worktree` surface because those operations also maintain
+worktree assignment metadata and provider session lifecycle.
+
 MCP entries are read-only. Mutations under `mcps` return `not_supported`.
 
 ### 5. Workflow Boundary

--- a/docs/specs/2026-07-08-library-cli-agent-capabilities.md
+++ b/docs/specs/2026-07-08-library-cli-agent-capabilities.md
@@ -1,6 +1,6 @@
 # Library CLI Agent Capabilities
 
-- **Status:** Proposed
+- **Status:** Implemented
 - **Date:** 2026-07-08
 
 ## Context and Problem Statement
@@ -64,6 +64,7 @@ wardian library tags <entry-ref> --set <tag>...
 
 wardian library deployments <skills/path>
 wardian library deploy <skills/path> --targets <target-list>
+wardian library deploy <skills/path> --clear
 wardian library orphans
 wardian library orphan delete --target <target> --skill <name>
 
@@ -76,16 +77,19 @@ wardian library restore-default <classes/name>
 user:global,class:Reviewer,agent:<agent-id>
 ```
 
-The target list must name at least one existing target. `class:<ClassName>`
+The target list must name at least one existing target. Duplicate targets are
+collapsed in first-seen order before reconciliation. `class:<ClassName>`
 must match a saved or initialized class, and `agent:<agent-id>` must match a
 known persisted or live agent id.
 
 ### 3. Read, Show, Create, and Write Semantics
 
 `list` returns Library index data. Without `--flat`, it returns tree-shaped JSON
-for the requested section or all sections. With `--flat`, it returns agent-
-friendly rows with `entry_ref`, `section`, `kind`, `name`, `description`,
-`tags`, `is_starred`, `deployment_count`, and any entry error.
+for the requested section or all sections. With `--flat`, it omits trees,
+deployments, and orphans and returns only agent-friendly `entries` rows with
+`entry_ref`, `section`, `kind`, `name`, `description`, `tags`, `is_starred`,
+`deployment_count`, and any entry error. Unscoped `list --flat` combines entries
+from every section in deterministic section order.
 
 `show <entry-ref>` returns JSON metadata and resolved paths. It does not emit raw
 content unless `--content` is set. For workflow entries, the response includes an
@@ -95,8 +99,9 @@ absolute `workflow_path` that can be passed to `wardian workflow ...`.
 can be piped directly into tools or another command.
 
 `create <entry-ref>` creates a new entry and fails with `already_exists` if the
-entry exists. Parent directories are created as needed for nested skills,
-prompts, and workflows.
+entry exists. Parent directories are created as needed for nested paths.
+Prompts and workflows require `.md` refs. Skill groups may contain skills, but a
+skill directory containing `SKILL.md` cannot itself contain another skill.
 
 `write <entry-ref>` replaces content for an existing entry and fails with
 `not_found` if the entry does not exist. There is no separate `save` command.
@@ -104,12 +109,16 @@ prompts, and workflows.
 ### 4. Section-Specific Rules
 
 Skills are directories containing `SKILL.md`. `create skills/...` writes the
-provided content to that file through the core Library content mapping.
+provided content to that file through the core Library content mapping. A skill
+cannot be nested inside another skill, and a group containing descendant skills
+cannot be converted into a skill.
 
-Prompts and workflows are markdown files. The CLI writes the file content
-directly at the section-relative path.
+Prompts and workflows are `.md` files. The CLI writes the file content directly
+at the section-relative path.
 
 Classes are flat Library entries backed by `<wardian-home>/classes/<Name>/`.
+First CLI access initializes bundled class definitions, `AGENTS.md`, and
+provider instruction stubs when the desktop app has not initialized them yet.
 `create classes/<Name>` creates the class directory, writes `AGENTS.md`, and
 creates provider compatibility stubs in the same shape the desktop app uses.
 `move classes/...` is not supported in this slice because class identity is
@@ -158,14 +167,24 @@ means "make these the complete desired targets for this skill." The CLI calls
 `wardian_core::library::set_skill_deployments`, so it adds missing targets and
 removes targets not present in the supplied non-empty list.
 
+The explicit command:
+
+```bash
+wardian library deploy skills/review/planner --clear
+```
+
+reconciles to an empty desired set. Empty `--targets` values remain invalid so
+an unset shell variable cannot remove deployments accidentally.
+
 `wardian library deployments <skills/path>` reports the current target list for
 one skill. `wardian library orphans` reports unresolved deployed skill
 directories. `wardian library orphan delete` removes one unresolved deployment
-directory and requires both the target and deployed skill directory name.
+directory and requires both the target and deployed skill directory name. The
+delete operation rechecks that exact tuple against the current orphan scan and
+refuses to remove a healthy deployment.
 
 The CLI does not add separate `deployments add`, `deployments remove`, or
-`undeploy` verbs in this slice. It also rejects empty target lists so an unset
-shell variable cannot accidentally clear every deployment for a skill.
+`undeploy` verbs. `--clear` is the only explicit empty-set operation.
 
 ### 7. Metadata Model
 
@@ -253,11 +272,10 @@ junction or symlink behavior. Browser E2E cannot prove those filesystem details.
   the Library CLI does not become a second workflow runtime.
 - **Positive:** Set-based deployment matches the core engine and avoids a
   proliferation of add/remove/undeploy aliases.
-- **Negative:** Undeploy-all is deferred instead of being encoded as an empty
-  `--targets` value, which keeps typo and unset-variable failures safer for
-  agents.
+- **Positive:** Explicit `--clear` supports undeploy-all without treating an
+  empty environment variable as destructive intent.
 - **Negative:** Raw metadata JSON mutation is deferred, so unusual metadata
   edits may still require direct file editing until a real use case justifies a
   broader command.
-- **Negative:** Class create/delete requires moving or extracting some
-  app-adjacent class logic before the CLI can remain thin and testable.
+- **Positive:** Shared class initialization and mutation helpers keep CLI and
+  desktop class state consistent without introducing Tauri dependencies.

--- a/docs/specs/2026-07-09-library-cli-hardening.md
+++ b/docs/specs/2026-07-09-library-cli-hardening.md
@@ -1,0 +1,161 @@
+# Library CLI Hardening
+
+- **Status:** Approved
+- **Date:** 2026-07-09
+
+## Context
+
+The first Library CLI release gives agents direct access to prompts, skills,
+classes, workflow blueprint files, metadata, and skill deployments. Live CLI
+exercise found several cases where accepted commands produce state that the
+Library cannot subsequently index, where destructive commands do not enforce
+their advertised preconditions, and where standalone CLI class state differs
+from desktop-initialized state.
+
+This pass fixes those concrete correctness and agent-experience gaps. It does
+not add cross-process locking. That broader concurrency problem needs a
+separate design covering all Wardian writers rather than Library-only locks.
+
+## Decisions
+
+### 1. Enforce Entry Shape in the Shared Core
+
+Library mutation APIs enforce the same shapes consumed by the index:
+
+- prompts and workflow blueprints must use a `.md` extension;
+- a skill directory containing `SKILL.md` cannot contain another skill;
+- a folder containing descendant skills cannot be converted into a skill;
+- skill moves must satisfy the same destination rules as skill creation.
+
+These checks live in `wardian-core::library`, so CLI and desktop callers cannot
+create state that the shared index hides. Existing malformed entries remain
+deletable so users and agents can repair old state.
+
+Workflow validation, parsing, normalization, execution, scheduling, and run
+inspection remain exclusively under `wardian workflow`. The Library check is
+only the file-shape invariant required by the Library index.
+
+### 2. Verify Orphans Before Deletion
+
+`wardian library orphan delete` removes a deployment only when the current
+deployment scan reports the exact `(target_type, target_id, skill_name)` tuple
+as orphaned. A healthy deployment or a stale caller request returns
+`not_found` and leaves the filesystem unchanged.
+
+The verification belongs in the shared core helper so every caller receives
+the same destructive-operation guarantee.
+
+### 3. Complete Set-Based Deployment Semantics
+
+Deployment target input is normalized into a unique, stable-order list before
+reconciliation. Duplicate targets therefore produce one durable operation and
+one result entry.
+
+The command accepts exactly one of:
+
+```text
+wardian library deploy <skills/ref> --targets <non-empty-target-list>
+wardian library deploy <skills/ref> --clear
+```
+
+`--clear` reconciles the skill to an empty desired target set. It is explicit
+so an unset or empty shell variable passed to `--targets` cannot undeploy a
+skill accidentally. No separate add/remove aliases are introduced.
+
+### 4. Make Flat Output Actually Flat
+
+`wardian library list <section> --flat` returns:
+
+```json
+{
+  "schema": 1,
+  "section": "skills",
+  "stubbed": false,
+  "entries": []
+}
+```
+
+It does not also include the tree. `wardian library list --flat` returns one
+combined `entries` array across all sections. Every row includes `section` in
+addition to the existing entry fields. Unscoped flat output omits deployments
+and orphans; their dedicated commands remain the efficient agent interfaces.
+
+Tree-shaped output without `--flat` remains backward compatible.
+
+### 5. Initialize and Clean Up Classes Consistently
+
+A reusable core initializer ensures `classes.json`, every class directory,
+`AGENTS.md`, and provider instruction stubs exist. Standalone Library CLI
+operations invoke it before listing or addressing classes and before class
+deployment target validation. Existing files are preserved.
+
+The desktop class initializer reuses the same core behavior after its legacy
+`custom_classes.json` migration. Desktop-only provider discovery links remain
+in the Tauri layer.
+
+Deleting a custom class removes its `classes/<Name>` Library metadata so a
+later class with the same name does not inherit stale tags or star state.
+
+### 6. Use Atomic JSON Replacement Where Touched
+
+Writes to `classes.json` and `library/library.json` serialize to a temporary
+file in the destination directory, flush it, and atomically replace the target
+using the existing cross-platform replacement behavior. This prevents a crash
+from leaving truncated JSON.
+
+Atomic replacement does not prevent two simultaneous load-modify-save writers
+from overwriting one another. Cross-process locking and merge semantics are
+explicitly deferred.
+
+### 7. Improve Agent-Facing Help
+
+Library commands and non-obvious arguments receive concise Clap documentation.
+Help text must explain section-qualified refs, repeated `--set` tags, complete
+desired-set deployment semantics, and the workflow boundary where relevant.
+
+Field projection and a CLI-wide compact JSON policy are deferred because they
+should be consistent across Wardian namespaces. Correct flat output addresses
+the immediate Library payload problem without creating a Library-only output
+framework.
+
+## Error Contracts
+
+Existing JSON error envelopes and exit-code behavior remain in place.
+
+- invalid markdown entry shapes return `invalid_ref`;
+- invalid nested skill layouts return `invalid_ref`;
+- deleting a deployment that is not currently orphaned returns `not_found`;
+- empty `--targets` remains invalid;
+- supplying both `--targets` and `--clear` is rejected by Clap.
+
+## Testing
+
+Core unit tests cover entry-shape validation, skill ancestor/descendant
+conflicts, verified orphan deletion, class initialization, class metadata
+cleanup, target deduplication, and atomic JSON replacement.
+
+CLI integration tests reproduce the live failures and prove:
+
+- extensionless prompts/workflows are rejected before files are written;
+- nested or folder-promoting skills are rejected without hiding entries;
+- healthy deployments survive `orphan delete`;
+- `--clear` removes the final deployment;
+- duplicate targets report one add and one durable target;
+- scoped and unscoped flat output contain entries without trees;
+- fresh-home default classes support list/show/read/write/deploy;
+- deleted and recreated classes do not inherit metadata;
+- workflow entries still hand off through `workflow_path`.
+
+No frontend behavior changes, so browser E2E and screenshot evidence are not
+required. Final verification follows the repository pre-commit checklist.
+
+## Consequences
+
+- Agents can rely on successful mutations remaining discoverable through the
+  same CLI.
+- Destructive orphan cleanup becomes state-checked and retry-safe.
+- Deployment reconciliation can represent every desired set, including empty.
+- Standalone CLI behavior no longer depends on the desktop app having seeded
+  class files first.
+- Multi-agent lost-update prevention remains unresolved until a coordinated
+  cross-process persistence design is implemented.

--- a/docs/superpowers/plans/2026-07-09-library-cli-hardening.md
+++ b/docs/superpowers/plans/2026-07-09-library-cli-hardening.md
@@ -1,0 +1,439 @@
+# Library CLI Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every accepted Library CLI mutation remain indexable, make destructive deployment cleanup state-checked, complete set-based deployment semantics, and make standalone class and flat-list behavior reliable for agents.
+
+**Architecture:** Put filesystem and persistence invariants in `wardian-core`, where both Tauri and CLI callers share them. Keep `wardian-cli` responsible for Clap contracts, class initialization before CLI-only access, stable JSON/error envelopes, and agent-sized output. Reuse one cross-platform atomic JSON writer for class definitions, Library metadata, and existing conversation persistence.
+
+**Tech Stack:** Rust 2021, Clap, Serde/serde_json, Wardian core Library APIs, Rust unit tests, CLI process integration tests.
+
+## Global Constraints
+
+- Do not add cross-process locking or merge semantics in this pass.
+- Workflow validation, parsing, normalization, execution, scheduling, and run inspection remain under `wardian workflow`.
+- Keep existing tree-shaped `library list` output backward compatible when `--flat` is absent.
+- Keep malformed historical entries deletable so users and agents can repair old state.
+- Preserve desktop-only provider discovery links in the Tauri layer.
+- No frontend behavior changes; browser E2E and screenshot evidence are not required.
+
+---
+
+### Task 1: Atomic JSON Persistence and Standalone Class Initialization
+
+**Files:**
+- Create: `crates/wardian-core/src/atomic_file.rs`
+- Modify: `crates/wardian-core/src/lib.rs`
+- Modify: `crates/wardian-core/src/conversations.rs`
+- Modify: `crates/wardian-core/src/library/metadata.rs`
+- Modify: `crates/wardian-core/src/classes.rs`
+- Modify: `src-tauri/src/manager/classes.rs`
+- Test: `crates/wardian-core/src/atomic_file.rs`
+- Test: `crates/wardian-core/src/classes.rs`
+- Test: `crates/wardian-core/src/library/metadata.rs`
+
+**Interfaces:**
+- Produces: `atomic_file::write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()>`.
+- Produces: `classes::initialize_classes(home: &Path) -> Result<Vec<AgentClassDefinition>, String>`.
+- Preserves: `conversations::write_json_atomic` as a public compatibility wrapper.
+- Changes: `classes::delete_class` also removes `classes/<Name>` metadata.
+
+- [ ] **Step 1: Write failing core tests**
+
+Add tests proving atomic JSON replacement overwrites valid JSON without leaving the temporary file, `initialize_classes` seeds default definitions plus `AGENTS.md`/provider stubs in a fresh home, and deleting/recreating a custom class does not retain metadata:
+
+```rust
+#[test]
+fn write_json_atomic_replaces_existing_json_and_removes_temp_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("state.json");
+    std::fs::write(&path, r#"{"old":true}"#).unwrap();
+
+    write_json_atomic(&path, &serde_json::json!({"new": true})).unwrap();
+
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(value, serde_json::json!({"new": true}));
+    assert!(!temp.path().join(".state.json.tmp").exists());
+}
+
+#[test]
+fn initialize_classes_materializes_defaults_in_a_fresh_home() {
+    let temp = tempfile::tempdir().unwrap();
+    let classes = super::initialize_classes(temp.path()).unwrap();
+
+    assert!(classes.iter().any(|class| class.name == "Reviewer"));
+    let root = temp.path().join("classes/Reviewer");
+    assert!(root.join("AGENTS.md").is_file());
+    assert_eq!(std::fs::read_to_string(root.join("GEMINI.md")).unwrap(), "@AGENTS.md\n");
+    assert_eq!(std::fs::read_to_string(root.join("CLAUDE.md")).unwrap(), "@AGENTS.md\n");
+}
+```
+
+In the class deletion test, set metadata for `classes/Custom`, delete the class, recreate it, and assert `MetadataStore::load(home).get("classes/Custom").is_none()`.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+cargo test -p wardian-core atomic_file
+cargo test -p wardian-core initialize_classes_materializes_defaults_in_a_fresh_home
+cargo test -p wardian-core delete_class_removes_metadata
+```
+
+Expected: compilation/test failures because `atomic_file`, `initialize_classes`, and metadata cleanup do not exist.
+
+- [ ] **Step 3: Implement the atomic writer and class lifecycle changes**
+
+Move the temp-path and cross-platform replacement implementation from `conversations.rs` into `atomic_file.rs`. The writer must create the parent, serialize pretty JSON plus a trailing newline, `sync_all`, and replace the destination. Keep this wrapper:
+
+```rust
+pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    crate::atomic_file::write_json_atomic(path, value)
+}
+```
+
+Use the shared writer in `save_class_definitions` and `MetadataStore::save`. Implement initialization as:
+
+```rust
+pub fn initialize_classes(home: &Path) -> Result<Vec<AgentClassDefinition>, String> {
+    let classes = if home.join("classes.json").exists() {
+        load_class_definitions(home)?
+    } else {
+        let defaults = default_class_definitions();
+        save_class_definitions(home, &defaults)?;
+        defaults
+    };
+    for class in &classes {
+        ensure_class_directory(home, class, None)?;
+    }
+    Ok(classes)
+}
+```
+
+After removing a custom class definition, remove `classes/<Name>` from `MetadataStore` and save it. Refactor `init_agent_classes` to call `initialize_classes` after its legacy custom-class migration, then retain its provider-link loop.
+
+- [ ] **Step 4: Run focused and dependent tests and verify GREEN**
+
+Run:
+
+```powershell
+cargo test -p wardian-core atomic_file
+cargo test -p wardian-core classes
+cargo test -p wardian-core library::metadata
+Set-Location src-tauri; cargo test manager::classes; Set-Location ..
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the task**
+
+```powershell
+git add crates/wardian-core/src/atomic_file.rs crates/wardian-core/src/lib.rs crates/wardian-core/src/conversations.rs crates/wardian-core/src/library/metadata.rs crates/wardian-core/src/classes.rs src-tauri/src/manager/classes.rs
+git commit -m "fix(core): harden library class persistence"
+```
+
+---
+
+### Task 2: Shared Library Entry-Shape Invariants
+
+**Files:**
+- Modify: `crates/wardian-core/src/library/mutations.rs`
+- Modify: `crates/wardian-core/src/library/mod.rs`
+- Modify: `crates/wardian-cli/src/library.rs`
+- Test: `crates/wardian-core/src/library/mutations.rs`
+- Test: `crates/wardian-cli/tests/library_cli.rs`
+
+**Interfaces:**
+- Produces: `library::validate_entry_destination(home: &Path, section: LibrarySectionId, rel: &str) -> Result<(), String>`.
+- Changes: `save_item` and `rename_entry` enforce the same destination invariant internally.
+- Consumes: CLI maps destination-validation failures to `CliError::invalid_ref` before mutation.
+
+- [ ] **Step 1: Write failing core and CLI regression tests**
+
+Add core tests for these exact cases:
+
+```rust
+assert!(save_item(home, LibrarySectionId::Prompts, "audit", "body").is_err());
+assert!(save_item(home, LibrarySectionId::Workflows, "audit.txt", "body").is_err());
+
+save_item(home, LibrarySectionId::Skills, "parent", "parent").unwrap();
+assert!(save_item(home, LibrarySectionId::Skills, "parent/child", "child").is_err());
+
+save_item(home, LibrarySectionId::Skills, "group/child", "child").unwrap();
+assert!(save_item(home, LibrarySectionId::Skills, "group", "parent").is_err());
+assert!(rename_entry(home, LibrarySectionId::Skills, "group/child", "parent/child").is_err());
+```
+
+Add CLI integration tests asserting extensionless prompt/workflow creation and both nested-skill conflict directions return `invalid_ref`, leave no content file behind, and preserve the previously indexed skill.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+cargo test -p wardian-core library::mutations::tests::save_rejects_unindexable_entry_shapes
+cargo test -p wardian-cli --test library_cli rejects_unindexable_entry_shapes
+```
+
+Expected: assertions fail because current saves accept all four malformed destinations.
+
+- [ ] **Step 3: Implement destination validation in core and CLI**
+
+`validate_entry_destination` must:
+
+- require a case-insensitive `.md` extension for prompts and workflows;
+- for skills, reject any ancestor directory containing `SKILL.md`;
+- for skills, reject converting a directory without its own `SKILL.md` when a recursive descendant contains `SKILL.md`;
+- allow writes to an existing valid skill itself;
+- perform no additional restrictions for classes;
+- rely on `resolve_entry_path` for traversal and MCP rejection.
+
+Call it at the start of `save_item` and on `to_rel` before `rename_entry` mutates anything. In CLI create/write/move handlers, call it before reading stdin or changing the filesystem and map failures through `CliError::invalid_ref`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+cargo test -p wardian-core library::mutations
+cargo test -p wardian-cli --test library_cli
+```
+
+Expected: all mutation and Library CLI integration tests pass.
+
+- [ ] **Step 5: Commit the task**
+
+```powershell
+git add crates/wardian-core/src/library/mutations.rs crates/wardian-core/src/library/mod.rs crates/wardian-cli/src/library.rs crates/wardian-cli/tests/library_cli.rs
+git commit -m "fix(library): reject unindexable entries"
+```
+
+---
+
+### Task 3: Safe and Complete Deployment Reconciliation
+
+**Files:**
+- Modify: `crates/wardian-core/src/library/deployments.rs`
+- Modify: `crates/wardian-core/src/library/mutations.rs`
+- Modify: `crates/wardian-cli/src/args.rs`
+- Modify: `crates/wardian-cli/src/library.rs`
+- Test: `crates/wardian-core/src/library/deployments.rs`
+- Test: `crates/wardian-core/src/library/mutations.rs`
+- Test: `crates/wardian-cli/src/args.rs`
+- Test: `crates/wardian-cli/tests/library_cli.rs`
+
+**Interfaces:**
+- Changes: `remove_orphan_deployment(...) -> Result<bool, String>`, returning `false` without mutation when the exact tuple is not currently orphaned.
+- Changes: `LibraryCommand::Deploy { skill_ref, targets: Option<String>, clear: bool }`.
+- Changes: target parsing returns unique targets in first-seen order.
+
+- [ ] **Step 1: Write failing deployment tests**
+
+Add tests proving:
+
+- `remove_orphan_deployment` returns `false` and preserves a healthy deployment;
+- it returns `true` and removes a scanned orphan;
+- duplicate desired targets produce `outcome.added == 1` and one scanned target;
+- Clap accepts exactly one of `--targets` and `--clear`;
+- CLI `deploy --clear` removes the final deployment;
+- CLI duplicate targets return one target and `added: 1`;
+- CLI healthy `orphan delete` returns `not_found` and preserves deployment state.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+cargo test -p wardian-core deployment
+cargo test -p wardian-cli parses_library_deploy_clear
+cargo test -p wardian-cli --test library_cli deploy
+cargo test -p wardian-cli --test library_cli orphan
+```
+
+Expected: failures show duplicate accounting, missing `--clear`, and unchecked orphan removal.
+
+- [ ] **Step 3: Implement deployment safety and explicit clear**
+
+Normalize desired targets with a `HashSet<(String, String)>` while retaining a `Vec<SkillDeployment>` in first-seen order. Use the normalized vector for both core reconciliation and CLI response JSON.
+
+Before orphan removal, collect sources, scan deployments, and match all three fields. Return `Ok(false)` without touching the path when absent. CLI maps `false` to `CliError::library_not_found` using a synthetic ref `deployment/<target>/<skill>`.
+
+Define Clap arguments with mutual exclusion and one-required semantics:
+
+```rust
+Deploy {
+    skill_ref: String,
+    #[arg(long, required_unless_present = "clear", conflicts_with = "clear")]
+    targets: Option<String>,
+    #[arg(long, required_unless_present = "targets", conflicts_with = "targets")]
+    clear: bool,
+}
+```
+
+`handle_deploy` passes an empty vector only for `clear == true`; an empty or malformed `--targets` string remains `invalid_target`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+cargo test -p wardian-core library::deployments
+cargo test -p wardian-core library::mutations
+cargo test -p wardian-cli args::tests
+cargo test -p wardian-cli --test library_cli
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the task**
+
+```powershell
+git add crates/wardian-core/src/library/deployments.rs crates/wardian-core/src/library/mutations.rs crates/wardian-cli/src/args.rs crates/wardian-cli/src/library.rs crates/wardian-cli/tests/library_cli.rs
+git commit -m "fix(cli): make library deployments safe and complete"
+```
+
+---
+
+### Task 4: Agent-Sized Flat Output, Class Access, and Help
+
+**Files:**
+- Modify: `crates/wardian-cli/src/args.rs`
+- Modify: `crates/wardian-cli/src/library.rs`
+- Test: `crates/wardian-cli/src/args.rs`
+- Test: `crates/wardian-cli/tests/library_cli.rs`
+
+**Interfaces:**
+- Changes: scoped `--flat` omits `tree`; unscoped `--flat` returns combined deterministic entries and omits deployments/orphans.
+- Changes: every flat row adds `section` without changing `LibraryEntry` storage models.
+- Consumes: `classes::initialize_classes` before class listing/access and class deployment validation.
+
+- [ ] **Step 1: Write failing flat-output, fresh-class, and help tests**
+
+Extend `list_flat_outputs_section_entries` to assert `tree` is absent and each row has `section == "skills"`. Add an unscoped test that seeds one prompt and one skill, asserts both appear in `entries`, and asserts `sections`, `tree`, `deployments`, and `orphans` are absent.
+
+Add a fresh-home test that runs class list/show/read/write and deployment to `class:Reviewer` without calling `seed_default_classes`, then checks `AGENTS.md`, `GEMINI.md`, and `CLAUDE.md` exist.
+
+Add parser/help assertions that `wardian library --help` and `wardian library deploy --help` contain command descriptions, `--clear`, complete desired-set wording, and workflow-boundary wording.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run:
+
+```powershell
+cargo test -p wardian-cli --test library_cli list_flat
+cargo test -p wardian-cli --test library_cli fresh_home_default_classes
+cargo test -p wardian-cli library_help_describes_agent_contracts
+```
+
+Expected: flat output still includes trees, unscoped flat lacks entries, fresh default classes are absent, and help descriptions are missing.
+
+- [ ] **Step 3: Implement output shaping, initialization, and Clap docs**
+
+For flat rows, serialize each `LibraryEntry` to a JSON object and insert its section name. Iterate `LibrarySectionId::ALL` for deterministic unscoped output rather than iterating the index `HashMap`.
+
+Initialize classes only when needed:
+
+- before unscoped lists and class-scoped lists;
+- before show/read/create/write/delete/restore-default for a class ref;
+- before validating class deployment targets.
+
+Add `///` documentation to every `LibraryCommand`, `LibraryOrphanCommand`, and non-obvious field. Explain that workflow entries are authored here but operated through `wardian workflow`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+cargo test -p wardian-cli args::tests
+cargo test -p wardian-cli --test library_cli
+```
+
+Expected: all parser and Library CLI integration tests pass.
+
+- [ ] **Step 5: Commit the task**
+
+```powershell
+git add crates/wardian-cli/src/args.rs crates/wardian-cli/src/library.rs crates/wardian-cli/tests/library_cli.rs
+git commit -m "feat(cli): improve library agent ergonomics"
+```
+
+---
+
+### Task 5: Documentation, Review, and Full Verification
+
+**Files:**
+- Modify: `docs/specs/2026-07-08-library-cli-agent-capabilities.md`
+- Modify: `docs/guide/cli.md`
+- Modify: `docs/guide/library.md`
+- Verify: all files changed since `89a8e7b1`
+
+**Interfaces:**
+- Documents: `--clear`, unique targets, flat output shape, entry-shape restrictions, standalone class initialization, and the unchanged workflow boundary.
+
+- [ ] **Step 1: Update user-facing documentation**
+
+Document these exact examples:
+
+```bash
+wardian library list --flat
+wardian library deploy skills/review/planner --clear
+```
+
+State that prompt/workflow refs end in `.md`, skills cannot contain other skills, deployment target lists are deduplicated, and class files initialize on first CLI access. Keep POSIX examples first and use no machine-specific paths.
+
+- [ ] **Step 2: Run documentation and formatting checks**
+
+Run:
+
+```powershell
+cargo fmt --all -- --check
+git diff --check
+git status --short
+```
+
+Expected: exit code 0 for formatting/diff checks and only intended files in status.
+
+- [ ] **Step 3: Request independent Wardian review**
+
+Ask `Wardian-Reviewer` to compare the implementation against `docs/specs/2026-07-09-library-cli-hardening.md`, reproduce the prior live failures, and return Critical/Important/Minor findings with file and line references. Fix all valid Critical and Important findings test-first.
+
+- [ ] **Step 4: Run the complete repository verification checklist**
+
+Run:
+
+```powershell
+cargo test -p wardian-cli
+cargo test -p wardian-core
+Set-Location src-tauri
+cargo clippy
+cargo test
+cargo check
+Set-Location ..
+npm run lint
+npm run test
+npm run build
+git diff --check
+git status --short --branch
+```
+
+Expected: every command exits 0; frontend tests may retain the repository's existing jsdom canvas warnings and Vite chunk-size warning, with no new failures.
+
+- [ ] **Step 5: Commit documentation and any review fixes**
+
+```powershell
+git add docs/specs/2026-07-08-library-cli-agent-capabilities.md docs/guide/cli.md docs/guide/library.md
+git commit -m "docs(cli): document library hardening"
+```
+
+- [ ] **Step 6: Verify final branch state**
+
+Run:
+
+```powershell
+git log --oneline --decorate -8
+git status --short --branch
+```
+
+Expected: a clean `feat/library-cli-agent-capabilities` worktree with the hardening commits ahead of its base.

--- a/e2e-native/tests/cli-shared-state-native.test.mjs
+++ b/e2e-native/tests/cli-shared-state-native.test.mjs
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { spawn, spawnSync } from "node:child_process";
 
 import {
@@ -579,6 +579,40 @@ test("native CLI control commands operate through the running app", { timeout: 1
     assert.equal(queued.delivery_state, "queued");
     assert.equal(queued.runtime_state, "provider_input_not_ready");
     assert.match(queued.message_id, /^msg_/);
+
+    const updatedWorkspace = path.join(harness.repoRoot, "crates");
+    const updateResult = runCliOk(cliPath, harness, [
+      "agent",
+      "update",
+      CONTROL_SESSION_NAME,
+      "--class",
+      "Coder",
+      "--workspace",
+      updatedWorkspace,
+    ]);
+    const update = JSON.parse(updateResult.stdout);
+    assert.deepEqual(update.updated_fields, ["class", "workspace"]);
+    assert.equal(update.restart_required, true);
+    assert.equal(update.agent.class, "Coder");
+    assert.equal(path.resolve(update.agent.workspace), path.resolve(updatedWorkspace));
+    await waitForCliField(cliPath, harness, CONTROL_SESSION_NAME, "class", "Coder");
+    await waitForCliField(
+      cliPath,
+      harness,
+      CONTROL_SESSION_NAME,
+      "workspace",
+      update.agent.workspace,
+    );
+    const persisted = JSON.parse(
+      readFileSync(path.join(harness.isolatedHome, "settings", "state.json"), "utf8"),
+    ).find((agent) => agent.session_id === source.uuid);
+    assert.equal(persisted.agent_class, "Coder");
+    assert.equal(path.resolve(persisted.folder), path.resolve(updatedWorkspace));
+    assert.ok(
+      persisted.system_include_directories.some((directory) =>
+        directory.replaceAll("\\", "/").endsWith("/classes/Coder"),
+      ),
+    );
 
     await watchStep(harness, `Cloning ${CONTROL_SESSION_NAME} through the CLI`);
     const cloneResult = runCliOk(cliPath, harness, [

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -102,6 +102,8 @@ app to be running for the same `WARDIAN_HOME`.
 
 ```bash
 wardian agent spawn --provider codex --class Reviewer --name reviewer-a1 --workspace <absolute-workspace-path>
+wardian agent update coder-a1 --class Reviewer
+wardian agent update coder-a1 --workspace <absolute-workspace-path>
 wardian agent clone coder-a1 --name coder-a2
 wardian agent worktree enable coder-a1 --name review-fixes
 wardian agent worktree join coder-a1 --worktree <absolute-worktree-path-or-id>
@@ -120,6 +122,15 @@ wardian reply ask_0123456789abcdef --status done --stdin
 defaults when creating agents. `agent clone` copies the source agent's provider,
 class, workspace, and context unless the CLI offers an override for the field
 you need.
+
+Use `agent update` instead of editing `settings/state.json` directly. It updates
+the running app and persisted state together. `--class` assigns an existing
+class and regenerates instruction include directories; `--workspace` moves an
+ordinary agent to an existing folder, such as after a workspace rename. Supply
+both flags for one atomic update. The response includes `updated_fields` and
+`restart_required`; restart the agent when required before relying on the new
+class instructions or working directory. Managed worktree agents must use
+`agent worktree join` or `agent worktree disable`.
 
 `agent wait <target> --until <status>` blocks until a single agent name or UUID
 reaches a normalized status such as `idle`, `processing`, `action_required`,

--- a/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
+++ b/src-tauri/resources/library/skills/wardian-skills/wardian-cli/SKILL.md
@@ -249,22 +249,56 @@ Return findings first, then tests run, then any residual risk.
 "@ | wardian send --stdin --to reviewer-a1 --wait-until idle --timeout 10m
 ```
 
+## Library
+
+Use `wardian library` to inspect and contribute reusable agent assets without
+opening the desktop app:
+
+```bash
+wardian library list --flat
+wardian library list skills --flat
+wardian library show prompts/review.md --content
+wardian library read classes/Reviewer
+wardian library create skills/review/planner --stdin
+wardian library write prompts/review.md --file <prompt-file.md>
+wardian library tags prompts/review.md --set review --set daily
+wardian library deploy skills/review/planner --targets user:global,class:Reviewer,agent:<agent-id>
+wardian library deployments skills/review/planner
+wardian library deploy skills/review/planner --clear
+wardian library orphans
+```
+
+Refs are section-qualified: `skills/<path>`, `prompts/<path>.md`,
+`classes/<Name>`, or `workflows/<path>.md`. Prompts and workflows require the
+`.md` extension. Skills are directories containing `SKILL.md`; do not place one
+skill inside another skill. Default class files initialize on first class
+access.
+
+`deploy --targets` treats the non-empty, deduplicated list as the complete
+desired set. Use explicit `--clear` to remove every deployment; never pass an
+empty variable to `--targets`. `orphan delete` only removes a deployment that
+the current scan still reports as orphaned.
+
+Library workflow commands author blueprint files only. Use the `wardian
+workflow` commands below for workflow-specific behavior.
+
 ## Workflows
 
 ```bash
-wardian workflow list
-wardian workflow show <id-or-name>
-wardian workflow run <id>
-wardian workflow stop <run-instance-id>
+wardian workflow node-types
+wardian workflow validate <path-to-workflow.md>
+wardian workflow parse <path-to-workflow.md>
+wardian workflow normalize <path-to-workflow.md> --write
+wardian workflow exec <path-to-workflow.md>
+wardian workflow runs
+wardian workflow run-show <blueprint-id> <run-id>
+wardian workflow replay <blueprint-id> <run-id>
+wardian workflow schedule list
 ```
 
-`workflow list` and `workflow show` try the running app first, then read
-workflow JSON files from disk when the app is unavailable. `workflow run` and
-`workflow stop` require the running app.
-
-Malformed workflow files may be reported as warnings or omitted depending on
-the CLI version. If `show` cannot find a workflow that exists on disk, inspect
-the workflow JSON for parse errors.
+`workflow validate`, `parse`, `normalize`, `runs`, `run-show`, and `replay` are
+disk-backed. Live `workflow exec` and schedule actions that launch a run require
+the desktop app for the same `WARDIAN_HOME`.
 
 ## Teams And Watchlists
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -204,6 +204,17 @@ async fn lock_agent_lifecycle(
     lifecycle_lock.lock_owned().await
 }
 
+async fn acquire_agent_lifecycle_guard(
+    state: &AppState,
+    session_id: &str,
+    existing: Option<tokio::sync::OwnedMutexGuard<()>>,
+) -> tokio::sync::OwnedMutexGuard<()> {
+    match existing {
+        Some(guard) => guard,
+        None => lock_agent_lifecycle(state, session_id).await,
+    }
+}
+
 struct PreparedAgentClear {
     termination: ActiveAgent,
     config: AgentConfig,
@@ -1723,6 +1734,121 @@ fn normalize_spawn_folder(folder: &str) -> Result<String, String> {
         .map(|path| normalize_workspace_record_path(&path))
 }
 
+fn normalize_agent_update_workspace(folder: &str) -> Result<String, String> {
+    let folder = folder.trim();
+    if folder.is_empty() {
+        return Err("Workspace path cannot be empty".to_string());
+    }
+    let path = std::path::Path::new(folder);
+    if !path.is_absolute() {
+        return Err("Workspace path must be absolute".to_string());
+    }
+    let normalized = normalize_spawn_folder(folder)?;
+    if !std::path::Path::new(&normalized).is_dir() {
+        return Err("Workspace path must be a directory".to_string());
+    }
+    Ok(normalized)
+}
+
+fn apply_agent_update_fields(
+    config: &mut AgentConfig,
+    class: Option<&str>,
+    workspace: Option<&str>,
+    classes: &[wardian_core::models::AgentClassDefinition],
+) -> Result<Vec<String>, String> {
+    let mut updated_fields = Vec::new();
+
+    if let Some(class) = class {
+        let class = class.trim();
+        let canonical = classes
+            .iter()
+            .find(|definition| definition.name.eq_ignore_ascii_case(class))
+            .ok_or_else(|| format!("Agent class not found: {class}"))?;
+        if config.agent_class != canonical.name {
+            config.agent_class = canonical.name.clone();
+            updated_fields.push("class".to_string());
+        }
+    }
+
+    if let Some(workspace) = workspace {
+        let normalized = normalize_agent_update_workspace(workspace)?;
+        if config.git_worktree == Some(true) {
+            return Err(
+                "Managed worktree agents must use `wardian agent worktree join` or `disable`"
+                    .to_string(),
+            );
+        }
+        if config.folder != normalized {
+            config.folder = normalized;
+            updated_fields.push("workspace".to_string());
+        }
+    }
+
+    Ok(updated_fields)
+}
+
+pub(crate) struct AgentUpdateOutcome {
+    pub config: AgentConfig,
+    pub previous_config: AgentConfig,
+    pub updated_fields: Vec<String>,
+    pub state_snapshot: Vec<AgentConfig>,
+    _lifecycle_guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+pub(crate) async fn update_agent_fields_in_state(
+    state: &AppState,
+    session_id: &str,
+    class: Option<&str>,
+    workspace: Option<&str>,
+    classes: &[wardian_core::models::AgentClassDefinition],
+) -> Result<AgentUpdateOutcome, String> {
+    if class.is_none() && workspace.is_none() {
+        return Err("At least one agent update field is required".to_string());
+    }
+
+    let lifecycle_guard = lock_agent_lifecycle(state, session_id).await;
+    let mut agents = state.agents.lock().await;
+    let order = state.agent_order.lock().await;
+    let agent = agents
+        .get_mut(session_id)
+        .ok_or_else(|| format!("Agent {session_id} not found"))?;
+    let previous_config = agent.config.lock().unwrap().clone();
+    let mut config = previous_config.clone();
+    let updated_fields = apply_agent_update_fields(&mut config, class, workspace, classes)?;
+
+    if updated_fields.iter().any(|field| field == "class") {
+        config.system_include_directories =
+            Some(crate::utils::fs::resolve_system_include_directories(
+                &config.agent_class,
+                &config.session_id,
+            ));
+    }
+
+    *agent.config.lock().unwrap() = config.clone();
+    let state_snapshot = manager::state_configs_snapshot(&agents, &order);
+    Ok(AgentUpdateOutcome {
+        config,
+        previous_config,
+        updated_fields,
+        state_snapshot,
+        _lifecycle_guard: lifecycle_guard,
+    })
+}
+
+pub(crate) async fn restore_agent_config_in_state(
+    state: &AppState,
+    session_id: &str,
+    config: AgentConfig,
+) -> Result<Vec<AgentConfig>, String> {
+    let mut agents = state.agents.lock().await;
+    let order = state.agent_order.lock().await;
+    let agent = agents
+        .get_mut(session_id)
+        .ok_or_else(|| format!("Agent {session_id} not found"))?;
+    *agent.config.lock().unwrap() = config;
+    Ok(manager::state_configs_snapshot(&agents, &order))
+}
+
 fn normalize_clone_folder_override(folder: Option<String>) -> Result<Option<String>, String> {
     folder.as_deref().map(normalize_spawn_folder).transpose()
 }
@@ -2658,17 +2784,7 @@ pub async fn clear_agent_session_with_reason(
     state: State<'_, AppState>,
     app: AppHandle,
 ) -> Result<(), String> {
-    clear_agent_session_inner(session_id, reason, state, app, None).await
-}
-
-async fn clear_agent_session_with_archive_snapshot(
-    session_id: String,
-    reason: Option<String>,
-    state: State<'_, AppState>,
-    app: AppHandle,
-    archive_snapshot: crate::commands::chat::AgentArchiveCaptureSnapshot,
-) -> Result<(), String> {
-    clear_agent_session_inner(session_id, reason, state, app, Some(archive_snapshot)).await
+    clear_agent_session_inner(session_id, reason, state, app, None, None).await
 }
 
 async fn clear_agent_session_inner(
@@ -2677,12 +2793,14 @@ async fn clear_agent_session_inner(
     state: State<'_, AppState>,
     app: AppHandle,
     archive_snapshot: Option<crate::commands::chat::AgentArchiveCaptureSnapshot>,
+    lifecycle_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
 ) -> Result<(), String> {
     manager::log_debug(&format!(
         "[WARDIAN] clear_agent_session called for session: {}",
         session_id
     ));
-    let _lifecycle_guard = lock_agent_lifecycle(&state, &session_id).await;
+    let _lifecycle_guard =
+        acquire_agent_lifecycle_guard(&state, &session_id, lifecycle_guard).await;
     let boundary_reason = conversation_boundary_for_clear_reason(reason.as_deref());
     let archive_result = if let Some(snapshot) = archive_snapshot {
         archive_agent_lifecycle_boundary_from_snapshot(
@@ -2953,6 +3071,7 @@ pub async fn update_agent_config(
     ));
     new_config.validate_provider_config_matches_provider()?;
     new_config.mark_provider_config_nested_for_save();
+    let _lifecycle_guard = lock_agent_lifecycle(&state, &new_config.session_id).await;
     let mut agents = state.agents.lock().await;
     let order = state.agent_order.lock().await;
 
@@ -3200,6 +3319,7 @@ pub async fn enable_agent_worktree(
     if session_id.is_empty() {
         return Err("Session id is required".to_string());
     }
+    let lifecycle_guard = lock_agent_lifecycle(&state, &session_id).await;
     let archive_snapshot =
         crate::commands::chat::agent_archive_capture_snapshot(&state, &session_id)
             .await
@@ -3269,7 +3389,14 @@ pub async fn enable_agent_worktree(
         }
     }
 
-    clear_agent_after_worktree_mutation(session_id, state, app, archive_snapshot).await
+    clear_agent_after_worktree_mutation(
+        session_id,
+        state,
+        app,
+        archive_snapshot,
+        lifecycle_guard,
+    )
+    .await
 }
 
 async fn clear_agent_after_worktree_mutation(
@@ -3277,13 +3404,18 @@ async fn clear_agent_after_worktree_mutation(
     state: State<'_, AppState>,
     app: AppHandle,
     archive_snapshot: Option<crate::commands::chat::AgentArchiveCaptureSnapshot>,
+    lifecycle_guard: tokio::sync::OwnedMutexGuard<()>,
 ) -> Result<(), String> {
     let reason = Some("worktree_switch".to_string());
-    if let Some(snapshot) = archive_snapshot {
-        clear_agent_session_with_archive_snapshot(session_id, reason, state, app, snapshot).await
-    } else {
-        clear_agent_session_with_reason(session_id, reason, state, app).await
-    }
+    clear_agent_session_inner(
+        session_id,
+        reason,
+        state,
+        app,
+        archive_snapshot,
+        Some(lifecycle_guard),
+    )
+    .await
 }
 
 #[tauri::command]
@@ -3318,6 +3450,7 @@ pub async fn assign_agent_worktree(
     if session_id.is_empty() {
         return Err("Session id is required".to_string());
     }
+    let lifecycle_guard = lock_agent_lifecycle(&state, &session_id).await;
     let archive_snapshot =
         crate::commands::chat::agent_archive_capture_snapshot(&state, &session_id)
             .await
@@ -3367,7 +3500,14 @@ pub async fn assign_agent_worktree(
         }
     }
 
-    clear_agent_after_worktree_mutation(session_id, state, app, archive_snapshot).await
+    clear_agent_after_worktree_mutation(
+        session_id,
+        state,
+        app,
+        archive_snapshot,
+        lifecycle_guard,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -3419,6 +3559,7 @@ pub async fn disable_agent_worktree(
     if session_id.is_empty() {
         return Err("Session id is required".to_string());
     }
+    let lifecycle_guard = lock_agent_lifecycle(&state, &session_id).await;
     let archive_snapshot =
         crate::commands::chat::agent_archive_capture_snapshot(&state, &session_id)
             .await
@@ -3439,7 +3580,14 @@ pub async fn disable_agent_worktree(
         }
     }
 
-    clear_agent_after_worktree_mutation(session_id, state, app, archive_snapshot).await
+    clear_agent_after_worktree_mutation(
+        session_id,
+        state,
+        app,
+        archive_snapshot,
+        lifecycle_guard,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -3459,7 +3607,8 @@ pub async fn reorder_agents(
 #[cfg(test)]
 mod tests {
     use super::{
-        agent_status_update_payload, archive_agent_lifecycle_boundary,
+        acquire_agent_lifecycle_guard, agent_status_update_payload, apply_agent_update_fields,
+        archive_agent_lifecycle_boundary,
         archive_agent_lifecycle_boundary_from_snapshot, assign_worktree_config,
         build_agent_cli_command_for_session_id_with_shells, build_agent_cli_command_with_shells,
         build_agent_clone_preview, capture_opencode_pause_resume_session,
@@ -3489,7 +3638,8 @@ mod tests {
         resolve_agent_worktree_branch_name, resolve_agent_worktree_path,
         resolve_requested_spawn_session_name, restore_runtime_state_snapshot_after_resume,
         strip_claude_embedded_stream_flags, sync_resumed_input_sender,
-        take_agent_runtime_for_termination, terminal_cleared_payload,
+        restore_agent_config_in_state, take_agent_runtime_for_termination,
+        terminal_cleared_payload, update_agent_fields_in_state,
         validate_assignable_worktree_for_agent, validate_deletable_agent_worktree,
         workspace_paths_match, AgentOrderPlacement, AgentWorktreeSummary, CloneProfileCopyPlan,
         CloneProfileSelection, DeletedAgentReferenceCleanup, DiscoveredGitWorktree,
@@ -3503,9 +3653,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use wardian_core::models::provider::AgentProvider;
     use wardian_core::models::{
-        AgentConfig, AgentSessionPersistenceOverride, AntigravityProviderConfig,
-        ClaudeProviderConfig, CodexProviderConfig, DeployedSkillRef, GeminiProviderConfig,
-        OpenCodeProviderConfig, ProviderConfig,
+        AgentClassDefinition, AgentConfig, AgentSessionPersistenceOverride,
+        AntigravityProviderConfig, ClaudeProviderConfig, CodexProviderConfig, DeployedSkillRef,
+        GeminiProviderConfig, OpenCodeProviderConfig, ProviderConfig,
     };
 
     struct WardianHomeGuard;
@@ -5038,6 +5188,210 @@ Add-Content -LiteralPath $env:WARDIAN_COMMAND_SMOKE_LOG -Value $lines
     }
 
     #[test]
+    fn agent_update_fields_canonicalize_class_and_workspace() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workspace = temp.path().join("renamed-workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        let classes = vec![AgentClassDefinition {
+            name: "Reviewer".to_string(),
+            description: "Reviews work".to_string(),
+            is_default: true,
+            instruction_content: None,
+            assigned_skills: None,
+        }];
+        let mut config = AgentConfig {
+            session_id: "agent-1".to_string(),
+            agent_class: "Coder".to_string(),
+            folder: temp.path().to_string_lossy().replace('\\', "/"),
+            ..Default::default()
+        };
+
+        let updated_fields = apply_agent_update_fields(
+            &mut config,
+            Some("reviewer"),
+            Some(&workspace.to_string_lossy()),
+            &classes,
+        )
+        .expect("update fields");
+
+        assert_eq!(updated_fields, vec!["class", "workspace"]);
+        assert_eq!(config.agent_class, "Reviewer");
+        assert_eq!(
+            config.folder,
+            normalize_spawn_folder(&workspace.to_string_lossy()).unwrap()
+        );
+    }
+
+    #[test]
+    fn agent_update_workspace_rejects_managed_worktree_assignment() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workspace = temp.path().join("renamed-workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        let mut config = AgentConfig {
+            git_worktree: Some(true),
+            folder: temp.path().to_string_lossy().replace('\\', "/"),
+            ..Default::default()
+        };
+
+        let error =
+            apply_agent_update_fields(&mut config, None, Some(&workspace.to_string_lossy()), &[])
+                .expect_err("managed worktree must use worktree commands");
+
+        assert!(error.contains("agent worktree"));
+
+        let current_workspace = config.folder.clone();
+        let no_op_error = apply_agent_update_fields(
+            &mut config,
+            None,
+            Some(&current_workspace),
+            &[],
+        )
+        .expect_err("managed worktree no-op must still use worktree commands");
+        assert!(no_op_error.contains("agent worktree"));
+    }
+
+    #[test]
+    fn agent_update_workspace_requires_an_absolute_existing_directory() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let file = temp.path().join("not-a-workspace.txt");
+        std::fs::write(&file, "not a directory").expect("create file");
+        let mut config = AgentConfig {
+            folder: temp.path().to_string_lossy().replace('\\', "/"),
+            ..Default::default()
+        };
+
+        let blank = apply_agent_update_fields(&mut config, None, Some("   "), &[])
+            .expect_err("blank workspace must be rejected");
+        assert!(blank.contains("cannot be empty"));
+
+        let relative = apply_agent_update_fields(&mut config, None, Some("."), &[])
+            .expect_err("relative workspace must be rejected");
+        assert!(relative.contains("absolute"));
+
+        let file_error =
+            apply_agent_update_fields(&mut config, None, Some(&file.to_string_lossy()), &[])
+                .expect_err("workspace file must be rejected");
+        assert!(file_error.contains("directory"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn agent_update_fields_mutate_live_state_and_capture_persisted_snapshot() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workspace = temp.path().join("renamed-workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        std::fs::create_dir_all(temp.path().join("classes/Reviewer"))
+            .expect("create class directory");
+        unsafe { std::env::set_var("WARDIAN_HOME", temp.path()) };
+
+        let classes = vec![AgentClassDefinition {
+            name: "Reviewer".to_string(),
+            description: "Reviews work".to_string(),
+            is_default: true,
+            instruction_content: None,
+            assigned_skills: None,
+        }];
+        let state = AppState::new();
+        let agent = make_test_agent();
+        {
+            let mut config = agent.config.lock().unwrap();
+            config.session_id = "agent-1".to_string();
+            config.session_name = "CoderOne".to_string();
+            config.agent_class = "Coder".to_string();
+            config.folder = temp.path().to_string_lossy().replace('\\', "/");
+        }
+        state
+            .agents
+            .lock()
+            .await
+            .insert("agent-1".to_string(), agent);
+        state.agent_order.lock().await.push("agent-1".to_string());
+
+        let outcome = update_agent_fields_in_state(
+            &state,
+            "agent-1",
+            Some("Reviewer"),
+            Some(&workspace.to_string_lossy()),
+            &classes,
+        )
+        .await
+        .expect("update live state");
+
+        assert_eq!(outcome.updated_fields, vec!["class", "workspace"]);
+        assert_eq!(outcome.config.agent_class, "Reviewer");
+        assert_eq!(outcome.state_snapshot.len(), 1);
+        assert_eq!(
+            outcome.state_snapshot[0].agent_class,
+            outcome.config.agent_class
+        );
+        assert_eq!(outcome.state_snapshot[0].folder, outcome.config.folder);
+        assert!(outcome
+            .config
+            .system_include_directories
+            .as_ref()
+            .unwrap()
+            .iter()
+            .any(|path| path.replace('\\', "/").ends_with("/classes/Reviewer")));
+
+        let rollback_snapshot = restore_agent_config_in_state(
+            &state,
+            "agent-1",
+            outcome.previous_config.clone(),
+        )
+        .await
+        .expect("restore previous config");
+        assert_eq!(rollback_snapshot[0].agent_class, "Coder");
+        assert_eq!(
+            rollback_snapshot[0].folder,
+            temp.path().to_string_lossy().replace('\\', "/")
+        );
+
+        unsafe { std::env::remove_var("WARDIAN_HOME") };
+    }
+
+    #[tokio::test]
+    async fn agent_update_fields_wait_for_the_agent_lifecycle_lock() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workspace = temp.path().join("renamed-workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+        let state = Arc::new(AppState::new());
+        let agent = make_test_agent();
+        {
+            let mut config = agent.config.lock().unwrap();
+            config.session_id = "agent-1".to_string();
+            config.folder = temp.path().to_string_lossy().replace('\\', "/");
+        }
+        state
+            .agents
+            .lock()
+            .await
+            .insert("agent-1".to_string(), agent);
+        state.agent_order.lock().await.push("agent-1".to_string());
+
+        let first_guard = lock_agent_lifecycle(&state, "agent-1").await;
+        let state_for_update = Arc::clone(&state);
+        let workspace_for_update = workspace.to_string_lossy().to_string();
+        let update = tokio::spawn(async move {
+            update_agent_fields_in_state(
+                &state_for_update,
+                "agent-1",
+                None,
+                Some(&workspace_for_update),
+                &[],
+            )
+            .await
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(!update.is_finished());
+        drop(first_guard);
+
+        let outcome = update.await.unwrap().expect("update after lifecycle lock");
+        assert_eq!(outcome.updated_fields, vec!["workspace"]);
+    }
+
+    #[test]
     fn resolve_agent_worktree_branch_name_slugifies_session_name() {
         assert_eq!(
             resolve_agent_worktree_branch_name("Repo Agent!! 2"),
@@ -6083,6 +6437,21 @@ Add-Content -LiteralPath $env:WARDIAN_COMMAND_SMOKE_LOG -Value $lines
             .await
             .expect("second lifecycle lock should acquire");
         waiter.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn existing_lifecycle_guard_is_reused_without_self_deadlock() {
+        let state = AppState::new();
+        let guard = lock_agent_lifecycle(&state, "agent-1").await;
+
+        let reused = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            acquire_agent_lifecycle_guard(&state, "agent-1", Some(guard)),
+        )
+        .await
+        .expect("existing lifecycle guard should be reused");
+
+        drop(reused);
     }
 
     #[test]

--- a/src-tauri/src/commands/class.rs
+++ b/src-tauri/src/commands/class.rs
@@ -21,47 +21,14 @@ pub async fn create_agent_class(
         return Err("Class name cannot be empty".to_string());
     }
 
-    let mut all = manager::get_all_agent_classes(&app);
-    if all
-        .iter()
-        .any(|c| c.name.to_lowercase() == trimmed_name.to_lowercase())
-    {
-        return Err(format!("A class named '{}' already exists", trimmed_name));
-    }
-
-    let new_class = AgentClassDefinition {
-        name: trimmed_name.clone(),
-        description: description.trim().to_string(),
-        is_default: false,
-        instruction_content: None,
-        assigned_skills: None,
-    };
-
-    all.push(new_class.clone());
-    manager::save_classes(&app, &all)?;
-
-    if let Some(app_dir) = crate::utils::fs::get_wardian_home() {
-        let role_dir = app_dir.join("classes").join(&trimmed_name);
-        let _ = std::fs::create_dir_all(&role_dir);
-
-        // Create AGENTS.md master instruction file
-        let agents_md_path = role_dir.join("AGENTS.md");
-        if !agents_md_path.exists() {
-            let content = match instruction_content {
-                Some(ref md) if !md.trim().is_empty() => md.clone(),
-                _ => format!("# Role: {}\n\n{}\n", trimmed_name, new_class.description),
-            };
-            let _ = std::fs::write(agents_md_path, content);
-        }
-
-        // Create thin compatibility stubs that point providers back to AGENTS.md.
-        for stub_name in &["GEMINI.md", "CLAUDE.md"] {
-            let stub_path = role_dir.join(stub_name);
-            if !stub_path.exists() {
-                let _ = std::fs::write(stub_path, "@AGENTS.md\n");
-            }
-        }
-    }
+    let app_dir = crate::utils::fs::get_wardian_home()
+        .ok_or_else(|| "Could not locate Wardian home directory".to_string())?;
+    wardian_core::classes::create_class(
+        &app_dir,
+        &trimmed_name,
+        description.trim(),
+        instruction_content.as_deref(),
+    )?;
 
     manager::init_agent_classes(&app);
     Ok(manager::get_all_agent_classes(&app))
@@ -74,24 +41,9 @@ pub async fn delete_agent_class(
 ) -> Result<Vec<AgentClassDefinition>, String> {
     manager::log_debug(&format!("[WARDIAN] delete_agent_class called: {}", name));
 
-    let mut all = manager::get_all_agent_classes(&app);
-    if let Some(found) = all.iter().find(|c| c.name == name) {
-        if found.is_default {
-            return Err("Cannot delete a default class".to_string());
-        }
-    } else {
-        return Err(format!("Class '{}' not found", name));
-    }
-
-    all.retain(|c| c.name != name);
-    manager::save_classes(&app, &all)?;
-
-    if let Some(app_dir) = crate::utils::fs::get_wardian_home() {
-        let role_dir = app_dir.join("classes").join(&name);
-        if role_dir.exists() {
-            let _ = std::fs::remove_dir_all(&role_dir);
-        }
-    }
+    let app_dir = crate::utils::fs::get_wardian_home()
+        .ok_or_else(|| "Could not locate Wardian home directory".to_string())?;
+    wardian_core::classes::delete_class(&app_dir, &name)?;
 
     Ok(manager::get_all_agent_classes(&app))
 }
@@ -103,35 +55,15 @@ pub async fn get_default_class_instruction(name: String, app: AppHandle) -> Resu
 }
 
 #[tauri::command]
-pub async fn reset_class_to_default(name: String, app: AppHandle) -> Result<(), String> {
+pub async fn reset_class_to_default(name: String, _app: AppHandle) -> Result<(), String> {
     manager::log_debug(&format!(
         "[WARDIAN] reset_class_to_default called: {}",
         name
     ));
 
-    let all = manager::get_all_agent_classes(&app);
-    let found = all
-        .iter()
-        .find(|c| c.name == name)
-        .ok_or_else(|| format!("Class '{}' not found", name))?;
-
-    if !found.is_default {
-        return Err(format!(
-            "'{}' is not a default class and cannot be reset.",
-            name
-        ));
-    }
-
-    let default_content = manager::get_agent_class_default_instruction(&app, &name)
-        .ok_or_else(|| format!("System default for '{}' not found", name))?;
-
-    if let Some(app_dir) = crate::utils::fs::get_wardian_home() {
-        let agents_md_path = app_dir.join("classes").join(&name).join("AGENTS.md");
-        std::fs::write(agents_md_path, default_content).map_err(|e| e.to_string())?;
-        Ok(())
-    } else {
-        Err("Could not locate Wardian home directory".to_string())
-    }
+    let app_dir = crate::utils::fs::get_wardian_home()
+        .ok_or_else(|| "Could not locate Wardian home directory".to_string())?;
+    wardian_core::classes::restore_default_instruction(&app_dir, &name)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -580,7 +580,13 @@ pub async fn remove_orphan_deployment(
     skill_name: String,
 ) -> Result<(), String> {
     let home = get_wardian_home().ok_or("Could not find Wardian home")?;
-    library::remove_orphan_deployment(&home, &target_type, &target_id, &skill_name)
+    if library::remove_orphan_deployment(&home, &target_type, &target_id, &skill_name)? {
+        Ok(())
+    } else {
+        Err(format!(
+            "Deployment is not currently orphaned: {target_type}:{target_id}/{skill_name}"
+        ))
+    }
 }
 
 // --- Watching (commands) ---------------------------------------------------

--- a/src-tauri/src/control.rs
+++ b/src-tauri/src/control.rs
@@ -12,13 +12,13 @@ use std::{
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use wardian_core::control::{
-    AgentListResponse, AgentResponse, AgentWatchResponse, AgentWorktreeListResponse,
-    AgentWorktreeMutationResponse, AgentWorktreeSummary, ApprovalAction, AskResponse,
-    ControlRequest, ConversationListResponse, ConversationShowResponse, DeliveryDetail,
-    DeliveryErrorDetail, DeliveryTransportKind, InteractionBodyRef, MessageInputMode,
-    MessageOrigin, OkResponse, ProviderInputReadiness, ProviderReadyEvidence, QueuePolicy,
-    ReplyResponse, ReplyStatus, SendMessageResponse, StructuredReply, WatchAgentSnapshot,
-    WatchDeliverySnapshot, WatchEvidenceError,
+    AgentListResponse, AgentResponse, AgentUpdateResponse, AgentWatchResponse,
+    AgentWorktreeListResponse, AgentWorktreeMutationResponse, AgentWorktreeSummary,
+    ApprovalAction, AskResponse, ControlRequest, ConversationListResponse,
+    ConversationShowResponse, DeliveryDetail, DeliveryErrorDetail, DeliveryTransportKind,
+    InteractionBodyRef, MessageInputMode, MessageOrigin, OkResponse, ProviderInputReadiness,
+    ProviderReadyEvidence, QueuePolicy, ReplyResponse, ReplyStatus, SendMessageResponse,
+    StructuredReply, WatchAgentSnapshot, WatchDeliverySnapshot, WatchEvidenceError,
 };
 use wardian_core::conversations::ConversationLoggingSetting;
 use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
@@ -26,6 +26,20 @@ use wardian_core::identity::{normalize_status, AgentIdentity, StatusSource};
 const STRUCTURED_ASK_INLINE_MESSAGE_MAX_BYTES: usize = 4096;
 const STRUCTURED_ASK_REQUESTS_DIR: &str = "requests";
 const CODEX_PAYLOAD_ECHO_TIMEOUT_MS: u64 = 750;
+
+async fn rollback_agent_update(
+    state: &AppState,
+    session_id: &str,
+    previous_config: wardian_core::models::AgentConfig,
+) -> Result<(), String> {
+    let snapshot = crate::commands::agent::restore_agent_config_in_state(
+        state,
+        session_id,
+        previous_config,
+    )
+    .await?;
+    manager::try_save_state_snapshot(&snapshot)
+}
 
 #[cfg(windows)]
 pub(crate) type ControlEndpointClaim = tokio::net::windows::named_pipe::NamedPipeServer;
@@ -243,6 +257,96 @@ async fn dispatch_request(line: &str, app: &AppHandle) -> Result<String, Control
                 .map_err(ControlError::request_failed)?;
             let identity = agent_config_to_identity(&config, app).await;
             ok_json(&AgentResponse::new(identity))
+        }
+
+        ControlRequest::AgentUpdate {
+            target,
+            class,
+            workspace,
+        } => {
+            let uuid = resolve_target_uuid(app, &target)
+                .await
+                .ok_or_else(|| ControlError::not_found(format!("agent not found: {target}")))?;
+            let home = crate::utils::fs::get_wardian_home()
+                .ok_or_else(|| ControlError::request_failed("Could not locate Wardian home"))?;
+            let classes = wardian_core::classes::initialize_classes(&home)
+                .map_err(ControlError::request_failed)?;
+            if let Some(class) = class.as_deref() {
+                if !classes
+                    .iter()
+                    .any(|definition| definition.name.eq_ignore_ascii_case(class.trim()))
+                {
+                    return Err(ControlError::not_found(format!(
+                        "agent class not found: {class}"
+                    )));
+                }
+            }
+
+            let state = app.state::<AppState>();
+            let outcome = crate::commands::agent::update_agent_fields_in_state(
+                state.inner(),
+                &uuid,
+                class.as_deref(),
+                workspace.as_deref(),
+                &classes,
+            )
+            .await
+            .map_err(ControlError::bad_request)?;
+            if let Err(error) = manager::try_save_state_snapshot(&outcome.state_snapshot) {
+                let rollback_error = rollback_agent_update(
+                    state.inner(),
+                    &uuid,
+                    outcome.previous_config.clone(),
+                )
+                .await
+                .err()
+                .map(|rollback| format!("; rollback also failed: {rollback}"))
+                .unwrap_or_default();
+                return Err(ControlError::request_failed(format!(
+                    "Failed to persist agent update: {error}{rollback_error}"
+                )));
+            }
+            let workspace =
+                crate::utils::fs::resolve_cwd(&outcome.config.folder, &outcome.config.session_id)
+                    .to_string_lossy()
+                    .to_string();
+            let project = wardian_core::db::project_name_from_workspace(&workspace);
+            let metadata_error = wardian_core::db::upsert_agent(&wardian_core::db::AgentUpsert {
+                session_id: &outcome.config.session_id,
+                session_name: &outcome.config.session_name,
+                agent_class: &outcome.config.agent_class,
+                provider: &outcome.config.provider,
+                workspace: Some(&workspace),
+                project: project.as_deref(),
+                is_off: outcome.config.is_off,
+                created_at: None,
+            })
+            .err()
+            .map(|error| error.to_string());
+            if let Some(error) = metadata_error {
+                let rollback_error = rollback_agent_update(
+                    state.inner(),
+                    &uuid,
+                    outcome.previous_config.clone(),
+                )
+                .await
+                .err()
+                .map(|rollback| format!("; rollback also failed: {rollback}"))
+                .unwrap_or_default();
+                return Err(ControlError::request_failed(format!(
+                    "Failed to persist agent metadata: {error}{rollback_error}"
+                )));
+            }
+            let _ = app.emit("agents-updated", ());
+            let restart_required = !outcome.updated_fields.is_empty() && !outcome.config.is_off;
+            let identity = agent_config_to_identity(&outcome.config, app).await;
+            ok_json(&AgentUpdateResponse {
+                schema: wardian_core::control::CONTROL_SCHEMA,
+                ok: true,
+                agent: identity,
+                updated_fields: outcome.updated_fields,
+                restart_required,
+            })
         }
 
         ControlRequest::AgentClone { target, name } => {

--- a/src-tauri/src/manager/classes.rs
+++ b/src-tauri/src/manager/classes.rs
@@ -50,13 +50,13 @@ pub fn init_agent_classes(app: &AppHandle) {
             let _ = save_classes(app, &defaults);
         }
 
-        let classes = get_all_agent_classes(app);
-        for cls in &classes {
-            let role_dir = classes_dir.join(&cls.name);
-            let _ = wardian_core::classes::ensure_class_directory(&app_dir, cls, None);
+        if let Ok(classes) = wardian_core::classes::initialize_classes(&app_dir) {
+            for cls in &classes {
+                let role_dir = classes_dir.join(&cls.name);
 
-            // Expose canonical skills through provider-specific discovery shims.
-            ensure_claude_skills_link(&role_dir);
+                // Expose canonical skills through provider-specific discovery shims.
+                ensure_claude_skills_link(&role_dir);
+            }
         }
     }
 }

--- a/src-tauri/src/manager/classes.rs
+++ b/src-tauri/src/manager/classes.rs
@@ -6,20 +6,14 @@ use wardian_core::models::AgentClassDefinition;
 const BUNDLED_COMMON_SKILLS: &[&str] = &["wardian-skills/wardian-cli"];
 
 pub fn get_all_agent_classes(_app: &AppHandle) -> Vec<AgentClassDefinition> {
-    if let Some(app_dir) = get_wardian_home() {
-        let classes_path = app_dir.join("classes.json");
-        if let Ok(data) = std::fs::read_to_string(&classes_path) {
-            return serde_json::from_str::<Vec<AgentClassDefinition>>(&data).unwrap_or_default();
-        }
-    }
-    Vec::new()
+    get_wardian_home()
+        .and_then(|app_dir| wardian_core::classes::load_class_definitions(&app_dir).ok())
+        .unwrap_or_default()
 }
 
 pub fn save_classes(_app: &AppHandle, classes: &[AgentClassDefinition]) -> Result<(), String> {
     let app_dir = get_wardian_home().ok_or("No home dir")?;
-    let json = serde_json::to_string_pretty(classes).map_err(|e| e.to_string())?;
-    std::fs::write(app_dir.join("classes.json"), json).map_err(|e| e.to_string())?;
-    Ok(())
+    wardian_core::classes::save_class_definitions(&app_dir, classes)
 }
 
 pub fn init_agent_classes(app: &AppHandle) {
@@ -37,11 +31,7 @@ pub fn init_agent_classes(app: &AppHandle) {
 
         // Migration and Initialization
         if !classes_path.exists() {
-            let mut defaults: Vec<AgentClassDefinition> =
-                serde_json::from_str(include_str!("../default_classes.json")).unwrap_or_default();
-            for d in defaults.iter_mut() {
-                d.is_default = true;
-            }
+            let mut defaults = wardian_core::classes::default_class_definitions();
 
             let custom_path = app_dir.join("custom_classes.json");
             if custom_path.exists() {
@@ -63,36 +53,10 @@ pub fn init_agent_classes(app: &AppHandle) {
         let classes = get_all_agent_classes(app);
         for cls in &classes {
             let role_dir = classes_dir.join(&cls.name);
-            let _ = std::fs::create_dir_all(&role_dir);
+            let _ = wardian_core::classes::ensure_class_directory(&app_dir, cls, None);
 
-            // 1. Create AGENTS.md master file
-            let agents_md_path = role_dir.join("AGENTS.md");
-            if !agents_md_path.exists() {
-                let content = if cls.is_default {
-                    app.path()
-                        .resolve(
-                            format!("agent_prompts/{}.md", cls.name),
-                            tauri::path::BaseDirectory::Resource,
-                        )
-                        .ok()
-                        .and_then(|p| std::fs::read_to_string(p).ok())
-                        .unwrap_or_default()
-                } else {
-                    format!("# {} Agent\n\n{}\n", cls.name, cls.description)
-                };
-                let _ = std::fs::write(agents_md_path, content);
-            }
-
-            // 2. Expose canonical skills through provider-specific discovery shims.
+            // Expose canonical skills through provider-specific discovery shims.
             ensure_claude_skills_link(&role_dir);
-
-            // 3. Create thin compatibility stubs that point providers back to AGENTS.md.
-            for stub_name in &["GEMINI.md", "CLAUDE.md"] {
-                let stub_path = role_dir.join(stub_name);
-                if !stub_path.exists() {
-                    let _ = std::fs::write(stub_path, "@AGENTS.md\n");
-                }
-            }
         }
     }
 }
@@ -195,14 +159,8 @@ fn init_bundled_common_skills(app: &AppHandle, app_dir: &Path) {
     }
 }
 
-pub fn get_agent_class_default_instruction(app: &AppHandle, class_name: &str) -> Option<String> {
-    app.path()
-        .resolve(
-            format!("agent_prompts/{}.md", class_name),
-            tauri::path::BaseDirectory::Resource,
-        )
-        .ok()
-        .and_then(|p| std::fs::read_to_string(p).ok())
+pub fn get_agent_class_default_instruction(_app: &AppHandle, class_name: &str) -> Option<String> {
+    wardian_core::classes::default_class_instruction(class_name).map(ToOwned::to_owned)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -43,6 +43,7 @@ use crate::state::{ActiveAgent, AppState};
 use portable_pty::CommandBuilder;
 use std::collections::HashMap;
 use tauri::{AppHandle, Emitter, Manager};
+use wardian_core::conversations::write_json_atomic;
 use wardian_core::control::{ProviderInputReadiness, ProviderReadyEvidence};
 use wardian_core::models::{AgentConfig, AgentEvent};
 pub(crate) fn session_bootstrap_prompt() -> &'static str {
@@ -568,16 +569,18 @@ pub(crate) fn state_configs_snapshot(
 }
 
 pub(crate) fn try_save_state_snapshot(configs: &[AgentConfig]) -> Result<(), String> {
-    let json = serde_json::to_string_pretty(configs).map_err(|error| error.to_string())?;
     let app_dir = get_wardian_home().ok_or_else(|| "Could not locate Wardian home".to_string())?;
     std::fs::create_dir_all(&app_dir).map_err(|error| error.to_string())?;
     let settings_dir = app_dir.join("settings");
     std::fs::create_dir_all(&settings_dir).map_err(|error| error.to_string())?;
-    std::fs::write(settings_dir.join("state.json"), json).map_err(|error| error.to_string())
+    write_json_atomic(&settings_dir.join("state.json"), configs)
+        .map_err(|error| error.to_string())
 }
 
 pub(crate) fn save_state_snapshot(_app: &AppHandle, configs: &[AgentConfig]) {
-    let _ = try_save_state_snapshot(configs);
+    if let Err(error) = try_save_state_snapshot(configs) {
+        log_debug(&format!("[WARDIAN] Failed to persist state snapshot: {error}"));
+    }
 }
 
 pub fn save_state(app: &AppHandle, agents: &HashMap<String, ActiveAgent>, order: &[String]) {
@@ -924,6 +927,31 @@ mod tests {
             None => unsafe { std::env::remove_var("WARDIAN_HOME") },
         }
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_save_state_snapshot_replaces_existing_state_atomically() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        let home = temp.path().join("wardian-home");
+        std::fs::create_dir_all(home.join("settings")).expect("create settings dir");
+        std::fs::write(home.join("settings/state.json"), r#"[{"session_id":"old"}]"#)
+            .expect("seed old snapshot");
+        let previous_home = std::env::var_os("WARDIAN_HOME");
+        unsafe { std::env::set_var("WARDIAN_HOME", &home) };
+
+        try_save_state_snapshot(&[AgentConfig::default()]).expect("atomic snapshot write");
+
+        let contents =
+            std::fs::read_to_string(home.join("settings/state.json")).expect("read snapshot");
+        let configs: Vec<AgentConfig> = serde_json::from_str(&contents).expect("parse snapshot");
+        assert_eq!(configs.len(), 1);
+        assert!(!home.join("settings/.state.json.tmp").exists());
+
+        match previous_home {
+            Some(value) => unsafe { std::env::set_var("WARDIAN_HOME", value) },
+            None => unsafe { std::env::remove_var("WARDIAN_HOME") },
+        }
     }
 
     #[test]

--- a/src-tauri/src/manager/mod.rs
+++ b/src-tauri/src/manager/mod.rs
@@ -567,15 +567,17 @@ pub(crate) fn state_configs_snapshot(
     configs
 }
 
+pub(crate) fn try_save_state_snapshot(configs: &[AgentConfig]) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(configs).map_err(|error| error.to_string())?;
+    let app_dir = get_wardian_home().ok_or_else(|| "Could not locate Wardian home".to_string())?;
+    std::fs::create_dir_all(&app_dir).map_err(|error| error.to_string())?;
+    let settings_dir = app_dir.join("settings");
+    std::fs::create_dir_all(&settings_dir).map_err(|error| error.to_string())?;
+    std::fs::write(settings_dir.join("state.json"), json).map_err(|error| error.to_string())
+}
+
 pub(crate) fn save_state_snapshot(_app: &AppHandle, configs: &[AgentConfig]) {
-    if let Ok(json) = serde_json::to_string_pretty(&configs) {
-        if let Some(app_dir) = get_wardian_home() {
-            let _ = std::fs::create_dir_all(&app_dir);
-            let _ = std::fs::create_dir_all(app_dir.join("settings"));
-            let state_path = app_dir.join("settings/state.json");
-            let _ = std::fs::write(state_path, json);
-        }
-    }
+    let _ = try_save_state_snapshot(configs);
 }
 
 pub fn save_state(app: &AppHandle, agents: &HashMap<String, ActiveAgent>, order: &[String]) {
@@ -905,6 +907,24 @@ pub(crate) fn display_log_path(path: &std::path::Path) -> String {
 mod tests {
     use super::*;
     use std::path::Path;
+
+    #[test]
+    fn try_save_state_snapshot_reports_write_failures() {
+        let _guard = crate::utils::wardian_test_env_lock();
+        let temp = tempfile::tempdir().expect("temp dir");
+        let blocked_home = temp.path().join("blocked-home");
+        std::fs::write(&blocked_home, "not a directory").expect("create blocking file");
+        let previous_home = std::env::var_os("WARDIAN_HOME");
+        unsafe { std::env::set_var("WARDIAN_HOME", &blocked_home) };
+
+        let result = try_save_state_snapshot(&[AgentConfig::default()]);
+
+        match previous_home {
+            Some(value) => unsafe { std::env::set_var("WARDIAN_HOME", value) },
+            None => unsafe { std::env::remove_var("WARDIAN_HOME") },
+        }
+        assert!(result.is_err());
+    }
 
     #[test]
     fn antigravity_interactive_launch_supplies_empty_prompt_value() {

--- a/src-tauri/src/utils/shell.rs
+++ b/src-tauri/src/utils/shell.rs
@@ -447,16 +447,11 @@ fn normalize_shell_overrides(mut overrides: ShellSettingsOverrides) -> ShellSett
     overrides.codex_runtime_policy = overrides
         .codex_runtime_policy
         .map(normalize_codex_runtime_policy_overrides)
-        .and_then(|policy| {
-            if policy.sandbox_mode.is_none()
+        .filter(|policy| {
+            !(policy.sandbox_mode.is_none()
                 && policy.approval_policy.is_none()
                 && policy.full_auto.is_none()
-                && policy.trust_workspaces.is_none()
-            {
-                None
-            } else {
-                Some(policy)
-            }
+                && policy.trust_workspaces.is_none())
         });
     overrides.default_provider = overrides
         .default_provider


### PR DESCRIPTION
## Description
Adds an agent-oriented `wardian library` surface over Wardian's disk-backed Library so agents can discover and contribute prompts, skills, classes, and workflow blueprints without requiring the desktop app.

Key behavior:
- machine-readable list/show/create/write/move/delete, metadata, deployment, orphan, and default-class restore commands
- fresh-home class initialization shared with the Tauri app
- desired-set skill deployment with target validation, deduplication, explicit `--clear`, and verified orphan deletion
- stable entry-shape validation for Markdown assets and non-nested skills
- atomic class and Library metadata persistence
- flat agent-sized output and command help that keeps workflow execution on `wardian workflow`
- `wardian agent update <target> --class <ClassName>` for live and persisted class reassignment with regenerated instruction include directories
- `wardian agent update <target> --workspace <absolute-path>` for existing ordinary workspace moves/renames; class and workspace can be updated atomically
- structured `updated_fields` and `restart_required` output without interrupting the active provider process
- lifecycle serialization across updates, resume/pause/clear, and worktree mutations, with live/state rollback when `state.json` or SQLite persistence fails
- managed worktree workspace changes remain on `wardian agent worktree`; direct update requests are rejected
- updated CLI/Library guides, bundled Wardian CLI skill, design history, and project PowerShell home-safety guidance

The CLI intentionally authors workflow blueprint files only. Validation, parsing, normalization, execution, runs, replay, and schedules remain on the dedicated `wardian workflow` surface.

## Related Issues
Fixes #270

Refs #650

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- `npm run lint`
- `npm run test` (134 files; 1,479 passed, 1 skipped)
- `npm run build`
- `npm run docs:check-llms`
- `npm run docs:build`
- `cargo test -p wardian-cli -p wardian-core` (139 CLI unit tests plus integration suites; 273 core tests passed, 1 intentionally ignored performance test)
- `cargo clippy --workspace -- -D warnings`
- `cargo test` in `src-tauri` (1,096 unit tests plus integration and doc tests)
- `cargo check --workspace`
- `npm run test:e2e:native:fast -- e2e-native/tests/cli-shared-state-native.test.mjs` (8 passed, 1 opt-in real-provider test skipped)
- bundled `wardian-cli` skill validation via `quick_validate.py`
- isolated live installed-CLI smoke covering fresh classes, prompt/skill/class/workflow authoring, metadata, flat output, deployment deduplication and clearing, healthy orphan rejection, entry-shape errors, and workflow validation
- independent Wardian reviewer pass after lifecycle and persistence fixes: no blocking findings

## Checklist:
- [x] My code follows the stylistic guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I checked `docs/developer/docs-maintenance.md` for user docs, public links, release notes, and screenshot refresh needs
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] (Frontend changes) Not applicable; this PR does not change frontend behavior


Follow-up: state.json persistence now uses atomic replacement and logs write failures instead of swallowing them.
